### PR TITLE
Batch 2 — P2 remediation: Junos RenderError, sanitize threadpool, pipeline freeze-guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,36 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+P2 remediation from the 2026-06-06 review (Batch 2) — sequenced in that
+dossier's `recommended-remediation-plan.md`.  No canonical-model or
+codec-grammar changes.
+
+### Fixed
+
+* **Junos render now raises `RenderError` (not `TypeError`) on
+  non-`CanonicalIntent` input** (finding R-03 / CC-01 / CF-03 / DD-01).
+  `juniper_junos.render_intent` was the only codec raising `TypeError`
+  from its input-type guard; the pipeline catches `RenderError`, so the
+  mismatch mis-bucketed the failure as an "unexpected error in stage
+  rendering" rather than a clean render error.  Now matches the
+  `CodecBase.render` contract and the other seven codecs.
+
+* **`POST /api/v1/sanitize` no longer blocks the event loop** (finding
+  R-04 / CA-01).  The async handler ran the synchronous, CPU-bound
+  parse → redact → render pipeline directly on the event loop; it now
+  offloads via `asyncio.to_thread` (matching the scheduler in
+  `routes/schedules.py`), so a large sanitise no longer stalls
+  concurrent requests.
+
+### Internal
+
+* **Frozen-signature guard test for the migration pipeline** (finding
+  R-11 / CD-03).  `run_plan` / `run_plan_with_rename` /
+  `run_plan_with_overrides` are called positionally by the UI, tests,
+  and README examples; a new test pins their parameter names, order,
+  kind, and defaults so an accidental signature change fails CI instead
+  of silently breaking positional callers.
+
 ## [0.1.3] - 2026-06-06
 
 Remediation of the two P1 findings from the read-only full-project

--- a/netcanon/api/routes/sanitize.py
+++ b/netcanon/api/routes/sanitize.py
@@ -15,6 +15,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
@@ -55,7 +56,13 @@ async def post_sanitize(
     raw = raw_bytes.decode("utf-8", errors="replace")
 
     try:
-        result = sanitize_text(raw, source_vendor, dry_run=dry_run)
+        # sanitize_text runs the full parse → redact → render pipeline,
+        # which is synchronous + CPU-bound.  Offload it so it never blocks
+        # the event loop (mirrors the scheduler's asyncio.to_thread dispatch
+        # in routes/schedules.py).
+        result = await asyncio.to_thread(
+            sanitize_text, raw, source_vendor, dry_run=dry_run
+        )
     except ParseError as e:
         raise HTTPException(
             status_code=400,

--- a/netcanon/migration/codecs/juniper_junos/render.py
+++ b/netcanon/migration/codecs/juniper_junos/render.py
@@ -72,6 +72,7 @@ from ..._user_secrets import (
     format_review_comment,
     is_migratable,
 )
+from ..base import RenderError
 from ...canonical.intent import CanonicalIntent
 
 logger = logging.getLogger(__name__)
@@ -99,12 +100,16 @@ def render_intent(tree: Any) -> str:
     their prefix stripped so parse(render(tree)) round-trips.
 
     Raises:
-        TypeError: If *tree* is not a :class:`CanonicalIntent`.
+        RenderError: If *tree* is not a :class:`CanonicalIntent`.  Matches
+            the ``CodecBase.render`` contract + the other seven codecs, so
+            the pipeline's ``except RenderError`` catches it in the render
+            stage instead of mis-bucketing it as an unexpected error.
     """
     if not isinstance(tree, CanonicalIntent):
-        raise TypeError(
+        raise RenderError(
             "juniper_junos.render: expected CanonicalIntent, got "
-            f"{type(tree).__name__}"
+            f"{type(tree).__name__}",
+            yang_path="/",
         )
 
     # Materialise port-centric switchport state from VLAN-centric

--- a/tests/unit/migration/test_juniper_junos.py
+++ b/tests/unit/migration/test_juniper_junos.py
@@ -25,7 +25,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalVlan,
     CanonicalVRRPGroup,
 )
-from netcanon.migration.codecs.base import ParseError
+from netcanon.migration.codecs.base import ParseError, RenderError
 from netcanon.migration.codecs.juniper_junos import JunosCodec
 from netcanon.migration.codecs.juniper_junos.port_names import (
     classify_port_name,
@@ -277,9 +277,10 @@ class TestParseValidation:
         assert intent.hostname == "sw1"
 
     def test_render_rejects_non_canonical_tree(self):
-        """Render is strict: anything other than a CanonicalIntent is a
-        programming error, fail loud."""
-        with pytest.raises(TypeError, match="CanonicalIntent"):
+        """Render is strict: anything other than a CanonicalIntent raises
+        RenderError — matching the CodecBase.render contract + the other
+        codecs, so the pipeline catches it in the render stage (R-03)."""
+        with pytest.raises(RenderError, match="CanonicalIntent"):
             JunosCodec().render({"hostname": "oops"})
 
 

--- a/tests/unit/migration/test_pipeline_signature_freeze.py
+++ b/tests/unit/migration/test_pipeline_signature_freeze.py
@@ -1,0 +1,89 @@
+"""Frozen-signature guard for the migration pipeline entry points.
+
+``run_plan``, ``run_plan_with_rename``, and ``run_plan_with_overrides``
+are a deliberately *frozen* public contract — documented in
+``netcanon/services/migration_pipeline.py``, ``ARCHITECTURE.md``, and
+``AGENTS.md`` — because the UI, integration/e2e tests, and README
+examples call them positionally.  The standing rule is "add a NEW
+function rather than change one of these signatures."
+
+This test mechanically enforces that rule (project review 2026-06-06,
+finding R-11 / CD-03): it pins each function's parameter names, order,
+kind, and defaults, so a reordered positional, a renamed parameter, a
+changed default, or a new required argument fails CI instead of silently
+breaking positional callers.  Annotations are intentionally NOT pinned —
+only the call-shape contract — so re-typing a parameter (e.g. widening a
+hint) doesn't trip the guard.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from netcanon.services.migration_pipeline import (
+    run_plan,
+    run_plan_with_overrides,
+    run_plan_with_rename,
+)
+
+pytestmark = pytest.mark.unit
+
+_REQUIRED = "<required>"
+
+
+def _param_spec(fn):
+    """``(name, kind, default)`` per parameter; ``<required>`` = no default."""
+    spec = []
+    for name, p in inspect.signature(fn).parameters.items():
+        default = p.default if p.default is not inspect.Parameter.empty else _REQUIRED
+        spec.append((name, p.kind.name, default))
+    return spec
+
+
+# The frozen contracts.  Changing any of these is a deliberate decision
+# that must update BOTH this guard AND the FROZEN docstrings +
+# AGENTS.md / ARCHITECTURE.md notes — or, preferably, add a new function.
+_FROZEN = {
+    run_plan: [
+        ("source", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("target", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("raw_text", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("transforms", "POSITIONAL_OR_KEYWORD", None),
+        ("transform_specs", "POSITIONAL_OR_KEYWORD", None),
+        ("force", "POSITIONAL_OR_KEYWORD", False),
+    ],
+    run_plan_with_rename: [
+        ("source", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("target", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("raw_text", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("port_rename_map", "POSITIONAL_OR_KEYWORD", None),
+        ("transforms", "POSITIONAL_OR_KEYWORD", None),
+        ("transform_specs", "POSITIONAL_OR_KEYWORD", None),
+        ("force", "POSITIONAL_OR_KEYWORD", False),
+    ],
+    run_plan_with_overrides: [
+        ("source", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("target", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("raw_text", "POSITIONAL_OR_KEYWORD", _REQUIRED),
+        ("port_rename_map", "POSITIONAL_OR_KEYWORD", None),
+        ("vlan_rename_map", "POSITIONAL_OR_KEYWORD", None),
+        ("local_user_rename_map", "POSITIONAL_OR_KEYWORD", None),
+        ("snmp_community_rename_map", "POSITIONAL_OR_KEYWORD", None),
+        ("snmpv3_user_rename_map", "POSITIONAL_OR_KEYWORD", None),
+        ("transforms", "POSITIONAL_OR_KEYWORD", None),
+        ("transform_specs", "POSITIONAL_OR_KEYWORD", None),
+        ("force", "POSITIONAL_OR_KEYWORD", False),
+    ],
+}
+
+
+@pytest.mark.parametrize("fn", list(_FROZEN), ids=lambda f: f.__name__)
+def test_pipeline_signature_is_frozen(fn):
+    assert _param_spec(fn) == _FROZEN[fn], (
+        f"{fn.__name__} signature drifted from its frozen contract. These "
+        "entry points are called positionally by the UI, tests, and README "
+        "examples — add a NEW function instead of changing this one (see the "
+        "FROZEN docstrings in migration_pipeline.py + AGENTS.md)."
+    )


### PR DESCRIPTION
## Summary

Batch 2 of the 2026-06-06 review remediation — three **P2** findings, all small and high-confidence. No canonical-model or codec-grammar changes. (Batch 1's two P1 fixes shipped in `v0.1.3`.)

### R-03 — Junos render raises `RenderError`, not `TypeError` (CC-01 / CF-03 / DD-01)
`juniper_junos.render_intent` was the only codec raising `TypeError` from its input-type guard. The pipeline catches `RenderError`, so the mismatch mis-bucketed the failure as "unexpected error in stage rendering" instead of a clean render error. Now raises `RenderError(..., yang_path="/")`, matching the `CodecBase.render` contract and the other seven codecs. The one test asserting `TypeError` is flipped to `RenderError`.

### R-04 — `POST /api/v1/sanitize` no longer blocks the event loop (CA-01)
The async handler ran the synchronous, CPU-bound parse → redact → render pipeline directly on the event loop (every other pipeline endpoint is threadpooled). Now offloaded via `asyncio.to_thread`, matching the scheduler in `routes/schedules.py`.

### R-11 — frozen-signature guard test for the pipeline (CD-03)
`run_plan` / `run_plan_with_rename` / `run_plan_with_overrides` are a documented frozen contract (called positionally by the UI, tests, README), but enforced only socially. New test pins each function's parameter name/order/kind/default so a reorder, rename, changed default, or new required arg fails CI. Annotations intentionally not pinned (only the call-shape).

## Test plan
- [x] `tests/unit` full suite green
- [x] targeted: `test_juniper_junos.py` (flipped assertion), `test_pipeline_signature_freeze.py` (new), `test_pipeline.py`, `test_sanitize_api.py` (R-04 route), `test_sanitize.py`
- [ ] e2e/browser not run (no UI change)

## Next
Remaining P3 tail (docstring de-stale, doc currency, codec fidelity, etc.) is in `docs/project-review/2026-06-06/recommended-remediation-plan.md` (Batches 3–6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
