### PR TITLE
chore(security): PII recurrence guard — CI scan + pre-push hook (remediation Phase 0)

### DIFF
--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -1,0 +1,60 @@
+name: PII guard
+
+# Recurrence guard for the 2026-06 PII remediation: fail the build if any
+# tracked file leaks the maintainer's personal email or an operator-machine
+# Windows user-profile path.  Runs on every PR and push to main.
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+# Read-only: this job only inspects the checked-out tree.
+permissions:
+  contents: read
+
+jobs:
+  scan-tracked-files:
+    name: No leaked personal identifiers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: git grep tracked files for leaked identifiers
+        run: |
+          # Scope: tracked files only.  The review dossier under
+          # docs/codebase-review/ intentionally quotes these values and is
+          # gitignored, so git grep never sees it.  Commit-message /
+          # Co-authored-by trailer hygiene is enforced locally by
+          # scripts/git-hooks/pre-push (see its header for how to enable it).
+          #
+          # The patterns use regex character classes (`[i]` = a literal
+          # `i`, `[\]` = a literal backslash) for two reasons:
+          #   1. The forbidden literals (the personal email and the
+          #      Windows user-profile path prefix) then never appear
+          #      verbatim ANYWHERE in this committed file — not even in
+          #      these comments — so the guard does not itself reintroduce
+          #      the very strings the remediation scrubs, and it does not
+          #      match its own text (no self-exclude needed).
+          #   2. `git grep -E` does NOT treat a bare `\\` as a reliable
+          #      literal backslash (it silently fails to match → the
+          #      guard would pass VACUOUSLY); a `[\]` class DOES match.
+          #      Both forms are verified against real operator-path
+          #      content.
+          #
+          # `git grep` exits 0 on match, 1 on no-match, 2 on error; we
+          # treat the error case as a FAILURE (fail closed), not "clean".
+          set +e
+          git grep -nI -E 'samuelr[i]pp09|C:[\]Users' -- .
+          rc=$?
+          set -e
+          if [ "${rc}" -eq 0 ]; then
+            echo "::error::A tracked file leaks a personal identifier or an operator-machine path (matches above). Redact it. (The review dossier that legitimately quotes these values is gitignored and is not scanned.)"
+            exit 1
+          elif [ "${rc}" -ne 1 ]; then
+            echo "::error::PII guard could not run (git grep exit ${rc}) — failing closed."
+            exit 1
+          fi
+          echo "PII guard: clean — no leaked identifiers in tracked files."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ timestamp if your timezone matters for an audit.
 
 ### Security
 
+* **PII-recurrence guard (Phase 0 of the 2026-06 PII remediation).**  A new
+  `.github/workflows/pii-guard.yml` job `git grep`s the tracked tree on every
+  PR / push and fails the build if any file leaks the maintainer's personal
+  email or an operator-machine Windows user-profile path.  A committed
+  local hook (`scripts/git-hooks/pre-push`, opt in with
+  `git config core.hooksPath scripts/git-hooks`) covers the
+  commit-message / `Co-authored-by:`-trailer / author-identity vector before
+  a push leaves the machine.  Both guards assemble or self-exclude their own
+  patterns so they don't match themselves, and the gitignored review dossier
+  (which legitimately quotes the values) is never scanned.  This phase also
+  redacted the one residual operator path that the original pre-launch sweep
+  missed (a committed review doc, `docs/project-review/.../01-investigation-CE-god-file.md`)
+  and corrected that sweep's stale "zero hits" assertion.  *Phase 1 (the
+  destructive history rewrite that scrubs the 17 `Co-authored-by:` gmail
+  trailers baked into pre-existing tags) is tracked separately; this is the
+  non-destructive recurrence guard only.*
+
 * **Opt-in SSH host-key verification for the backup collectors (review finding
   #11).**  Both collectors previously installed paramiko `AutoAddPolicy` —
   trusting any host key unconditionally, so a man-in-the-middle on the
@@ -3777,8 +3794,12 @@ of the file explaining the situation honestly.
 Verified clean:
 
 * No maintainer name / email variants present in the tracked tree
-* No operator-machine path leaks (Windows `C:\Users\...` /
-  Linux `/home/<user>/` — zero hits)
+* No operator-machine path leaks (Windows user-profile or Linux
+  home-directory paths).  *Correction (see the "PII-recurrence guard"
+  entry under [Unreleased]): this sweep was incomplete — one residual
+  operator path survived in a committed review doc and was missed
+  here; it has since been redacted and a CI guard now enforces the
+  invariant on every push.*
 * All sample IPs in tracked content are RFC1918 (`192.168.x` /
   `10.x.x.x` / `172.16.x.x`) or RFC5737 (`192.0.2.x` /
   `198.51.100.x` / `203.0.113.x`) docs ranges — no real WAN IPs

--- a/docs/project-review/2026-06-06/code-review/01-investigation-CE-god-file.md
+++ b/docs/project-review/2026-06-06/code-review/01-investigation-CE-god-file.md
@@ -1,7 +1,7 @@
 # 01 — Investigation CE — God-File / Cohesion / SRP Assessment
 
 *Reviewer lens: CE. Read-only, review-grade. Commit `b08040c` (v0.1.2).*
-*Repo root: `C:\Users\user12\Desktop\Test fgopn\.claude\worktrees\gifted-swirles`.*
+*Repo root: `<repo>` (operator-machine path redacted).*
 
 ---
 

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# pre-push PII guard — block pushing commits whose MESSAGE, author, or
+# committer identity leaks the maintainer's personal email or an
+# operator-machine Windows user-profile path.
+#
+# This is the local complement to the CI `pii-guard.yml` workflow:
+#   * CI scans tracked FILE CONTENT on the server (the file-leak vector).
+#   * this hook scans pushed COMMIT MESSAGES + author/committer identity
+#     on your machine (the trailer / identity vector — the 2026-06 leak
+#     was 17 `Co-authored-by:` gmail trailers in commit bodies).
+# Recurrence guard for the 2026-06 PII remediation.
+#
+# Enable once per clone (the hook is committed but git does not run
+# hooks from a tracked directory automatically):
+#
+#     git config core.hooksPath scripts/git-hooks
+#
+# The forbidden patterns use regex character classes so the literal
+# strings never appear verbatim in this file — that keeps the CI
+# `pii-guard.yml` content scan (which fixed-string-matches the same
+# values) from flagging this hook.  `[i]` matches a literal `i`; `[\]`
+# matches a literal backslash.  Both are confirmed to match in `grep
+# -E` (a bare `\\` is NOT a reliable literal-backslash there).
+set -euo pipefail
+
+ZERO='0000000000000000000000000000000000000000'
+
+email_re='samuelr[i]pp09'
+path_re='C:[\]Users[\]user12'
+combined_re="${email_re}|${path_re}"
+
+fail=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Nothing to push for this ref (a branch delete).
+    [ "${local_sha}" = "${ZERO}" ] && continue
+
+    if [ "${remote_sha}" = "${ZERO}" ]; then
+        # New branch on the remote: only the commits not already on a
+        # remote-tracking branch, so shared history isn't re-scanned.
+        range_args="${local_sha} --not --remotes"
+    else
+        range_args="${remote_sha}..${local_sha}"
+    fi
+
+    # Scan author + committer identity AND the full commit message of
+    # every pushed commit.  (File content is the CI guard's job.)
+    hits=$(git log --format='%an <%ae>%n%cn <%ce>%n%B' ${range_args} 2>/dev/null \
+             | grep -nE "${combined_re}" || true)
+    if [ -n "${hits}" ]; then
+        echo "pre-push: leaked identifier in commits ${range_args}:" >&2
+        echo "${hits}" >&2
+        fail=1
+    fi
+done
+
+if [ "${fail}" -ne 0 ]; then
+    echo "" >&2
+    echo "pre-push: BLOCKED — a pushed commit's message or identity leaks" >&2
+    echo "a personal identifier or operator path (see matches above)." >&2
+    echo "Fix the author/committer (git config user.email) or amend the" >&2
+    echo "message, then re-push." >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

**Phase 0 (non-destructive)** of the 2026-06 PII remediation. Stops the operator-path / personal-email leak from *recurring*, and redacts the one residual the pre-launch sweep missed. *(Phase 1 — the destructive history rewrite that scrubs the gmail trailers baked into existing tags — is tracked separately.)*

### What's added
- **`.github/workflows/pii-guard.yml`** — a CI job that `git grep`s the tracked tree on every PR / push and **fails the build** if any file leaks the maintainer's personal email or a Windows user-profile path. Fails **closed** on a `git grep` error (exit 2) so a malformed pattern can't pass vacuously — a trap this PR hit and fixed during development.
- **`scripts/git-hooks/pre-push`** — a committed local hook (opt in with `git config core.hooksPath scripts/git-hooks`) that blocks pushing commits whose **message / author / committer identity** carries the same patterns. This covers the trailer vector (the original leak was `Co-authored-by:` gmail trailers in commit bodies).

### Design notes
- Both guards use regex **character classes** (`[i]`, `[\]`) so the forbidden literals **never appear verbatim in any committed file** — the guard can neither reintroduce what the remediation scrubs nor match its own text (so no self-exclude is needed).
- The gitignored review dossier (`docs/codebase-review/`) legitimately quotes these values and is never scanned (untracked).

### Redactions in this PR
- The residual operator path in a committed review doc (`docs/project-review/2026-06-06/code-review/01-investigation-CE-god-file.md`).
- Corrected that pre-launch sweep's now-inaccurate "zero hits" CHANGELOG note.

### Verification (local)
- Guard **matches** real `C:\Users…` + email content (rc 0); **rc 1** on the now-clean tree; **zero** literal occurrences of either pattern anywhere in the tracked tree (incl. the guard files themselves).
- Pre-push hook detects a planted trailer and does not self-match.
- This PR's own CI run exercises `pii-guard.yml` against the branch — it should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)