### PR TITLE
docs(review): reconcile vendor breadth (7->12) + decouple certified from deploy-ready

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,11 +232,18 @@ devices via this layer; for now the flow is file → codec → file.
 Every codec declares `certainty` — a promise about how battle-tested
 it is:
 
-| Level | Criterion | Deploy-ready? |
+| Level | Criterion | UI signal |
 |---|---|---|
-| `experimental` | Synthetic fixtures only | No — UI shows red banner |
-| `best_effort` | ≥1 real fixture round-trips clean | Staging only — UI shows yellow banner |
-| `certified` | ≥3 real captures from ≥2 OS versions, all round-trip stable | Yes — UI shows green chip |
+| `experimental` | Synthetic fixtures only | Red banner |
+| `best_effort` | ≥1 real fixture round-trips clean | Yellow banner |
+| `certified` | ≥3 real captures from ≥2 OS versions, all round-trip stable | Green chip |
+
+**Certainty rates round-trip fidelity, not deploy automation.**  A
+`certified` chip means the translation is trustworthy enough to hand to
+an operator — *not* that Netcanon will push it to a device.  There is no
+deploy path today; rendered output is for manual review and apply (the
+deploy endpoints remain on the roadmap — see
+[`netcanon/api/routes/migration.py`](netcanon/api/routes/migration.py)).
 
 The bar is intentionally strict.  Per-codec status is tracked in
 [`tests/fixtures/real/RESULTS.md`](tests/fixtures/real/RESULTS.md) —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ timestamp if your timezone matters for an audit.
   `aruba_aoscx`, `vyos`), generated from each codec's `CapabilityMatrix`, so
   §A now enumerates every codec's declared exceptions rather than only the
   original eight (also flagged by the 2026-06-14 review).
+* **Front-door honesty pass — vendor breadth + "certified" semantics (review
+  findings #14, #15).**  README / `docs/COMPARISON.md` / `docs/IDENTITY.md`
+  now describe the shipped breadth (twelve codecs across Cisco / Juniper /
+  Arista / Aruba / Fortinet / MikroTik / OPNsense / VyOS) instead of the stale
+  seven-vendor list, and `vyos` is added to the `pyproject.toml` keywords +
+  IDENTITY GitHub-topics so the new VyOS family is discoverable on PyPI /
+  GitHub.  The Tier-1 "every shipped codec renders these fully" line now
+  excepts the interfaces-only `cisco_iosxe` NETCONF stub.  `ARCHITECTURE.md`,
+  `docs/CAPABILITIES.md`, and `translator-plans.txt` decouple `certified`
+  (round-trip fidelity) from "deploy-ready": there is no deploy path today —
+  rendered output is for manual review/apply.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 **Multi-vendor network config translator with a verifiable cross-vendor audit.**
 
-Translates running-config between Cisco IOS-XE, Juniper Junos, Aruba
-AOS-S, Arista EOS, Fortinet FortiGate, MikroTik RouterOS, and OPNsense.
+Translates running-config across twelve codecs spanning Cisco (IOS-XE,
+NX-OS, IOS-XR), Juniper Junos, Arista EOS, Aruba (AOS-S, AOS-CX),
+Fortinet FortiGate, MikroTik RouterOS, OPNsense, and VyOS — see
+[`docs/CAPABILITIES.md`](docs/CAPABILITIES.md) for the full per-codec list.
 You point Netcanon at a config from one vendor and it renders the
 equivalent config for another — through a shared canonical model, with
 every translatable field declared as supported, lossy, or unsupported.
@@ -193,7 +195,9 @@ across vendors.  Full per-codec matrix is in
 * **Tier 1 — auto-translatable.**  hostname, interfaces (name /
   description / enabled state / IPv4 + IPv6 addresses / per-interface
   VRF binding), VLANs, static routes, DNS / NTP / syslog servers,
-  timezone.  Every shipped codec parses + renders these fully.
+  timezone.  Every shipped codec parses + renders these fully (the
+  experimental `cisco_iosxe` NETCONF stub excepted — it renders
+  interfaces only).
 * **Tier 2 — translatable with caveats.**  SNMP (incl. SNMPv3 USM),
   LAGs, local users, RADIUS, DHCP server pools, VXLAN VNIs, EVPN
   type-5 routes, routing instances / VRFs, Junos `apply-groups`.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -45,6 +45,11 @@ authoring guide and the live `/definitions` page in the running app
 for the per-vendor inventory.  RESULTS.md is the source of truth for
 current certification — this table summarises but does not gate.
 
+> **Certified ≠ deploy-ready.**  The `certainty` label rates *round-trip
+> fidelity* (how reliably a config survives parse → render), not deploy
+> automation.  Netcanon has no deploy path today — rendered output is for
+> manual review and apply; the deploy endpoints remain on the roadmap.
+
 ---
 
 ## Translation tiers

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -31,7 +31,7 @@ per-field capability declarations.
 
 | Tool | Scope | Direction | Multi-vendor? | Translation accuracy posture |
 |---|---|---|---|---|
-| **Netcanon** | Multi-vendor native running-config translation | Parse + Render bidirectional | ✅ Cisco / Juniper / Fortinet / Aruba / Arista / MikroTik / OPNsense | Per-field capability matrix (supported / lossy / unsupported with cited reasons); cross-mesh audit harness; explicit Tier-3 boundary; matrix-honesty discipline |
+| **Netcanon** | Multi-vendor native running-config translation | Parse + Render bidirectional | ✅ Cisco / Juniper / Fortinet / Aruba / Arista / MikroTik / OPNsense / VyOS | Per-field capability matrix (supported / lossy / unsupported with cited reasons); cross-mesh audit harness; explicit Tier-3 boundary; matrix-honesty discipline |
 | [**Batfish**](https://github.com/batfish/batfish) | Network config analysis + routing simulation | Parse only | ✅ Many | Models behaviour; doesn't translate to other formats |
 | [**Capirca**](https://github.com/google/capirca) / [**Aerleon**](https://github.com/aerleon/aerleon) | Firewall ACL DSL → vendor-native syntax | Render only (DSL → multiple vendors) | ✅ Firewall scope | DSL is the source of truth; not a translator between native vendor formats |
 | [**NAPALM**](https://github.com/napalm-automation/napalm) | Get / set running-config; vendor-agnostic device interactions | Wraps device drivers | ✅ | Each device sees its native syntax; no translation |

--- a/docs/IDENTITY.md
+++ b/docs/IDENTITY.md
@@ -31,7 +31,7 @@ surface.
 ## GitHub repo description (extended)
 
 ```
-Multi-vendor network config translator — Cisco / Juniper / Fortinet / Aruba / Arista / MikroTik / OPNsense. Cross-mesh audit catches silent translation errors before they ship.
+Multi-vendor network config translator — Cisco / Juniper / Fortinet / Aruba / Arista / MikroTik / OPNsense / VyOS. Cross-mesh audit catches silent translation errors before they ship.
 ```
 
 (Fits comfortably under GitHub's 350-char limit.  Names the vendor
@@ -56,6 +56,7 @@ aruba
 arista
 mikrotik
 opnsense
+vyos
 vendor-translation
 config-migration
 python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ keywords = [
     "mikrotik",
     "opnsense",
     "arista",
+    "vyos",
     "vendor-translation",
     "config-migration",
     "python",

--- a/translator-plans.txt
+++ b/translator-plans.txt
@@ -125,7 +125,9 @@ LAYER 4 — TRANSPORT
 --- CERTAINTY MODEL (per-codec) ---
 
   certified      — round-trip invariant tested against ≥3 real device
-                   captures from ≥2 OS versions.  Deploy-ready.
+                   captures from ≥2 OS versions.  Round-trip-validated;
+                   output is for manual review/apply (no deploy path
+                   ships today — Phase 2+ roadmap).
   best_effort    — round-trip invariant tested against synthetic
                    samples only.  Expected to work; needs human review.
   experimental   — parse-only, or incomplete render.  Output is a


### PR DESCRIPTION
## Summary

Front-door honesty remediation for the 2026-06-14 multi-lens review findings
**#14** ("certified" ≠ deploy-ready) and **#15** (7-vendor under-claim). Pure
docs/metadata — no code or test changes.

## #15 — vendor breadth (the product under-claimed its differentiator)
README / `docs/COMPARISON.md` / `docs/IDENTITY.md` described a **7-vendor**
product while **12 codecs** ship, and VyOS — a genuinely new family — had zero
PyPI/GitHub discoverability.

- Refreshed to count-resilient phrasing naming all families: Cisco (IOS-XE,
  NX-OS, IOS-XR) / Juniper / Arista / Aruba (AOS-S, AOS-CX) / Fortinet /
  MikroTik / OPNsense / **VyOS**, pointing at `CAPABILITIES.md` for the full list.
- Added `vyos` to `pyproject.toml` keywords + the IDENTITY GitHub-topics list
  (the IDENTITY rule "when a new vendor codec ships, add its topic here AND in
  pyproject" had been missed at v0.1.7).
- Excepted the interfaces-only `cisco_iosxe` NETCONF stub from the Tier-1
  "every shipped codec renders these fully" line.

## #14 — "certified" ≠ "deploy-ready"
`ARCHITECTURE.md`'s certainty table literally read **"Deploy-ready? → Yes"**
for `certified`, but no deploy path ships (`migration.py` says deploy endpoints
remain on the roadmap). Decoupled the label across `ARCHITECTURE.md`,
`docs/CAPABILITIES.md`, and `translator-plans.txt`: `certified` rates
*round-trip fidelity*; rendered output is for manual review/apply.

## Verification
No code/test surface touched; `pyproject.toml` re-parses and carries the new
keyword. Verified no test asserts the changed doc strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
