### PR TITLE
feat(migration): walk every populated Tier-2 surface for honest validation (review #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,25 @@ timestamp if your timezone matters for an audit.
 
 ### Changed
 
+* **Interactive validation report now sees every populated Tier-2 surface
+  (review finding #7).**  The shared canonical walker (`_walk_canonical`, reused
+  by 10 codecs' `iter_xpaths`) previously yielded xpaths only for system
+  scalars, interfaces, VLANs, static routes, and SNMP — so
+  `validate_against` was structurally blind to DHCP pools, LAGs, local users,
+  RADIUS servers, VXLAN/EVPN, routing-instances, and the per-interface
+  `mtu` / `vrf` / `lag-member-of` sub-fields.  A migration whose target codec
+  drops or lossy-converts one of those could read `severity: ok`.  The walker
+  now yields a granular hyphenated xpath for **every** populated surface
+  (guarded so an empty surface still yields nothing), so the report can flag
+  the loss before an operator commits.  This only ever makes the report *more*
+  conservative (more warn/block, never less); it does not touch parse/render
+  output, so the cross-mesh fidelity matrix is unchanged.  The stale "Phase 1
+  adds glob/prefix matching" promise in `CapabilityMatrix.classify` (never
+  built, not needed under the shared-vocabulary design) is removed from the
+  docstring.  New coverage guard:
+  `tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py`.
+  (Per-interface switchport sub-fields and the matrix-vocabulary normalisation
+  — review #8 — follow in a separate pass.)
 * **Documentation honesty pass (multi-lens review remediation).**  The README
   trust-signal now states the live `CODEC_BUG` residual (5 triaged-benign cells)
   and names `tests/fixtures/real/PHASE4_RECONCILIATION.md` as the authoritative

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -495,7 +495,31 @@ _IOS_BANNER_HITS: tuple[tuple[str, int], ...] = (
 
 
 def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
-    """Yield schema xpaths from a CanonicalIntent for validation.
+    """Yield schema xpaths for every populated field of a CanonicalIntent.
+
+    This is the input to :func:`netcanon.services.migration_validate.
+    validate_against` — the validator classifies each yielded xpath
+    against the *target* codec's :class:`CapabilityMatrix` so the
+    interactive migration report can surface lossy / unsupported
+    surfaces before the operator commits.  The honesty contract
+    ("loss is visible in the report, not hidden") therefore depends on
+    this walker yielding an xpath for **every** populated surface — a
+    field the walker skips can never be flagged, no matter how the
+    target declares it.  So the walker covers all of Tier 1 + Tier 2:
+    system scalars, every interface sub-field, VLANs, static routes,
+    SNMP (incl. v3 sub-fields), DHCP pools, LAGs, local users, RADIUS
+    servers, VXLAN VNIs, EVPN Type-5 routes, and routing-instances.
+
+    Each yield is guarded on the field being populated, so the walker
+    emits xpaths only for data the source config actually carried — an
+    empty surface yields nothing and so classifies as neither lossy nor
+    unsupported (there is nothing to lose).
+
+    The xpath vocabulary is the granular hyphenated shape the codec
+    capability matrices declare (e.g. ``/lags/lag/mode``,
+    ``/local-users/user/role``); :meth:`CapabilityMatrix.classify` is
+    exact-string-match, so the walker and the matrices must speak the
+    same strings for a declaration to be reachable.
 
     Kept at module level (rather than relocating to :mod:`.parse` or
     :mod:`.render`) so that the
@@ -503,13 +527,25 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
     import surface every cross-codec ``iter_xpaths`` consumer relies
     on stays intact.  Used by the OPNsense / Aruba / FortiGate / Arista /
     Juniper / MikroTik / Cisco-NETCONF codecs.
+
+    Note: ``run_full_mesh.py``'s cross-mesh field-disposition matrix
+    does NOT consume this walker — it compares ``model_dump()`` output
+    and reads each matrix's ``unsupported`` declarations directly — so
+    expanding this walker affects only the live validation report.
     """
+    # ── Tier 1 — system scalars ──
     if intent.hostname:
         yield "/system/hostname"
+    if intent.domain:
+        yield "/system/domain"
     for _ in intent.dns_servers:
         yield "/system/dns-server"
     for _ in intent.ntp_servers:
         yield "/system/ntp-server"
+    if intent.timezone:
+        yield "/system/timezone"
+    for _ in intent.syslog_servers:
+        yield "/system/syslog-server"
     for iface in intent.interfaces:
         yield "/interfaces/interface/name"
         if iface.description:
@@ -532,6 +568,21 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
             yield "/interfaces/interface/dhcp-client-v6"
         if iface.tunnel_type:
             yield "/interfaces/interface/tunnel-type"
+        if iface.mtu is not None:
+            yield "/interfaces/interface/config/mtu"
+        if iface.vrf:
+            yield "/interfaces/interface/config/vrf"
+        if iface.lag_member_of:
+            yield "/interfaces/interface/lag-member-of"
+        # NB: per-interface switchport fields (switchport-mode / access-vlan
+        # / trunk-vlans / native-vlan / voice-vlan) are intentionally NOT
+        # walked here.  L2 membership honesty is carried by the VLAN-centric
+        # ``/vlans/vlan/{tagged,untagged}-ports`` surface, and no codec yet
+        # declares a switchport disposition — so walking them would be inert
+        # (always classifies ``supported``).  Surfacing switchport loss for
+        # router / firewall targets requires those codecs to declare the
+        # paths ``unsupported`` first; deferred to the matrix-normalisation
+        # pass (review #8).
         for _ in iface.vrrp_groups:
             yield "/interfaces/interface/vrrp-groups/group"
     for _ in intent.vlans:
@@ -543,7 +594,7 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
             yield "/routing/static-route/vrf"
     if intent.anycast_gateway_mac:
         yield "/anycast-gateway-mac"
-    # Tier 2 — emit only what's populated
+    # ── Tier 2 — emit only what's populated ──
     if intent.snmp is not None:
         if intent.snmp.community:
             yield "/snmp/community"
@@ -553,5 +604,50 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
             yield "/snmp/contact"
         for _ in intent.snmp.trap_hosts:
             yield "/snmp/trap-host"
-        for _ in intent.snmp.v3_users:
+        for v3 in intent.snmp.v3_users:
             yield "/snmp/v3-user"
+            if v3.auth_passphrase:
+                yield "/snmp/v3-user/auth-passphrase"
+            if v3.engine_id:
+                yield "/snmp/v3-user/engine-id"
+    for _ in intent.dhcp_servers:
+        yield "/dhcp-servers/pool"
+    for _ in intent.lags:
+        yield "/lags/lag/name"
+        yield "/lags/lag/members"
+        yield "/lags/lag/mode"
+    for user in intent.local_users:
+        yield "/local-users/user/name"
+        if user.role:
+            yield "/local-users/user/role"
+        if user.hashed_password:
+            yield "/local-users/user/hashed-password"
+        yield "/local-users/user/privilege-level"
+    for _ in intent.radius_servers:
+        yield "/radius-servers/server/host"
+        yield "/radius-servers/server/key"
+    for vx in intent.vxlan_vnis:
+        yield "/vxlan-vnis/vni"
+        if vx.source_interface:
+            yield "/vxlan-vnis/source-interface"
+        if vx.mcast_group:
+            yield "/vxlan-vnis/mcast-group"
+        if vx.flood_list:
+            yield "/vxlan-vnis/flood-list"
+        yield "/vxlan-vnis/udp-port"
+        yield "/vxlan-vnis/vlan-id"
+    for _ in intent.evpn_type5_routes:
+        yield "/evpn-type5-routes/route"
+    for inst in intent.routing_instances:
+        yield "/routing-instances/instance"
+        yield "/routing-instances/instance/name"
+        if inst.description:
+            yield "/routing-instances/instance/description"
+        if inst.route_distinguisher:
+            yield "/routing-instances/instance/route-distinguisher"
+        if inst.rt_imports:
+            yield "/routing-instances/instance/rt-imports"
+        if inst.rt_exports:
+            yield "/routing-instances/instance/rt-exports"
+        if inst.l3_vni is not None:
+            yield "/routing-instances/instance/l3-vni"

--- a/netcanon/models/migration.py
+++ b/netcanon/models/migration.py
@@ -207,8 +207,17 @@ class CapabilityMatrix(BaseModel):
                not otherwise classified is assumed supported for
                adapters that choose to declare only the exceptions).
 
-        The Phase 0 implementation uses simple string equality; Phase 1
-        adds glob/prefix matching (e.g. a pattern ending in ``/**``).
+        Matching is exact string equality.  This is deliberate: the
+        canonical-tree walker (``_walk_canonical`` in
+        :mod:`netcanon.migration.codecs.cisco_iosxe_cli.codec`) and the
+        per-codec matrices share one granular hyphenated xpath
+        vocabulary, so an exact lookup reaches every declaration without
+        glob/prefix machinery.  A declared path that no walker yields is
+        simply unreachable by live validation — the registry-wide
+        honesty parity test guards against that drift.  (An earlier
+        docstring promised glob/prefix matching "in Phase 1"; it was
+        never built and is not needed under the shared-vocabulary
+        design — see the 2026-06 architecture review.)
         """
         for up in self.unsupported:
             if up.path == xpath:

--- a/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
+++ b/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
@@ -1,0 +1,244 @@
+"""
+Coverage guard for the shared canonical walker (``_walk_canonical``).
+
+The interactive validation report (``validate_against``) is only as
+honest as the walker is complete: a populated ``CanonicalIntent`` field
+the walker never yields an xpath for can never be classified
+lossy / unsupported, so its loss is invisible in the report.  The
+2026-06 architecture review flagged that the walker covered only a
+narrow slice of Tier 2 — LAGs, local users, RADIUS, DHCP, VXLAN/EVPN
+and VRFs were silently dropped.
+
+This module is the inverse of the per-codec render-honesty guard in
+``tests/unit/migration/codecs/cisco_iosxe/test_capability_matrix_honesty.py``:
+it asserts that for a kitchen-sink intent populating EVERY top-level
+field (plus the per-interface sub-fields the review called out), the
+walker emits at least one xpath per surface.  A new
+``CanonicalIntent`` field that lands without a matching walker yield
+trips :func:`test_every_top_level_field_is_walked`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalDHCPPool,
+    CanonicalEvpnType5Route,
+    CanonicalIntent,
+    CanonicalInterface,
+    CanonicalIPv4Address,
+    CanonicalIPv6Address,
+    CanonicalLAG,
+    CanonicalLocalUser,
+    CanonicalRADIUSServer,
+    CanonicalRoutingInstance,
+    CanonicalSNMP,
+    CanonicalSNMPv3User,
+    CanonicalStaticRoute,
+    CanonicalVlan,
+    CanonicalVxlan,
+)
+from netcanon.migration.codecs.cisco_iosxe_cli.codec import _walk_canonical
+
+pytestmark = pytest.mark.unit
+
+
+def _kitchen_sink() -> CanonicalIntent:
+    """A CanonicalIntent with every translatable surface populated."""
+    return CanonicalIntent(
+        # ── Tier 1 scalars / lists ──
+        hostname="walk-guard",
+        domain="example.test",
+        dns_servers=["10.0.0.53"],
+        ntp_servers=["10.0.0.123"],
+        timezone="UTC",
+        syslog_servers=["10.0.0.514"],
+        interfaces=[
+            CanonicalInterface(
+                name="GigabitEthernet1/0/1",
+                description="walked",
+                enabled=True,
+                interface_type="ianaift:ethernetCsmacd",
+                mtu=9000,
+                vrf="TENANT-A",
+                lag_member_of="Port-Channel1",
+                switchport_mode="trunk",
+                access_vlan=10,
+                trunk_allowed_vlans=[10, 20],
+                trunk_native_vlan=99,
+                voice_vlan=200,
+                ipv4_addresses=[
+                    CanonicalIPv4Address(
+                        ip="198.51.100.1",
+                        prefix_length=30,
+                        virtual_gateway_address="198.51.100.254",
+                    ),
+                ],
+                ipv6_addresses=[
+                    CanonicalIPv6Address(ip="2001:db8::1", prefix_length=64),
+                ],
+                dhcp_client_v6="dhcp6",
+                tunnel_type="gre",
+            ),
+        ],
+        vlans=[CanonicalVlan(id=10, name="USERS")],
+        static_routes=[
+            CanonicalStaticRoute(
+                destination="0.0.0.0/0", gateway="198.51.100.2", vrf="TENANT-A"
+            ),
+        ],
+        # ── Tier 2 ──
+        dhcp_servers=[
+            CanonicalDHCPPool(network="192.0.2.0/24", start_ip="192.0.2.10"),
+        ],
+        snmp=CanonicalSNMP(
+            community="ro",
+            location="lab",
+            contact="ops@example.test",
+            trap_hosts=["10.0.0.10"],
+            v3_users=[
+                CanonicalSNMPv3User(
+                    name="v3guard",
+                    group="g",
+                    auth_protocol="sha",
+                    auth_passphrase="$9$auth",
+                    priv_protocol="aes",
+                    priv_passphrase="$9$priv",
+                    engine_id="80000009feedface",
+                ),
+            ],
+        ),
+        lags=[
+            CanonicalLAG(
+                name="Port-Channel1",
+                members=["GigabitEthernet1/0/1"],
+                mode="active",
+            ),
+        ],
+        local_users=[
+            CanonicalLocalUser(
+                name="admin",
+                privilege_level=15,
+                hashed_password="$9$hash",
+                role="admin",
+            ),
+        ],
+        radius_servers=[CanonicalRADIUSServer(host="10.0.0.1", key="$9$radius")],
+        vxlan_vnis=[
+            CanonicalVxlan(
+                vlan_id=10,
+                vni=10010,
+                mcast_group="239.1.1.1",
+                flood_list=["10.0.0.5"],
+                source_interface="Loopback0",
+            ),
+        ],
+        evpn_type5_routes=[
+            CanonicalEvpnType5Route(vrf="TENANT-A", prefix="10.10.0.0/16"),
+        ],
+        routing_instances=[
+            CanonicalRoutingInstance(
+                name="TENANT-A",
+                instance_type="vrf",
+                route_distinguisher="65000:100",
+                rt_imports=["65000:100"],
+                rt_exports=["65000:100"],
+                description="tenant a",
+                l3_vni=50010,
+            ),
+        ],
+        anycast_gateway_mac="00:1c:73:00:dc:01",
+    )
+
+
+#: Each populated top-level CanonicalIntent surface → an xpath (exact or
+#: prefix) the walker MUST emit when that surface carries data.  This is
+#: the honesty floor: the live validator cannot flag a surface the
+#: walker never yields.
+_FIELD_TO_EXPECTED_XPATH: dict[str, str] = {
+    "hostname": "/system/hostname",
+    "domain": "/system/domain",
+    "dns_servers": "/system/dns-server",
+    "ntp_servers": "/system/ntp-server",
+    "timezone": "/system/timezone",
+    "syslog_servers": "/system/syslog-server",
+    "interfaces": "/interfaces/interface/name",
+    "vlans": "/vlans/vlan/id",
+    "static_routes": "/routing/static-route",
+    "dhcp_servers": "/dhcp-servers/pool",
+    "snmp": "/snmp/community",
+    "lags": "/lags/lag/name",
+    "local_users": "/local-users/user/name",
+    "radius_servers": "/radius-servers/server/host",
+    "vxlan_vnis": "/vxlan-vnis/vni",
+    "evpn_type5_routes": "/evpn-type5-routes/route",
+    "routing_instances": "/routing-instances/instance",
+    "anycast_gateway_mac": "/anycast-gateway-mac",
+}
+
+
+def test_every_top_level_field_is_walked():
+    """Every populated top-level surface yields at least one xpath."""
+    intent = _kitchen_sink()
+    emitted = set(_walk_canonical(intent))
+
+    # Sanity: the kitchen-sink really does populate every audited field
+    # (so a missing-yield failure below means the WALKER is incomplete,
+    # not that the fixture forgot to set something).
+    dump = intent.model_dump()
+    for field in _FIELD_TO_EXPECTED_XPATH:
+        value = dump.get(field)
+        assert value not in (None, "", [], {}), (
+            f"kitchen-sink fixture left intent.{field} empty — fix the "
+            f"fixture, not the walker"
+        )
+
+    for field, xpath in _FIELD_TO_EXPECTED_XPATH.items():
+        assert xpath in emitted, (
+            f"_walk_canonical does not yield {xpath!r} for populated "
+            f"intent.{field}: the live validation report is structurally "
+            f"blind to this surface.  Add a yield in _walk_canonical."
+        )
+
+
+def test_per_interface_subfields_are_walked():
+    """The per-interface Tier-2 sub-fields with a real disposition
+    (mtu / vrf / lag-member-of) are walked.
+
+    Switchport sub-fields are deliberately NOT walked yet — see the
+    note in ``_walk_canonical`` (no codec declares a switchport
+    disposition, so walking them would be inert).  That arrives with
+    the matrix-normalisation pass (review #8)."""
+    emitted = set(_walk_canonical(_kitchen_sink()))
+    for xpath in (
+        "/interfaces/interface/config/mtu",
+        "/interfaces/interface/config/vrf",
+        "/interfaces/interface/lag-member-of",
+    ):
+        assert xpath in emitted, f"_walk_canonical drops {xpath!r}"
+    # Switchport paths are intentionally absent in this PR.
+    assert "/interfaces/interface/config/switchport-mode" not in emitted
+
+
+def test_snmp_v3_subfields_are_walked():
+    """SNMPv3 auth/engine sub-fields (declared lossy by several codecs)
+    must be walked so the report surfaces the key-portability caveat."""
+    emitted = set(_walk_canonical(_kitchen_sink()))
+    assert "/snmp/v3-user/auth-passphrase" in emitted
+    assert "/snmp/v3-user/engine-id" in emitted
+
+
+def test_empty_intent_yields_nothing():
+    """An empty intent has no populated surface, so the walker yields
+    nothing — there is no loss to report."""
+    assert list(_walk_canonical(CanonicalIntent())) == []
+
+
+def test_unpopulated_surfaces_are_not_walked():
+    """A surface that carries no data must not yield an xpath — else the
+    report would flag a non-existent loss.  Populate ONLY hostname and
+    assert no Tier-2 family xpath leaks."""
+    intent = CanonicalIntent(hostname="only-host")
+    emitted = set(_walk_canonical(intent))
+    assert emitted == {"/system/hostname"}


### PR DESCRIPTION
## What

Keystone PR-1 of 3 (review findings #7/#8/#9 — the validation-honesty keystone).

The shared canonical walker `_walk_canonical` (reused by 10 codecs' `iter_xpaths`) only yielded xpaths for system scalars, interfaces, VLANs, static routes, and SNMP. So the interactive `validate_against` report was **structurally blind** to DHCP pools, LAGs, local users, RADIUS servers, VXLAN/EVPN, routing-instances, and the per-interface `mtu`/`vrf`/`lag-member-of` sub-fields — a migration whose target codec dropped one of those could read `severity: ok`, the exact "silent drop" the honesty model exists to police (architecture review, finding #7).

## Change

- `_walk_canonical` now yields a granular hyphenated xpath for **every populated** Tier-1 + Tier-2 surface, each guarded on the field carrying data (an empty surface still yields nothing).
- Removed the stale *"Phase 1 adds glob/prefix matching"* promise from `CapabilityMatrix.classify` — never built, unnecessary under the shared-vocabulary design.
- New coverage guard `test_walk_canonical_coverage.py` (inverse of the per-codec render-honesty guard).

## Why it's safe

- **Only ever more conservative.** A newly-walked path that no matrix declares classifies as `supported` (default) — same as today; where a matrix already declares it lossy/unsupported, the report now correctly surfaces it. Validation can only gain warn/block, never lose it.
- **Cross-mesh artifact unchanged.** `run_full_mesh.py` diffs `model_dump()` and reads each matrix's `unsupported` strings directly — it never consumed this walker. Parse/render output is untouched, so no regen is needed and `CODEC_BUG` is unaffected.

## Deferred to PR-2 (review #8)

Per-interface **switchport** sub-fields are intentionally not walked yet: no codec declares a switchport disposition, so walking them is inert until router/firewall codecs declare them `unsupported` — a per-codec render-disposition decision that belongs with the matrix-vocabulary normalisation. PR-3 (review #9) then promotes the cisco_iosxe render-honesty guard to a registry-wide parity test.

## Test

Full unit + integration gate: **4548 passed, 82 skipped** (4543 baseline + 5 new walker tests). The 4 existing per-codec `test_xpaths_match_capability_matrix` guards stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
