### PR TITLE
chore(ci): publish on-main guard + Dependabot-trackable PyPI pin + MSI license notice (#18/#19)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# CODEOWNERS — version-controls who must review changes to which paths.
+#
+# ⚠️ SETUP REQUIRED — this file is a template.  For it to actually gate
+# merges you must, in the GitHub repo settings, BOTH:
+#   1. Replace `@netcanon/maintainers` below with a real team or user that
+#      exists (e.g. `@your-handle`).  An unknown owner makes the rule inert
+#      (GitHub shows a "code owner not found" notice and enforces nothing).
+#   2. Enable branch protection / a Ruleset on `main` with
+#      "Require review from Code Owners" + "Require status checks to pass".
+#      CODEOWNERS alone does NOT block merges — branch protection does.
+#
+# Rationale: the 2026-06-14 review (finding #19) noted that "CI gates
+# merges" depended on invisible repo settings with no version-controlled
+# CODEOWNERS.  This file makes the review intent explicit and reviewable;
+# the two settings above are the half that lives in repo configuration.
+
+# Default owner for everything in the repo.
+* @netcanon/maintainers
+
+# Security-sensitive surfaces — call them out explicitly so a future
+# split of ownership keeps these gated even if the catch-all changes.
+/.github/workflows/   @netcanon/maintainers
+/netcanon/security/   @netcanon/maintainers
+/netcanon/api/        @netcanon/maintainers
+/setup_desktop.py     @netcanon/maintainers

--- a/.github/workflows/desktop-msi-publish.yml
+++ b/.github/workflows/desktop-msi-publish.yml
@@ -73,6 +73,21 @@ jobs:
           # (not git config); no git push from this job either.
           persist-credentials: false
 
+      # Refuse to build/attach an MSI for a tag that isn't on main (see
+      # pypi-publish.yml for rationale).  Covers both tag-push and the
+      # workflow_dispatch backfill path — `git rev-parse HEAD` is the
+      # checked-out tag's commit either way.
+      - name: Verify the build commit is on main
+        shell: bash
+        run: |
+          head_sha="$(git rev-parse HEAD)"
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$head_sha" FETCH_HEAD; then
+            echo "::error::Build commit $head_sha is not an ancestor of origin/main — refusing to publish."
+            exit 1
+          fi
+          echo "OK: build commit $head_sha is on origin/main."
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,10 +35,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
         with:
+          # Full history so the on-main ancestry guard below can run a
+          # merge-base against origin/main (shallow clone lacks the graph).
+          fetch-depth: 0
           # Registry logins use explicit secrets passed to
           # docker/login-action; cosign uses keyless OIDC; no git push
           # from this job.  Clear the token-in-.git/config default.
           persist-credentials: false
+
+      # Refuse to publish a tag that isn't on main (see pypi-publish.yml
+      # for the rationale — "tag = publish" with no ancestry check would
+      # let a tag on any commit push an image + move :latest).
+      - name: Verify the build commit is on main
+        shell: bash
+        run: |
+          head_sha="$(git rev-parse HEAD)"
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$head_sha" FETCH_HEAD; then
+            echo "::error::Build commit $head_sha is not an ancestor of origin/main — refusing to publish."
+            exit 1
+          fi
+          echo "OK: build commit $head_sha is on origin/main."
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -34,6 +34,22 @@ jobs:
           # persist); no git push from this job either.
           persist-credentials: false
 
+      # Refuse to publish a tag that isn't on main.  "Tag = publish" with
+      # no ancestry check means a `v9.9.9` tag on any commit would push an
+      # immutable release to PyPI.  Releases are cut as a CHANGELOG PR
+      # merged to main and then tagged on main, so the tagged commit is
+      # always an ancestor of origin/main; an off-main tag fails here.
+      - name: Verify the build commit is on main
+        shell: bash
+        run: |
+          head_sha="$(git rev-parse HEAD)"
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$head_sha" FETCH_HEAD; then
+            echo "::error::Build commit $head_sha is not an ancestor of origin/main — refusing to publish."
+            exit 1
+          fi
+          echo "OK: build commit $head_sha is on origin/main."
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -82,6 +98,6 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1 (branch ref; Dependabot will not auto-bump — manual SHA refresh required)
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         # No `with:` block needed — Trusted Publishing infers everything
         # from the OIDC token + the environment configured on PyPI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ timestamp if your timezone matters for an audit.
 
 ### Security
 
+* **Publish jobs refuse to release a tag that isn't on `main` (review finding
+  #19).**  The PyPI, Docker, and desktop-MSI publish workflows each gain an
+  early `git merge-base --is-ancestor` guard, so the "tag = publish" trigger
+  can no longer push an immutable PyPI release / move the Docker `:latest` /
+  attach an MSI from a tag cut on an arbitrary off-`main` commit.  The
+  PyPI-publish action is also re-pinned with a `# v1.14.0` comment (the SHA was
+  already that release's commit but was labelled as a branch ref, so Dependabot
+  wasn't tracking it for security bumps).
+
 * **Device-profile credentials are write-only over the API; backups resolve
   them server-side.**  The device-profile REST routes (`GET`/`LIST`/`POST`/`PUT
   /api/v1/devices`) now serialise through a new `DeviceProfilePublic` response
@@ -101,6 +110,18 @@ timestamp if your timezone matters for an audit.
   rendered output is for manual review/apply.
 
 ### Added
+
+* **Desktop MSI ships a third-party license notice (review finding #18).**  The
+  Windows installer redistributes PySide6/Qt (LGPLv3), paramiko (LGPL-2.1), and
+  pystray (LGPL-3.0) as binaries; `setup_desktop.py` now bundles
+  `THIRD-PARTY-NOTICES.txt` (component inventory + SPDX licenses + the LGPL
+  source-offer) and the project `LICENSE` next to the EXE, closing the
+  attribution gap on the distributed artifact.  (The PyPI wheel only declares
+  the deps, so it was never affected.)
+* **`.github/CODEOWNERS` (review finding #19).**  A version-controlled,
+  documented template for review ownership — the file makes the gate intent
+  explicit; the maintainer still wires the real owner handle + the
+  "require Code Owner review" branch-protection setting (noted in the header).
 
 * **VyOS codec — set-form input (`show configuration commands`).**  The
   `vyos` codec now accepts VyOS *set-form* configuration (the flat `set

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,73 @@
+THIRD-PARTY SOFTWARE NOTICES
+============================
+
+Netcanon itself is distributed under the MIT License (see the bundled
+LICENSE.txt).  The Windows desktop installer (MSI), built with cx_Freeze,
+*redistributes* the third-party components listed below as compiled
+binaries / bundled Python packages.  This file satisfies their attribution
+requirement and, for the copyleft (LGPL) components, records the written
+offer of source and the right to relink.
+
+The PyPI wheel and the source distribution declare these only as
+dependencies (resolved + downloaded by the user's own package manager) and
+do not redistribute their binaries — this notice is primarily relevant to
+the MSI.
+
+How to read this file
+---------------------
+Each entry lists the component, its SPDX license identifier, the copyright
+holder, and the canonical project URL.  The full, authoritative license
+text for each component ships inside that component's own distribution
+(e.g. the package's `LICENSE` / `LICENSE.txt`) and is available at the URL
+shown; the well-known GNU license texts are published verbatim at
+https://www.gnu.org/licenses/ (LGPL-3.0: lgpl-3.0.txt, LGPL-2.1:
+lgpl-2.1.txt).  SPDX identifiers map to texts at https://spdx.org/licenses/.
+
+Copyleft (LGPL) components — source offer + relink right
+--------------------------------------------------------
+For each LGPL component below, the corresponding source code (the exact
+version bundled in this installer) is obtainable from its project URL or
+from PyPI (`pip download <name>==<version>`).  You may modify and relink
+that component with this application as permitted by its license.
+
+* Qt for Python (PySide6) and the underlying Qt 6 libraries
+  License: LGPL-3.0-only (also available under GPL / commercial terms)
+  Copyright: The Qt Company Ltd. and Qt contributors
+  Homepage: https://www.qt.io/qt-for-python  ·  https://www.qt.io/licensing
+
+* paramiko (SSH transport used by the backup collectors)
+  License: LGPL-2.1-or-later
+  Copyright: Jeff Forcier and contributors
+  Homepage: https://www.paramiko.org  ·  https://github.com/paramiko/paramiko
+
+* pystray (system-tray integration for the desktop shell)
+  License: LGPL-3.0-or-later
+  Copyright: Moses Palmér
+  Homepage: https://github.com/moses-palmer/pystray
+
+Permissive components (attribution)
+-----------------------------------
+* Pillow            — HPND (PIL/MIT-CMU style) — Jeffrey A. Clark and contributors — https://python-pillow.github.io
+* FastAPI           — MIT            — Sebastián Ramírez — https://github.com/fastapi/fastapi
+* Starlette         — BSD-3-Clause   — Encode OSS Ltd.   — https://www.starlette.io
+* Uvicorn           — BSD-3-Clause   — Encode OSS Ltd.   — https://www.uvicorn.org
+* Pydantic / pydantic-core — MIT     — Pydantic Services Inc. and contributors — https://docs.pydantic.dev
+* Jinja2            — BSD-3-Clause   — Pallets           — https://palletsprojects.com/p/jinja/
+* Netmiko           — MIT            — Kirk Byers         — https://github.com/ktbyers/netmiko
+* PyYAML            — MIT            — Ingy döt Net, Kirill Simonov and contributors — https://pyyaml.org
+* anyio             — MIT            — Alex Grönholm      — https://github.com/agronholm/anyio
+* cryptography      — Apache-2.0 OR BSD-3-Clause — The cryptography developers — https://cryptography.io
+* keyring           — MIT            — Jason R. Coombs    — https://github.com/jaraco/keyring
+* defusedxml        — PSF-2.0        — Christian Heimes   — https://github.com/tiran/defusedxml
+* CPython runtime   — PSF-2.0        — Python Software Foundation — https://www.python.org
+
+Notes
+-----
+* Version ranges for each component are declared in `pyproject.toml`
+  (`dependencies` + the `desktop` / `desktop-build` extras).  The exact
+  versions bundled in a given MSI are those resolved at build time; run
+  `pip freeze` in the build environment for the precise pin set.
+* This is an attribution + source-offer notice.  If you require the full
+  verbatim license texts bundled alongside the binaries, drop the
+  upstream `LICENSE` files into a `licenses/` directory and add it to
+  `setup_desktop.py`'s `include_files`; the URLs above are authoritative.

--- a/setup_desktop.py
+++ b/setup_desktop.py
@@ -100,6 +100,13 @@ build_exe_options: dict = {
         (str(DEFINITIONS_DIR), "definitions"),
         # Jinja2 templates bundled with the netcanon package.
         (str(HERE / "netcanon" / "templates"), "lib/netcanon/templates"),
+        # License + third-party notices.  The MSI redistributes PySide6/Qt
+        # (LGPLv3), paramiko (LGPL-2.1), and pystray (LGPL-3.0) as binaries,
+        # which carry an attribution + source-offer obligation; ship the
+        # notices next to the EXE so the installed app satisfies it
+        # (2026-06-14 review finding #18).
+        (str(HERE / "LICENSE"), "LICENSE.txt"),
+        (str(HERE / "THIRD-PARTY-NOTICES.txt"), "THIRD-PARTY-NOTICES.txt"),
     ],
     # Exclude large packages that are not needed at runtime to keep the
     # installer size reasonable.


### PR DESCRIPTION
## Summary

Closes review findings **#18** (MSI third-party license notice) and **#19**
(CI/release governance). CI/packaging + docs only — no runtime Python changed.

## #19 — release governance
- **On-main ancestry guard** on all three publish workflows (PyPI / Docker /
  desktop-MSI): an early `git merge-base --is-ancestor HEAD origin/main` step
  refuses to publish a tag cut on an off-`main` commit. "Tag = publish" with no
  ancestry check previously meant any `v*.*.*` tag on any commit would push an
  immutable PyPI release / move Docker `:latest` / attach an MSI. Releases are
  cut as a CHANGELOG PR → merge to main → tag on main, so the guard is a no-op
  for the real flow. `docker-publish` gains `fetch-depth: 0` for the graph.
- **PyPI action re-pinned** with a `# v1.14.0` comment. The pinned SHA was
  already that release's commit but was labelled as a branch ref, so Dependabot
  wasn't tracking it for security bumps — **comment-only, no behaviour change**.
- **`.github/CODEOWNERS`** added as a documented template (the maintainer wires
  the real owner handle + the "require Code Owner review" branch-protection
  setting — both repo-config, noted in the file header).

## #18 — MSI license compliance
- `setup_desktop.py` bundles **`THIRD-PARTY-NOTICES.txt`** (component inventory +
  SPDX licenses + the LGPL source-offer for PySide6/Qt, paramiko, pystray) and
  the project **`LICENSE`** into the installer, closing the attribution gap on
  the redistributed LGPL binaries. The PyPI wheel only declares deps → never
  affected. (Full verbatim upstream texts can be dropped into a `licenses/`
  dir later if strict bundling is wanted; the notice cites the canonical URLs.)

## Verification
Workflow YAML parses; `setup_desktop.py` compiles. The ancestry guard is
exercised the next time a release tag is pushed; for non-tag `workflow_dispatch`
runs HEAD is main's tip, so it passes trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
