### PR TITLE
fix: lock-guard the shared device_profiles registry across threads (review #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ timestamp if your timezone matters for an audit.
   underlying case-mismatch duplicate-LAG round-trip defect is tracked
   separately.)
 
+* **Shared device-profile registry is now lock-guarded across threads (review
+  finding #10).**  The backup worker thread persists a profile's
+  `detected_facts` while route handlers (which FastAPI runs in a threadpool for
+  sync endpoints) create / update / delete the same dict + on-disk files.  A
+  new `DEVICE_PROFILE_REGISTRY_LOCK` (in `storage/device_profile_store.py`)
+  serialises every read-modify-write-persist + delete critical section, and the
+  worker re-checks membership inside the lock before saving — so a
+  delete-then-save interleaving can no longer resurrect a just-deleted profile
+  to disk, and concurrent `detected_facts` updates can't be lost.
+
 ### Changed
 
 * **Documentation honesty pass (multi-lens review remediation).**  The README

--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -18,7 +18,10 @@ from ...models.device_profile import (
     DeviceProfilePublic,
     DeviceProfileUpdate,
 )
-from ...storage.device_profile_store import FileDeviceProfileStore
+from ...storage.device_profile_store import (
+    DEVICE_PROFILE_REGISTRY_LOCK,
+    FileDeviceProfileStore,
+)
 from ..deps import get_device_profile_store, get_device_profiles
 
 logger = logging.getLogger(__name__)
@@ -90,8 +93,11 @@ def create_device_profile(
             detail="Maximum device profile limit reached (1000). Delete unused profiles first.",
         )
     profile = DeviceProfile(**body.model_dump())
-    device_profiles[profile.id] = profile
-    device_profile_store.save(profile)
+    # Serialise dict-mutate + persist against the backup worker thread and
+    # the other route mutators (review finding #10).
+    with DEVICE_PROFILE_REGISTRY_LOCK:
+        device_profiles[profile.id] = profile
+        device_profile_store.save(profile)
     logger.info(
         "Created device profile '%s' (id=%s)", profile.name, profile.id[:8]
     )
@@ -124,15 +130,18 @@ def update_device_profile(
     Raises:
         HTTPException 404: If no profile with *profile_id* exists.
     """
-    if profile_id not in device_profiles:
-        raise HTTPException(
-            status_code=404, detail=f"Device profile not found: {profile_id!r}"
-        )
-    profile = device_profiles[profile_id]
-    updates = {k: v for k, v in body.model_dump().items() if v is not None}
-    updated_profile = profile.model_copy(update=updates)
-    device_profiles[profile_id] = updated_profile
-    device_profile_store.save(updated_profile)
+    # Hold the lock across the existence check + mutate + persist so a
+    # concurrent delete can't slip between them (review finding #10).
+    with DEVICE_PROFILE_REGISTRY_LOCK:
+        if profile_id not in device_profiles:
+            raise HTTPException(
+                status_code=404, detail=f"Device profile not found: {profile_id!r}"
+            )
+        profile = device_profiles[profile_id]
+        updates = {k: v for k, v in body.model_dump().items() if v is not None}
+        updated_profile = profile.model_copy(update=updates)
+        device_profiles[profile_id] = updated_profile
+        device_profile_store.save(updated_profile)
     logger.info(
         "Updated device profile '%s' (id=%s)", updated_profile.name, profile_id[:8]
     )
@@ -160,22 +169,26 @@ def delete_device_profile(
     Raises:
         HTTPException 404: If no profile with *profile_id* exists.
     """
-    if profile_id not in device_profiles:
-        raise HTTPException(
-            status_code=404, detail=f"Device profile not found: {profile_id!r}"
-        )
-    # Warn if any schedules reference this profile.
-    referencing = [
-        s.name
-        for s in request.app.state.schedules.values()
-        if profile_id in s.target_device_ids
-    ]
-    if referencing:
-        logger.warning(
-            "Deleting profile %s which is referenced by schedules: %s",
-            profile_id[:8],
-            referencing,
-        )
-    del device_profiles[profile_id]
-    device_profile_store.delete(profile_id)
+    # Hold the lock across the existence check + delete + file removal so it
+    # can't interleave with the backup worker's detected_facts save and
+    # resurrect the profile on disk (review finding #10).
+    with DEVICE_PROFILE_REGISTRY_LOCK:
+        if profile_id not in device_profiles:
+            raise HTTPException(
+                status_code=404, detail=f"Device profile not found: {profile_id!r}"
+            )
+        # Warn if any schedules reference this profile.
+        referencing = [
+            s.name
+            for s in request.app.state.schedules.values()
+            if profile_id in s.target_device_ids
+        ]
+        if referencing:
+            logger.warning(
+                "Deleting profile %s which is referenced by schedules: %s",
+                profile_id[:8],
+                referencing,
+            )
+        del device_profiles[profile_id]
+        device_profile_store.delete(profile_id)
     logger.info("Deleted device profile %s", profile_id[:8])

--- a/netcanon/services/backup_runner.py
+++ b/netcanon/services/backup_runner.py
@@ -63,7 +63,10 @@ from ..models.backup import BackupJob, BackupResult, JobStatus
 from ..models.device import BackupRequest, DeviceTarget
 from ..models.device_profile import DeviceProfile
 from ..storage.base import BaseConfigStore
-from ..storage.device_profile_store import FileDeviceProfileStore
+from ..storage.device_profile_store import (
+    DEVICE_PROFILE_REGISTRY_LOCK,
+    FileDeviceProfileStore,
+)
 from ..storage.job_store import FileJobStore
 
 logger = logging.getLogger(__name__)
@@ -203,10 +206,15 @@ def _process_one_device(
         and device_profile_store is not None
     ):
         try:
-            profile = device_profiles.get(device.device_profile_id)
-            if profile is not None:
-                profile.detected_facts = detected_facts
-                device_profile_store.save(profile)
+            # Re-check membership and persist atomically: this worker thread
+            # races route handlers that may delete/update the same profile.
+            # The lock + in-loop re-fetch prevents a delete-then-save from
+            # resurrecting a just-deleted profile to disk (review finding #10).
+            with DEVICE_PROFILE_REGISTRY_LOCK:
+                profile = device_profiles.get(device.device_profile_id)
+                if profile is not None:
+                    profile.detected_facts = detected_facts
+                    device_profile_store.save(profile)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "Failed to persist detected_facts for profile %s: %s",

--- a/netcanon/storage/device_profile_store.py
+++ b/netcanon/storage/device_profile_store.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from pathlib import Path
 
 from ..models.device_profile import DeviceProfile
@@ -26,6 +27,22 @@ from ..security.credentials import encrypt
 from ..security.migration import migrate_credential_fields
 
 logger = logging.getLogger(__name__)
+
+#: Guards cross-thread access to the in-memory device-profile registry
+#: (``app.state.device_profiles``) **together with** its on-disk store.
+#: The backup worker thread mutates a profile's ``detected_facts`` and
+#: re-saves it (:func:`netcanon.services.backup_runner._process_one_device`)
+#: while route handlers create / update / delete the same dict + files —
+#: and FastAPI runs sync ``def`` endpoints in a threadpool, so these are
+#: genuinely different threads.  Without serialisation a delete-then-save
+#: interleaving can resurrect a just-deleted profile to disk, and
+#: concurrent ``detected_facts`` updates can be lost.  Hold this lock around
+#: every registry read-modify-write-persist (and delete) critical section.
+#: Process-wide by design: the registry is effectively process-global (one
+#: app per process), and the lock is only ever held for the brief
+#: dict-mutation + file-write — never across an ``await`` or an SSH call —
+#: so it cannot deadlock or serialise the backup hot path.
+DEVICE_PROFILE_REGISTRY_LOCK = threading.Lock()
 
 
 class FileDeviceProfileStore:

--- a/tests/unit/test_device_profiles_lock.py
+++ b/tests/unit/test_device_profiles_lock.py
@@ -1,0 +1,89 @@
+"""Concurrency guard for the shared device-profile registry (review #10).
+
+The backup worker thread mutates a profile's ``detected_facts`` and re-saves
+it while route handlers (run in FastAPI's threadpool for sync ``def``
+endpoints) create / update / delete the same dict + on-disk files.  A
+``threading.Lock`` (``DEVICE_PROFILE_REGISTRY_LOCK``) serialises every
+read-modify-write-persist + delete critical section so a delete-then-save
+interleaving can't resurrect a just-deleted profile to disk.
+
+These tests pin (a) that the lock is one shared object across the producer
+and consumer modules and (b) that the locked persist/delete pattern keeps the
+in-memory registry and the on-disk store in agreement under contention.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from netcanon.api.routes import device_profiles as routes_mod
+from netcanon.models.device_profile import DeviceProfile
+from netcanon.services import backup_runner as runner_mod
+from netcanon.storage.device_profile_store import (
+    DEVICE_PROFILE_REGISTRY_LOCK,
+    FileDeviceProfileStore,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_lock_is_a_lock() -> None:
+    assert hasattr(DEVICE_PROFILE_REGISTRY_LOCK, "acquire")
+    assert hasattr(DEVICE_PROFILE_REGISTRY_LOCK, "release")
+
+
+def test_lock_is_shared_across_producer_and_consumer() -> None:
+    """The backup worker and the route handlers must guard the same object —
+    a per-module lock would not serialise anything."""
+    assert runner_mod.DEVICE_PROFILE_REGISTRY_LOCK is DEVICE_PROFILE_REGISTRY_LOCK
+    assert routes_mod.DEVICE_PROFILE_REGISTRY_LOCK is DEVICE_PROFILE_REGISTRY_LOCK
+
+
+def _profile(pid: str) -> DeviceProfile:
+    return DeviceProfile(
+        id=pid,
+        name="r1",
+        type_key="Cisco",
+        host="10.0.0.1",
+        username="admin",
+        password="hunter2",
+    )
+
+
+def test_locked_persist_and_delete_never_resurrect(tmp_path) -> None:
+    """Race the worker's locked ``persist detected_facts`` against a route's
+    locked ``delete`` many times; the on-disk store and the in-memory
+    registry must always agree (no file left behind for a deleted id)."""
+    store = FileDeviceProfileStore(tmp_path)
+    registry: dict[str, DeviceProfile] = {}
+    pid = "race-id"
+
+    def persist() -> None:  # mirrors backup_runner's locked critical section
+        with DEVICE_PROFILE_REGISTRY_LOCK:
+            prof = registry.get(pid)
+            if prof is not None:
+                prof.detected_facts = {"detected_os_version": "17.12"}
+                store.save(prof)
+
+    def delete() -> None:  # mirrors the delete route's locked critical section
+        with DEVICE_PROFILE_REGISTRY_LOCK:
+            if registry.pop(pid, None) is not None:
+                store.delete(pid)
+
+    for _ in range(200):
+        registry[pid] = _profile(pid)
+        store.save(registry[pid])
+        ta = threading.Thread(target=persist)
+        tb = threading.Thread(target=delete)
+        ta.start()
+        tb.start()
+        ta.join()
+        tb.join()
+        on_disk = pid in store.load_all()
+        in_memory = pid in registry
+        assert on_disk == in_memory, (
+            "registry/disk disagreement (resurrection): "
+            f"on_disk={on_disk} in_memory={in_memory}"
+        )


### PR DESCRIPTION
## Summary

Closes review finding **#10**: the shared in-memory device-profile registry
(`app.state.device_profiles`) was mutated from two threads with no lock — the
backup worker thread persists a profile's `detected_facts` while route handlers
(which FastAPI runs in a threadpool for sync `def` endpoints) create / update /
delete the same dict + on-disk JSON files. A delete-then-save interleaving could
**resurrect a just-deleted profile to disk**, and concurrent `detected_facts`
updates could be lost.

## Fix
- New module-level `DEVICE_PROFILE_REGISTRY_LOCK` (`threading.Lock`) in
  `storage/device_profile_store.py` — shared by both the worker and the routes
  (one process-wide guard for the effectively-process-global registry).
- `backup_runner._process_one_device` re-fetches the profile **inside** the lock
  before saving, so a concurrent delete either runs first (save skipped) or after
  (file removed) — never a resurrection.
- The create / update / delete route handlers hold the lock across their
  existence-check + dict-mutate + persist critical sections.

Chosen over threading a lock parameter through `run_backup_job` →
`_process_one_device` → `create_backup` + the scheduler (6 sites): a module-level
lock is the minimal-blast-radius guard and never held across an `await` or SSH
call, so it can't deadlock or serialise the backup hot path.

## Tests
`tests/unit/test_device_profiles_lock.py`:
- the lock is one shared object across the worker + route modules (a per-module
  lock would serialise nothing);
- a 200-round threaded race of the locked persist vs. locked delete patterns
  asserts the in-memory registry and the on-disk store always agree (no
  resurrection).

Full `tests/unit tests/integration` gate green (**4512 passed, 82 skipped**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
