### PR TITLE
Batch 4 — de-stale docstrings + ARCHITECTURE security / _tier3 sections

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,33 @@ authoring notes.
 
 ---
 
+## Credential security (encryption at rest)
+
+Device credentials (passwords, enable passwords) used by the backup
+collectors are encrypted at rest under
+[`netcanon/security/`](netcanon/security/):
+
+- **`credentials.py`** — Fernet symmetric encryption.  The key is
+  resolved first-hit-wins across three tiers: (1) the
+  `NETCANON_FERNET_KEY` environment variable (operator-explicit;
+  recommended for container / production), (2) the OS keyring (Windows
+  Credential Manager / macOS Keychain / Linux SecretService; best fit
+  for desktop installs), (3) a file fallback at
+  `$NETCANON_DATA_DIR/.fernet_key` (zero-config bootstrap for headless
+  deployments, auto-generated on first use).  In-memory model objects
+  always hold **plaintext** — encryption is a storage-layer concern
+  applied on write and reversed on read.
+- **`migration.py`** — `migrate_credential_fields(data, fields)`, the
+  shared legacy-plaintext upgrade helper.  Both `FileDeviceProfileStore`
+  and `FileScheduleStore` call it on first load: a field that fails to
+  decrypt (`InvalidToken`) is treated as a pre-encryption plaintext
+  value, returned as-is, and flagged for re-save with encryption.
+
+Operator-facing key-management guidance lives in
+[`SECURITY.md`](SECURITY.md); this section is the architectural pointer.
+
+---
+
 ## Migration — four-layer model
 
 The migration pipeline decouples four concerns that tend to get
@@ -414,6 +441,17 @@ paths: Aruba `oobm` block, FortiGate `mgmt1` port, OPNsense
 `opt_mgmt` zone, Junos routing-instance binding.  Honours the
 canonical `kind` field; never emit a regular physical port for
 mgmt-classified interfaces.
+
+**Tier-3 drop detection** (`netcanon/migration/_tier3_detection.py`).
+Tier-3 stanzas (firewall / NAT / VPN / routing-protocols) have no
+canonical surface, so codec parsers silently skip them.  Each parser
+calls its per-vendor `detect_tier3_sections_<vendor>(raw)` before
+returning, populating `CanonicalIntent.dropped_tier3_sections` with
+human-readable labels that the migrate page surfaces as a "Detected in
+source but not translated" banner.  Output-only — a notification
+surface, never fed to the renderer or any transform — so the
+deliberate drop is surfaced honestly (the silent-drop-honesty
+discipline `docs/METHODOLOGY.md` treats as flagship).
 
 When adding a new codec, audit each policy and decide whether to
 opt in.  Most cases: opt in.  Re-implementing the policy locally is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
-P2 + documentation remediation from the 2026-06-06 review (Batches 2–3)
+P2 + documentation remediation from the 2026-06-06 review (Batches 2–4)
 — sequenced in that dossier's `recommended-remediation-plan.md`.  No
 canonical-model or codec-grammar changes.
 
@@ -73,6 +73,20 @@ canonical-model or codec-grammar changes.
   `SECURITY.md (line 385)` reference for a durable section anchor (R-10);
   and removed a dangling `@pytest.mark.slow` snippet from the NX-OS codec
   test-plan (the `slow` marker was removed in v0.1.2 — R-28).
+
+* **Docstrings + `ARCHITECTURE.md` brought in line with the shipped
+  architecture** (findings R-09, R-14, R-15).  `ARCHITECTURE.md` now
+  documents the `netcanon/security/` credential-encryption package
+  (Fernet + 3-tier key resolution) and the `_tier3_detection.py`
+  silent-drop-honesty policy — closing the gap `AGENTS.md` already
+  claimed was closed.  The VRRP / anycast docstrings in
+  `canonical/intent.py` now read "wired in v0.2.0 (Wave B/C)" instead of
+  the stale "ship-before-wire / every codec lists this unsupported".
+  And the "Phase 0 / libyang-in-Phase-0.5 / opaque `dict[str,str]`"
+  framing in `migration/__init__.py`, `canonical/__init__.py`, and
+  `models/migration.py` is replaced with present-tense reality (the
+  Pydantic canonical IR shipped; `canonical/loader.py` remains a
+  deliberately-unused libyang stub).
 
 ## [0.1.3] - 2026-06-06
 

--- a/netcanon/migration/__init__.py
+++ b/netcanon/migration/__init__.py
@@ -1,18 +1,19 @@
 """
-Translator / migration engine — Phase 0.
+Translator / migration engine.
 
-Scope (see ``translator-plans.txt`` §12):
+Provides:
     * CodecBase + CapabilityMatrix contract.
-    * In-memory codec registry.
-    * One reference codec (``_mock``) that round-trips a trivial
-      dict-of-strings "tree" so the contract itself is testable
-      without any real YANG tooling.
-    * Capability-matrix-driven ``ValidationReport`` and a thin
-      ``run_plan`` pipeline skeleton (``netcanon/services/``).
+    * In-memory codec registry (auto-discovered below).
+    * The canonical intent tree — a Pydantic model
+      (:mod:`netcanon.migration.canonical.intent`), NOT the
+      originally-planned libyang-backed tree; ``canonical/loader.py``
+      remains an unused libyang stub.
+    * Shared cross-vendor transforms (``canonical/transforms.py``)
+      plus the capability-matrix-driven ``ValidationReport`` and the
+      ``run_plan`` pipeline (``netcanon/services/``).
 
-Out of scope for Phase 0 (queued for Phase 0.5+):
-    * libyang-backed canonical tree (``canonical/loader.py`` is a stub).
-    * Transforms, deploy, snapshot (Phase 2+).
+The ``_mock`` reference codec round-trips a trivial dict-of-strings
+"tree" so the contract itself is testable in isolation.
 
 Importing this package auto-discovers every codec sub-package under
 ``netcanon/migration/codecs/`` and imports it, firing its module-

--- a/netcanon/migration/canonical/__init__.py
+++ b/netcanon/migration/canonical/__init__.py
@@ -1,8 +1,11 @@
 """
-Canonical YANG intent tree — loader, schema, and validation helpers.
+Canonical intent tree — the shared vendor-neutral model every codec
+parses into and renders from.
 
-Phase 0 ships only this stub.  The real libyang context loader arrives
-in Phase 0.5; Phase 0 code treats the "tree" as an opaque
-adapter-internal type and the mock adapter round-trips via plain
-``dict[str, str]``.
+The tree is a Pydantic model hierarchy rooted at
+:class:`.intent.CanonicalIntent` (interfaces, VLANs, VRRP groups, SNMP,
+users, static routes, …).  The originally-planned libyang-backed loader
+was not adopted — ``loader.py`` remains an unused stub kept for a stable
+import path — so validation is the model's own Pydantic constraints,
+not external YANG-schema validation.
 """

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -101,11 +101,10 @@ class CanonicalIPv4Address(BaseModel):
             (``ip address virtual Y/M``) populate this with ``Y``;
             NX-OS DAG ``ip address X/M anycast`` mirrors the address
             into this field (``X == virtual_gateway_address``).
-            Empty string means no anycast companion.  Ship-before-
-            wire (v0.2.0) — every codec's ``CapabilityMatrix`` lists
-            ``/interfaces/interface/ipv4/address/virtual-gateway-
-            address`` as ``unsupported`` until the per-codec wire-
-            up lands.  Anycast is a sibling concept to VRRP
+            Empty string means no anycast companion.  Wired in v0.2.0
+            (Wave B/C): Arista VARP, Cisco IOS-XE CLI, and Junos declare
+            this xpath ``supported`` and populate it; codecs without an
+            anycast grammar declare it ``unsupported``.  Anycast is a sibling concept to VRRP
             (:class:`CanonicalVRRPGroup`) and lives on the address
             record because it is a property of the IP, not a
             router-group election — see ``docs/v0.2.0-planning/``
@@ -574,11 +573,11 @@ class CanonicalVRRPGroup(BaseModel):
             priority-decrement value is per-vendor lossy.
         description: Operator-supplied description.
 
-    Ship-before-wire (v0.2.0): every codec's
-    :class:`CapabilityMatrix` lists ``/interfaces/interface/
-    vrrp-groups/group`` as ``unsupported`` until the per-codec wire-
-    up lands (Wave B of the v0.2.0 plan documented in
-    ``docs/v0.2.0-planning/``).
+    Wired in v0.2.0 (Wave B/C): the seven bidirectional codecs declare
+    ``/interfaces/interface/vrrp-groups/group`` ``supported``/``lossy``
+    and round-trip it; the Cisco IOS-XE NETCONF stub declares it
+    ``unsupported``.  (Wave B of the v0.2.0 plan, documented in
+    ``docs/v0.2.0-planning/``.)
     """
 
     group_id: int = Field(ge=1, le=255)
@@ -825,7 +824,7 @@ class CanonicalIntent(BaseModel):
             docstring for the vendor-shape comparison.  Per-interface
             membership lives on :attr:`CanonicalInterface.vrf`, not
             a redundant list here.
-        anycast_gateway_mac: Ship-before-wire (v0.2.0) — system-wide
+        anycast_gateway_mac: Wired in v0.2.0 (Wave B/C) — system-wide
             anycast-gateway MAC.  Vendors that declare it at chassis
             scope populate this from their grammar:
 

--- a/netcanon/models/migration.py
+++ b/netcanon/models/migration.py
@@ -1,9 +1,11 @@
 """
 Pydantic models for the translator / migration engine.
 
-Phase 0 scope: types used by the adapter contract, capability matrix,
-validation report, and the ``MigrationJob`` lifecycle.  No I/O; no
-schema work (libyang comes in Phase 0.5).
+Types used by the adapter contract, capability matrix, validation
+report, and the ``MigrationJob`` lifecycle.  No I/O.  (The
+originally-planned libyang schema layer was not adopted — the canonical
+tree is the Pydantic model in
+``netcanon/migration/canonical/intent.py``.)
 
 All severity fields use the same three-step convention introduced by
 ``CompatibilityReport`` in ``netcanon.models.diff``:


### PR DESCRIPTION
## Summary

Batch 4 of the 2026-06-06 review remediation — the documentation/docstring de-stale tail. **No code-behavior change** (docstring + Markdown only). Full unit suite green.

| Finding | Fix |
|---------|-----|
| **R-09** (DF-02/DF-03) | `ARCHITECTURE.md` now has a **Credential security (encryption at rest)** section inventorying `netcanon/security/` (Fernet + 3-tier key resolution; the shared `migrate_credential_fields` helper), and a **`_tier3_detection.py`** paragraph in Cross-cutting policies — making `AGENTS.md`'s "all three migration siblings ARE documented" claim actually true. |
| **R-14** (CB-01) | `canonical/intent.py` VRRP/anycast docstrings (`virtual_gateway_address`, `anycast_gateway_mac`, `vrrp_groups`, `CanonicalVRRPGroup`) corrected from "ship-before-wire / every codec lists this **unsupported**" to "wired in v0.2.0 (Wave B/C)" — the adversarial pass confirmed the `_CAPS` were already honest; only the prose lagged. |
| **R-15** (DD-02/CB-02) | Replaced the stale "Phase 0 / libyang-in-Phase-0.5 / opaque `dict[str,str]`" framing in `migration/__init__.py`, `canonical/__init__.py`, `models/migration.py` with present-tense reality (the Pydantic canonical IR shipped). |

### Deliberately preserved
- **`is_secondary`** docstring left untouched — its wiring is genuinely partial (Arista VARP only), tracked as **R-13** (a fidelity fix, not a doc de-stale).
- **`canonical/loader.py`** kept as the honestly-labelled *unused libyang stub* — the 2026-05-21 audit's intentional call; the de-staled `__init__` docstrings now point at it accurately rather than implying libyang is imminent.

## Test plan
- [x] `tests/unit` full suite green
- [ ] e2e/browser not run (doc/docstring only)

## Remaining (later batches)
Per `recommended-remediation-plan.md`: R-06 (FortiGate `_CAPS` MTU — matrix change w/ regen ripple), R-08 (regen CROSS_MESH/PHASE4 artifacts), R-12 (`ui.py` `/docs` split), R-13/R-17 (codec fidelity), R-16 (sanitiser PII tail), and the interlink/header sweep (R-23–R-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
