### PR TITLE
chore(release): cut v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-06-14
+
 ### Added
 
 * **VyOS codec — Phase 4 (certified).**  Flips the `vyos` codec from


### PR DESCRIPTION
Rolls `[Unreleased]` into `## [0.1.7] - 2026-06-14`.

**Publishes the complete VyOS codec** (netcanon's 12th), shipped across Phases 1–4 since v0.1.6:

- **P1** — Tier-1 curly-brace `config.boot` (hostname, interfaces, `vif` VLANs, static routes)
- **P2** — local users + NTP + bonding LAGs
- **P3** — `service snmp` (v1/v2c + v3 USM) + VRF routing-instances
- **P4** — certified flip on a 6-config `cisagov/prescup-challenges` (MIT) real corpus

`vyos` joins `cisco_nxos` / `cisco_iosxr` / `aruba_aoscx` as **complete + certified**. CODEC_BUG held flat at 5 across all four phases; cross-mesh 836 → 996.

On merge: tag `v0.1.7` → fires `pypi-publish` / `docker-publish` / `desktop-msi-publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
