### PR TITLE
Batch 8 — sanitiser PII / network-tail redaction (R-16)

### DIFF
--- a/BUG_REPORTING.md
+++ b/BUG_REPORTING.md
@@ -141,9 +141,12 @@ the same redacted value all 5 times).
 | Local user names | `localuserN` (iterative per-class numbering, cross-reference-stable so AAA / sudo / role references resolve to the same placeholder) |
 | Local user hashed passwords | Format-preserving fakes (Junos `$9$`, FortiGate `ENC`, crypt `$5$`/`$6$`, bcrypt `$2y$`, Cisco type-7 hex, Aruba SHA-1) |
 | SNMP communities | `public_redacted_N` |
+| SNMP contact / location (operator PII — email / name / site) | `<contact redacted>` / `<location redacted>` |
 | SNMPv3 user names (USM securityName) | `snmpv3userN` (independent counter from local-user-name) |
 | SNMPv3 auth/priv passphrases | `REDACTED-AUTH-N` / `REDACTED-PRIV-N` |
 | RADIUS shared secrets | `REDACTED-RADIUS-N` |
+| RADIUS server / SNMP trap-target / DHCP-gateway hosts | Public IPv4 → docs ranges; private / hostname preserved |
+| VLAN-SVI IPv4 addresses (the VLAN interface's L3 config) | Public IPv4 → docs ranges; private preserved |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall, NAT, VPN) | Stripped entirely |
@@ -164,6 +167,10 @@ Full rules and limitations in the sanitiser's module docstring at
 - **IPv6-public redaction is IPv4-only at v0.1.0.**  IPv6 addresses
   pass through verbatim.  If your config has public IPv6 addresses,
   hand-redact those before submitting.
+- **Host fields given as DNS names pass through.**  IP-typed
+  redaction (RADIUS server, SNMP trap target, DHCP gateway) acts on
+  bare IPv4 only; a target written as a hostname (`nms.corp.example`)
+  is preserved.  Hand-edit name-form hosts if they are identifying.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,30 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
-P2 + documentation remediation from the 2026-06-06 review (Batches 2–7)
+P2 + documentation remediation from the 2026-06-06 review (Batches 2–8)
 — sequenced in that dossier's `recommended-remediation-plan.md`.  No
 canonical-model or codec-grammar changes.
+
+### Security
+
+* **Sanitiser now redacts the PII / network tail it previously left
+  intact** (finding R-16 / CF-04).  `netcanon sanitize` redacted
+  secrets and interface L3 addresses but skipped five identifying
+  fields that parsers populate and renderers emit: SNMP `contact` /
+  `location` (operator email / name / site), the SNMP trap-target +
+  RADIUS-server + DHCP-pool-gateway hosts (public IPv4), and — the
+  material leak — VLAN-SVI addresses on `CanonicalVlan.ipv4_addresses`,
+  a field separate from `interfaces[].ipv4_addresses` that the
+  interface walk never reached.  On Aruba AOS-S the SVI is a property
+  of the VLAN and renders straight off that un-walked list, so a public
+  SVI IP survived sanitisation verbatim.  Contact / location now map to
+  opaque placeholders; the host / SVI fields reuse the existing
+  public-IPv4 → RFC 5737 docs-range policy (private / loopback /
+  hostname forms preserved, cross-references stable).  These are
+  PII/network rather than secrets, so they are deliberately kept out of
+  the secret-coverage guard's registry; a new forward test pins that
+  they no longer survive.  Host fields written as DNS names remain a
+  documented passthrough (`SECURITY.md` / `BUG_REPORTING.md`).
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -309,8 +309,11 @@ on the canonical model:
 | Public IPv4 | RFC 5737 docs ranges |
 | Hashed passwords | Format-preserving fakes (Junos `$9$`, FortiGate `ENC`, crypt `$5$`/`$6$`, bcrypt `$2y$`, Cisco type-7 hex, Aruba SHA-1) |
 | SNMP communities | `public_redacted_N` |
+| SNMP contact / location (operator PII) | `<contact redacted>` / `<location redacted>` |
 | SNMPv3 auth/priv passphrases | `REDACTED-AUTH-N` / `REDACTED-PRIV-N` |
 | RADIUS shared secrets | `REDACTED-RADIUS-N` |
+| RADIUS server / SNMP trap-target / DHCP-gateway hosts (public IPv4) | RFC 5737 docs ranges |
+| VLAN-SVI IPv4 addresses (public) | RFC 5737 docs ranges |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall / NAT / VPN) | Stripped entirely |
@@ -322,8 +325,9 @@ substitution table for operator review before writing output.
 
 Known limitations are listed in
 [`BUG_REPORTING.md`](BUG_REPORTING.md) — notably IPv6-public redaction
-is IPv4-only at v0.1.0; banner / comment text is parse-and-ignored
-rather than redacted.
+is IPv4-only at v0.1.0; host fields given as DNS names (a RADIUS / trap
+target like `nms.corp.example`) pass through; banner / comment text is
+parse-and-ignored rather than redacted.
 
 ---
 

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -28,11 +28,17 @@ Field-typed rules (counter-per-session):
   preserved; Cisco type-7 hex preserved; Linux ``$5$`` / ``$6$`` /
   bcrypt ``$2y$`` shapes preserved)
 * ``CanonicalSNMP.community`` → ``public_redacted_N``
+* ``CanonicalSNMP.contact`` → ``<contact redacted>`` (operator PII —
+  email / name)
+* ``CanonicalSNMP.location`` → ``<location redacted>`` (operator PII —
+  site / address)
+* ``CanonicalSNMP.trap_hosts`` (public entries) → docs range
 * ``CanonicalSNMPv3User.name`` → ``snmpv3userN`` (Phase-3 R6.1 — same
   rationale as local-user-name above)
 * ``CanonicalSNMPv3User.auth_passphrase`` → ``REDACTED-AUTH-N``
 * ``CanonicalSNMPv3User.priv_passphrase`` → ``REDACTED-PRIV-N``
 * ``CanonicalRADIUSServer.key`` → ``REDACTED-RADIUS-N``
+* ``CanonicalRADIUSServer.host`` (public) → docs range
 * ``CanonicalVRRPGroup.authentication`` → ``<scheme>:REDACTED-VRRP-AUTH-N``
   — the ``<scheme>:`` prefix (``plain:`` / ``md5:`` / ``carp-key:``) is
   metadata and is preserved so the renderer still emits valid syntax;
@@ -40,6 +46,10 @@ Field-typed rules (counter-per-session):
   key-string for ``md5:``) is replaced
 * ``CanonicalInterface.description`` → ``description redacted``
 * ``CanonicalDHCPPool.dns_servers`` (public entries) → docs range
+* ``CanonicalDHCPPool.gateway`` (public) → docs range
+* ``CanonicalVlan.ipv4_addresses`` (public SVI L3 addresses) → docs
+  range — SEPARATE field from ``interfaces[].ipv4_addresses``; the
+  Aruba / Junos SVI-on-VLAN model renders these directly
 * ``CanonicalStaticRoute.gateway`` (public) → docs range
 * ``CanonicalIntent.dropped_tier3_sections`` → stripped entirely
   (Tier-3 carry-through may contain anything; never share)
@@ -51,6 +61,10 @@ Limitations:
   Tier-3 stanzas in the source bytes are not field-typed redacted —
   Tier-3 content is dropped on parse, banners are typically
   parse-and-ignore.
+* IP-typed redaction (interface / SVI / DHCP / RADIUS / trap-target
+  addresses) acts on IPv4 only.  IPv6 addresses and host fields given
+  as DNS NAMES (e.g. a RADIUS / trap target of ``nms.corp.example``)
+  pass through verbatim — hand-edit those before sharing.
 * Round-trip is sub-lossless: parse drops Tier-3 content, and render
   emits only what the codec models.  Operators sharing a sanitized
   config get the supported subset, not a byte-identical-shape
@@ -258,6 +272,29 @@ def sanitize_intent(
                 ))
                 group.authentication = new_auth
 
+    # ---- VLAN SVI IPv4 addresses ----
+    # R-16 / CF-04: SVI L3 addressing lives on ``CanonicalVlan.
+    # ipv4_addresses`` (intent.py), a SEPARATE field from
+    # ``interfaces[].ipv4_addresses``.  The interface walk above does
+    # NOT reach it.  On Aruba AOS-S the SVI is a property of the VLAN
+    # (no sibling interface) and renders straight off this list, so a
+    # public SVI IP would otherwise survive sanitisation verbatim;
+    # Junos IRB folds here too, and Cisco/Arista keep an independent
+    # synthesised copy.  ``redact_ipv4`` is cache-keyed by IP string,
+    # so a copy that mirrors an interface address resolves to the SAME
+    # docs-range substitute (cross-reference stable).
+    for i, vlan in enumerate(sanitized.vlans):
+        for j, addr in enumerate(vlan.ipv4_addresses):
+            new_ip = table.redact_ipv4(addr.ip)
+            if new_ip != addr.ip:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"vlans[{i}].ipv4_addresses[{j}].ip",
+                    original=addr.ip,
+                    redacted=new_ip,
+                ))
+                addr.ip = new_ip
+
     # ---- local users (usernames + hashed passwords) ----
     # Phase-3 R6.1: redact the username too.  Operator-chosen
     # usernames (`alice`, `john.smith`, or the Windows-login-mirror
@@ -299,6 +336,48 @@ def sanitize_intent(
             ))
             sanitized.snmp.community = new_value
 
+        # R-16 / CF-04: SNMP contact + location are operator PII.
+        # ``contact`` commonly carries an email / name
+        # (``admin@corp.example``, ``"Jane Doe x4012"``); ``location``
+        # carries a physical site / street address.  Free-text →
+        # opaque placeholder (mirrors the ``description redacted``
+        # pattern), NOT an IP redaction.
+        if sanitized.snmp.contact:
+            redacted_contact = "<contact redacted>"
+            subs.append(Substitution(
+                category="snmp-contact",
+                field="snmp.contact",
+                original=sanitized.snmp.contact,
+                redacted=redacted_contact,
+            ))
+            sanitized.snmp.contact = redacted_contact
+
+        if sanitized.snmp.location:
+            redacted_location = "<location redacted>"
+            subs.append(Substitution(
+                category="snmp-location",
+                field="snmp.location",
+                original=sanitized.snmp.location,
+                redacted=redacted_location,
+            ))
+            sanitized.snmp.location = redacted_location
+
+        # R-16 / CF-04: SNMP trap-target hosts.  Public IPv4 → docs
+        # range; private / loopback / hostname forms preserved (same
+        # policy as every other IP field).
+        new_traps: list[str] = []
+        for j, host in enumerate(sanitized.snmp.trap_hosts):
+            new_host = table.redact_ip_string(host)
+            if new_host != host:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"snmp.trap_hosts[{j}]",
+                    original=host,
+                    redacted=new_host,
+                ))
+            new_traps.append(new_host)
+        sanitized.snmp.trap_hosts = new_traps
+
         for j, v3user in enumerate(sanitized.snmp.v3_users):
             # Phase-3 R6.1: redact the SNMPv3 username too (same
             # rationale as local-user-name above — USM securityName
@@ -331,8 +410,21 @@ def sanitize_intent(
                 ))
                 v3user.priv_passphrase = new_value
 
-    # ---- RADIUS shared secrets (canonical field name: ``key``) ----
+    # ---- RADIUS server host + shared secret (field name: ``key``) ----
     for i, server in enumerate(sanitized.radius_servers):
+        # R-16 / CF-04: the RADIUS server address is network-
+        # identifying.  Public IPv4 → docs range; private / hostname
+        # preserved (same IP policy as everywhere else).
+        if server.host:
+            new_host = table.redact_ip_string(server.host)
+            if new_host != server.host:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"radius_servers[{i}].host",
+                    original=server.host,
+                    redacted=new_host,
+                ))
+                server.host = new_host
         if server.key:
             new_value = table.redact_secret("RADIUS")
             subs.append(Substitution(
@@ -343,7 +435,7 @@ def sanitize_intent(
             ))
             server.key = new_value
 
-    # ---- DHCP pool DNS servers ----
+    # ---- DHCP pool DNS servers + gateway ----
     for i, pool in enumerate(sanitized.dhcp_servers):
         new_dns = []
         for j, ip in enumerate(pool.dns_servers):
@@ -357,6 +449,20 @@ def sanitize_intent(
                 ))
             new_dns.append(new_ip)
         pool.dns_servers = new_dns
+
+        # R-16 / CF-04: pool gateway (sibling of the already-redacted
+        # static-route gateway).  Public IPv4 → docs range; private
+        # preserved (the common case for a LAN default-gateway).
+        if pool.gateway:
+            new_gw = table.redact_ip_string(pool.gateway)
+            if new_gw != pool.gateway:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"dhcp_servers[{i}].gateway",
+                    original=pool.gateway,
+                    redacted=new_gw,
+                ))
+                pool.gateway = new_gw
 
     # ---- static-route gateways ----
     for i, route in enumerate(sanitized.static_routes):

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -37,6 +37,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalSNMP,
     CanonicalSNMPv3User,
     CanonicalStaticRoute,
+    CanonicalVlan,
     CanonicalVRRPGroup,
 )
 from netcanon.tools.sanitize import (
@@ -760,3 +761,218 @@ class TestSecretRedactionCoverage:
             "Registered secret field(s) no longer on the model — remove "
             f"from _REGISTERED_SECRET_FIELDS: {sorted(stale)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# R-16 / CF-04 — PII / network tail redaction
+#
+# Non-secret-but-identifying fields the sanitiser previously left
+# untouched: SNMP contact/location (operator PII), SNMP trap-target +
+# RADIUS server + DHCP-gateway hosts (public IPv4), and VLAN-SVI IPv4
+# (a SEPARATE canonical field from interfaces[].ipv4_addresses).
+#
+# These are PII/network, not secrets, so they are intentionally NOT in
+# _REGISTERED_SECRET_FIELDS and do NOT trip TestSecretRedactionCoverage
+# (that guard introspects secret-NAMED fields only).  This forward
+# block is the durable "these PII fields don't survive" check.
+# ---------------------------------------------------------------------------
+
+
+class TestSNMPContactLocationRedaction:
+    """SNMP contact (email/name) + location (site/address) are operator
+    PII.  Free-text → opaque placeholder, not an IP redaction."""
+
+    def test_contact_redacted_to_placeholder(self):
+        intent = CanonicalIntent(
+            snmp=CanonicalSNMP(community="", contact="admin@corp.example")
+        )
+        sanitized, subs = sanitize_intent(intent)
+        assert sanitized.snmp.contact == "<contact redacted>"
+        assert "admin@corp.example" not in sanitized.snmp.contact
+        assert any(
+            s.category == "snmp-contact" and s.original == "admin@corp.example"
+            for s in subs
+        )
+
+    def test_location_redacted_to_placeholder(self):
+        intent = CanonicalIntent(
+            snmp=CanonicalSNMP(community="", location="Rack 7, 12 Real Street")
+        )
+        sanitized, subs = sanitize_intent(intent)
+        assert sanitized.snmp.location == "<location redacted>"
+        assert any(s.category == "snmp-location" for s in subs)
+
+    def test_empty_contact_and_location_no_substitution(self):
+        intent = CanonicalIntent(snmp=CanonicalSNMP(community="x"))
+        sanitized, subs = sanitize_intent(intent)
+        assert sanitized.snmp.contact == ""
+        assert sanitized.snmp.location == ""
+        assert not any(s.category == "snmp-contact" for s in subs)
+        assert not any(s.category == "snmp-location" for s in subs)
+
+
+class TestSNMPTrapHostRedaction:
+    """SNMP trap-target hosts: public IPv4 → docs range, private
+    preserved, hostname preserved."""
+
+    def test_public_trap_host_redacted_private_preserved(self):
+        intent = CanonicalIntent(
+            snmp=CanonicalSNMP(
+                community="",
+                trap_hosts=["8.8.8.8", "192.168.50.5"],
+            )
+        )
+        sanitized, subs = sanitize_intent(intent)
+        assert sanitized.snmp.trap_hosts[0] != "8.8.8.8"
+        assert sanitized.snmp.trap_hosts[0].startswith(
+            ("192.0.2.", "198.51.100.", "203.0.113.")
+        )
+        assert sanitized.snmp.trap_hosts[1] == "192.168.50.5"  # private kept
+        assert len([s for s in subs if s.category == "ipv4-public"]) == 1
+
+    def test_hostname_trap_target_preserved(self):
+        intent = CanonicalIntent(
+            snmp=CanonicalSNMP(community="", trap_hosts=["nms.corp.example"])
+        )
+        sanitized, _ = sanitize_intent(intent)
+        # Documented residual: name-form hosts pass through.
+        assert sanitized.snmp.trap_hosts[0] == "nms.corp.example"
+
+
+class TestRADIUSHostRedaction:
+    """RADIUS server host: public IPv4 → docs range, private preserved.
+    Complements the existing key-redaction test."""
+
+    def test_public_host_redacted(self):
+        intent = CanonicalIntent(
+            radius_servers=[
+                CanonicalRADIUSServer(host="203.0.113.200", key="s"),
+                CanonicalRADIUSServer(host="9.9.9.9", key="s2"),
+            ]
+        )
+        sanitized, subs = sanitize_intent(intent)
+        # 203.0.113.x is already a docs range -> preserved as-is.
+        assert sanitized.radius_servers[0].host == "203.0.113.200"
+        # 9.9.9.9 is public -> redacted.
+        assert sanitized.radius_servers[1].host != "9.9.9.9"
+        assert sanitized.radius_servers[1].host.startswith(
+            ("192.0.2.", "198.51.100.", "203.0.113.")
+        )
+        assert any(
+            s.category == "ipv4-public"
+            and s.field == "radius_servers[1].host"
+            for s in subs
+        )
+
+    def test_private_host_preserved(self):
+        intent = CanonicalIntent(
+            radius_servers=[CanonicalRADIUSServer(host="10.0.0.5", key="s")]
+        )
+        sanitized, _ = sanitize_intent(intent)
+        assert sanitized.radius_servers[0].host == "10.0.0.5"
+
+
+class TestDHCPGatewayRedaction:
+    """DHCP pool gateway: sibling of the already-redacted static-route
+    gateway.  Public IPv4 → docs range; private (the common case)
+    preserved."""
+
+    def test_public_gateway_redacted_private_preserved(self):
+        intent = CanonicalIntent(
+            dhcp_servers=[
+                CanonicalDHCPPool(network="10.0.0.0/24", gateway="1.1.1.1"),
+                CanonicalDHCPPool(network="10.1.0.0/24", gateway="10.1.0.1"),
+            ]
+        )
+        sanitized, subs = sanitize_intent(intent)
+        assert sanitized.dhcp_servers[0].gateway != "1.1.1.1"
+        assert sanitized.dhcp_servers[1].gateway == "10.1.0.1"  # private kept
+        assert any(
+            s.field == "dhcp_servers[0].gateway" for s in subs
+        )
+
+
+class TestVlanSviIPv4Redaction:
+    """The material R-16 leak: SVI L3 addresses live on
+    CanonicalVlan.ipv4_addresses — a SEPARATE field the interface walk
+    never reaches.  On Aruba / Junos these render straight off the VLAN
+    record, so a public SVI IP previously survived sanitisation."""
+
+    def test_public_svi_ip_redacted_private_preserved(self):
+        intent = CanonicalIntent(
+            vlans=[
+                CanonicalVlan(
+                    id=10,
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="8.8.4.4", prefix_length=24),
+                        CanonicalIPv4Address(ip="192.168.10.1", prefix_length=24),
+                    ],
+                )
+            ]
+        )
+        sanitized, subs = sanitize_intent(intent)
+        svi = sanitized.vlans[0].ipv4_addresses
+        assert svi[0].ip != "8.8.4.4"
+        assert svi[0].ip.startswith(("192.0.2.", "198.51.100.", "203.0.113."))
+        assert svi[1].ip == "192.168.10.1"  # private SVI gateway preserved
+        assert any(
+            s.category == "ipv4-public"
+            and s.field == "vlans[0].ipv4_addresses[0].ip"
+            for s in subs
+        )
+
+    def test_svi_copy_matches_interface_copy_cross_reference(self):
+        """Cisco/Arista keep an independent synthesised vlan copy of the
+        SVI interface address.  Because redact_ipv4 is cache-keyed by IP
+        string, the same public IP on both the interface and the vlan
+        record resolves to the SAME docs-range substitute."""
+        intent = CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(
+                    name="Vlan10",
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="11.22.33.44", prefix_length=24)
+                    ],
+                )
+            ],
+            vlans=[
+                CanonicalVlan(
+                    id=10,
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="11.22.33.44", prefix_length=24)
+                    ],
+                )
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        iface_ip = sanitized.interfaces[0].ipv4_addresses[0].ip
+        vlan_ip = sanitized.vlans[0].ipv4_addresses[0].ip
+        assert iface_ip != "11.22.33.44"
+        assert vlan_ip == iface_ip  # cross-reference stable
+
+
+class TestPiiTailRenderedOutputClean:
+    """End-to-end: sanitize_intent -> render must not emit the original
+    PII.  Exercises the Aruba SVI-on-VLAN render path (the field that
+    leaked) plus SNMP contact."""
+
+    def test_aruba_svi_and_contact_absent_from_render(self):
+        from netcanon.migration.codecs.registry import get_codec
+
+        intent = CanonicalIntent(
+            hostname="r1",
+            vlans=[
+                CanonicalVlan(
+                    id=10,
+                    name="USERS",
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="9.9.9.9", prefix_length=24)
+                    ],
+                )
+            ],
+            snmp=CanonicalSNMP(community="", contact="admin@corp.example"),
+        )
+        sanitized, _ = sanitize_intent(intent)
+        rendered = get_codec("aruba_aoss").render(sanitized)
+        assert "9.9.9.9" not in rendered            # SVI leak closed
+        assert "admin@corp.example" not in rendered   # contact leak closed


### PR DESCRIPTION
## What

Closes **R-16 / CF-04** from the 2026-06-06 review: `netcanon sanitize` walked secrets + interface L3 addresses but left five identifying **PII / network** fields intact. All are live (parser-populated, renderer-emitted), so they survived `netcanon sanitize` — the tool operators are told to run before posting a public bug report.

| Field | Redaction |
|---|---|
| `CanonicalSNMP.contact` | `<contact redacted>` (operator email / name) |
| `CanonicalSNMP.location` | `<location redacted>` (site / address) |
| `CanonicalSNMP.trap_hosts[]` | public IPv4 → RFC 5737 docs range |
| `CanonicalRADIUSServer.host` | public IPv4 → docs range |
| `CanonicalDHCPPool.gateway` | public IPv4 → docs range |
| **`CanonicalVlan.ipv4_addresses[].ip`** (SVI) | public IPv4 → docs range — **the material leak** |

### The material leak (VLAN-SVI)

SVI L3 addressing lives on `CanonicalVlan.ipv4_addresses`, a field **separate** from `interfaces[].ipv4_addresses` that `sanitize_intent` never walked. On **Aruba AOS-S** the SVI is a property of the VLAN (no sibling interface) and the renderer emits it straight off that un-walked list — so a public SVI IP survived sanitisation verbatim. Junos IRB folds here too; Cisco/Arista keep an independent synthesised copy. `redact_ipv4` is cache-keyed by IP string, so a copy mirroring an interface address resolves to the **same** docs substitute (cross-reference stable).

## Design decisions (the two open judgment calls in the spec)

- **`snmp.location` — accepted.** Same PII class as `contact`; for a sanitiser the conservative choice is to redact.
- **DHCP `gateway` — accepted.** Direct symmetric sibling of the already-redacted `static_routes[].gateway`; public-only, so private (the common case) is a no-op.

## Not secrets → not in the secret guard

These are PII/network, **not** secrets, so they are deliberately **not** added to `_REGISTERED_SECRET_FIELDS` (their names don't match the secret-name regex; adding them would falsely widen the secret contract). `TestSecretRedactionCoverage` stays green; a new **forward** test block pins that the PII fields don't survive.

## Tests

- `tests/unit/tools/test_sanitize.py`: +6 classes (contact/location, trap-host, RADIUS host, DHCP gateway, VLAN-SVI incl. cross-reference stability, and an end-to-end Aruba render that asserts the SVI IP + contact are absent from rendered output).
- **Full unit suite green** (`py -m pytest tests/unit -q`).

## Docs

`SECURITY.md` + `BUG_REPORTING.md` sanitiser tables gain the new rows; both note the residual **hostname-form host** passthrough (a RADIUS/trap target written as `nms.corp.example` is preserved — IP-typed redaction acts on bare IPv4 only). IPv6 remains the documented IPv4-only limitation.

Additive only — no canonical-model or codec-grammar change. Actuated from `docs/project-review/2026-06-06/remediation-sweep/result-RA-16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)