### PR TITLE
Batch 7 — cross-vendor is_secondary fidelity for classic secondary IPs (R-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
-P2 + documentation remediation from the 2026-06-06 review (Batches 2–6)
+P2 + documentation remediation from the 2026-06-06 review (Batches 2–7)
 — sequenced in that dossier's `recommended-remediation-plan.md`.  No
 canonical-model or codec-grammar changes.
 
@@ -58,6 +58,17 @@ canonical-model or codec-grammar changes.
   (the code-smell half of R-13 / CC-02; the cross-vendor `is_secondary`
   fidelity fix is tracked separately as it needs multi-site parser
   changes + round-trip tests).
+
+* **Classic `ip address X secondary` now survives cross-vendor
+  translation** (finding R-13 / CC-02 — the fidelity half, review
+  Batch 7).  `cisco_iosxe_cli` parse now captures `is_secondary` (its
+  render stays positional, so self-round-trips are byte-stable);
+  `arista_eos` parse reads the plain-`ip address` `secondary` trailer
+  instead of dropping it; and `arista_eos`'s plain render branch emits
+  ` secondary` for flagged addresses.  A secondary address is no longer
+  silently demoted to primary on `cisco_iosxe_cli → arista_eos` (or
+  `arista_eos → arista_eos`).  Additive on the common IP-address path;
+  +6 round-trip tests.
 
 ### Internal
 

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -978,16 +978,22 @@ def _apply_iface_subcommand(
         return
     if line.startswith("ip address "):
         # ``ip address 10.0.0.1/31`` — CIDR form only (EOS).
+        # ``ip address 10.0.0.1/31 secondary`` — secondary address.
         rest = line.split(None, 2)[2].strip()
-        # Some ``ip address`` lines have ``secondary`` trailer —
-        # ignore the trailer, first address wins.
-        addr = rest.split()[0]
+        tokens = rest.split()
+        addr = tokens[0]
+        # Mirror the VARP branch: a ``secondary`` keyword after the
+        # address marks an additional (non-primary) address.  Captured
+        # into ``is_secondary`` (R-13) so the fact survives the round-
+        # trip and cross-vendor hops, instead of being silently dropped.
+        is_secondary = len(tokens) >= 2 and tokens[1].lower() == "secondary"
         if "/" in addr:
             ip, prefix = addr.split("/", 1)
             try:
                 iface.ipv4_addresses.append(CanonicalIPv4Address(
                     ip=ip,
                     prefix_length=int(prefix),
+                    is_secondary=is_secondary,
                 ))
             except ValueError:
                 pass

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -595,9 +595,12 @@ def render_intent(tree: Any) -> str:
                         primary_line += " secondary"
                     out.append(primary_line)
             else:
-                out.append(
+                plain_line = (
                     f"   ip address {addr.ip}/{addr.prefix_length}"
                 )
+                if addr.is_secondary:
+                    plain_line += " secondary"
+                out.append(plain_line)
         # GAP-EVPN-3: IPv6 addresses.  Link-local form re-emits
         # the explicit ``link-local`` keyword; global form emits
         # plain ``ipv6 address X/Y``.  Wave C IPv6 VARP (EOS 4.30+)

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -72,7 +72,8 @@ logger = logging.getLogger(__name__)
 _IFACE_RE = re.compile(r"^interface\s+(\S+)", re.IGNORECASE)
 _DESC_RE = re.compile(r"^\s+description\s+(.+)", re.IGNORECASE)
 _IP_RE = re.compile(
-    r"^\s+ip\s+address\s+(\d+\.\d+\.\d+\.\d+)\s+(\d+\.\d+\.\d+\.\d+)",
+    r"^\s+ip\s+address\s+(\d+\.\d+\.\d+\.\d+)\s+(\d+\.\d+\.\d+\.\d+)"
+    r"(?:\s+(secondary))?",
     re.IGNORECASE,
 )
 # GAP-EVPN-3: ``ipv6 address 2001:db8::1/64`` (global) or
@@ -785,14 +786,21 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
             prefix_len = _mask_to_prefix(mask_str)
             # IOS-XE accepts one primary + multiple secondary addresses
             # per interface (``ip address X.X.X.X MASK [secondary]``).
-            # The render-side companion in :mod:`.render` emits the
-            # ``secondary`` keyword for index>=1.  Trailing ``secondary``
-            # is captured but not stored — the canonical model represents
-            # the address list ordering as primary-first; the keyword is
-            # recoverable on re-render.  Per Cisco IP Addressing Services
-            # Configuration Guide, IOS-XE 17.x.
+            # The render-side companion in :mod:`.render` re-derives the
+            # ``secondary`` keyword *positionally* (index>=1), so cisco
+            # self-round-trips are unaffected by the flag below.  We DO
+            # capture ``is_secondary`` into the canonical model now (R-13)
+            # so the fact survives a cross-vendor hop to a codec whose
+            # render honours the flag explicitly (e.g. arista_eos's plain
+            # ``ip address`` branch).  Per Cisco IP Addressing Services
+            # Configuration Guide, IOS-XE 17.x — ``ip address ip-address
+            # mask [secondary [vrf vrf-name]]``.
             current["ipv4"].append(
-                {"ip": ip_str, "prefix_length": prefix_len},
+                {
+                    "ip": ip_str,
+                    "prefix_length": prefix_len,
+                    "is_secondary": im.group(3) is not None,
+                },
             )
             continue
 
@@ -1069,6 +1077,7 @@ def _build_canonical_interface(raw: dict[str, Any]) -> CanonicalInterface:
         ipv4_addrs.append(CanonicalIPv4Address(
             ip=a["ip"],
             prefix_length=a["prefix_length"],
+            is_secondary=a.get("is_secondary", False),
             virtual_gateway_address=vga,
         ))
 

--- a/tests/unit/migration/test_is_secondary_fidelity.py
+++ b/tests/unit/migration/test_is_secondary_fidelity.py
@@ -1,0 +1,141 @@
+"""R-13 / CC-02 — cross-vendor fidelity of classic ``ip address X secondary``.
+
+Before R-13, the `cisco_iosxe_cli` `ip address` handler dropped the
+`secondary` keyword (round-tripping it only *positionally*) and the
+`arista_eos` plain `ip address` parse branch dropped the trailer
+outright ("first address wins").  So a classic secondary address lost
+its `is_secondary` designation on `cisco_iosxe_cli → arista_eos` and on
+`arista_eos → arista_eos`.
+
+The fix (additive): cisco parse now captures `is_secondary` (its render
+stays positional, so cisco self-round-trips are byte-stable); arista
+parse sets the flag from the trailer; arista's plain `ip address` render
+branch emits ` secondary` when the flag is set.  This module guards all
+three.  (The VARP `ip address virtual … secondary` path already worked
+and is covered by `test_arista_eos.py::TestVARPAnycast`.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.arista_eos import AristaEOSCodec
+from netcanon.migration.codecs.cisco_iosxe_cli import CiscoIOSXECLICodec
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalIPv4Address,
+    CanonicalInterface,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestPlainSecondaryAddressFidelity:
+    """Arista plain (non-VARP) ``ip address X/Y secondary`` round-trips."""
+
+    def test_arista_plain_parse_sets_is_secondary(self):
+        raw = (
+            "hostname sw1\n"
+            "interface Vlan20\n"
+            "   ip address 10.0.20.1/24\n"
+            "   ip address 10.0.99.1/24 secondary\n"
+            "!\n"
+        )
+        intent = AristaEOSCodec().parse(raw)
+        iface = next(i for i in intent.interfaces if i.name == "Vlan20")
+        assert len(iface.ipv4_addresses) == 2
+        assert iface.ipv4_addresses[0].ip == "10.0.20.1"
+        assert iface.ipv4_addresses[0].is_secondary is False
+        assert iface.ipv4_addresses[1].ip == "10.0.99.1"
+        assert iface.ipv4_addresses[1].is_secondary is True
+        # Plain addresses must NOT be mistaken for VARP.
+        assert iface.ipv4_addresses[1].virtual_gateway_address == ""
+
+    def test_arista_plain_render_emits_secondary(self):
+        intent = CanonicalIntent(
+            hostname="sw1",
+            interfaces=[
+                CanonicalInterface(
+                    name="Vlan20",
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="10.0.20.1", prefix_length=24),
+                        CanonicalIPv4Address(
+                            ip="10.0.99.1", prefix_length=24, is_secondary=True,
+                        ),
+                    ],
+                ),
+            ],
+        )
+        out = AristaEOSCodec().render(intent)
+        assert "   ip address 10.0.20.1/24" in out
+        assert "   ip address 10.0.99.1/24 secondary" in out
+        # The primary must NOT carry the trailer.
+        assert "   ip address 10.0.20.1/24 secondary" not in out
+
+    def test_arista_plain_self_round_trip_preserves_secondary(self):
+        raw = (
+            "hostname sw1\n"
+            "interface Vlan20\n"
+            "   ip address 10.0.20.1/24\n"
+            "   ip address 10.0.99.1/24 secondary\n"
+            "!\n"
+        )
+        codec = AristaEOSCodec()
+        tree1 = codec.parse(raw)
+        tree2 = codec.parse(codec.render(tree1))
+        i1 = next(i for i in tree1.interfaces if i.name == "Vlan20")
+        i2 = next(i for i in tree2.interfaces if i.name == "Vlan20")
+        assert len(i1.ipv4_addresses) == len(i2.ipv4_addresses) == 2
+        for a, b in zip(i1.ipv4_addresses, i2.ipv4_addresses):
+            assert a.ip == b.ip
+            assert a.prefix_length == b.prefix_length
+            assert a.is_secondary == b.is_secondary
+        assert i2.ipv4_addresses[1].is_secondary is True
+
+    def test_cisco_cli_to_arista_preserves_secondary(self):
+        """The R-13 cross-vendor target: cisco_iosxe_cli dotted-mask
+        ``secondary`` → arista CIDR ``secondary``."""
+        cisco_raw = (
+            "hostname r1\n"
+            "interface Vlan20\n"
+            " ip address 10.0.20.1 255.255.255.0\n"
+            " ip address 10.0.99.1 255.255.255.0 secondary\n"
+            "!\n"
+        )
+        intent = CiscoIOSXECLICodec().parse(cisco_raw)
+        iface = next(i for i in intent.interfaces if i.name == "Vlan20")
+        assert iface.ipv4_addresses[0].is_secondary is False
+        assert iface.ipv4_addresses[1].is_secondary is True
+        out = AristaEOSCodec().render(intent)
+        assert "   ip address 10.0.20.1/24" in out
+        assert "   ip address 10.0.99.1/24 secondary" in out
+        assert "   ip address 10.0.20.1/24 secondary" not in out
+
+
+class TestCiscoCLISecondaryAddress:
+    """cisco_iosxe_cli now CAPTURES ``is_secondary`` on parse while its
+    render stays POSITIONAL, so self-round-trips remain byte-stable."""
+
+    _RAW = (
+        "hostname r1\n"
+        "interface Vlan20\n"
+        " ip address 10.0.20.1 255.255.255.0\n"
+        " ip address 10.0.99.1 255.255.255.0 secondary\n"
+        "!\n"
+    )
+
+    def test_parse_sets_is_secondary_from_trailer(self):
+        intent = CiscoIOSXECLICodec().parse(self._RAW)
+        iface = next(i for i in intent.interfaces if i.name == "Vlan20")
+        assert iface.ipv4_addresses[0].is_secondary is False
+        assert iface.ipv4_addresses[1].is_secondary is True
+
+    def test_self_round_trip_positional_secondary_unchanged(self):
+        codec = CiscoIOSXECLICodec()
+        out = codec.render(codec.parse(self._RAW))
+        assert " ip address 10.0.20.1 255.255.255.0" in out
+        assert " ip address 10.0.99.1 255.255.255.0 secondary" in out
+        # Primary must not gain a spurious trailer.
+        assert " ip address 10.0.20.1 255.255.255.0 secondary" not in out
+        # Idempotent: a second pass is identical.
+        assert codec.render(codec.parse(out)) == out


### PR DESCRIPTION
## Summary

Completes **R-13 / CC-02** — the fidelity half (the `_VRRP_IP_RE` non-capturing cleanup already shipped in #15). Actuated from `docs/project-review/2026-06-06/remediation-sweep/result-RA-13.md` (Opus agent), validated + applied.

**Problem:** a classic `ip address X secondary` was silently demoted to primary on `cisco_iosxe_cli → arista_eos` (and `arista_eos → arista_eos`): cisco parse dropped the keyword (round-tripping it only positionally) and arista parse + plain render ignored the `secondary` trailer.

**Fix (additive, backward-compatible — the common IP-address path):**
- `cisco_iosxe_cli` parse captures `is_secondary` from the trailer; its render stays positional, so cisco self-round-trips are byte-stable (verified by a test).
- `arista_eos` parse reads the plain-`ip address` `secondary` trailer (mirroring its already-correct VARP branch).
- `arista_eos` plain render emits ` secondary` when `is_secondary` is set.

The VARP `ip address virtual … secondary` path already worked and is untouched.

## Test plan
- [x] `tests/unit/migration/test_is_secondary_fidelity.py` — +6 tests (arista parse/render/self-round-trip, **cisco→arista cross-vendor**, cisco self-round-trip stability + idempotence)
- [x] `test_arista_eos.py` + `test_cisco_iosxe_cli.py` regression green
- [x] `tests/unit` full suite green
- [ ] e2e/browser not run (no UI change)

## Sweep remaining
R-16 (sanitiser PII), R-21 (NETCONF port-name banner), R-18 (backup_runner extract), R-12 (ui.py `/docs` split), R-06+R-08 (FortiGate `_CAPS` MTU + artifact regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
