### PR TITLE
chore(release): cut v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-13
+
 ### Added
 
 * **Cisco NX-OS codec — Phase 2c (HSRP), completing Phase 2.**  Parses the


### PR DESCRIPTION
## Release cut — v0.1.4

Renames the `[Unreleased]` CHANGELOG section to **`[0.1.4] - 2026-06-13`**
and opens a fresh `[Unreleased]` stub.  Merging this, then pushing the
`v0.1.4` tag, fires the publish workflows (pypi + docker + desktop-MSI +
GitHub Release).  Version is **setuptools_scm-derived from the tag** — no
manual version bump.

### What v0.1.4 collects (since v0.1.3)

- **New codec: Cisco NX-OS (`cisco_nxos`)** — Phases 1–2 complete
  ([#25](https://github.com/netcanon/netcanon/pull/25) / [#26](https://github.com/netcanon/netcanon/pull/26) / [#27](https://github.com/netcanon/netcanon/pull/27) / [#28](https://github.com/netcanon/netcanon/pull/28)): hostname / L3 interfaces / VLANs /
  vrf-context / default-VRF static, L2 switchport + LAG, SNMPv2c/v3 +
  local-users, HSRP.  `certainty=best_effort`.
- **Per-VRF static routes** on `cisco_iosxe_cli` ([#23](https://github.com/netcanon/netcanon/pull/23)) + `juniper_junos` ([#24](https://github.com/netcanon/netcanon/pull/24)).
- The Batches 2–12 P2 / docs remediation already in `[Unreleased]`.

CODEC_BUG held flat at 5 across the whole series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)