### PR TITLE
ci: build + publish desktop MSI on every release tag

### DIFF
--- a/.github/workflows/desktop-msi-publish.yml
+++ b/.github/workflows/desktop-msi-publish.yml
@@ -1,0 +1,151 @@
+name: Desktop — build MSI + attach to Release
+
+# Builds the Windows desktop MSI installer for every released RC and
+# final tag, attaches it to the GitHub Release for that tag (creating
+# the release if necessary).  Operators can download the MSI from the
+# Release page rather than building from source.
+#
+# Trigger surfaces:
+#   * Tag push matching `v*.*.*` or `v*.*.*-*` (covers final + pre-release
+#     tags, same pattern as pypi-publish.yml / docker-publish.yml).
+#   * Manual `workflow_dispatch` — lets the maintainer backfill a missed
+#     tag (e.g. retroactively build the MSI for a tag pushed before this
+#     workflow existed) or rebuild a corrupted artefact.
+#
+# Output:
+#   * `Netcanon-<version>-win64.msi` attached to the GitHub Release for
+#     the triggering tag.  Also kept for 30 days as a workflow artefact
+#     for diagnostic purposes.
+#
+# What it does NOT do (yet):
+#   * No code signing.  The MSI is unsigned; Windows SmartScreen will
+#     show a warning on first install.  Future work: integrate SignPath
+#     (free for OSS projects) or a purchased EV cert.
+#   * No Mac / Linux desktop installers — only Windows.  cx_Freeze
+#     supports them but they're not currently wired.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build MSI for (e.g. v0.1.0-rc7)"
+        required: true
+        type: string
+
+# Need write access to the Releases API so the action can create the
+# release page + upload the MSI as a release asset.
+permissions:
+  contents: write
+
+# Prevent two simultaneous MSI builds for the same ref from racing
+# the release-upload step.  Within a single ref, we let the second
+# wait (rather than cancel) so a maintainer who re-triggers a build
+# doesn't lose the queued one.
+concurrency:
+  group: msi-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # Opt-in to Node.js 24 for JavaScript actions ahead of the June 2026
+  # forced cutover.  Same pragma as the other workflows.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  build-msi:
+    name: Build Windows MSI
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout (full history for setuptools_scm)
+        uses: actions/checkout@v6
+        with:
+          # When triggered by workflow_dispatch the user supplies a tag
+          # name as `inputs.tag`; checkout's `ref` accepts either a tag
+          # name (`v0.1.0-rc7`) or a full ref (`refs/tags/...`).  On
+          # tag-push triggers, github.ref already has the full ref form.
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Compute MSI version from tag
+        shell: bash
+        run: |
+          # On workflow_dispatch the tag is inputs.tag.  On tag-push it's
+          # github.ref_name (the tag name without the refs/tags/ prefix).
+          tag="${{ inputs.tag || github.ref_name }}"
+          # Strip leading 'v' if present.
+          tag="${tag#v}"            # e.g. 0.1.0-rc7
+          # Drop the rc/alpha/beta suffix (everything after the first '-')
+          # because Windows MSI ProductVersion format is M.m.b[.r] only.
+          msi_version="${tag%%-*}"  # e.g. 0.1.0
+          echo "NETCANON_MSI_VERSION=$msi_version" >> "$GITHUB_ENV"
+          echo "Building MSI with ProductVersion: $msi_version (source tag: $tag)"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # The [desktop-build] extra pulls in PySide6 + pystray +
+          # Pillow + cx_Freeze.  Editable install so setup_desktop.py
+          # can find the source tree.
+          pip install -e ".[desktop-build]"
+
+      - name: Build MSI via cx_Freeze
+        # cx_Freeze auto-downloads WiX on first use (Windows runners
+        # have the .NET Framework runtime needed for it).
+        run: python setup_desktop.py bdist_msi
+
+      - name: Sanity-check MSI exists + reasonable size
+        shell: bash
+        run: |
+          msi=$(ls dist/*.msi 2>/dev/null | head -1)
+          if [ -z "$msi" ]; then
+            echo "FAIL: no MSI produced under dist/"
+            ls -la dist/ || true
+            exit 1
+          fi
+          # PySide6 + Chromium WebEngine + Python interpreter should
+          # produce ~200-300 MB.  Anything under 50 MB suggests
+          # cx_Freeze silently dropped a major package.
+          size=$(stat -c%s "$msi" 2>/dev/null || wc -c <"$msi")
+          printf "MSI: %s\nSize: %s bytes\n" "$msi" "$size"
+          if [ "$size" -lt 52428800 ]; then
+            echo "FAIL: MSI suspiciously small ($size < 50MB).  cx_Freeze probably skipped a critical package."
+            exit 1
+          fi
+
+      - name: Upload MSI as workflow artefact
+        # Diagnostic copy — survives 30 days regardless of whether the
+        # release-asset upload below succeeds.
+        uses: actions/upload-artifact@v7
+        with:
+          name: msi
+          path: dist/*.msi
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attach MSI to GitHub Release
+        # softprops/action-gh-release creates the release page if it
+        # doesn't yet exist (handy for tags pushed before this workflow
+        # existed) and otherwise appends the MSI to the existing one.
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: dist/*.msi
+          fail_on_unmatched_files: true
+          # When the release page is auto-created here (e.g. backfill
+          # via workflow_dispatch on a tag with no release page yet),
+          # populate it with the auto-generated PR / commit changelog.
+          generate_release_notes: true
+          # Mark pre-release tags (e.g. v0.1.0-rc7) as "Pre-release" so
+          # the GitHub Releases page sorts them correctly and the
+          # "latest release" link skips over them.
+          prerelease: ${{ contains(inputs.tag || github.ref_name, '-rc') || contains(inputs.tag || github.ref_name, '-alpha') || contains(inputs.tag || github.ref_name, '-beta') }}

--- a/netcanon_desktop/README.md
+++ b/netcanon_desktop/README.md
@@ -21,11 +21,33 @@ python -m netcanon_desktop
 
 ## Building an MSI Installer
 
+There are two paths.  Most operators want **Path A** (download the MSI
+from a GitHub Release page).  Contributors / forks that need a custom
+build go through **Path B**.
+
+### Path A — Download the CI-built MSI
+
+Every release tag (`v*.*.*` final + `v*.*.*-*` pre-release) triggers
+the `Desktop — build MSI + attach to Release` workflow, which builds
+the MSI on a `windows-latest` runner and attaches it as a release
+asset on https://github.com/netcanon/netcanon/releases.
+
+The CI MSI is currently **unsigned** — Windows SmartScreen will prompt
+on first install.  Future work: integrate SignPath (free for OSS) or
+a purchased EV cert; see the workflow file's header comment.
+
+### Path B — Build locally
+
 ```bash
 pip install -e ".[desktop-build]"
 python setup_desktop.py bdist_msi
-# Installer written to dist/
+# Installer written to dist/Netcanon-<version>-win64.msi
 ```
+
+The `version` in the MSI defaults to `MSI_VERSION_DEFAULT` (hardcoded
+in `setup_desktop.py`); the CI workflow overrides it by setting the
+`NETCANON_MSI_VERSION` env var from the triggering tag.  For local
+builds, bump `MSI_VERSION_DEFAULT` manually if you care.
 
 The MSI:
 * Installs to `C:\Program Files\Netcanon\`

--- a/setup_desktop.py
+++ b/setup_desktop.py
@@ -17,13 +17,35 @@ Requirements::
 
 See https://cx-freeze.readthedocs.io/en/stable/setup_script.html for full
 option documentation.
+
+Versioning
+----------
+
+The Windows MSI ``ProductVersion`` field has a strict ``M.m.b[.r]`` format
+that does NOT accept the rc / alpha / beta suffixes the rest of the project
+uses (e.g. ``0.1.0rc7``).  Two paths are supported:
+
+* **Local builds**: the default ``MSI_VERSION`` constant below is used —
+  bump it manually if you care about the in-installer version.
+* **CI builds**: the ``desktop-msi-publish.yml`` workflow derives the
+  version from the triggering git tag (stripping the rc-suffix) and
+  passes it via the ``NETCANON_MSI_VERSION`` env var.  This script
+  honours that override when set so CI doesn't have to edit this file.
 """
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 from cx_Freeze import Executable, setup
+
+# Default MSI version used when no env override is supplied (i.e. local
+# manual builds).  Bump this manually between releases — Windows MSI
+# format constraints mean we can't reuse the setuptools_scm rc-suffixed
+# version directly.  CI sets NETCANON_MSI_VERSION from the tag.
+MSI_VERSION_DEFAULT = "0.1.0"
+MSI_VERSION = os.environ.get("NETCANON_MSI_VERSION", MSI_VERSION_DEFAULT)
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -160,7 +182,7 @@ executables = [
 
 setup(
     name="Netcanon",
-    version="0.1.0",
+    version=MSI_VERSION,
     description="Netcanon — Network Configuration Collector",
     author="Netcanon contributors",
     options={


### PR DESCRIPTION
## Summary

First post-launch CI improvement: auto-build the Windows desktop MSI on every release tag and attach it to the GitHub Release page.  Eliminates the only-build-locally requirement that pre-rc7 made the desktop installer a manual artefact.

## What ships

- **`.github/workflows/desktop-msi-publish.yml`** (new) — runs on `v*.*.*` + `v*.*.*-*` tag pushes (same pattern as pypi-publish.yml / docker-publish.yml).  Plus `workflow_dispatch` so the maintainer can backfill tags pushed before this workflow existed (e.g. retroactively build rc7's MSI).
- **`setup_desktop.py`** — honours `NETCANON_MSI_VERSION` env var if set; falls back to a hardcoded default for local builds.  Required because Windows MSI ProductVersion format (`M.m.b[.r]`) doesn't accept the rc-suffixed Python versions from setuptools_scm.
- **`netcanon_desktop/README.md`** — restructured "Building an MSI Installer" section into Path A (download from Releases — operators) + Path B (local build — contributors).

## Build pipeline shape

```
tag push (v*.*.*)
  → workflow fires on windows-latest
  → checkout @tag with full history
  → derive MSI version from tag (strips rc suffix)
  → pip install -e ".[desktop-build]"
  → python setup_desktop.py bdist_msi
  → sanity-check (MSI exists, size > 50 MB)
  → upload as 30-day workflow artefact (diagnostic)
  → attach to GitHub Release (creates page if missing; marks rc as pre-release)
```

## Verification plan

- [x] Workflow file syntactically valid (no `yamllint`-failing issues by inspection)
- [x] Local `setup_desktop.py` build path unchanged — env var override defaults to existing `0.1.0`
- [ ] CI matrix green (regular tests still pass)
- [ ] Post-merge: `workflow_dispatch` against `v0.1.0-rc7` to backfill that tag's MSI
- [ ] Confirm MSI installs on a clean Windows machine + launches the app

## Known limitations (deferred)

- **Unsigned MSI** — SmartScreen warns on first install.  Worth integrating SignPath (free for OSS) or a purchased EV cert in a follow-up.
- **Windows only** — cx_Freeze supports Mac/Linux too; not wired.
- **All rcs share the same MSI ProductVersion** within a major.minor.build (e.g., rc7, rc8, and final 0.1.0 all → "0.1.0").  Workaround: manually uninstall before installing a different rc, or only ship MSIs for final releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)