### PR TITLE
fix(desktop): drop httpx from setup_desktop.py packages list

### DIFF
--- a/setup_desktop.py
+++ b/setup_desktop.py
@@ -68,7 +68,11 @@ UPGRADE_CODE = "{A3F2C1B0-7E4D-4A9F-8B3C-2D5E6F7A8B9C}"
 
 build_exe_options: dict = {
     # Extra packages that cx_Freeze cannot discover automatically through
-    # static import analysis (dynamic imports, conditional imports, etc.)
+    # static import analysis (dynamic imports, conditional imports, etc.).
+    # Every entry must be a runtime dependency installed by the
+    # `[desktop]` extra group in pyproject.toml — dev-only deps (e.g.
+    # httpx, used by pytest's TestClient) must not be listed here or
+    # cx_Freeze fails with ImportError during the build.
     "packages": [
         "netcanon",
         "netcanon.templates",
@@ -88,7 +92,6 @@ build_exe_options: dict = {
         "PySide6",
         "PIL",
         "yaml",
-        "httpx",
     ],
     # Non-Python files that must be included in the build tree.
     "include_files": [


### PR DESCRIPTION
## Summary

Second latent setup_desktop.py issue surfaced by the new desktop-msi-publish.yml CI workflow.  rc8 built fine on PyPI + Docker; MSI build failed with:

```
ImportError: No module named 'httpx'
```

httpx is a **dev dependency** (pytest's TestClient backend) — not imported anywhere in `netcanon/` or `netcanon_desktop/` at runtime.  Listing it in cx_Freeze's `packages:` list told cx_Freeze to bundle it, but the `[desktop-build]` extra group doesn't install dev deps.

Audited every other entry against `pyproject.toml`'s `[project.dependencies]` + `[desktop]` extra — all other entries are legitimate runtime deps.  Added a comment to the `packages:` list flagging the constraint for future audits.

## Plan

- [ ] CI green on this PR
- [ ] Merge
- [ ] Tag v0.1.0-rc9 → desktop-msi-publish.yml fires + (hopefully) succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)