### PR TITLE
feat(security): opt-in egress allow-list for backup targets (review #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ timestamp if your timezone matters for an audit.
 
 ### Security
 
+* **Optional egress allow-list for backup targets (review finding #3).**  A new
+  `Settings.block_private_egress` (`NETCANON_BLOCK_PRIVATE_EGRESS`, default
+  `false`) makes the backup entry points (`POST /api/v1/backups` + the schedule
+  trigger) refuse targets that resolve to loopback or link-local addresses —
+  including the `169.254.169.254` cloud-metadata endpoint — so a reachable
+  non-operator can't turn the unauthenticated backup engine into an internal
+  port-scanner / metadata probe.  RFC-1918 ranges stay allowed (real managed
+  devices live there).  Default-off → zero change for desktop / trusted-VLAN
+  deployments; enforced at the entry point, not yet at SSH-connect time (a
+  noted DNS-rebinding follow-up).  See SECURITY.md.
+
 * **Publish jobs refuse to release a tag that isn't on `main` (review finding
   #19).**  The PyPI, Docker, and desktop-MSI publish workflows each gain an
   early `git merge-base --is-ancestor` guard, so the "tag = publish" trigger

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,17 @@ Netcanon ships in two deployment shapes:
    controls (nginx + auth_request, Caddy + basic-auth, Cloudflare
    Access, etc.) and restrict ingress at the network layer.
 
+   For this shape you can also set `NETCANON_BLOCK_PRIVATE_EGRESS=true`
+   (default `false`): the backup entry points then refuse any target
+   that resolves to a loopback or link-local address — including the
+   `169.254.169.254` cloud-metadata endpoint — so a reachable
+   non-operator can't turn the (unauthenticated) backup engine into an
+   internal port-scanner / metadata probe.  RFC-1918 ranges stay
+   allowed (real managed devices live there).  The check runs at the
+   request / schedule entry point, not at SSH-connect time, so it does
+   not fully defeat a DNS-rebinding attacker who controls a hostname;
+   connect-time re-validation is a noted follow-up.
+
 | Actor | Trust level |
 |-------|-------------|
 | Local user running the desktop app | Fully trusted |

--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -60,6 +60,7 @@ from ...definitions.schema import DeviceDefinition
 from ...models.backup import BackupJob, JobStatus
 from ...models.device import BackupRequest, DeviceCredentials, DeviceTarget
 from ...models.device_profile import DeviceProfile
+from ...services.egress import EgressBlocked, assert_egress_allowed
 from ...services.backup_runner import run_backup_job
 from ...storage.base import BaseConfigStore
 from ...storage.device_profile_store import FileDeviceProfileStore
@@ -193,6 +194,16 @@ def create_backup(
     resolved_request = BackupRequest(
         devices=_resolve_credentials(request_body.devices, device_profiles)
     )
+
+    # Egress allow-list (opt-in via Settings.block_private_egress): refuse
+    # targets that resolve to loopback / link-local (incl. the cloud
+    # metadata endpoint) to blunt the SSRF surface (review finding #3).
+    if request.app.state.settings.block_private_egress:
+        for device in resolved_request.devices:
+            try:
+                assert_egress_allowed(device.host)
+            except EgressBlocked as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     job = BackupJob(
         id=str(uuid.uuid4()),

--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -177,6 +177,33 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
         )
         return
 
+    # Egress allow-list (opt-in via Settings.block_private_egress): drop any
+    # scheduled target that resolves to loopback / link-local rather than
+    # failing the whole run (review finding #3).
+    if app.state.settings.block_private_egress:
+        from ...services.egress import EgressBlocked, assert_egress_allowed
+
+        kept = []
+        for d in devices:
+            try:
+                assert_egress_allowed(d.host)
+                kept.append(d)
+            except EgressBlocked as exc:
+                logger.warning(
+                    "Schedule '%s': skipping target %s — %s",
+                    schedule.name,
+                    d.host,
+                    exc,
+                )
+        devices = kept
+        if not devices:
+            logger.warning(
+                "Schedule '%s': all targets blocked by egress policy — "
+                "skipping run",
+                schedule.name,
+            )
+            return
+
     request = BackupRequest(devices=devices)
 
     job = BackupJob(

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -59,6 +59,16 @@ class Settings(BaseSettings):
             by ID via the registry's transparent disk lazy-load.  Default
             1000 caps memory at ~5 MB.  Set to 0 to disable in-memory
             caching entirely (every read hits disk).
+        block_private_egress: When ``True``, the backup entry points
+            reject targets that resolve to loopback (``127.0.0.0/8``,
+            ``::1``) or link-local (``169.254.0.0/16`` — which includes the
+            cloud metadata endpoint ``169.254.169.254`` — and ``fe80::/10``)
+            addresses.  Defaults to ``False`` so the desktop / trusted
+            management-VLAN deployments see no behaviour change; turn it on
+            (``NETCANON_BLOCK_PRIVATE_EGRESS=true``) for a network-exposed
+            web deployment to blunt the SSRF surface noted in SECURITY.md.
+            RFC-1918 ranges stay allowed — that is where real managed
+            devices live.
     """
 
     definitions_dir: Path = Path("definitions")
@@ -71,6 +81,7 @@ class Settings(BaseSettings):
     backup_concurrency: int = Field(default=MAX_BACKUP_CONCURRENCY,
                                     ge=1, le=MAX_BACKUP_CONCURRENCY)
     max_memory_jobs: int = Field(default=1000, ge=0)
+    block_private_egress: bool = False
 
     model_config = SettingsConfigDict(
         env_prefix="NETCANON_",

--- a/netcanon/services/egress.py
+++ b/netcanon/services/egress.py
@@ -1,0 +1,108 @@
+"""Egress allow-list guard for backup targets (review finding #3).
+
+When ``Settings.block_private_egress`` is enabled, backup entry points call
+:func:`assert_egress_allowed` before enqueuing a device so that a target
+resolving to a loopback or link-local address — most notably the cloud
+metadata endpoint ``169.254.169.254`` — is refused.  This blunts the SSRF
+surface the 2026-06-14 review flagged: the no-auth API + the default
+``0.0.0.0`` bind otherwise let any reachable caller turn the backup engine
+into an internal port-scanner / metadata probe.
+
+Scope + honest limits:
+
+* Enforced at the **entry points** (``create_backup`` + the schedule
+  trigger), not at SSH-connect time, so it does not fully defeat a
+  DNS-rebinding attacker who controls a hostname that resolves benign here
+  and malicious at connect.  Connect-time re-validation in the collector
+  layer is a noted follow-up.
+* RFC-1918 (``10/8``, ``172.16/12``, ``192.168/16``) and CGNAT
+  (``100.64/10``) are **allowed** — real managed devices live there.  Only
+  loopback + link-local are blocked.
+* Default-off: with the setting disabled the guard is never invoked, so
+  there is zero behaviour change for desktop / trusted-VLAN deployments.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+
+class EgressBlocked(Exception):
+    """Raised when a backup target is denied by the egress policy."""
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """A target IP is blocked if it is loopback or link-local.
+
+    ``is_link_local`` covers ``169.254.0.0/16`` (and ``fe80::/10``), which
+    includes the ``169.254.169.254`` cloud-metadata endpoint.
+
+    IPv4-mapped IPv6 literals (``::ffff:127.0.0.1``) parse as IPv6 and would
+    otherwise sidestep the IPv4 loopback/link-local checks, so the embedded
+    IPv4 address is unwrapped and re-checked.
+    """
+    if ip.is_loopback or ip.is_link_local:
+        return True
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None and (mapped.is_loopback or mapped.is_link_local):
+        return True
+    return False
+
+
+def assert_egress_allowed(host: str) -> None:
+    """Raise :class:`EgressBlocked` if *host* resolves to a blocked address.
+
+    *host* may be an IPv4/IPv6 literal or a hostname.  Hostnames are
+    resolved and **every** returned address is checked (a single blocked
+    answer rejects the target).  A resolution failure is *not* treated as a
+    block — the subsequent SSH connect will surface that error on its own;
+    failing closed here would turn transient DNS hiccups into spurious
+    backup failures.
+
+    Callers must only invoke this when ``Settings.block_private_egress`` is
+    enabled.
+    """
+    host = host.strip()
+
+    # IP literal — check directly, no DNS.
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        if _is_blocked_ip(ip):
+            raise EgressBlocked(
+                f"Egress to {host!r} is blocked by policy "
+                "(loopback / link-local address; set "
+                "NETCANON_BLOCK_PRIVATE_EGRESS=false to allow)."
+            )
+        return
+
+    # Hostname — resolve and check every answer.
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError as exc:
+        logger.warning(
+            "Egress guard could not resolve %r (%s); deferring to the "
+            "connect attempt.",
+            host,
+            exc,
+        )
+        return
+
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if _is_blocked_ip(ip):
+            raise EgressBlocked(
+                f"Egress to {host!r} is blocked by policy: it resolves to "
+                f"{addr} (loopback / link-local). Set "
+                "NETCANON_BLOCK_PRIVATE_EGRESS=false to allow."
+            )

--- a/tests/integration/test_backups_api.py
+++ b/tests/integration/test_backups_api.py
@@ -656,3 +656,83 @@ class TestServerSideCredentialResolution:
         """The ad-hoc path (inline credentials, no profile) is unchanged."""
         job = _post_and_get(client)
         assert job["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Egress allow-list (2026-06 review finding #3) — opt-in, default off
+# ---------------------------------------------------------------------------
+
+
+class _OkCollector:
+    def collect(self, device, definition):  # noqa: ARG002
+        return "! config for " + device.host
+
+
+class TestEgressAllowlist:
+    """With `block_private_egress` enabled, backups to loopback / link-local
+    targets are refused (400) before any connection; default-off keeps the
+    legacy behaviour (no egress check)."""
+
+    @staticmethod
+    def _strict_app(test_settings):
+        from netcanon.main import create_app
+
+        strict = test_settings.model_copy(update={"block_private_egress": True})
+        return create_app(strict)
+
+    def test_loopback_target_rejected_when_enabled(self, test_settings):
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        app = self._strict_app(test_settings)
+        with patch(
+            "netcanon.api.routes.backups.get_collector",
+            return_value=_OkCollector(),
+        ):
+            with TestClient(app, raise_server_exceptions=True) as c:
+                resp = c.post(
+                    "/api/v1/backups",
+                    json={"devices": [_device_payload(host="127.0.0.1")]},
+                )
+        assert resp.status_code == 400
+        assert "block" in resp.json()["detail"].lower()
+
+    def test_metadata_endpoint_rejected_when_enabled(self, test_settings):
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        app = self._strict_app(test_settings)
+        with patch(
+            "netcanon.api.routes.backups.get_collector",
+            return_value=_OkCollector(),
+        ):
+            with TestClient(app, raise_server_exceptions=True) as c:
+                resp = c.post(
+                    "/api/v1/backups",
+                    json={"devices": [_device_payload(host="169.254.169.254")]},
+                )
+        assert resp.status_code == 400
+
+    def test_public_target_allowed_when_enabled(self, test_settings):
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        app = self._strict_app(test_settings)
+        with patch(
+            "netcanon.api.routes.backups.get_collector",
+            return_value=_OkCollector(),
+        ):
+            with TestClient(app, raise_server_exceptions=True) as c:
+                resp = c.post(
+                    "/api/v1/backups",
+                    json={"devices": [_device_payload(host="8.8.8.8")]},
+                )
+        assert resp.status_code == 202
+
+    def test_loopback_allowed_when_disabled(self, client):
+        """Default-off: no egress check, so loopback targets still enqueue."""
+        resp = _post_backup(client, devices=[_device_payload(host="127.0.0.1")])
+        assert resp.status_code == 202

--- a/tests/unit/test_egress.py
+++ b/tests/unit/test_egress.py
@@ -1,0 +1,63 @@
+"""Unit tests for the backup egress allow-list guard (review finding #3).
+
+`assert_egress_allowed` blocks targets that resolve to loopback or
+link-local addresses (the latter covers the 169.254.169.254 cloud-metadata
+endpoint) while leaving RFC-1918 / CGNAT / public addresses alone.  A
+resolution failure is deferred to the connect attempt, never treated as a
+block.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.services.egress import EgressBlocked, assert_egress_allowed
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1",
+        "127.5.5.5",
+        "::1",
+        "169.254.169.254",  # cloud metadata endpoint
+        "169.254.0.1",
+        "fe80::1",
+        "::ffff:127.0.0.1",      # IPv4-mapped IPv6 loopback (bypass guard)
+        "::ffff:169.254.169.254",  # IPv4-mapped metadata endpoint
+    ],
+)
+def test_loopback_and_link_local_are_blocked(host: str) -> None:
+    with pytest.raises(EgressBlocked):
+        assert_egress_allowed(host)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "8.8.8.8",
+        "1.1.1.1",
+        "192.168.1.1",   # RFC-1918 — real managed devices live here
+        "10.0.0.1",
+        "172.16.0.1",
+        "100.64.0.1",    # CGNAT
+        "2001:db8::1",
+    ],
+)
+def test_public_and_private_ranges_are_allowed(host: str) -> None:
+    assert assert_egress_allowed(host) is None
+
+
+def test_localhost_hostname_is_blocked() -> None:
+    # 'localhost' resolves locally (no network) to a loopback address.
+    with pytest.raises(EgressBlocked):
+        assert_egress_allowed("localhost")
+
+
+def test_unresolvable_host_is_not_blocked() -> None:
+    # A resolution failure defers to the connect attempt — failing closed
+    # here would turn DNS hiccups into spurious backup failures.  The
+    # `.invalid` TLD is guaranteed non-resolvable (RFC 6761).
+    assert assert_egress_allowed("netcanon-egress-test.invalid") is None


### PR DESCRIPTION
## Summary

Closes review finding **#3** (SSRF surface). The backup engine connects
outbound to any operator-supplied `host:port`; with the no-auth API + the
default `0.0.0.0` web bind, a reachable non-operator could use it as an
internal port-scanner / cloud-metadata probe.

## Fix — opt-in, default-off
- New `Settings.block_private_egress` (`NETCANON_BLOCK_PRIVATE_EGRESS`, default
  `False`). When enabled, the backup entry points — `POST /api/v1/backups` and
  the schedule trigger — refuse targets that resolve to **loopback** or
  **link-local** addresses (the latter covers the `169.254.169.254` cloud
  metadata endpoint). **RFC-1918 / CGNAT / public stay allowed** (real managed
  devices live there).
- `netcanon/services/egress.py::assert_egress_allowed(host)` resolves the host
  and checks **every** answer. IPv4-mapped IPv6 literals (`::ffff:127.0.0.1`)
  are unwrapped so they can't sidestep the IPv4 checks. Resolution failures
  **defer** to the connect attempt (no spurious blocks on DNS hiccups).
- The route rejects with **400**; the scheduler **drops** blocked targets with
  a warning rather than failing the whole run.

## Scope / honest limits
- **Default-off → zero behaviour change** for desktop / trusted-VLAN deployments.
- Enforced at the **entry point**, not yet at SSH-connect time, so it doesn't
  fully defeat a DNS-rebinding attacker controlling a hostname — connect-time
  re-validation is a noted follow-up. Documented in SECURITY.md.

## Tests
`tests/unit/test_egress.py` — loopback / link-local / metadata / IPv4-mapped-IPv6
blocked; RFC-1918 / CGNAT / public allowed; `localhost` blocked; unresolvable
deferred. Integration (`test_backups_api.py`) — enabled → 400 on `127.0.0.1` and
the metadata endpoint, 202 on a public IP; disabled → loopback still enqueues.
Full `tests/unit tests/integration` gate green (**4531 passed**).

> Note: this is the **#3** half of the #3/#11 cluster. **#11 (SSH host-key TOFU)**
> is intentionally held — it changes the SSH security boundary and can't be
> integration-tested against the mocked collectors; awaiting an explicit go to
> do it as a focused, real-SSH-tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
