### PR TITLE
fix(arista): round-trip fidelity — SVI/VLAN-name fold, RADIUS line-bleed, trunk stale access-VLAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,36 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Fixed
+
+* **arista_eos round-trip fidelity (3 defects).**  Surfaced while
+  diffing `parse(render(parse(x)))` against `parse(x)` on an Arista AVD
+  `eos_cli_config_gen` golden config during the 2026-06-15
+  `fixture-gap-hunt`; each broke parse→render→parse stability and is now
+  covered by a focused regression test.
+    1. **SVI-description / VLAN-name fold.**  The shared
+       `project_svi_to_vlan` transform folds an `interface Vlan<N>`
+       `description` into the synthesised VLAN name.  arista parse now
+       (a) normalises VLAN names to the EOS-safe form render emits
+       (`\s+`→`_`), so a multi-word `SVI Description` no longer drifts to
+       `SVI_Description` on the re-parse, and (b) runs the SVI fold
+       *before* the EVPN `router bgp / vlan N` pass so MAC-VRF names key
+       off the same VLAN names on both parses (previously
+       `routing_instances` drifted and collapsed 20→18).  The
+       synthesised-VLAN branch of `project_svi_to_vlan` now also dedupes
+       copied addresses, matching its merge branch.
+    2. **RADIUS line-bleed.**  `_RADIUS_SERVER_RE` no longer lets a bare
+       `radius-server host <ip>` line (what render emits for a key-less
+       server) consume the trailing newline and bleed into the next
+       line, which had swallowed entries / cross-attributed keys on
+       round-trip (12→9).
+    3. **Trunk stale access-VLAN.**  A port made a trunk now clears any
+       earlier `switchport access vlan` (render's trunk branch never
+       emits it, so a lingering value silently dropped on round-trip).
+  The real-capture round-trip harness now also sorts `routing_instances`
+  by name (cosmetic order, consistent with the 7 collections it already
+  sorts).
+
 ## [0.1.8] - 2026-06-15
 
 ### Security

--- a/netcanon/migration/canonical/transforms.py
+++ b/netcanon/migration/canonical/transforms.py
@@ -346,15 +346,31 @@ def project_svi_to_vlan(intent: CanonicalIntent) -> None:
         vid = int(m.group(1))
         existing = by_id.get(vid)
         if existing is None:
-            synthesised = CanonicalVlan(
-                id=vid,
-                name=iface.description,
-                ipv4_addresses=[
+            # Dedupe the copied addresses by (ip, prefix_length) — the
+            # same key the merge branch below uses.  Without this, an SVI
+            # carrying multiple addresses that reduce to the same
+            # (ip, prefix) pair (e.g. several VARP ``ip address virtual``
+            # entries that fold to empty-ip /N records) synthesises
+            # duplicate VLAN addresses on the first parse, while the merge
+            # branch dedupes them on the rendered-output re-parse — an
+            # asymmetry that breaks round-trip stability (observed on
+            # VLAN 83 of the Arista AVD kitchen-sink capture).
+            seen_synth: set[tuple[str, int]] = set()
+            synth_addrs: list[CanonicalIPv4Address] = []
+            for a in iface.ipv4_addresses:
+                pair = (a.ip, a.prefix_length)
+                if pair in seen_synth:
+                    continue
+                seen_synth.add(pair)
+                synth_addrs.append(
                     CanonicalIPv4Address(
                         ip=a.ip, prefix_length=a.prefix_length,
                     )
-                    for a in iface.ipv4_addresses
-                ],
+                )
+            synthesised = CanonicalVlan(
+                id=vid,
+                name=iface.description,
+                ipv4_addresses=synth_addrs,
             )
             intent.vlans.append(synthesised)
             by_id[vid] = synthesised

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -145,8 +145,16 @@ _USERNAME_RE = re.compile(
 # Form: ``radius-server host <ip> [auth-port N] [acct-port N] [key SECRET]``
 # Token order is fixed (host first) but the optional clauses may appear in
 # any order on the wire.  Match host + remainder, then post-extract.
+# NOTE the ``[^\S\n]`` (whitespace-except-newline) matchers, NOT ``\s``.
+# A bare ``radius-server host <ip>`` line (no trailing clauses — exactly
+# what render emits for a key-less server) followed by another
+# ``radius-server host ...`` line would, with a plain ``\s*`` before the
+# ``(.*)`` tail, let the ``\s*`` consume the newline and the ``(.*)``
+# bleed into the NEXT line — swallowing entries + cross-attributing keys
+# on a render->re-parse round-trip (same line-bleed hazard the username
+# regex documents above).  ``[^\S\n]*`` keeps the match on one line.
 _RADIUS_SERVER_RE = re.compile(
-    r"^radius-server\s+host\s+(\d+\.\d+\.\d+\.\d+)\s*(.*)$",
+    r"^radius-server[^\S\n]+host[^\S\n]+(\d+\.\d+\.\d+\.\d+)[^\S\n]*(.*)$",
     re.MULTILINE,
 )
 _RADIUS_AUTH_PORT_RE = re.compile(r"\bauth-port\s+(\d+)")
@@ -541,9 +549,6 @@ def parse_intent(raw: str) -> CanonicalIntent:
     #     current-stanza tracking, same pattern as cisco_iosxe_cli) ---
     _parse_stanzas(raw, intent)
 
-    # --- router bgp <asn> / vrf <name> / rd + route-target (GAP 6) ---
-    _parse_router_bgp(raw, intent)
-
     # SVI fold: ``interface Vlan<N> / ip address ...`` lines carry
     # the Layer-3 surface for VLAN <N>.  VLAN-centric renderers
     # (Aruba AOS-S, OPNsense) read the L3 off
@@ -551,11 +556,39 @@ def parse_intent(raw: str) -> CanonicalIntent:
     # interface, so without this fold the SVI IP silently drops on
     # cross-vendor render.  Mirrors the same call in
     # ``cisco_iosxe_cli/parse.py``.  See translator-plans.txt BUG 1.
+    #
+    # Ordering (round-trip fix, 2026-06): the fold runs BEFORE
+    # ``_parse_router_bgp`` so the EVPN MAC-VRF name derivation
+    # (``router bgp / vlan N`` -> CanonicalRoutingInstance keyed by the
+    # matching CanonicalVlan.name) sees the SAME vlan names on the
+    # source parse and the rendered-output re-parse.  Previously the
+    # fold ran AFTER _parse_router_bgp, so a description-only SVI had no
+    # VLAN record yet on the source parse (MAC-VRF fell back to the
+    # synthetic ``VLAN<id>`` name) while the re-parse saw the
+    # render-emitted ``vlan N name <desc>`` stanza and keyed off the
+    # folded name -> routing_instances drifted + collapsed (20->18 on
+    # the AVD kitchen-sink capture).
     from ...canonical.transforms import (
         project_svi_to_vlan,
         project_switchport_to_vlan,
     )
     project_svi_to_vlan(intent)
+
+    # EOS VLAN names are whitespace-tokenised (no spaces permitted); the
+    # render path collapses each whitespace run in ``name`` to a single
+    # underscore (see ``render.py`` "VLANs" block).  Apply the SAME
+    # normalisation here so the canonical name produced by parse already
+    # equals what render will emit -- otherwise an SVI-description-folded
+    # name like ``SVI Description`` round-trips unstably (parse
+    # ``SVI Description`` -> render ``SVI_Description`` -> re-parse
+    # ``SVI_Description``).  Real ``vlan N name X`` stanzas are already
+    # single-token, so this is a no-op for them.
+    for _vlan in intent.vlans:
+        if _vlan.name:
+            _vlan.name = re.sub(r"\s+", "_", _vlan.name.strip())
+
+    # --- router bgp <asn> / vrf <name> / rd + route-target (GAP 6) ---
+    _parse_router_bgp(raw, intent)
 
     # Bug 3 transpose: mirror per-port switchport state into the
     # VLAN-centric tagged_ports / untagged_ports lists so VLAN-
@@ -1110,6 +1143,12 @@ def _apply_iface_subcommand(
     if line.startswith("switchport trunk allowed vlan "):
         # ``switchport trunk allowed vlan 10,20,30-35``
         iface.switchport_mode = "trunk"
+        # A trunk port has no access VLAN.  Clear any access_vlan set by
+        # an earlier (now-superseded) ``switchport access vlan`` line in
+        # the same stanza so the canonical is internally consistent —
+        # render's trunk branch never emits ``switchport access vlan``,
+        # so a lingering access_vlan would silently drop on round-trip.
+        iface.access_vlan = None
         tail = line.split(None, 4)[-1]
         iface.trunk_allowed_vlans = _expand_vlan_list(tail)
         return
@@ -1129,6 +1168,9 @@ def _apply_iface_subcommand(
         return
     if line == "switchport mode trunk":
         iface.switchport_mode = "trunk"
+        # Trunk ports carry no access VLAN — clear a stale access_vlan
+        # (see the ``switchport trunk allowed vlan`` handler above).
+        iface.access_vlan = None
         return
     if line == "switchport mode access":
         iface.switchport_mode = "access"

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -1913,3 +1913,111 @@ class TestVARPAnycast:
         )
         # System MAC.
         assert intent.anycast_gateway_mac == "00:1c:73:00:dc:01"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip fidelity regressions — surfaced by the AVD eos_cli_config_gen
+# ``host1.cfg`` kitchen-sink real capture (2026-06).  Each is a minimal
+# synthetic repro of one defect that broke parse->render->parse stability.
+# ---------------------------------------------------------------------------
+
+
+def _rt(raw: str) -> tuple[CanonicalIntent, CanonicalIntent]:
+    """parse -> render -> parse; return (first, second) intents."""
+    codec = AristaEOSCodec()
+    first = codec.parse(raw)
+    second = codec.parse(codec.render(first))
+    return first, second
+
+
+class TestRoundTripFixes:
+    def test_trunk_clears_stale_access_vlan(self):
+        """Defect 3: a port set to ``switchport access vlan N`` and THEN
+        made a trunk must not retain the access VLAN — render's trunk
+        branch never emits ``switchport access vlan`` so a lingering
+        value silently drops on round-trip (Port-Channel100 in the AVD
+        capture: access_vlan 200 -> None)."""
+        raw = (
+            "interface Port-Channel20\n"
+            "   switchport access vlan 200\n"
+            "   switchport trunk allowed vlan 10-11\n"
+            "!\n"
+        )
+        first, second = _rt(raw)
+        po = next(i for i in first.interfaces if i.name == "Port-Channel20")
+        assert po.switchport_mode == "trunk"
+        assert po.access_vlan is None  # cleared when the port became a trunk
+        # And the round-trip is stable on the interface set.
+        def ifaces(intent):
+            return sorted(
+                (i.name, i.switchport_mode, i.access_vlan,
+                 tuple(sorted(i.trunk_allowed_vlans)))
+                for i in intent.interfaces
+            )
+        assert ifaces(first) == ifaces(second)
+
+    def test_svi_description_vlan_name_and_macvrf_stable(self):
+        """Defect 1: an ``interface Vlan<N>`` whose only label is a
+        multi-word ``description`` (no ``vlan <N>`` stanza) folds the
+        description into the VLAN name; EOS names can't contain spaces so
+        render sanitises ``SVI Description`` -> ``SVI_Description``.  Parse
+        must apply the same normalisation, and the EVPN MAC-VRF name
+        derivation must be consistent across both parses so
+        routing_instances neither drift nor collapse."""
+        raw = (
+            "interface Vlan24\n"
+            "   description SVI Description\n"
+            "   ip address 10.0.24.1/24\n"
+            "!\n"
+            "interface Vlan25\n"
+            "   description SVI Description\n"
+            "   ip address 10.0.25.1/24\n"
+            "!\n"
+            "router bgp 65001\n"
+            "   vlan 24\n"
+            "      rd 1.1.1.1:24\n"
+            "      route-target both 65001:24\n"
+            "   !\n"
+            "   vlan 25\n"
+            "      rd 1.1.1.1:25\n"
+            "      route-target both 65001:25\n"
+            "   !\n"
+            "!\n"
+        )
+        first, second = _rt(raw)
+        # VLAN names are EOS-safe (no whitespace) already after parse.
+        for v in first.vlans:
+            assert " " not in v.name, f"vlan {v.id} name {v.name!r} has a space"
+        # The two distinct VLANs do NOT collapse their MAC-VRFs, and the
+        # routing-instance set is stable across the round-trip.
+        def ri_names(intent):
+            return sorted(r.name for r in intent.routing_instances)
+        assert ri_names(first) == ri_names(second)
+        assert len(first.routing_instances) == len(second.routing_instances)
+        def vlans(intent):
+            return sorted((v.id, v.name) for v in intent.vlans)
+        assert vlans(first) == vlans(second)
+
+    def test_radius_bare_host_lines_dont_bleed(self):
+        """Defect 2: a key-less ``radius-server host <ip>`` line (which
+        render emits for a server with no key) must not let the parse
+        regex consume the newline and bleed into the next line —
+        previously the ``\\s*`` tail ate the ``\\n`` and swallowed
+        entries / cross-attributed keys (12 -> 9 on the AVD capture)."""
+        raw = (
+            "radius-server host 10.10.11.156\n"
+            "radius-server host 10.10.11.156 key 7\n"
+            "radius-server host 10.10.11.156\n"
+            "radius-server host 10.10.10.249 key 0\n"
+        )
+        first, second = _rt(raw)
+        assert len(first.radius_servers) == 4
+        # No key bled across lines: the bare 156 lines stay key-less and
+        # the 249 server keeps its own key.
+        s249 = [s for s in first.radius_servers if s.host == "10.10.10.249"]
+        assert len(s249) == 1 and s249[0].key == "0"
+        assert sum(1 for s in first.radius_servers if s.host == "10.10.11.156") == 3
+        # Round-trip stable on (host, key).
+        def rad(intent):
+            return sorted((s.host, s.key) for s in intent.radius_servers)
+        assert rad(first) == rad(second)

--- a/tests/unit/migration/test_real_captures.py
+++ b/tests/unit/migration/test_real_captures.py
@@ -354,6 +354,14 @@ def test_real_capture_round_trips_stable(
             ("dhcp_servers", "network"),
             ("local_users", "name"),
             ("radius_servers", "host"),
+            # routing_instances order is cosmetic (a set of VRFs /
+            # MAC-VRFs has no inherent order), same class as the
+            # collections above.  A renderer may emit them in a
+            # different order than the source file — e.g. EVPN MAC-VRFs
+            # keyed off VLAN names whose synthesis order shifts on a
+            # re-parse of rendered output.  Sort by name so the
+            # comparison checks canonical *meaning*, not emission order.
+            ("routing_instances", "name"),
         ]:
             if key in d and isinstance(d[key], list):
                 d[key] = sorted(d[key], key=lambda x: x.get(id_key, ""))


### PR DESCRIPTION
## What

Fixes **three `parse → render → parse` round-trip fidelity defects** in the
certified `arista_eos` codec. All are pure code fixes — **CODEC_BUG stays flat
at 5** and `CROSS_MESH_RESULTS.md` / `PHASE4_RECONCILIATION.md` are byte-identical
to `main` (the defects only manifest on a kitchen-sink config the existing corpus
doesn't contain).

## Why / how found

Surfaced while diffing `parse(render(parse(x)))` against `parse(x)` on an Arista
AVD `eos_cli_config_gen` golden config during the 2026-06-15 `fixture-gap-hunt`.
Each defect silently dropped or corrupted data on a render → re-parse and is now
covered by a focused synthetic regression test.

## The three defects

1. **SVI-description / VLAN-name fold.** The shared `project_svi_to_vlan`
   transform folds an `interface Vlan<N>` `description` into the synthesised VLAN
   name. arista parse now (a) normalises VLAN names to the EOS-safe (`\s+`→`_`)
   form render emits — so a multi-word `SVI Description` no longer drifts to
   `SVI_Description` on the re-parse — and (b) runs the SVI fold **before** the
   EVPN `router bgp / vlan N` pass, so MAC-VRF names key off the same VLAN names
   on both parses (`routing_instances` had drifted and collapsed 20→18). The
   synthesised-VLAN branch of `project_svi_to_vlan` now also dedupes copied
   addresses, matching its merge branch.

2. **RADIUS line-bleed.** `_RADIUS_SERVER_RE` no longer lets a bare
   `radius-server host <ip>` line (what render emits for a key-less server)
   consume the trailing newline and bleed into the next line, which had swallowed
   entries / cross-attributed keys on round-trip (12→9). Now anchored with
   `[^\S\n]` (whitespace-except-newline) instead of `\s`.

3. **Trunk stale access-VLAN.** A port made a trunk now clears any earlier
   `switchport access vlan` (render's trunk branch never emits it, so a lingering
   value silently dropped on round-trip).

The real-capture round-trip harness now also sorts `routing_instances` by name
(cosmetic order, consistent with the 7 collections it already sorts).

## Tests / verification

* `+3` focused `arista_eos` regression tests (`TestRoundTripFixes`).
* Full `tests/unit` + `tests/integration` suite green (2 pre-existing skips).
* Cross-mesh + phase4 regenerated locally: **CODEC_BUG = 5** (baseline), both
  `.md` artifacts byte-identical to `main`.

## Deferred (follow-up)

The AVD `eos_cli_config_gen` kitchen-sink fixture that surfaced these defects is
**intentionally not included here** — as a generated grammar torture-config it
adds ~9 `arista_eos → *` CODEC_BUG cells that each need phase4 triage. It (or a
realistic replacement exercising the same SNMPv3 / VRRP / IPv6-VARP / DHCP-pool /
tunnel / DHCPv6 surfaces) is tracked separately. Design notes:
`docs/fixture-gap-analysis/2026-06-15/arista-roundtrip-fix-plan.md` (on #68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
