### PR TITLE
fix(security): device-profile creds write-only over API + server-side backup resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ timestamp if your timezone matters for an audit.
 
 ### Security
 
+* **Device-profile credentials are write-only over the API; backups resolve
+  them server-side.**  The device-profile REST routes (`GET`/`LIST`/`POST`/`PUT
+  /api/v1/devices`) now serialise through a new `DeviceProfilePublic` response
+  model that omits `password` / `enable_password`, so the Fernet-decrypted
+  credential is never returned to a client — closing the top finding of the
+  2026-06-14 multi-lens review.  Credentials are accepted in create / update
+  request bodies but never echoed.  To keep the web "Run backup now" flows
+  working without that round-trip, `POST /api/v1/backups` now resolves a
+  device's credentials *server-side* from its `device_profile_id` when none are
+  supplied inline (mirroring the existing scheduled-trigger path), so the
+  plaintext password no longer has to traverse the browser at all.
+  `DeviceTarget.credentials` is now optional; a device with neither inline
+  credentials nor a resolvable profile is rejected with HTTP 422.  A two-sided
+  guard test (`tests/unit/test_device_profile_public.py`) keeps the public
+  model in lockstep with `DeviceProfile` minus the two credential fields.
+
 * **VLAN-range expansion is bounded before materialization (DoS hardening).**
   The four comma/range VLAN-list expanders (`cisco_iosxe_cli`, `cisco_nxos`,
   `aruba_aoscx`, `arista_eos`) clamp a range to the valid VLAN space (1..4094)
@@ -57,6 +73,11 @@ timestamp if your timezone matters for an audit.
   (`netcanon/migration/codecs/README.md`) is corrected from "Eight codecs" to
   twelve (count-resilient, pointing at `RESULTS.md`) and its Tier-3 detector
   enumeration refreshed to the full per-vendor set.
+* **`docs/CAPABILITIES.md` §A completeness.**  Added the four missing
+  per-codec "Unsupported / Lossy" panels (`cisco_nxos`, `cisco_iosxr`,
+  `aruba_aoscx`, `vyos`), generated from each codec's `CapabilityMatrix`, so
+  §A now enumerates every codec's declared exceptions rather than only the
+  original eight (also flagged by the 2026-06-14 review).
 
 ### Added
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -317,6 +317,113 @@ output.
 | `/snmp/v3-user` | Unsupported | OPNsense's SNMPv3 lives in raw `snmpd.conf` — Tier 3. |
 | `/vxlan-vnis/{vni,source-interface,udp-port}` | Unsupported | VXLAN not modelled — OPNsense is a firewall codec. |
 
+#### `cisco_nxos` (Cisco NX-OS, bidirectional, certified)
+
+46 supported surfaces (L1/L3 + L2 switchport/LAG + SNMP/local-users +
+HSRP + VRF RD/RT + per-VRF static + VXLAN-EVPN/L3VNI + IPv4 Distributed
+Anycast Gateway).  The lossy / unsupported exceptions:
+
+| Path | Class | Reason |
+|---|---|---|
+| `/interfaces/interface/config/type` | Lossy | Interface-type inferred from the name prefix (Ethernet → ethernetCsmacd, loopback → softwareLoopback, Vlan → l3ipvlan, port-channel → ieee8023adLag, nve → tunnel, mgmt → ethernetCsmacd).  Best-effort; may not catch every IANA type. |
+| `/system/raw-sections/vdc` | Lossy | `vdc <name> id N / limit-resource …` (N7K virtualisation) has no canonical primitive; the source block is discarded and a default single-VDC `vdc <hostname> id 1` wrapper is synthesised on render. |
+| `/system/raw-sections/features` | Lossy | `feature <name>` lines are derived on render from the canonical-tree shape (any SVI → `feature interface-vlan`, etc).  Source features not motivated by a canonical surface (`feature scp-server`, `feature telnet`) are dropped; re-authorise on the target. |
+| `/local-users/user/privilege-level` | Lossy | NX-OS uses a named `role` (network-admin / network-operator / custom), not a numeric privilege.  network-admin / vdc-admin → 15, everything else → 1.  The named role round-trips losslessly same-vendor. |
+| `/snmp/v3-user/auth-passphrase` | Lossy | NX-OS 10.x `localizedV2key` digest is normalised to the older `localizedkey` form on render; re-key SNMPv3 users on the target across OS-version / vendor boundaries. |
+| `/snmp/v3-user/engine-id` | Lossy | engineID emitted colon-decimal (`128:0:0:9:…`); cross-vendor sources typically use hex.  Preserved verbatim same-vendor; cross-vendor render may need re-keying. |
+| `/interfaces/interface/vrrp-groups/group` | Lossy | FHRP is expressed as HSRP (`interface VlanN / hsrp N / ip <vip> / priority / preempt`).  EVERY `CanonicalVRRPGroup` renders as an `hsrp` block regardless of source `mode` — the virtual-IP redundancy intent survives but the wire protocol changes.  Same-vendor HSRP round-trips losslessly; sub-second timers / virtual-MAC / track objects are not modelled. |
+| `/routing-instances/instance/route-distinguisher` | Lossy | `rd auto` is preserved verbatim as a sentinel; cross-vendor renderers that don't recognise it must synthesise an explicit RD.  An explicit `rd <asn>:<nn>` round-trips losslessly. |
+| `/routing-instances/instance/rt-imports` | Lossy | `route-target both <rt> evpn` advertises in both IPv4-unicast and L2VPN-EVPN; the `evpn` address-family scope does not round-trip cross-vendor (RT value preserved, scope reverts to IPv4 unicast).  Same-vendor round-trips. |
+| `/vxlan-vnis/vni` | Lossy | `interface nve1 / member vni N` per-VNI sub-flags (`suppress-arp`, alternate ingress-replication) do not round-trip — render always emits the modern BGP-EVPN head-end shape (`host-reachability protocol bgp`).  The VLAN↔VNI binding round-trips via `vlan N / vn-segment`. |
+| `/evpn-type5-routes/route` | Lossy | EVPN Type-5 is modelled as a VRF property via `CanonicalRoutingInstance.l3_vni` (`vrf context X / vni N` + `member vni N associate-vrf`), not per-prefix records; no route-map / prefix-filter parsing in v1. |
+| `/interfaces/interface/ipv6/address/virtual-gateway-address` | Unsupported | IPv4 Distributed Anycast Gateway IS supported; the IPv6 companion parses-and-ignores in v1 (no fixture coverage; parity with the IOS-XE IPv6-anycast deferral). |
+| `/routing-protocols/bgp` | Unsupported | `router bgp <asn>` is Tier-3 — captured for the dropped-Tier-3 banner, never auto-rendered cross-vendor. |
+| `/routing-protocols/ospf` | Unsupported | Tier-3. |
+| `/routing-protocols/eigrp` | Unsupported | Tier-3. |
+| `/routing-protocols/isis` | Unsupported | Tier-3. |
+| `/access-list/{extended,standard,ipv6}` | Unsupported | ACLs are Tier-3 — auto-translating ACL semantics across vendors risks subtly-permissive rules.  Operator authors firewall policy manually (mirrors cisco_iosxe_cli). |
+| `/firewall` | Unsupported | NX-OS hosts no stateful firewall; declared unsupported for cross-vendor surface consistency. |
+| `/nat` | Unsupported | NX-OS hosts no typical edge NAT. |
+| `/qos` | Unsupported | `class-map / policy-map type qos / service-policy` is Tier-3 — DC-grade QoS is too platform-specific to auto-translate. |
+
+#### `cisco_iosxr` (Cisco IOS-XR, bidirectional, certified)
+
+22 supported surfaces (Tier-1 + VRF + RT + per-interface VRF + LAG +
+local users + per-VRF static + dot1q sub-interfaces).  The lossy /
+unsupported exceptions:
+
+| Path | Class | Reason |
+|---|---|---|
+| `/interfaces/interface/config/type` | Lossy | Type inferred from the name prefix (GigabitEthernet → ethernetCsmacd, Loopback → softwareLoopback, Bundle-Ether → ieee8023adLag, MgmtEth → ethernetCsmacd, tunnel-ip/te → tunnel); sub-interfaces with vendor-specific encapsulation classify as `other`. |
+| `/interfaces/interface/4th-port-segment` | Lossy | IOS-XR port names use 4 segments (rack/slot/instance/port); the cross-vendor `PortIdentity` supports 3.  The 4th segment round-trips via `PortIdentity.meta['iosxr_port_index']` same-vendor but DROPS to `0` when renaming to a 3-segment target (IOS-XE / Arista) — verify via the rename modal. |
+| `/routing-instances/instance` | Lossy | `vrf <name>` + `address-family ipv4 unicast` / `import\|export route-target` + per-interface `vrf <name>` membership round-trip, but `route_distinguisher` must be read from / rendered to the BGP block (`router bgp <asn> / vrf <name> / rd <rd>`).  A minimal BGP-RD carrier is synthesised on render with ASN derived from the RD administrator field; a config whose BGP ASN differs re-emits the normalised ASN (cosmetic — the RD round-trips).  No `router bgp` ⇒ `route_distinguisher=''`.  `l3_vni` (EVPN Type-5) is not modelled. |
+| `/snmp/community` | Unsupported | SNMP parse + render is out of the v1 XR scope. |
+| `/routing/bgp` | Unsupported | `router bgp <asn>` is Tier-3 (a minimal per-VRF RD harvest aside); full BGP modelling stays unsupported. |
+| `/routing/ospf` | Unsupported | `router ospf <pid>` parse-and-ignore (Tier-3). |
+| `/routing/isis` | Unsupported | `router isis <name>` parse-and-ignore (Tier-3). |
+| `/mpls` | Unsupported | `mpls ldp` / `mpls traffic-eng` / `mpls oam` are SP-platform fundamentals with no canonical model; Tier-3 banner notes the dropped surface. |
+| `/policy/{route-policy,prefix-set,community-set,as-path-set}` | Unsupported | The IOS-XR RPL `… end-policy` / `… end-set` set-form DSL is structurally distinct from IOS-XE `route-map` sequence form; Tier-3 by design (parity with Junos `policy-options`). |
+| `/vxlan-vnis/{vni,source-interface,udp-port}` | Unsupported | IOS-XR VXLAN (NCS 5500 / 540 `nve`) is rare in the SP corpus; no canonical demand surfaced.  Parse-and-ignore in v1. |
+| `/evpn-type5-routes/route` | Unsupported | IOS-XR EVPN runs under top-level `l2vpn` + `evpn` + `bridge group` — grammatically distant from the IOS-XE / Arista / NX-OS model.  No canonical mapping in v1. |
+| `/access-list/{extended,ipv6}` | Unsupported | `ipv4 access-list NAME / N permit …` is Tier-3 — auto-translating ACL semantics risks subtly-permissive rules (parity with IOS-XE). |
+| `/firewall` | Unsupported | IOS-XR firewall features are Tier-3 stateful surfaces (parity with IOS-XE). |
+| `/nat` | Unsupported | IOS-XR NAT (`nat64` / `cgnat`) is Tier-3. |
+
+#### `aruba_aoscx` (Aruba AOS-CX, bidirectional, certified)
+
+36 supported surfaces (Tier-1 + L2 switchport/LAG + local users + SNMP
+v2c/v3 + IPv4 active-gateway anycast + VXLAN L2VNI VLAN↔VNI binding).
+Distinct from the campus `aruba_aoss` (AOS-S) codec.  The lossy /
+unsupported exceptions:
+
+| Path | Class | Reason |
+|---|---|---|
+| `/interfaces/interface/config/type` | Lossy | No IANA ifType is declared; inferred from the name shape (`1/1/1` → ethernetCsmacd, `vlan N` → l3ipvlan, `lag N` → ieee8023adLag, `loopback N` → softwareLoopback, `mgmt` → ethernetCsmacd, `vxlan N` → tunnel).  Best-effort. |
+| `/system/raw-sections/version-banner` | Lossy | The `!Version ArubaOS-CX <release>` banner + service footer lines (`ssh server`, `https-server`, `clock`, `ntp`, `spanning-tree`, `system interface-group`) are discarded on parse and a synthesised banner is emitted on render; re-apply management-plane services on the target. |
+| `/local-users/user/privilege-level` | Lossy | Named `group` (administrators / operators / auditors / custom), not numeric: administrators → 15, everything else → 1.  The `password ciphertext` blob is AES-encrypted with the device key (portable same-device only); cross-vendor migration requires re-keying. |
+| `/snmp/v3-user/auth-passphrase` | Lossy | SNMPv3 auth/priv keys are `ciphertext` blobs encrypted with the device key (portable same-device only); cross-vendor / cross-device migration emits the blob verbatim but the operator must re-key.  The `plaintext` key form is normalised to `ciphertext` on render. |
+| `/vxlan-vnis/source-interface` | Lossy | AOS-CX states the VTEP source as an IPv4 *address* (`interface vxlan 1 / source ip <X>`), not an interface name (NX-OS / Arista `source-interface loopbackN`).  Stored verbatim in the opaque `source_interface` field; a cross-vendor source carrying an interface *name* has no `source ip` form so the line is omitted on render (VLAN↔VNI bindings still emit).  Set the loopback→IP mapping on the target manually. |
+| `/snmp/trap-host` | Unsupported | The `snmp-server host … trap …` trap-receiver grammar is deferred; v2c community + system-location / system-contact + v3 USM users are supported. |
+| `/routing-instances/instance/{description,route-distinguisher,rt-imports,rt-exports}` | Unsupported | The `vrf <name>` stanza is a bare name in v1; descriptions / RD / route-targets live under the deferred `evpn` / `router bgp` blocks. |
+| `/routing/static-route/vrf` | Unsupported | Per-VRF static-route binding parses-and-ignores in Phase 1; only default-VRF `ip route` is wired. |
+| `/interfaces/interface/vrrp-groups/group` | Unsupported | AOS-CX VRRP (`vrrp <vrid> address-family` under an SVI) is a later phase; the `active-gateway` distributed-gateway anycast surface IS supported. |
+| `/interfaces/interface/ipv6/address/virtual-gateway-address` | Unsupported | IPv4 active-gateway is supported; the IPv6 anycast companion parses-and-ignores in v1 (parity with NX-OS / IOS-XE). |
+| `/vxlan-vnis/l2vni-route-target` | Unsupported | The per-VLAN L2VNI RD/RT (`evpn / vlan N / rd auto / route-target …`) is almost always `auto`-derived and has no cross-vendor canonical home; the VLAN↔VNI binding IS translated, the RD/RT is re-derived on the target. |
+| `/routing-instances/instance/l3-vni` | Unsupported | EVPN symmetric-IRB L3VNI (`vni N / vrf <name>` under the VTEP + `router bgp / vrf`) is a later phase; the L2VNI binding IS supported. |
+| `/routing-protocols/bgp` | Unsupported | `router bgp <asn>` (incl. the EVPN address-family) is Tier-3 — captured for the dropped-Tier-3 banner, never auto-rendered cross-vendor. |
+| `/routing-protocols/ospf` | Unsupported | Tier-3. |
+| `/access-list/{extended,standard}` | Unsupported | ACLs are Tier-3 — auto-translating risks subtly-permissive rules (mirrors cisco_nxos). |
+| `/qos` | Unsupported | QoS (`class` / `policy` / `apply qos`) is Tier-3 — too platform-specific to auto-translate. |
+| `/nat` | Unsupported | AOS-CX hosts no typical edge NAT. |
+
+#### `vyos` (VyOS, bidirectional, certified)
+
+30 supported surfaces (curly-brace `config.boot` **and** set-form
+`show configuration commands` input; Tier-1 + local users + NTP +
+bonding LAGs + SNMP + VRF + VXLAN L2VNI).  Render always emits the
+curly-brace form.  The lossy / unsupported exceptions:
+
+| Path | Class | Reason |
+|---|---|---|
+| `/interfaces/interface/config/type` | Lossy | No IANA ifType; inferred from the name shape (`ethN` → ethernetCsmacd, `lo`/`dumN` → softwareLoopback, `bondN` → ieee8023adLag).  Best-effort. |
+| `/system/raw-sections/version-banner` | Lossy | The `// vyos-config-version` trailer + not-yet-modelled `service` / `system` management blocks (SSH / syslog / DNS) are discarded on parse and a synthesised trailer is emitted on render; re-apply those services on the target. |
+| `/local-users/user/privilege-level` | Lossy | `system login user` accounts have no numeric privilege in the common case; every login user maps to privilege 15 / role `admin`.  The `encrypted-password` hash round-trips verbatim same-vendor; cross-vendor migration requires re-keying. |
+| `/lags/lag/mode` | Lossy | Bonding `mode 802.3ad` (LACP) → `active`; the non-LACP modes (`active-backup` / `balance-rr` / `balance-xor` / …) collapse to `static` (the balancing algorithm is dropped — re-select on the target). |
+| `/snmp/v3-user/auth-passphrase` | Lossy | v3 USM auth/privacy keys are an opaque `encrypted-password` blob; round-trips verbatim same-vendor but cross-vendor migration requires re-keying (vendor-specific salts).  Plaintext keys are never accepted. |
+| `/snmp/v3-user/engine-id` | Lossy | VyOS declares a single config-wide `engineid` for the whole agent; the canonical model carries it per-user, so the one value maps onto every v3 user (and a single `engineid` is emitted when the users share one). |
+| `/routing-instances/instance/table` | Lossy | VyOS requires a numeric `table <id>` on every `vrf name <X>`; the canonical RoutingInstance carries no table number, so a deterministic id (`100 + sort-index`) is synthesised on render.  The original table id is not preserved. |
+| `/vxlan-vnis/source-interface` | Lossy | The VTEP source is `source-address <ip>` (or `source-interface <if>`) on the vxlan netdev; the opaque string round-trips same-vendor but a cross-vendor source (e.g. `Loopback0`) is re-emitted verbatim and may need an operator port-rename. |
+| `/vxlan-vnis/vlan-id` | Lossy | VyOS models ONE VNI per `vxlan vxlanN` netdev with no on-device VLAN (the L2 binding lives on a separate `bridge`); the required canonical `vlan_id` is synthesised from the VNI and the netdev name regenerated `vxlan<index>` on render — both deterministic (stable same-vendor, advisory cross-vendor). |
+| `/vlans/vlan/id` | Unsupported | VyOS has no top-level VLAN database; 802.1Q VLANs are `vif <vid>` sub-interfaces (rendered as `ethN.<vid>` interfaces), which ARE supported. |
+| `/routing/static-route/vrf` | Unsupported | Per-VRF static routes (`vrf name <X> { protocols static route … }`) are deferred past the Phase-3 VRF wire-up; the `vrf name` instances + per-interface binding ARE supported. |
+| `/vxlan-vnis/l2vni-route-target` | Unsupported | EVPN per-VNI RD/RT lives under `protocols bgp … address-family l2vpn-evpn` (Tier-3, dropped); the L2 VLAN↔VNI binding is supported but the control-plane RD/RT is not auto-translated. |
+| `/routing-instances/instance/l3-vni` | Unsupported | Symmetric-IRB L3VNI (a VNI bound to a VRF for inter-subnet routing) is out of scope for the Phase-5 per-netdev L2-VNI model. |
+| `/routing-protocols/bgp` | Unsupported | `protocols bgp` is Tier-3 — captured for the dropped-Tier-3 banner, never auto-rendered cross-vendor. |
+| `/routing-protocols/ospf` | Unsupported | Tier-3. |
+| `/nat` | Unsupported | `nat source` / `nat destination` is Tier-3 — too platform-specific to auto-translate. |
+| `/firewall` | Unsupported | `firewall` rule-sets are Tier-3 — auto-translating risks subtly-permissive rules. |
+| `/access-list/extended` | Unsupported | VyOS `policy` route-maps / prefix-lists are Tier-3. |
+
 ### B. Tier-3 sections detected banner
 
 When a source codec parses a config that contains stanzas it

--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -47,6 +47,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from pydantic import SecretStr
 
 # ``get_collector`` is imported here — and only here — to preserve the
 # documented mock-point ``netcanon.api.routes.backups.get_collector``.
@@ -57,7 +58,7 @@ from ...config import MAX_BACKUP_CONCURRENCY
 from ...definitions.loader import DefinitionLoader
 from ...definitions.schema import DeviceDefinition
 from ...models.backup import BackupJob, JobStatus
-from ...models.device import BackupRequest
+from ...models.device import BackupRequest, DeviceCredentials, DeviceTarget
 from ...models.device_profile import DeviceProfile
 from ...services.backup_runner import run_backup_job
 from ...storage.base import BaseConfigStore
@@ -76,6 +77,64 @@ from ..deps import (
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/backups", tags=["backups"])
+
+
+def _resolve_credentials(
+    devices: list[DeviceTarget],
+    device_profiles: dict[str, DeviceProfile],
+) -> list[DeviceTarget]:
+    """Fill missing per-device credentials from the linked profile, server-side.
+
+    A device may omit inline ``credentials`` when it carries a
+    ``device_profile_id`` that resolves to a stored profile — the credentials
+    are then read from that profile (decrypted in memory, never sent to or
+    received from the client).  This mirrors the scheduled-trigger path in
+    :mod:`netcanon.api.routes.schedules` and lets the web "run backup now"
+    flows operate without the plaintext password ever crossing the API
+    boundary.  Inline credentials, when present, win (ad-hoc backup or an
+    explicit per-run override).
+
+    Args:
+        devices: The request's device targets (credentials may be ``None``).
+        device_profiles: In-memory profile registry (``app.state``).
+
+    Returns:
+        A new list of ``DeviceTarget`` with ``credentials`` populated.
+
+    Raises:
+        HTTPException 422: A device has neither inline credentials nor a
+            resolvable ``device_profile_id``.
+    """
+    resolved: list[DeviceTarget] = []
+    for idx, device in enumerate(devices):
+        if device.credentials is not None:
+            resolved.append(device)
+            continue
+        profile = (
+            device_profiles.get(device.device_profile_id)
+            if device.device_profile_id
+            else None
+        )
+        if profile is None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"devices[{idx}] (host={device.host!r}): no credentials "
+                    "supplied and no resolvable device_profile_id. Provide "
+                    "credentials inline or reference an existing device profile."
+                ),
+            )
+        creds = DeviceCredentials(
+            username=profile.username,
+            password=SecretStr(profile.password),
+            enable_password=(
+                SecretStr(profile.enable_password)
+                if profile.enable_password
+                else None
+            ),
+        )
+        resolved.append(device.model_copy(update={"credentials": creds}))
+    return resolved
 
 
 @router.post(
@@ -127,11 +186,19 @@ def create_backup(
             ),
         )
 
+    # Resolve any omitted credentials from the linked device profile,
+    # server-side — so callers (notably the web "run backup now" flows)
+    # never have to fetch or relay the plaintext password.  Raises 422 for
+    # any device with neither inline credentials nor a resolvable profile.
+    resolved_request = BackupRequest(
+        devices=_resolve_credentials(request_body.devices, device_profiles)
+    )
+
     job = BackupJob(
         id=str(uuid.uuid4()),
         status=JobStatus.pending,
         created_at=datetime.now(timezone.utc),
-        total_devices=len(request_body.devices),
+        total_devices=len(resolved_request.devices),
     )
     jobs[job.id] = job
     max_workers = getattr(
@@ -140,7 +207,7 @@ def create_backup(
     background_tasks.add_task(
         run_backup_job,
         job,
-        request_body,
+        resolved_request,
         definitions,
         storage,
         job_store,

--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -12,7 +12,12 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from ...models.device_profile import DeviceProfile, DeviceProfileCreate, DeviceProfileUpdate
+from ...models.device_profile import (
+    DeviceProfile,
+    DeviceProfileCreate,
+    DeviceProfilePublic,
+    DeviceProfileUpdate,
+)
 from ...storage.device_profile_store import FileDeviceProfileStore
 from ..deps import get_device_profile_store, get_device_profiles
 
@@ -22,19 +27,23 @@ router = APIRouter(prefix="/devices", tags=["device-profiles"])
 
 @router.get(
     "/",
-    response_model=list[DeviceProfile],
+    response_model=list[DeviceProfilePublic],
     summary="List all device profiles",
 )
 def list_device_profiles(
     device_profiles: dict[str, DeviceProfile] = Depends(get_device_profiles),
 ) -> list[DeviceProfile]:
-    """Return all device profiles sorted newest-first."""
+    """Return all device profiles sorted newest-first.
+
+    Credentials are stripped by the ``DeviceProfilePublic`` response model —
+    they are never serialised over the API.
+    """
     return sorted(device_profiles.values(), key=lambda p: p.created_at, reverse=True)
 
 
 @router.get(
     "/{profile_id}",
-    response_model=DeviceProfile,
+    response_model=DeviceProfilePublic,
     summary="Get a device profile by ID",
 )
 def get_device_profile(
@@ -59,7 +68,7 @@ def get_device_profile(
 @router.post(
     "/",
     status_code=201,
-    response_model=DeviceProfile,
+    response_model=DeviceProfilePublic,
     summary="Create a device profile",
 )
 def create_device_profile(
@@ -91,7 +100,7 @@ def create_device_profile(
 
 @router.put(
     "/{profile_id}",
-    response_model=DeviceProfile,
+    response_model=DeviceProfilePublic,
     summary="Update a device profile",
 )
 def update_device_profile(

--- a/netcanon/models/device.py
+++ b/netcanon/models/device.py
@@ -37,9 +37,15 @@ class DeviceTarget(BaseModel):
             definition (e.g. ``"Cisco"``, ``"Fortigate"``).
         host: Hostname or IP address (IPv4, IPv6, or RFC-1123 hostname).
         port: SSH port number.  Defaults to 22.
-        credentials: Login credentials.
+        credentials: Login credentials.  Optional: omit them when
+            ``device_profile_id`` references a stored profile, in which
+            case the backup endpoint resolves credentials server-side from
+            that profile (so the plaintext password never has to be sent
+            from the browser).  When supplied inline, they win — used for
+            ad-hoc backups or to override a profile's stored credentials.
         device_profile_id: UUID of the linked DeviceProfile, or None for
-            ad-hoc backups.
+            ad-hoc backups.  When set and ``credentials`` is omitted, the
+            endpoint fills credentials from this profile.
         os_version: Optional pin for version-specific definition
             overlay selection (e.g. ``"17.12"``).  When set, the
             backup pipeline resolves the matching overlay via
@@ -54,7 +60,7 @@ class DeviceTarget(BaseModel):
     type_key: str = Field(..., description="Must match a loaded definition type_key")
     host: str
     port: int = Field(22, ge=1, le=65535)
-    credentials: DeviceCredentials
+    credentials: DeviceCredentials | None = None
     device_profile_id: str | None = None
     os_version: str | None = None
     model: str | None = None

--- a/netcanon/models/device_profile.py
+++ b/netcanon/models/device_profile.py
@@ -70,6 +70,40 @@ class DeviceProfile(BaseModel):
         return _validate_host(v)
 
 
+class DeviceProfilePublic(BaseModel):
+    """Read-side view of a :class:`DeviceProfile` with credentials removed.
+
+    Used as the ``response_model`` for every device-profile API route so
+    ``password`` / ``enable_password`` — decrypted in memory for backup
+    use — are never serialised back to a client.  Credentials are
+    *write-only* over the API: supplied in create / update request bodies,
+    never echoed in any response.
+
+    The web "run backup now" flows no longer need credentials returned: the
+    backup endpoint resolves them server-side from the stored profile (see
+    :func:`netcanon.api.routes.backups._resolve_credentials`), so the
+    plaintext password never crosses the API boundary at all.
+
+    This model lists every non-credential ``DeviceProfile`` field; a guard
+    test (``tests/unit/test_device_profile_public.py``) asserts the field
+    set is exactly ``DeviceProfile``'s minus ``{password, enable_password}``
+    so a future field added to ``DeviceProfile`` cannot silently fail to
+    surface in the read API.
+    """
+
+    id: str
+    name: str
+    type_key: str
+    host: str
+    port: int
+    username: str
+    notes: str | None = None
+    os_version: str | None = None
+    model: str | None = None
+    detected_facts: dict[str, str] | None = None
+    created_at: datetime
+
+
 class DeviceProfileCreate(BaseModel):
     """Request body for ``POST /api/v1/devices/``.
 

--- a/netcanon/templates/devices.html
+++ b/netcanon/templates/devices.html
@@ -117,7 +117,9 @@
   {% for profile in device_profiles %}
   <div class="device-card" data-testid="device-card"
        data-device-id="{{ profile.id }}"
-       data-profile="{{ profiles_safe[profile.id] | tojson }}">
+       data-type-key="{{ profile.type_key }}"
+       data-host="{{ profile.host }}"
+       data-port="{{ profile.port }}">
 
     <div class="device-card-header" data-testid="device-card-header"
          onclick="toggleDevice(this)">
@@ -404,20 +406,14 @@ deviceForm.addEventListener('submit', async function(e) {
 
 /* ── Run backup now for a single profile ── */
 async function runDeviceBackup(profileId) {
-  /* Fetch the full profile (including credentials) from the API rather than
-     reading from a DOM attribute, so passwords are never embedded in the page. */
-  var fullProfile;
-  try {
-    var pr = await fetch('/api/v1/devices/' + encodeURIComponent(profileId));
-    if (!pr.ok) { showToast('Could not load device credentials.', 'error'); return; }
-    fullProfile = await pr.json();
-  } catch (e) {
-    showToast('Network error: ' + e.message, 'error');
-    return;
-  }
-
-  var credentials = { username: fullProfile.username, password: fullProfile.password };
-  if (fullProfile.enable_password) credentials.enable_password = fullProfile.enable_password;
+  /* Send only the profile id plus the non-secret connection fields (read
+     from the card's credential-free data-* attributes).  The backup
+     endpoint resolves the password server-side from the stored profile,
+     so the plaintext credential never reaches the browser. */
+  var card = document.querySelector(
+    '.device-card[data-device-id="' + profileId + '"]'
+  );
+  if (!card) { showToast('Could not find this device.', 'error'); return; }
 
   try {
     var res = await fetch('/api/v1/backups', {
@@ -425,11 +421,10 @@ async function runDeviceBackup(profileId) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         devices: [{
-          type_key: fullProfile.type_key,
-          host:     fullProfile.host,
-          port:     fullProfile.port,
-          credentials: credentials,
-          device_profile_id: fullProfile.id,
+          type_key: card.dataset.typeKey,
+          host:     card.dataset.host,
+          port:     parseInt(card.dataset.port, 10) || 22,
+          device_profile_id: profileId,
         }],
       }),
     });

--- a/netcanon/templates/index.html
+++ b/netcanon/templates/index.html
@@ -172,31 +172,39 @@ function initRow(row) {
        updateRemoveButtons();
      });
   var profileSel = row.querySelector('[name="device_profile_id"]');
+  var pwInput = row.querySelector('[name="password"]');
+  /* Password is required only when entering a brand-new device; when an
+     existing profile is selected the server resolves credentials from it. */
+  if (pwInput) pwInput.required = !(profileSel && profileSel.value);
   if (profileSel) {
-    profileSel.addEventListener('change', async function() {
+    profileSel.addEventListener('change', function() {
       var opt = profileSel.options[profileSel.selectedIndex];
+      var ep = row.querySelector('[name="enable_password"]');
       if (opt.value) {
-        row.querySelector('[name="type_key"]').value   = opt.dataset.typeKey || '';
-        row.querySelector('[name="host"]').value       = opt.dataset.host || '';
-        row.querySelector('[name="port"]').value       = opt.dataset.port || '22';
-        row.querySelector('[name="username"]').value   = opt.dataset.username || '';
-        /* Clear credential fields while we fetch — never read from DOM */
-        row.querySelector('[name="password"]').value   = '';
-        var ep = row.querySelector('[name="enable_password"]');
+        /* Existing profile: prefill the non-secret connection fields from
+           the option's data-* attributes.  Credentials are NOT fetched —
+           the backup endpoint resolves them server-side, so the plaintext
+           password never reaches the browser. */
+        row.querySelector('[name="type_key"]').value = opt.dataset.typeKey || '';
+        row.querySelector('[name="host"]').value     = opt.dataset.host || '';
+        row.querySelector('[name="port"]').value     = opt.dataset.port || '22';
+        row.querySelector('[name="username"]').value = opt.dataset.username || '';
+        if (pwInput) {
+          pwInput.value = '';
+          pwInput.required = false;
+          pwInput.placeholder = 'using stored credentials — leave blank';
+        }
         if (ep) ep.value = '';
-        try {
-          var r = await fetch('/api/v1/devices/' + encodeURIComponent(opt.value));
-          if (r.ok) {
-            var p = await r.json();
-            row.querySelector('[name="password"]').value = p.password || '';
-            if (ep) ep.value = p.enable_password || '';
-          }
-        } catch (_) { /* non-fatal: user can type credentials manually */ }
         var ng = row.querySelector('.profile-name-group');
         if (ng) ng.style.display = 'none';
       } else {
-        var ng = row.querySelector('.profile-name-group');
-        if (ng) ng.style.display = '';
+        /* New device: the operator must type credentials. */
+        if (pwInput) {
+          pwInput.required = true;
+          pwInput.placeholder = '';
+        }
+        var ng2 = row.querySelector('.profile-name-group');
+        if (ng2) ng2.style.display = '';
       }
       updateEnableGroup(row);
     });
@@ -277,16 +285,24 @@ form.addEventListener('submit', async function(e) {
       }
     }
 
+    var pwVal = g('password');
     var deviceObj = {
       type_key: g('type_key'),
       host:     g('host'),
       port:     parseInt(g('port'), 10) || 22,
-      credentials: Object.assign(
-        { username: g('username'), password: g('password') },
-        ep ? { enable_password: ep } : {}
-      ),
     };
-    if (deviceProfileId) deviceObj.device_profile_id = deviceProfileId;
+    if (deviceProfileId && !pwVal) {
+      /* Existing profile, no typed override → let the server resolve
+         credentials from the stored profile; nothing secret is sent. */
+      deviceObj.device_profile_id = deviceProfileId;
+    } else {
+      /* New device, or an explicit per-run password override. */
+      deviceObj.credentials = Object.assign(
+        { username: g('username'), password: pwVal },
+        ep ? { enable_password: ep } : {}
+      );
+      if (deviceProfileId) deviceObj.device_profile_id = deviceProfileId;
+    }
     devices.push(deviceObj);
   }
 

--- a/tests/integration/test_backups_api.py
+++ b/tests/integration/test_backups_api.py
@@ -553,3 +553,106 @@ class TestGetJob:
         job_id = _post_backup(client).json()["id"]
         resp = client.get(f"/api/v1/backups/{job_id}")
         assert len(resp.json()["results"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Server-side credential resolution (2026-06 review finding #1)
+# ---------------------------------------------------------------------------
+
+
+class _CredCapturingCollector:
+    """Collector that records the resolved credentials it was handed."""
+
+    def __init__(self) -> None:
+        self.seen: list[tuple[str, str, str | None]] = []
+
+    def collect(self, device, definition):  # noqa: ARG002
+        c = device.credentials
+        self.seen.append(
+            (
+                c.username,
+                c.password.get_secret_value(),
+                c.enable_password.get_secret_value()
+                if c.enable_password
+                else None,
+            )
+        )
+        return "! config for " + device.host
+
+
+class TestServerSideCredentialResolution:
+    """A backup may omit inline credentials and reference a stored profile;
+    the endpoint resolves the password server-side so the plaintext value
+    never has to be sent from (or returned to) the client."""
+
+    def test_profile_backup_resolves_credentials_server_side(self, test_app):
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        collector = _CredCapturingCollector()
+        with patch(
+            "netcanon.api.routes.backups.get_collector",
+            return_value=collector,
+        ):
+            with TestClient(test_app, raise_server_exceptions=True) as c:
+                profile = c.post(
+                    "/api/v1/devices/",
+                    json={
+                        "name": "Core",
+                        "type_key": "Cisco",
+                        "host": "10.9.9.9",
+                        "username": "netops",
+                        "password": "s3cr3t",
+                        "enable_password": "en4ble",
+                    },
+                ).json()
+                # No inline credentials — only the profile reference.
+                resp = c.post(
+                    "/api/v1/backups",
+                    json={
+                        "devices": [
+                            {
+                                "type_key": "Cisco",
+                                "host": "10.9.9.9",
+                                "port": 22,
+                                "device_profile_id": profile["id"],
+                            }
+                        ]
+                    },
+                )
+                assert resp.status_code == 202
+
+        # The collector was handed the profile's stored credentials,
+        # resolved entirely server-side.
+        assert collector.seen == [("netops", "s3cr3t", "en4ble")]
+
+    def test_no_credentials_and_no_profile_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/backups",
+            json={
+                "devices": [{"type_key": "Cisco", "host": "10.0.0.1", "port": 22}]
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_unknown_profile_id_without_credentials_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/backups",
+            json={
+                "devices": [
+                    {
+                        "type_key": "Cisco",
+                        "host": "10.0.0.1",
+                        "port": 22,
+                        "device_profile_id": "does-not-exist",
+                    }
+                ]
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_inline_credentials_still_accepted(self, client):
+        """The ad-hoc path (inline credentials, no profile) is unchanged."""
+        job = _post_and_get(client)
+        assert job["status"] == "completed"

--- a/tests/integration/test_device_profiles_api.py
+++ b/tests/integration/test_device_profiles_api.py
@@ -133,3 +133,55 @@ class TestGetReturnsAllFields:
         assert body["model"] == "C9300-48P"
         # detected_facts starts null (probe hasn't run yet in P1C2).
         assert body["detected_facts"] is None
+
+
+class TestCredentialsNeverSerialised:
+    """Credentials are write-only over the API (2026-06 review finding #1).
+
+    ``password`` / ``enable_password`` are accepted in create / update
+    request bodies but must never appear in *any* response — the
+    ``DeviceProfilePublic`` response model strips them so the decrypted
+    value never crosses the API boundary."""
+
+    _CRED_KEYS = ("password", "enable_password")
+
+    def test_create_response_omits_credentials(self, client):
+        body = client.post(
+            "/api/v1/devices/",
+            json=_create_body(enable_password="enable-secret"),
+        ).json()
+        for key in self._CRED_KEYS:
+            assert key not in body, f"POST response leaked {key!r}"
+        # Non-secret fields are still present.
+        assert body["username"] == "admin"
+        assert body["host"] == "10.0.0.1"
+
+    def test_get_response_omits_credentials(self, client):
+        profile_id = client.post(
+            "/api/v1/devices/", json=_create_body(enable_password="enable-secret")
+        ).json()["id"]
+        body = client.get(f"/api/v1/devices/{profile_id}").json()
+        for key in self._CRED_KEYS:
+            assert key not in body, f"GET response leaked {key!r}"
+
+    def test_list_response_omits_credentials(self, client):
+        client.post("/api/v1/devices/", json=_create_body(host="10.0.0.1"))
+        client.post("/api/v1/devices/", json=_create_body(host="10.0.0.2"))
+        items = client.get("/api/v1/devices/").json()
+        assert len(items) >= 2
+        for item in items:
+            for key in self._CRED_KEYS:
+                assert key not in item, f"LIST response leaked {key!r}"
+
+    def test_update_response_omits_credentials(self, client):
+        profile_id = client.post(
+            "/api/v1/devices/", json=_create_body()
+        ).json()["id"]
+        # Change the password via PUT; the response must still not echo it.
+        body = client.put(
+            f"/api/v1/devices/{profile_id}",
+            json={"password": "rotated-secret", "notes": "rotated"},
+        ).json()
+        for key in self._CRED_KEYS:
+            assert key not in body, f"PUT response leaked {key!r}"
+        assert body["notes"] == "rotated"

--- a/tests/unit/test_device_profile_public.py
+++ b/tests/unit/test_device_profile_public.py
@@ -1,0 +1,57 @@
+"""Guard: ``DeviceProfilePublic`` is the read-side view of ``DeviceProfile``
+with exactly the two credential fields removed.
+
+The device-profile API serialises every response through
+``DeviceProfilePublic`` so decrypted credentials never cross the API
+boundary (2026-06 review finding #1).  Because ``DeviceProfilePublic`` lists
+its fields explicitly (rather than deriving them), a field added to
+``DeviceProfile`` later could silently fail to appear in the read API.  This
+two-sided invariant catches that drift in both directions:
+
+  * a new non-credential ``DeviceProfile`` field that wasn't mirrored, and
+  * a credential field that leaked back into the public model.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.models.device_profile import DeviceProfile, DeviceProfilePublic
+
+pytestmark = pytest.mark.unit
+
+# The two write-only credential fields that must never be serialised.
+_CRED_FIELDS = {"password", "enable_password"}
+
+
+def test_public_model_is_full_model_minus_credentials() -> None:
+    full = set(DeviceProfile.model_fields)
+    public = set(DeviceProfilePublic.model_fields)
+    assert public == full - _CRED_FIELDS, (
+        "DeviceProfilePublic field set drifted from DeviceProfile minus "
+        f"credentials. Missing: {(full - _CRED_FIELDS) - public}; "
+        f"unexpected: {public - (full - _CRED_FIELDS)}"
+    )
+
+
+def test_public_model_omits_both_credential_fields() -> None:
+    assert _CRED_FIELDS.isdisjoint(DeviceProfilePublic.model_fields)
+
+
+def test_public_model_dump_has_no_credentials() -> None:
+    """Even constructed from a full profile, the serialised dict is clean."""
+    profile = DeviceProfile(
+        name="r1",
+        type_key="Cisco",
+        host="10.0.0.1",
+        username="admin",
+        password="hunter2",
+        enable_password="enable-secret",
+    )
+    public = DeviceProfilePublic.model_validate(profile.model_dump())
+    dumped = public.model_dump()
+    assert "password" not in dumped
+    assert "enable_password" not in dumped
+    # Non-secret fields still round-trip.
+    assert dumped["host"] == "10.0.0.1"
+    assert dumped["username"] == "admin"


### PR DESCRIPTION
## Summary

Closes the top finding of the 2026-06-14 multi-lens codebase review: the
device-profile REST routes returned the **Fernet-decrypted** `password` /
`enable_password` in their responses, defeating credential-at-rest encryption.

The naive fix (scrub the responses) would have broken both web "Run backup
now" flows, which fetched `GET /api/v1/devices/{id}` purely to relay the
plaintext password into a backup POST. So this PR closes the leak **completely**
by moving credential resolution server-side — credentials no longer cross the
API boundary at all for profile-based backups (mirroring the existing
scheduled-trigger path in `schedules.py`).

## What changed

**Credential scrub**
- New `DeviceProfilePublic` response model (omits `password` / `enable_password`),
  set on `GET` / `LIST` / `POST` / `PUT /api/v1/devices`. Credentials are now
  **write-only**: accepted in request bodies, never echoed.

**Server-side resolution**
- `POST /api/v1/backups` resolves a device's credentials from its
  `device_profile_id` when none are supplied inline. `DeviceTarget.credentials`
  is now optional; a device with neither inline credentials nor a resolvable
  profile → **HTTP 422**. Inline credentials still work (ad-hoc / override).

**Frontends**
- `devices.html` `runDeviceBackup` and `index.html` (profile-select + submit)
  no longer GET-prefetch credentials — they send `device_profile_id` and let
  the server resolve. The dashboard password field is no longer `required` when
  a profile is selected.
- Replaced the broken JSON-in-attribute `data-profile` blob (Jinja `tojson`
  doesn't escape `"`, so the double-quoted attribute truncated to `{`) with
  individual server-escaped `data-type-key` / `data-host` / `data-port` attrs.

**Docs (same review)**
- `CAPABILITIES.md` §A gains the four missing per-codec panels (`cisco_nxos`,
  `cisco_iosxr`, `aruba_aoscx`, `vyos`), generated from each `CapabilityMatrix`.

## Tests
- `tests/unit/test_device_profile_public.py` — two-sided field-parity guard
  (`DeviceProfilePublic` == `DeviceProfile` minus the two credential fields).
- Response-scrub assertions on all four device routes.
- Server-side-resolution (capturing collector sees the profile's stored creds)
  + 422 (no creds, no profile) backup tests.

## Verification
- Full `tests/unit tests/integration` gate green (**4509 passed, 82 skipped**).
- Live browser-preview checks: API LIST+GET omit credentials; dashboard
  profile-select leaves password blank + non-required; `/devices` Run-backup
  builds a creds-free body with `device_profile_id`; live 422 with the exact
  detail message (no job created, no device contacted).

No canonical-surface change → cross-mesh artifact unaffected (no regen needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
