### PR TITLE
chore(release): cut v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-06-13
+
 ### Added
 
 * **Cisco IOS-XR codec — Phase 4 (`certified`), completing the codec.**


### PR DESCRIPTION
## Release v0.1.5

Moves the `[Unreleased]` CHANGELOG entries under a `## [0.1.5] - 2026-06-13` heading. Version is derived from the git tag via `setuptools_scm`; the `v0.1.5` tag is pushed on this merge commit (which fires the PyPI / Docker / desktop-MSI publish workflows).

### What's in v0.1.5

Everything that landed on `main` after v0.1.4:

- **Cisco IOS-XR codec — complete (Phases 1–4, [#32](https://github.com/netcanon/netcanon/pull/32) / [#33](https://github.com/netcanon/netcanon/pull/33) / [#34](https://github.com/netcanon/netcanon/pull/34) / [#35](https://github.com/netcanon/netcanon/pull/35)).** New 10th codec, bidirectional / **certified**. Interfaces (4-segment) + VRF + RT + RD-from-`router bgp` + per-iface VRF + Bundle-Ether LAGs + local users + per-VRF static + dot1q→VLAN; SP-routing / route-policy / MPLS / IS-IS surfaced via the Tier-3 banner. Round-trip-validated against a 10-config real corpus from two sources (`batfish/lab-validation` + `ios-xr/xrd-tools`).
- **Cisco NX-OS codec — Phases 3–4 ([#30](https://github.com/netcanon/netcanon/pull/30) / [#31](https://github.com/netcanon/netcanon/pull/31)), completing it.** VRF RD/RT + per-VRF static + VXLAN-EVPN / L3VNI / `vtep` PortKind.

CODEC_BUG held flat at 5 across every phase. CHANGELOG-only diff; the four codec PRs were each independently gated + CI-green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)