### PR TITLE
test(migration): registry-wide capability-matrix honesty guard + complete the walker (review #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,36 @@ timestamp if your timezone matters for an audit.
 
 ### Changed
 
+* **Registry-wide capability-matrix honesty guard + walker completion (review
+  finding #9).**  The two-sided render/walker honesty invariant was enforced
+  for exactly one codec (the cisco_iosxe NETCONF stub); the 11 production
+  codecs were ungated, so a render expansion or matrix loosening could drift a
+  codec's declared capabilities from its real behaviour with no failing test.
+  New `tests/unit/migration/test_registry_capability_honesty.py` parametrises
+  over every bidirectional codec and enforces the two *false-positive-free*
+  directions of the invariant: **reverse-parity** (every declared `supported`
+  xpath must be one the shared canonical walker can emit — a path it can't is
+  unreachable by `validate_against` and so a dead declaration; review #8c) and
+  **rendered ⇒ not-unsupported** (a top-level field that survives a
+  render→re-parse round-trip must not be declared `unsupported` — a matrix that
+  calls a surface unsupported while round-tripping it would wrongly block/warn a
+  migration), plus a no-supported/unsupported-overlap check.  To make
+  reverse-parity pass, `_walk_canonical` is completed to yield the remaining
+  declared surfaces — VLAN `tagged-ports` / `untagged-ports` / `description`,
+  the per-interface switchport view (`switchport-mode` / `access-vlan` /
+  `trunk-allowed-vlans` / `trunk-native-vlan`, no-`config/` spelling matching
+  nxos/aoscx), `dhcp-client` (v4), and the IPv6 `virtual-gateway-address` /
+  `virtual-gateway-mac` (plus IPv4 `virtual-gateway-mac`) the IPv4 path already
+  carried — and the redundant `/interfaces/interface/config/name` declaration
+  (five codecs) is dropped in favour of the walkable `/interfaces/interface/name`.
+  aruba_aoss now declares its switchport view `supported` (it round-trips L2
+  membership) and mikrotik declares `/vlans/vlan/description` lossy (RouterOS
+  overloads the single per-VLAN comment).  No parse/render change, no
+  `unsupported` declaration changed → cross-mesh fidelity matrix untouched
+  (CODEC_BUG flat at 5).  (The third honesty direction — *dropped* ⇒
+  unsupported — stays covered by the per-codec round-trip tests + cross-mesh
+  audit; a single universal kitchen-sink can't detect drops without
+  vendor-naming false positives.)
 * **Capability-matrix xpath vocabularies normalised to one granular shape
   (review finding #8).**  Codecs declared the same canonical surface under two
   incompatible xpath spellings, so half of them were unreachable by the

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -302,6 +302,7 @@ output.
 | `/routing/static-route/vrf` | Unsupported | Per-VRF static-route binding parses-and-ignores in v1. |
 | `/interfaces/interface/config/type` | Lossy | RouterOS does not expose IANA `ifType`; codec infers it from interface-name prefix (`etherN` → ethernetCsmacd, `vlanN` → l3ipvlan). |
 | `/vlans/vlan/name` | Lossy | MikroTik stores a VLAN's name as the L3 interface name (e.g. `vlan10`), not a separate descriptive name field; cross-vendor rendering may conflate the two. |
+| `/vlans/vlan/description` | Lossy | RouterOS exposes a single per-VLAN `comment` field, which the parser maps to the VLAN name; a separate description collides with it on render. |
 | `/filter/rule` | Unsupported | Firewall filter rules are Tier 3 (informational) and not auto-rendered. |
 | `/nat/rule` | Unsupported | NAT rules are Tier 3 — informational only. |
 | `/vxlan-vnis/{vni,source-interface,udp-port}` | Unsupported | RouterOS VXLAN exists but is rare in canonical scope and not modelled in v1. |

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -128,7 +128,6 @@ class ArubaAOSCXCodec(CodecBase):
             "/system/hostname",
             # Interfaces — name + basic L3 (Phase 1)
             "/interfaces/interface/name",
-            "/interfaces/interface/config/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
             "/interfaces/interface/config/mtu",

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -123,6 +123,17 @@ class ArubaAOSSCodec(CodecBase):
             "/vlans/vlan/name",
             "/vlans/vlan/tagged-ports",
             "/vlans/vlan/untagged-ports",
+            # Per-interface switchport view — AOS-S models L2 membership
+            # VLAN-centrically (``vlan N / tagged|untagged <ports>``), but
+            # parse populates the transposed per-interface switchport_mode /
+            # access_vlan / trunk_* fields too (kept in sync via the VLAN
+            # projection), and the membership round-trips.  Declared
+            # ``supported`` so the canonical walker's switchport xpaths
+            # classify correctly.
+            "/interfaces/interface/switchport-mode",
+            "/interfaces/interface/access-vlan",
+            "/interfaces/interface/trunk-allowed-vlans",
+            "/interfaces/interface/trunk-native-vlan",
             "/routing/static-route",
             # Tier 2 — SNMP
             "/snmp/community",

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -109,7 +109,6 @@ class CiscoIOSXECLICodec(CodecBase):
         supported=[
             "/system/hostname",
             "/interfaces/interface/name",
-            "/interfaces/interface/config/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
             "/interfaces/interface/ipv4/address/ip",
@@ -561,9 +560,24 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
                     "/interfaces/interface/ipv4/address/"
                     "virtual-gateway-address"
                 )
-        for _ in iface.ipv6_addresses:                # GAP-EVPN-3
+            if addr.virtual_gateway_mac:
+                yield (
+                    "/interfaces/interface/ipv4/address/"
+                    "virtual-gateway-mac"
+                )
+        for addr6 in iface.ipv6_addresses:            # GAP-EVPN-3
             yield "/interfaces/interface/ipv6/address/ip"
             yield "/interfaces/interface/ipv6/address/prefix-length"
+            if addr6.virtual_gateway_address:
+                yield (
+                    "/interfaces/interface/ipv6/address/"
+                    "virtual-gateway-address"
+                )
+            if addr6.virtual_gateway_mac:
+                yield (
+                    "/interfaces/interface/ipv6/address/"
+                    "virtual-gateway-mac"
+                )
         if iface.dhcp_client_v6:
             yield "/interfaces/interface/dhcp-client-v6"
         if iface.tunnel_type:
@@ -574,20 +588,36 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
             yield "/interfaces/interface/config/vrf"
         if iface.lag_member_of:
             yield "/interfaces/interface/lag-member-of"
-        # NB: per-interface switchport fields (switchport-mode / access-vlan
-        # / trunk-vlans / native-vlan / voice-vlan) are intentionally NOT
-        # walked here.  L2 membership honesty is carried by the VLAN-centric
-        # ``/vlans/vlan/{tagged,untagged}-ports`` surface, and no codec yet
-        # declares a switchport disposition — so walking them would be inert
-        # (always classifies ``supported``).  Surfacing switchport loss for
-        # router / firewall targets requires those codecs to declare the
-        # paths ``unsupported`` first; deferred to the matrix-normalisation
-        # pass (review #8).
+        if iface.dhcp_client:
+            yield "/interfaces/interface/dhcp-client"
+        # Per-interface switchport view (the transpose of the VLAN-centric
+        # ``/vlans/vlan/{tagged,untagged}-ports`` surface).  Switch codecs
+        # declare these ``supported``; router / firewall codecs that drop
+        # them declare ``unsupported`` — so walking them surfaces the L2
+        # loss when a switch config is migrated to a routed target.  The
+        # spelling matches the existing nxos / aoscx matrix declarations
+        # (no ``config/`` segment).
+        if iface.switchport_mode:
+            yield "/interfaces/interface/switchport-mode"
+        if iface.access_vlan is not None:
+            yield "/interfaces/interface/access-vlan"
+        if iface.trunk_allowed_vlans:
+            yield "/interfaces/interface/trunk-allowed-vlans"
+        if iface.trunk_native_vlan is not None:
+            yield "/interfaces/interface/trunk-native-vlan"
+        if iface.voice_vlan is not None:
+            yield "/interfaces/interface/voice-vlan"
         for _ in iface.vrrp_groups:
             yield "/interfaces/interface/vrrp-groups/group"
-    for _ in intent.vlans:
+    for vlan in intent.vlans:
         yield "/vlans/vlan/id"
         yield "/vlans/vlan/name"
+        if vlan.description:
+            yield "/vlans/vlan/description"
+        for _ in vlan.tagged_ports:
+            yield "/vlans/vlan/tagged-ports"
+        for _ in vlan.untagged_ports:
+            yield "/vlans/vlan/untagged-ports"
     for route in intent.static_routes:
         yield "/routing/static-route"
         if route.vrf:

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -124,7 +124,6 @@ class CiscoIOSXRCodec(CodecBase):
             "/system/hostname",
             # Interfaces — name + basic L3
             "/interfaces/interface/name",
-            "/interfaces/interface/config/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
             "/interfaces/interface/config/mtu",

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -122,7 +122,6 @@ class CiscoNXOSCodec(CodecBase):
             "/system/hostname",
             # Interfaces — name + basic L3
             "/interfaces/interface/name",
-            "/interfaces/interface/config/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
             "/interfaces/interface/config/mtu",

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -178,6 +178,16 @@ class MikroTikRouterOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "RouterOS exposes a single per-VLAN ``comment`` field, "
+                    "which the parser maps to the VLAN name; a separate "
+                    "description collides with it on render and may be "
+                    "conflated with the name."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/dhcp-client-v6",
                 reason=(
                     "RouterOS exposes IPv6 DHCPv6 client config under "

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -128,7 +128,6 @@ class VyOSCodec(CodecBase):
             # Interfaces — name + basic L3 (Phase 1; incl. vif VLAN
             # sub-interfaces modelled as ethN.<vid> interfaces).
             "/interfaces/interface/name",
-            "/interfaces/interface/config/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
             "/interfaces/interface/config/mtu",

--- a/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
+++ b/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
@@ -203,22 +203,22 @@ def test_every_top_level_field_is_walked():
 
 
 def test_per_interface_subfields_are_walked():
-    """The per-interface Tier-2 sub-fields with a real disposition
-    (mtu / vrf / lag-member-of) are walked.
-
-    Switchport sub-fields are deliberately NOT walked yet — see the
-    note in ``_walk_canonical`` (no codec declares a switchport
-    disposition, so walking them would be inert).  That arrives with
-    the matrix-normalisation pass (review #8)."""
+    """The per-interface Tier-2 sub-fields are walked — mtu / vrf /
+    lag-member-of / dhcp-client plus the switchport view (using the
+    no-``config/`` spelling that matches the nxos / aoscx matrix
+    declarations).  Switchport coverage landed with the registry
+    honesty guard (review #9)."""
     emitted = set(_walk_canonical(_kitchen_sink()))
     for xpath in (
         "/interfaces/interface/config/mtu",
         "/interfaces/interface/config/vrf",
         "/interfaces/interface/lag-member-of",
+        "/interfaces/interface/switchport-mode",
+        "/interfaces/interface/access-vlan",
+        "/interfaces/interface/trunk-allowed-vlans",
+        "/interfaces/interface/trunk-native-vlan",
     ):
         assert xpath in emitted, f"_walk_canonical drops {xpath!r}"
-    # Switchport paths are intentionally absent in this PR.
-    assert "/interfaces/interface/config/switchport-mode" not in emitted
 
 
 def test_snmp_v3_subfields_are_walked():

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -1,0 +1,295 @@
+"""
+Registry-wide capability-matrix honesty guard (review finding #9).
+
+The 2026-06 architecture review flagged that the two-sided
+render/walker honesty invariant was enforced for exactly ONE codec
+(the cisco_iosxe NETCONF stub, in
+``tests/unit/migration/codecs/cisco_iosxe/test_capability_matrix_honesty.py``)
+and left the 11 production codecs ungated: a render expansion or a
+matrix loosening could drift a codec's declared capabilities away from
+its real behaviour with no failing test.
+
+This module promotes the guard to the whole registry.  It enforces the
+two *robust* directions of the honesty invariant — the ones that have
+no false positives across a single universal kitchen-sink:
+
+1. **Reverse-parity** (``test_declared_supported_is_walkable``): every
+   ``supported`` xpath a codec declares must be a string the shared
+   canonical walker (``_walk_canonical``) can actually emit.  A declared
+   path the walker never yields is unreachable by ``validate_against``
+   (``CapabilityMatrix.classify`` is exact-string match) — a dead
+   declaration.  This is the guard the project's own expectation YAML
+   asked for (``cisco_iosxe_cli__cisco_iosxe.yaml``: "assert every
+   supported path is actually walked by the codec's iter_xpaths").
+
+2. **Rendered ⇒ not-unsupported** (``test_rendered_field_not_unsupported``):
+   render a kitchen-sink, re-parse it, and for every top-level field
+   that SURVIVES the round-trip (i.e. the codec demonstrably renders it)
+   assert the codec does NOT declare that field ``unsupported``.  A
+   matrix that calls a surface unsupported while the codec actually
+   round-trips it is a lie that would wrongly block / warn a migration.
+   Field *survival* is unambiguous (no vendor-naming false positives),
+   so this direction is safe to enforce registry-wide.
+
+3. **No supported/unsupported overlap** (``test_no_supported_unsupported_overlap``).
+
+The third honesty direction — *dropped*-field ⇒ ``unsupported`` — is
+NOT enforced here.  Detecting a "drop" from a single universal
+kitchen-sink produces vendor-naming false positives (e.g. a LAG whose
+member interface name isn't valid for a given vendor fails to render,
+which looks like "drops all LAGs" when the codec supports LAGs with
+native names).  Forcing declarations from those false positives would
+make the matrices *less* honest.  That direction stays covered by the
+per-codec round-trip tests (``parse(render(x)) == x`` for the supported
+subset) and the offline cross-mesh fidelity audit, plus the dedicated
+cisco_iosxe stub guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalDHCPPool,
+    CanonicalEvpnType5Route,
+    CanonicalIntent,
+    CanonicalInterface,
+    CanonicalIPv4Address,
+    CanonicalIPv6Address,
+    CanonicalLAG,
+    CanonicalLocalUser,
+    CanonicalRADIUSServer,
+    CanonicalRoutingInstance,
+    CanonicalSNMP,
+    CanonicalSNMPv3User,
+    CanonicalStaticRoute,
+    CanonicalVlan,
+    CanonicalVRRPGroup,
+    CanonicalVxlan,
+)
+from netcanon.migration.codecs.cisco_iosxe_cli.codec import _walk_canonical
+from netcanon.migration.codecs.registry import get_codec, list_codecs
+
+# Explicit imports so every codec is registered when this module runs
+# standalone (mirrors run_full_mesh.py / test_cross_mesh_overrides.py).
+from netcanon.migration.codecs import (  # noqa: F401
+    arista_eos,
+    aruba_aoscx,
+    aruba_aoss,
+    cisco_iosxe,
+    cisco_iosxe_cli,
+    cisco_iosxr,
+    cisco_nxos,
+    fortigate_cli,
+    juniper_junos,
+    mikrotik_routeros,
+    opnsense,
+    vyos,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Registry under test — every BIDIRECTIONAL codec except the reference
+# mock adapter (which uses a flat-dict tree, not the canonical walker).
+# ---------------------------------------------------------------------------
+
+def _bidirectional_codec_names() -> list[str]:
+    names = []
+    for name in sorted(list_codecs()):
+        if name == "mock":
+            continue
+        codec = get_codec(name)
+        if getattr(codec, "direction", "bidirectional") == "bidirectional":
+            names.append(name)
+    return names
+
+
+_CODEC_NAMES = _bidirectional_codec_names()
+
+
+def _maximal_intent() -> CanonicalIntent:
+    """A CanonicalIntent populating every canonical sub-field the walker
+    yields conditionally, so ``set(_walk_canonical(intent))`` is the full
+    universe of emittable xpaths.
+
+    Internally consistent (LAG members + VLAN ports reference defined
+    interfaces) so codecs render + re-parse it without raising.
+    """
+    addr4 = CanonicalIPv4Address(
+        ip="10.0.0.1", prefix_length=24,
+        virtual_gateway_address="10.0.0.254",
+        virtual_gateway_mac="00:00:5e:00:01:01",
+    )
+    addr6 = CanonicalIPv6Address(
+        ip="2001:db8::1", prefix_length=64,
+        virtual_gateway_address="2001:db8::254",
+        virtual_gateway_mac="00:00:5e:00:02:01",
+    )
+    iface = CanonicalInterface(
+        name="Ethernet1", default_name="Ethernet1", description="d",
+        enabled=True, interface_type="ianaift:ethernetCsmacd", mtu=9000,
+        ipv4_addresses=[addr4], ipv6_addresses=[addr6],
+        switchport_mode="trunk", access_vlan=10, trunk_allowed_vlans=[10, 20],
+        trunk_native_vlan=99, voice_vlan=200, lag_member_of="Port-Channel1",
+        dhcp_client=True, dhcp_client_v6="dhcp6", tunnel_type="gre",
+        vrf="TENANT",
+        vrrp_groups=[CanonicalVRRPGroup(group_id=10, virtual_ips=["10.0.0.254"])],
+    )
+    iface2 = CanonicalInterface(
+        name="Ethernet2", enabled=True,
+        interface_type="ianaift:ethernetCsmacd",
+    )
+    return CanonicalIntent(
+        hostname="h", domain="d.test", dns_servers=["10.0.0.53"],
+        ntp_servers=["10.0.0.123"], timezone="UTC",
+        syslog_servers=["10.0.0.514"],
+        interfaces=[iface, iface2],
+        vlans=[CanonicalVlan(
+            id=10, name="V", description="desc",
+            tagged_ports=["Ethernet1"], untagged_ports=["Ethernet2"],
+            ipv4_addresses=[addr4])],
+        static_routes=[CanonicalStaticRoute(
+            destination="0.0.0.0/0", gateway="10.0.0.2", vrf="TENANT")],
+        anycast_gateway_mac="00:1c:73:00:dc:01",
+        dhcp_servers=[CanonicalDHCPPool(
+            network="10.0.0.0/24", start_ip="10.0.0.10", end_ip="10.0.0.99")],
+        snmp=CanonicalSNMP(
+            community="c", location="l", contact="ct", trap_hosts=["10.0.0.9"],
+            v3_users=[CanonicalSNMPv3User(
+                name="u", group="g", auth_protocol="sha",
+                auth_passphrase="$9$a", priv_protocol="aes",
+                priv_passphrase="$9$p", engine_id="80000009ff")]),
+        lags=[CanonicalLAG(
+            name="Port-Channel1", members=["Ethernet1"], mode="active")],
+        local_users=[CanonicalLocalUser(
+            name="admin", privilege_level=15, hashed_password="$9$h",
+            role="admin")],
+        radius_servers=[CanonicalRADIUSServer(host="10.0.0.1", key="$9$r")],
+        vxlan_vnis=[CanonicalVxlan(
+            vlan_id=10, vni=10010, mcast_group="239.1.1.1",
+            flood_list=["10.0.0.5"], source_interface="Loopback0",
+            udp_port=4789)],
+        evpn_type5_routes=[CanonicalEvpnType5Route(
+            vrf="TENANT", prefix="10.0.0.0/16")],
+        routing_instances=[CanonicalRoutingInstance(
+            name="TENANT", instance_type="vrf",
+            route_distinguisher="65000:1", rt_imports=["65000:1"],
+            rt_exports=["65000:1"], description="t", l3_vni=50010)],
+    )
+
+
+#: Every xpath the shared walker can emit when every surface is populated.
+_WALKABLE = frozenset(_walk_canonical(_maximal_intent()))
+
+
+#: Top-level CanonicalIntent fields → the xpath markers that declare the
+#: WHOLE field unsupported (the top-level field-marker ``/{field}`` plus
+#: the field's primary-identity / base path).  Deliberately exact-match,
+#: NOT prefix-match: a codec that declares a *sub-field* unsupported
+#: (e.g. opnsense ``/snmp/v3-user``, vyos ``/vxlan-vnis/l2vni-route-target``,
+#: aoscx ``/routing-instances/instance/description``) while supporting the
+#: base surface is exercising normal partial support, not declaring the
+#: field unsupported — so a prefix match would mis-fire on it.
+_FIELD_TO_UNSUPPORTED_MARKERS: dict[str, tuple[str, ...]] = {
+    "hostname": ("/system/hostname", "/hostname"),
+    "domain": ("/system/domain", "/domain"),
+    "dns_servers": ("/system/dns-server", "/dns_servers"),
+    "ntp_servers": ("/system/ntp-server", "/ntp_servers"),
+    "syslog_servers": ("/system/syslog-server", "/syslog_servers"),
+    "vlans": ("/vlans", "/vlans/vlan/id"),
+    "static_routes": ("/routing/static-route", "/static_routes"),
+    "dhcp_servers": ("/dhcp-servers/pool", "/dhcp_servers"),
+    "snmp": ("/snmp", "/snmp/community"),
+    "lags": ("/lags", "/lags/lag/name"),
+    "local_users": ("/local_users", "/local-users/user/name"),
+    "radius_servers": ("/radius_servers", "/radius-servers/server/host"),
+    "vxlan_vnis": ("/vxlan_vnis", "/vxlan-vnis/vni"),
+    "evpn_type5_routes": ("/evpn_type5_routes", "/evpn-type5-routes/route"),
+    "routing_instances": (
+        "/routing_instances",
+        "/routing-instances/instance",
+        "/routing-instances/instance/name",
+    ),
+}
+
+
+def _declares_unsupported(unsupported: set[str], markers: tuple[str, ...]) -> bool:
+    """True iff the WHOLE field is declared unsupported (exact match on a
+    field-marker / primary-identity path)."""
+    return any(m in unsupported for m in markers)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_non_empty():
+    """Sanity: the bidirectional registry resolved to the expected fleet."""
+    assert len(_CODEC_NAMES) >= 11, _CODEC_NAMES
+
+
+@pytest.mark.parametrize("name", _CODEC_NAMES)
+def test_declared_supported_is_walkable(name: str):
+    """Every ``supported`` xpath a codec declares must be a string the
+    shared canonical walker can emit (reverse-parity, review #8c).
+
+    A ``supported`` path the walker never yields is unreachable by
+    ``validate_against`` — exact-string ``classify`` can never be invoked
+    with it — so it is a dead declaration that silently drifts the matrix
+    from the walker's vocabulary."""
+    codec = get_codec(name)
+    supported = set(codec.capabilities.supported)
+    unreachable = sorted(supported - _WALKABLE)
+    assert not unreachable, (
+        f"{name}: declares supported xpath(s) the canonical walker never "
+        f"emits, so validate_against can never reach them: {unreachable}.  "
+        f"Either normalise the declaration to the walker's vocabulary or "
+        f"add the yield to _walk_canonical."
+    )
+
+
+@pytest.mark.parametrize("name", _CODEC_NAMES)
+def test_rendered_field_not_unsupported(name: str):
+    """A top-level field that SURVIVES a render→re-parse round-trip is
+    demonstrably emitted by the codec, so it must NOT be declared
+    ``unsupported`` (review #9, the safe half of the render-honesty
+    invariant — field survival has no vendor-naming false positives)."""
+    codec = get_codec(name)
+    intent = _maximal_intent()
+    src = intent.model_dump()
+    rendered = codec.render(intent)
+    reparsed = codec.parse(rendered).model_dump()
+    unsupported = {u.path for u in codec.capabilities.unsupported}
+
+    lies = []
+    for field, markers in _FIELD_TO_UNSUPPORTED_MARKERS.items():
+        survived = bool(src.get(field)) and bool(reparsed.get(field))
+        if survived and _declares_unsupported(unsupported, markers):
+            lies.append(field)
+    assert not lies, (
+        f"{name}: declares these field(s) unsupported yet round-trips them "
+        f"(render→parse preserves the surface): {lies}.  The matrix lies in "
+        f"the dangerous direction — a real migration would be wrongly "
+        f"warned/blocked.  Remove the UnsupportedPath or fix the render."
+    )
+
+
+@pytest.mark.parametrize("name", _CODEC_NAMES)
+def test_no_supported_unsupported_overlap(name: str):
+    """No xpath may appear in BOTH supported and unsupported (copy-paste
+    drift guard; generalises the per-codec cisco_iosxe check)."""
+    caps = get_codec(name).capabilities
+    overlap = set(caps.supported) & {u.path for u in caps.unsupported}
+    assert not overlap, f"{name}: xpath(s) both supported AND unsupported: {overlap}"
+
+
+def test_maximal_intent_exercises_every_top_level_field():
+    """Guard the guard: the kitchen-sink must populate every top-level
+    field, else the reverse-parity universe (_WALKABLE) would be too
+    small and the checks above would pass vacuously."""
+    dump = _maximal_intent().model_dump()
+    for field in _FIELD_TO_UNSUPPORTED_MARKERS:
+        assert dump.get(field), f"_maximal_intent left {field!r} empty"


### PR DESCRIPTION
## What

Keystone PR-3 of 3 (review finding #9 — the durable guard). Builds on [#60](https://github.com/netcanon/netcanon/pull/60) + [#61](https://github.com/netcanon/netcanon/pull/61).

The two-sided render/walker honesty invariant was enforced for exactly **one** codec (the cisco_iosxe NETCONF stub). The 11 production codecs were ungated — a render expansion or matrix loosening could drift declared capabilities from real behaviour with no failing test (architecture review, finding #9).

## The guard

New `tests/unit/migration/test_registry_capability_honesty.py` parametrises over every bidirectional codec and enforces the two **false-positive-free** directions of the invariant:

- **Reverse-parity** (#8c): every declared `supported` xpath must be one the shared canonical walker can emit. A path it can't yield is unreachable by `validate_against` (exact-string `classify`) → a dead declaration. *(This is the guard the project's own `cisco_iosxe_cli__cisco_iosxe.yaml` comment asked for.)*
- **Rendered ⇒ not-unsupported**: a top-level field that survives a render→re-parse round-trip must not be declared `unsupported` — a matrix calling a round-tripped surface unsupported would wrongly block/warn a real migration. Field *survival* is unambiguous → no vendor-naming false positives.
- Plus no-supported/unsupported-overlap + a guard-the-guard kitchen-sink completeness check.

## Walker completion (finishes #7)

To make reverse-parity pass, `_walk_canonical` now yields the remaining declared surfaces:
- VLAN `tagged-ports` / `untagged-ports` / `description`
- per-interface switchport view (`switchport-mode` / `access-vlan` / `trunk-allowed-vlans` / `trunk-native-vlan`, no-`config/` spelling matching nxos/aoscx)
- `dhcp-client` (v4)
- IPv6 `virtual-gateway-address` / `virtual-gateway-mac` + IPv4 `virtual-gateway-mac` (the IPv4 path already carried `-address`)

…and the redundant `/interfaces/interface/config/name` declaration (5 codecs) is dropped in favour of the walkable `/interfaces/interface/name`. aruba_aoss now declares its switchport view `supported` (round-trips L2 membership); mikrotik declares `/vlans/vlan/description` lossy (RouterOS overloads its single per-VLAN comment).

## Why it's safe

No parse/render change and **no `unsupported` declaration changed**, so the committed cross-mesh fidelity matrix is untouched (**CODEC_BUG flat at 5**) — regen not required.

## Scope note

The third honesty direction — *dropped*-field ⇒ unsupported — is **not** enforced here: detecting a "drop" from a single universal kitchen-sink produces vendor-naming false positives (a LAG whose member name isn't valid for a vendor fails to render → looks like "drops all LAGs" when the codec supports LAGs natively). Forcing declarations from those would make matrices *less* honest. That direction stays covered by the per-codec round-trip tests + the offline cross-mesh audit + the dedicated cisco_iosxe stub guard.

## Test

Full unit + integration gate: **4586 passed, 82 skipped** (+38 registry tests: reverse-parity ×12, rendered⇒not-unsupported ×12, no-overlap ×12, +2 sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
