### PR TITLE
fix(desktop): cx_Freeze 8.x renamed base Win32GUI -> gui

### DIFF
--- a/netcanon_desktop/README.md
+++ b/netcanon_desktop/README.md
@@ -52,7 +52,7 @@ builds, bump `MSI_VERSION_DEFAULT` manually if you care.
 The MSI:
 * Installs to `C:\Program Files\Netcanon\`
 * Creates a Start Menu shortcut (pinnable to the taskbar)
-* Uses `base="Win32GUI"` — no console window
+* Uses `base="gui"` — no console window (cx_Freeze 8.x naming; previously `Win32GUI`)
 
 ---
 

--- a/setup_desktop.py
+++ b/setup_desktop.py
@@ -164,8 +164,12 @@ executables = [
     Executable(
         # Entry point — runs netcanon_desktop.__main__:main()
         script="netcanon_desktop/__main__.py",
-        # Win32GUI suppresses the console window so the app runs silently.
-        base="Win32GUI" if sys.platform == "win32" else None,
+        # "gui" suppresses the console window so the app runs silently.
+        # cx_Freeze 8.x renamed the old "Win32GUI" base to lowercase
+        # "gui" + made it cross-platform (the underlying behaviour on
+        # Windows is still the legacy Win32GUI bootstrap).  Old name
+        # raised DistutilsOptionError on cx_Freeze >= 8.0.
+        base="gui" if sys.platform == "win32" else None,
         target_name="netcanon.exe",
         # The icon embedded in the EXE itself (taskbar / alt-tab).
         icon=_build_icon(),


### PR DESCRIPTION
## Summary

PR #1 (desktop MSI CI scaffolding) merged successfully but the first backfill run for v0.1.0-rc7 failed at the cx_Freeze build step with:

```
distutils.errors.DistutilsOptionError: no base named 'legacy/win32gui' (...) - Did you mean 'gui'?
```

cx_Freeze 8.x renamed the legacy Windows-only `"Win32GUI"` base name to lowercase cross-platform `"gui"` (still uses the Win32GUI bootstrap under the hood on Windows). The `pyproject.toml` desktop-build extra pins `cx_Freeze>=7.0` which includes 8.x; the GHA runner installed 8.x and tripped on the old name.

Local builds with cx_Freeze 7.x would have continued to work, but nobody had actually run `setup_desktop.py` against a fresh install since cx_Freeze shipped 8.0. The CI scaffolding from PR #1 is what surfaced this latent breakage — exactly what scaffolded CI is for.

## Fix

One-line change in `setup_desktop.py` + a footnote update in the desktop README.

## Test plan

- [x] Failure clearly diagnosed from CI logs (run 25784309584)
- [ ] CI matrix green on this PR
- [ ] After merge, re-trigger workflow_dispatch on `v0.1.0-rc7` → MSI builds + attaches to a fresh Release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)