### PR TITLE
Release v0.1.3 — sanitiser secret-leak + demo packaging fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-06-06
+
 Remediation of the two P1 findings from the read-only full-project
 review at [`docs/project-review/2026-06-06/`](docs/project-review/2026-06-06/)
 (two-fleet review + adversarial verification).  No canonical-model or


### PR DESCRIPTION
## Release v0.1.3

Promotes the CHANGELOG `[Unreleased]` section to `[0.1.3] - 2026-06-06`. **No code changes** — the two P1 fixes already landed in #10; this is the release-prep step.

Once merged, pushing the **`v0.1.3`** tag triggers the PyPI + Docker publish workflows (`setuptools_scm` derives the package version from the tag).

### Shipping in 0.1.3
- **Security (R-01 / CF-01):** `netcanon sanitize` now redacts `vrrp_groups[].authentication` (VRRP/CARP/HSRP auth secrets) instead of emitting them verbatim into bug-report output.
- **Fixed (R-02 / CF-02 / DA-01):** the demo now ships as `netcanon demo` (in the wheel + Docker image); the README hero command works against published artifacts.

Both originate from the read-only review dossier at `docs/project-review/2026-06-06/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
