### PR TITLE
chore(release): cut v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.1.6] - 2026-06-13
+
 ### Added
 
 * **Aruba AOS-CX codec — Phase 4 (VXLAN L2VNI + certified).**  Parses +


### PR DESCRIPTION
## Release v0.1.6

Moves the `[Unreleased]` CHANGELOG entries under a `## [0.1.6] - 2026-06-13` heading. Version is derived from the git tag via `setuptools_scm`; the `v0.1.6` tag is pushed on this merge commit (which fires the PyPI / Docker / desktop-MSI publish workflows).

### What's in v0.1.6

Everything that landed on `main` after v0.1.5:

- **Aruba AOS-CX codec — complete (Phases 1–4, [#39](https://github.com/netcanon/netcanon/pull/39) / [#40](https://github.com/netcanon/netcanon/pull/40) / [#41](https://github.com/netcanon/netcanon/pull/41) / [#42](https://github.com/netcanon/netcanon/pull/42) / [#43](https://github.com/netcanon/netcanon/pull/43)).** New **11th codec**, bidirectional / **certified**. Multi-token interface names + L3/L2 switchport + VLANs + LAGs + local users + SNMP + `active-gateway` anycast (VSX/EVPN distributed gateway) + VXLAN L2 VLAN↔VNI binding. Round-trip-validated against a 4-config `aruba/aoscx-ansible-dcn-workflows` real corpus (2 EVPN-VXLAN leaves + 2 active-gateway L3-agg cores, AOS-CX 10.04 / 10.13). Distinct from the legacy `aruba_aoss` (AOS-S) codec.
- **Cisco NX-OS codec — IPv4 Distributed Anycast Gateway + `certified` ([#37](https://github.com/netcanon/netcanon/pull/37) / [#38](https://github.com/netcanon/netcanon/pull/38)).** DAG (`fabric forwarding mode anycast-gateway` + `anycast-gateway-mac`) reusing the certified anycast surface; flipped to `certified` on a 6-config `batfish/lab-validation` corpus.

CODEC_BUG held flat at 5 across every phase. CHANGELOG-only diff; all codec PRs were each independently gated + CI-green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)