### PR TITLE
Batch 5 — PortIdentity.original contract (R-17) + cisco VRRP regex cleanup (R-13 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
-P2 + documentation remediation from the 2026-06-06 review (Batches 2–4)
+P2 + documentation remediation from the 2026-06-06 review (Batches 2–5)
 — sequenced in that dossier's `recommended-remediation-plan.md`.  No
 canonical-model or codec-grammar changes.
 
@@ -46,6 +46,18 @@ canonical-model or codec-grammar changes.
   offloads via `asyncio.to_thread` (matching the scheduler in
   `routes/schedules.py`), so a large sanitise no longer stalls
   concurrent requests.
+
+* **`classify_port_name` now populates `PortIdentity.original` on all
+  paths** for `arista_eos` and `juniper_junos` (finding R-17 / CC-03).
+  The field is documented "always populated by the source classifier"
+  (the cross-vendor port-name bridge echoes it verbatim when a target
+  can't represent an identity), but the two codecs returned it empty on
+  every path — a latent contract violation.  Added a guard test pinning
+  the contract.  Separately, converted an unused `(?P<secondary>…)`
+  capture in `cisco_iosxe_cli`'s VRRP regex to a non-capturing group
+  (the code-smell half of R-13 / CC-02; the cross-vendor `is_secondary`
+  fidelity fix is tracked separately as it needs multi-site parser
+  changes + round-trip tests).
 
 ### Internal
 

--- a/netcanon/migration/codecs/arista_eos/port_names.py
+++ b/netcanon/migration/codecs/arista_eos/port_names.py
@@ -88,11 +88,13 @@ def classify_port_name(name: str) -> PortIdentity:
                 breakout_lane=int(b),
                 breakout_parent=f"Ethernet{a}",
                 name_speed_hint="gig",   # default class; real speed from SFP
+                original=name,
             )
         return PortIdentity(
             kind="physical",
             port=a,
             name_speed_hint="gig",
+            original=name,
         )
 
     # Management — physical-but-mgmt.
@@ -102,6 +104,7 @@ def classify_port_name(name: str) -> PortIdentity:
             kind="mgmt",
             port=int(m.group("a")),
             name_speed_hint="gig",
+            original=name,
         )
 
     # Logical interfaces — LAG / SVI / loopback / tunnel.
@@ -111,11 +114,12 @@ def classify_port_name(name: str) -> PortIdentity:
             return PortIdentity(
                 kind=kind,
                 index=int(lm.group(1)),
+                original=name,
             )
 
     # Unknown — pass through verbatim.  Cross-vendor targets will
     # treat this as "can't represent" and auto-drop with a warning.
-    return PortIdentity(kind="unknown")
+    return PortIdentity(kind="unknown", original=name)
 
 
 def format_port_identity(identity: PortIdentity) -> str | None:

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -124,7 +124,11 @@ _TUNNEL_MODE_RE = re.compile(
 # § "Cisco IOS-XE" for the full grammar reference.
 _VRRP_IP_RE = re.compile(
     r"^\s+vrrp\s+(?P<group>\d+)\s+ip\s+(?P<ip>\S+)"
-    r"(?P<secondary>\s+secondary)?\s*$",
+    # Non-capturing: the ``secondary`` trailer must be consumed for the
+    # line to match, but the VRRP-VIP path doesn't model secondary VIPs,
+    # so there's no named group to read (R-13 / CC-02: was an unused
+    # ``(?P<secondary>…)`` capture).
+    r"(?:\s+secondary)?\s*$",
     re.IGNORECASE,
 )
 _VRRP_IPV6_RE = re.compile(

--- a/netcanon/migration/codecs/juniper_junos/port_names.py
+++ b/netcanon/migration/codecs/juniper_junos/port_names.py
@@ -94,6 +94,7 @@ def classify_port_name(name: str) -> PortIdentity:
             module=int(m.group("pic")),
             port=int(m.group("port")),
             name_speed_hint=_MEDIA_TO_SPEED.get(media, ""),
+            original=name,
         )
 
     # Management (em0 / me0 / fxp0)
@@ -103,6 +104,7 @@ def classify_port_name(name: str) -> PortIdentity:
             kind="mgmt",
             port=int(m.group("n")),
             name_speed_hint="gig",
+            original=name,
         )
 
     # Loopback
@@ -111,6 +113,7 @@ def classify_port_name(name: str) -> PortIdentity:
         return PortIdentity(
             kind="loopback",
             index=int(m.group("n")),
+            original=name,
         )
 
     # Aggregated Ethernet = LAG
@@ -119,6 +122,7 @@ def classify_port_name(name: str) -> PortIdentity:
         return PortIdentity(
             kind="lag",
             index=int(m.group("n")),
+            original=name,
         )
 
     # Integrated Routing and Bridging = SVI-ish
@@ -127,6 +131,7 @@ def classify_port_name(name: str) -> PortIdentity:
         return PortIdentity(
             kind="svi",
             index=int(m.group("n")),
+            original=name,
         )
 
     # Legacy ``vlan.N`` (older EX platforms).
@@ -135,9 +140,10 @@ def classify_port_name(name: str) -> PortIdentity:
         return PortIdentity(
             kind="svi",
             index=int(m.group("n")),
+            original=name,
         )
 
-    return PortIdentity(kind="unknown")
+    return PortIdentity(kind="unknown", original=name)
 
 
 def format_port_identity(identity: PortIdentity) -> str | None:

--- a/tests/unit/migration/test_port_identity_original.py
+++ b/tests/unit/migration/test_port_identity_original.py
@@ -1,0 +1,57 @@
+"""Guard: ``classify_port_name`` always populates ``PortIdentity.original``.
+
+Project review 2026-06-06, finding R-17 / CC-03: ``PortIdentity.original``
+is documented "Always populated by the source classifier" (used by the
+cross-vendor port-name bridge to echo the source token back when a
+target can't represent an identity), but arista_eos and juniper_junos
+returned it empty on every path — a latent contract violation.  This
+test pins the contract for the codecs that ship a classifier, including
+cisco_iosxe_cli as a known-compliant control.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.arista_eos.port_names import (
+    classify_port_name as arista_classify,
+)
+from netcanon.migration.codecs.cisco_iosxe_cli.port_names import (
+    classify_port_name as cisco_classify,
+)
+from netcanon.migration.codecs.juniper_junos.port_names import (
+    classify_port_name as junos_classify,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "classify, samples",
+    [
+        (
+            arista_classify,
+            ["Ethernet1", "Ethernet3/1", "Management1", "Port-Channel5",
+             "Vlan10", "Loopback0", "this-is-not-a-port"],
+        ),
+        (
+            junos_classify,
+            ["ge-0/0/0", "xe-1/2/3", "em0", "lo0", "ae5", "irb",
+             "vlan.100", "this-is-not-a-port"],
+        ),
+        (
+            cisco_classify,  # known-compliant control
+            ["GigabitEthernet0/0/1", "TenGigabitEthernet1/0/1",
+             "Port-channel2", "Vlan20", "this-is-not-a-port"],
+        ),
+    ],
+    ids=["arista_eos", "juniper_junos", "cisco_iosxe_cli"],
+)
+def test_classify_populates_original(classify, samples):
+    for name in samples:
+        identity = classify(name)
+        assert identity.original == name, (
+            f"{classify.__module__}.classify_port_name({name!r}) left "
+            f"`original` = {identity.original!r}; the PortIdentity contract "
+            "requires the source classifier to echo the verbatim input."
+        )


### PR DESCRIPTION
## Summary

Batch 5 of the 2026-06-06 review remediation — codec fidelity. Full unit suite green; one new guard test.

### R-17 (CC-03) — `PortIdentity.original` contract
The field is documented "always populated by the source classifier" — the cross-vendor port-name bridge echoes it verbatim when a target can't represent an identity — but `arista_eos` and `juniper_junos` returned it **empty** on every `classify_port_name` path (latent contract violation; `cisco_iosxe_cli` was already compliant). Added `original=name` to all **5 arista + 7 junos** return paths, plus a **guard test** pinning the contract across the two fixed codecs + cisco as a compliant control.

### R-13 (CC-02) — partial: regex cleanup only
Converted the unused `(?P<secondary>…)` **named capture** in `cisco_iosxe_cli`'s `_VRRP_IP_RE` to a **non-capturing** group. (The capture was never read, but the pattern must still consume the `secondary` trailer to match — deleting it would have broken VRRP-secondary parsing, so this is the correct behavior-preserving cleanup.)

**Deliberately deferred:** the cross-vendor `is_secondary` fidelity loss (cisco round-trips `secondary` *positionally* and never sets the flag; arista's render honors the flag → classic secondary IPs are dropped cisco→arista). The real fix is **additive parser surgery across cisco parse + arista parse/render on the common IP-address path**, and it deserves its own PR with cisco↔arista round-trip tests rather than a session-tail change. Still tracked as R-13 in `recommended-remediation-plan.md`.

## Test plan
- [x] `tests/unit` full suite green
- [x] new `test_port_identity_original.py` (arista/junos/cisco); cisco regex change verified against `test_cisco_iosxe_cli.py`
- [ ] e2e/browser not run (no UI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
