### PR TITLE
fix(aruba_aoss): correct VRRP grammar to real AOS-S form (router vrrp + vrrp vrid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **aruba_aoss VRRP grammar corrected to the real AOS-S form.**  The
+  parser required `ip vrrp vrid <N>` and the renderer emitted it, but
+  real ArubaOS-Switch uses a global `router vrrp` enable plus
+  `vrrp vrid <N>` (NO `ip` prefix) nested in the `vlan N` stanza —
+  verified against the AOS-S 16.10 "Basic configuration process" CLI
+  reference and four independent operator captures (the
+  `fixture-gap-hunt` flagged this as the worst-covered codec's primary
+  blocker).  Parse now accepts the real `vrrp vrid` form (and still the
+  legacy `ip vrrp vrid` for back-compat), tolerates the older
+  `virtual-ip-address <ip> <mask>` two-token VIP, and maps the `owner`
+  role keyword to the canonical priority ceiling 254 (255 is reserved /
+  unrepresentable); render emits `router vrrp` + `vrrp vrid`.  No
+  cross-mesh change (no aoss fixture exercised VRRP); CODEC_BUG flat at
+  5.  Unblocks importing a real AOS-S VRRP capture.
+
 * **Cross-vendor VLAN SVI L3 now survives translation to SVI-model
   targets.**  A VLAN carrying its Layer-3 on
   ``CanonicalVlan.ipv4_addresses`` with NO sibling ``Vlan<N>`` interface

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -246,7 +246,7 @@ output.
 
 | Path | Class | Reason |
 |---|---|---|
-| `/interfaces/interface/vrrp-groups/group` | Supported (Wave B) | Parses + renders `ip vrrp vrid <N> / virtual-ip-address <Y> / priority / preempt / enable` inside `vlan N` stanzas (AOS-S binds VRRP to the SVI's VLAN, not the L3 interface). |
+| `/interfaces/interface/vrrp-groups/group` | Supported (Wave B) | Parses + renders a global `router vrrp` enable + `vrrp vrid <N> / owner\|priority / virtual-ip-address <Y> / preempt / enable` inside `vlan N` stanzas (AOS-S binds VRRP to the SVI's VLAN, not the L3 interface). The `vrrp vrid` header carries **no** `ip` prefix per the AOS-S 16.10 CLI reference; the legacy `ip vrrp vrid` form is still accepted on parse. `owner` maps to the canonical priority ceiling 254 (255 unrepresentable). |
 | `/interfaces/interface/vrrp-groups/group/virtual-ips` | Lossy (Wave B) | AOS-S `virtual-ip-address` accepts only ONE address per vrid; cross-vendor migration from Cisco IOS-XE secondaries or Junos `virtual-address [ list ]` drops the tail with a review comment. |
 | `/interfaces/interface/ipv4/address/virtual-gateway-address` | Unsupported | AOS-S has no anycast-gateway grammar (campus L2/L3 codec). |
 | `/interfaces/interface/ipv6/address/virtual-gateway-address` | Unsupported | Same as IPv4 — no native anycast grammar. |
@@ -644,7 +644,7 @@ different bytes on the wire.
 | Cisco IOS-XE | `interface X / vrrp 10 ip 192.168.1.254 / vrrp 10 priority 110 / vrrp 10 preempt` | `vrrp` (HSRP via `standby` grammar parses but renders as VRRP) |
 | Arista EOS | `interface VlanN / vrrp 10 ipv4 192.168.1.254 / vrrp 10 priority 110` (modern multi-line) | `vrrp` |
 | Juniper Junos | `set interfaces irb unit N family inet address X vrrp-group 10 virtual-address Y / priority 110 / preempt` | `vrrp` (IPv6 via `vrrp-inet6-group`) |
-| Aruba AOS-S | `vlan N / ip vrrp vrid 10 / virtual-ip-address Y / priority 110 / preempt / enable` | `vrrp` |
+| Aruba AOS-S | `router vrrp` + `vlan N / vrrp vrid 10 / virtual-ip-address Y / priority 110 / preempt / enable` | `vrrp` |
 | FortiGate | `config system interface / edit X / config vrrp / edit 10 / set vrip Y / set priority 110 / set preempt enable / next / end` | `vrrp` |
 | MikroTik RouterOS | `/interface vrrp add interface=ether1 vrid=10 priority=110 v3-protocol=ipv4` | `vrrp` |
 | OPNsense (BSD CARP) | `<virtualip><vip><mode>carp</mode><vhid>10</vhid><advskew>0</advskew><password>…</password><subnet>Y</subnet></vip></virtualip>` | `carp` (priority ↔ `254 − advskew`) |

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -20,7 +20,7 @@ location / contact / trap-host / v3 USM users with separate
 servers, VLANs (with absorbed SVI L3), physical interfaces
 (IPv4 + IPv6 with global / link-local scope discriminator), LAG
 trunk membership, static routes / default-gateway, and **VRRP
-groups** (``ip vrrp vrid N`` sub-block inside ``vlan N`` stanza
+groups** (``vrrp vrid N`` sub-block inside ``vlan N`` stanza
 with virtual-ip-address / priority / preempt / enable /
 authentication mode plaintext-password).  VRRP groups attach to
 the synthesised ``VlanN`` :class:`CanonicalInterface` via the
@@ -258,11 +258,14 @@ _IPV6_ADDR_RE = re.compile(
 )
 _IFACE_NAME_RE = re.compile(r'^name\s+"?([^"\n]+)"?', re.IGNORECASE)
 
-# VRRP grammar (Wave B v0.2.0) — nested inside ``vlan N`` stanzas.
+# VRRP grammar — nested inside ``vlan N`` stanzas, with a global
+# ``router vrrp`` enable.
 #
+#   router vrrp
 #   vlan 100
 #      ip address 10.0.100.1 255.255.255.0
-#      ip vrrp vrid 10
+#      vrrp vrid 10
+#         owner | backup
 #         virtual-ip-address 10.0.100.254
 #         priority 110
 #         preempt
@@ -275,11 +278,21 @@ _IFACE_NAME_RE = re.compile(r'^name\s+"?([^"\n]+)"?', re.IGNORECASE)
 # IS the SVI on this platform).  The canonical model attaches the
 # group to the synthesised ``Vlan<N>`` :class:`CanonicalInterface`
 # created by the SVI-absorption path — see _svi_absorption.py.
+#
+# The vrid header is ``vrrp vrid N`` (NO ``ip`` prefix) — verified
+# against the AOS-S 16.10 "Basic configuration process" CLI reference
+# (arubanetworking.hpe.com/techdocs/AOS-S/16.10/MRG) and four
+# independent operator captures (E5406/5406R-ZL2/E5400 + AOS-S 16.11
+# docs).  The optional ``(?:ip\s+)?`` keeps the older / mis-documented
+# ``ip vrrp vrid`` form parseable too (back-compat — the codec emitted
+# it through v0.1.8).  ``virtual-ip-address`` tolerates the legacy
+# K.15 ``<ip> <mask>`` two-token form (mask dropped — the canonical
+# carries the bare VIP); 16.x emits the bare ``<ip>``.
 _VRRP_VRID_HEADER_RE = re.compile(
-    r"^ip\s+vrrp\s+vrid\s+(\d+)\s*$", re.IGNORECASE,
+    r"^(?:ip\s+)?vrrp\s+vrid\s+(\d+)\s*$", re.IGNORECASE,
 )
 _VRRP_VIRTUAL_IP_RE = re.compile(
-    r"^virtual-ip-address\s+(\S+)\s*$", re.IGNORECASE,
+    r"^virtual-ip-address\s+(\S+)(?:\s+[\d.]+)?\s*$", re.IGNORECASE,
 )
 _VRRP_PRIORITY_RE = re.compile(
     r"^priority\s+(\d+)\s*$", re.IGNORECASE,
@@ -469,12 +482,12 @@ def _parse_vlan_stanza(
     """Parse a ``vlan N`` stanza starting at *start* (body line).
 
     Returns the parsed :class:`CanonicalVlan`, the list of nested
-    :class:`CanonicalVRRPGroup` instances (one per ``ip vrrp vrid N``
+    :class:`CanonicalVRRPGroup` instances (one per ``vrrp vrid N``
     sub-block), and the index of the first line AFTER the stanza's
     outer ``exit``.
 
     VRRP groups parse here (rather than at the top level) because
-    AOS-S nests the ``ip vrrp vrid N`` block INSIDE the ``vlan N``
+    AOS-S nests the ``vrrp vrid N`` block INSIDE the ``vlan N``
     stanza — the VLAN is the SVI on this platform.  Returned groups
     attach to the synthesised ``Vlan<N>`` :class:`CanonicalInterface`
     by the caller (the SVI-absorption path in :func:`parse_intent`).
@@ -554,7 +567,7 @@ def _parse_vlan_stanza(
             i += 1
             continue
 
-        # VRRP sub-block — `ip vrrp vrid N` opens a nested stanza
+        # VRRP sub-block — `vrrp vrid N` opens a nested stanza
         # terminated by its own `exit`.  See _parse_vrrp_group_stanza
         # for the body grammar.  The group attaches to the synthesised
         # Vlan<N> CanonicalInterface (NOT to the CanonicalVlan itself)
@@ -575,14 +588,18 @@ def _parse_vlan_stanza(
 def _parse_vrrp_group_stanza(
     lines: list[str], start: int, gid: int,
 ) -> tuple[CanonicalVRRPGroup, int]:
-    """Walk the body of ``ip vrrp vrid N`` until the inner ``exit``.
+    """Walk the body of ``vrrp vrid N`` until the inner ``exit``.
 
     Returns the parsed :class:`CanonicalVRRPGroup` and the index of
     the first line AFTER the sub-block's ``exit``.
 
-    Body grammar (AOS-S 16.10 Advanced Traffic Management Guide):
+    Body grammar (AOS-S 16.10 "Basic configuration process" CLI ref):
 
+      * ``owner``                   — VIP owner → ``priority = 254``
+        (canonical ceiling; 255 reserved-but-unrepresentable)
+      * ``backup``                  — explicit backup role (no field)
       * ``virtual-ip-address X``    — append to ``virtual_ips``
+        (legacy ``X <mask>`` two-token form tolerated; mask dropped)
       * ``priority N``              — integer 1-254
       * ``preempt``                 — presence = enabled
       * ``enable``                  — group is active (implicit on
@@ -622,6 +639,24 @@ def _parse_vrrp_group_stanza(
         pri = _VRRP_PRIORITY_RE.match(stripped)
         if pri:
             group.priority = int(pri.group(1))
+            i += 1
+            continue
+
+        # ``owner`` declares this switch the VIP owner — VRRP reserves
+        # priority 255 for the owner (RFC 5798 §6.1).  The canonical
+        # ``priority`` field caps at 254 (255 is intentionally
+        # unrepresentable — the owner role isn't a first-class canonical
+        # concept), so we map ``owner`` to the canonical ceiling 254:
+        # this preserves the "this switch is the highest-priority
+        # master" intent for cross-vendor render rather than silently
+        # dropping to the default 100.  ``backup`` is the complementary
+        # explicit role with no priority implication — consume it
+        # (priority stays whatever ``priority N`` set, or the default).
+        if stripped.lower() == "owner":
+            group.priority = 254
+            i += 1
+            continue
+        if stripped.lower() == "backup":
             i += 1
             continue
 
@@ -1126,7 +1161,7 @@ def parse_intent(raw: str) -> CanonicalIntent:
             # so downstream consumers (and renderers of *other*
             # vendors that DO use ``interface Vlan<N>``) see the
             # L3 record at the canonical location.  VRRP groups
-            # parsed from the nested ``ip vrrp vrid N`` blocks
+            # parsed from the nested ``vrrp vrid N`` blocks
             # attach to this same Vlan<N> interface — VRRP is an
             # interface property in the canonical model.
             #

--- a/netcanon/migration/codecs/aruba_aoss/render.py
+++ b/netcanon/migration/codecs/aruba_aoss/render.py
@@ -11,9 +11,9 @@ Extracted from ``codec.py`` during the parse/render split per the
 Emission order mirrors what AOS-S's own ``show running-config`` puts
 on the wire so device round-trips diff cleanly: hostname, DNS, SNTP,
 SNMP, RADIUS, DHCP-relay-comment-block, local users, LAG trunks,
-VLAN stanzas (with absorbed SVI L3 + nested **VRRP groups** —
-``ip vrrp vrid N / virtual-ip-address X / priority / preempt /
-enable / exit`` emitted inside the VLAN stanza after the SVI IP),
+VLAN stanzas (with absorbed SVI L3 + nested **VRRP groups** — a
+global ``router vrrp`` enable then ``vrrp vrid N / virtual-ip-address
+X / owner|priority / preempt / enable / exit`` inside the VLAN stanza),
 physical interface stanzas, static routes / default-gateway.
 Multi-VIP cross-vendor sources drop secondaries with ``; review:``
 comments (AOS-S supports one virtual IP per VRID).  Non-``vrrp``
@@ -579,6 +579,16 @@ def render_intent(tree: Any) -> str:
     # loop skips them (otherwise we'd emit `interface vlan0.10` after
     # the L3 was already rolled into `vlan 10`).
     absorbed_iface_names: set[str] = set()
+    # AOS-S requires the global ``router vrrp`` enable BEFORE any VLAN
+    # mounts a ``vrrp vrid`` instance (AOS-S 16.10 "Basic configuration
+    # process": ``router vrrp`` then ``vlan N / vrrp vrid``).  Emit it
+    # once when any interface carries a classic-VRRP group.
+    if any(
+        g.mode == "vrrp"
+        for iface in tree.interfaces
+        for g in iface.vrrp_groups
+    ):
+        lines.append("router vrrp")
     for vlan in tree.vlans:
         lines.append(f"vlan {vlan.id}")
         if vlan.name:
@@ -649,7 +659,7 @@ def render_intent(tree: Any) -> str:
                     )
                     continue
                 lines.append(
-                    f"   ip vrrp vrid {group.group_id}"
+                    f"   vrrp vrid {group.group_id}"
                 )
                 if group.virtual_ips:
                     # AOS-S accepts only ONE virtual-ip-address per

--- a/tests/fixtures/real/WANTED.md
+++ b/tests/fixtures/real/WANTED.md
@@ -157,7 +157,7 @@ has a vendor-native grammar for it.
 | Cisco NX-OS | `interface Vlan10 / hsrp N { preempt; ip X }` | (Tier-D — see above) | queued (lands with NX-OS codec, v0.3.0) |
 | Arista EOS | `interface Vlan10 / ip address virtual X/Y` (VARP) | indirectly in `batfish_labval_dc1_leaf2a_eos4230.txt` + `batfish_eos_evpn_vlan_based_leaf.txt` | shipped (classic + modern multi-line + VARP) |
 | Juniper Junos | `set interfaces irb unit N family inet address X virtual-gateway-address Y` (anycast) **or** `vrrp-group N virtual-address X` (classic) | `ksator_labmgmt_qfx10k2_junos173.set` (anycast form) | shipped (classic + anycast + per-unit MAC overrides) |
-| Aruba AOS-S | `ip vrrp vrid N / virtual-ip-address X / enable` | not in corpus | shipped (parse + render; fixture still wanted) |
+| Aruba AOS-S | `router vrrp` + `vlan N / vrrp vrid N / owner\|priority / virtual-ip-address X / enable` | not in corpus | shipped (parse + render); parser now accepts the **real** `vrrp vrid` grammar (no `ip` prefix) per AOS-S 16.10 CLI ref — a real forum-share capture can now be imported (donor-blocked: forum snippets only, no full running-config) |
 | FortiGate | `config router vrrp / edit N / set vrip X` | not in corpus | shipped (parse + render with implicit `set version 3` on vrip6; fixture still wanted) |
 | MikroTik | `/ip address vrrp` (older) or `/ip vrrp` | not in corpus | shipped (two-stage `/interface vrrp` + `/ip address` correlation; fixture still wanted) |
 | OPNsense (CARP) | `<virtualip><vip><mode>carp</mode>...` | not in corpus | shipped (CARP variant via `mode="carp"` discriminator; fixture still wanted) |

--- a/tests/unit/migration/test_aruba_aoss.py
+++ b/tests/unit/migration/test_aruba_aoss.py
@@ -647,10 +647,11 @@ class TestRegistry:
 # input that exercises the parse and render paths end-to-end.
 _VRRP_BASIC = """\
 hostname "vrrp-test"
+router vrrp
 vlan 100
    name "MGMT"
    ip address 10.0.100.1 255.255.255.0
-   ip vrrp vrid 10
+   vrrp vrid 10
       virtual-ip-address 10.0.100.254
       priority 110
       preempt
@@ -665,16 +666,17 @@ vlan 100
 # another, both inside the same ``vlan N`` body).
 _VRRP_MULTI = """\
 hostname "vrrp-multi"
+router vrrp
 vlan 200
    name "USERS"
    ip address 10.0.200.1/24
-   ip vrrp vrid 20
+   vrrp vrid 20
       virtual-ip-address 10.0.200.254
       priority 110
       preempt
       enable
       exit
-   ip vrrp vrid 21
+   vrrp vrid 21
       virtual-ip-address 10.0.200.253
       priority 90
       enable
@@ -689,7 +691,7 @@ class TestVRRPGroups:
     # ----------------------------- Parse -----------------------------
 
     def test_parse_basic_group_attaches_to_vlan_interface(self):
-        """A single ``ip vrrp vrid`` block inside a VLAN stanza
+        """A single ``vrrp vrid`` block inside a VLAN stanza
         surfaces as one CanonicalVRRPGroup on the synthesised
         Vlan<N> CanonicalInterface."""
         tree = ArubaAOSSCodec().parse(_VRRP_BASIC)
@@ -709,7 +711,7 @@ class TestVRRPGroups:
         raw = (
             'vlan 50\n'
             '   ip address 10.0.50.1/24\n'
-            '   ip vrrp vrid 5\n'
+            '   vrrp vrid 5\n'
             '      virtual-ip-address 10.0.50.254\n'
             '      enable\n'
             '      exit\n'
@@ -720,7 +722,7 @@ class TestVRRPGroups:
         assert svi.vrrp_groups[0].preempt is False
 
     def test_parse_multiple_groups_in_same_vlan(self):
-        """Two ``ip vrrp vrid`` blocks inside the same VLAN stanza
+        """Two ``vrrp vrid`` blocks inside the same VLAN stanza
         parse into two distinct CanonicalVRRPGroup records on the
         single Vlan<N> interface, ordered by source appearance."""
         tree = ArubaAOSSCodec().parse(_VRRP_MULTI)
@@ -739,7 +741,7 @@ class TestVRRPGroups:
         raw = (
             'vlan 30\n'
             '   ip address 10.0.30.1/24\n'
-            '   ip vrrp vrid 3\n'
+            '   vrrp vrid 3\n'
             '      virtual-ip-address 10.0.30.254\n'
             '      authentication mode plaintext-password "SECRET"\n'
             '      enable\n'
@@ -755,7 +757,7 @@ class TestVRRPGroups:
         raw = (
             'vlan 70\n'
             '   ip address 10.0.70.1/24\n'
-            '   ip vrrp vrid 7\n'
+            '   vrrp vrid 7\n'
             '      virtual-ip-address 10.0.70.254\n'
             '      enable\n'
             '      exit\n'
@@ -778,8 +780,8 @@ class TestVRRPGroups:
     # ----------------------------- Render -----------------------------
 
     def test_render_emits_nested_vrrp_block(self):
-        """Render emits ``ip vrrp vrid N`` + body + ``exit`` inside
-        the ``vlan N`` stanza."""
+        """Render emits a global ``router vrrp`` + ``vrrp vrid N`` +
+        body + ``exit`` inside the ``vlan N`` stanza."""
         tree = CanonicalIntent(
             vlans=[CanonicalVlan(
                 id=100, name="MGMT",
@@ -802,9 +804,12 @@ class TestVRRPGroups:
             )],
         )
         out = ArubaAOSSCodec().render(tree)
+        # The global enable must precede the VLAN-mounted instance.
+        assert "router vrrp" in out
+        assert out.index("router vrrp") < out.index("vlan 100")
         # The block must sit INSIDE the vlan stanza.
         assert "vlan 100" in out
-        assert "   ip vrrp vrid 10" in out
+        assert "   vrrp vrid 10" in out
         assert "      virtual-ip-address 10.0.100.254" in out
         assert "      priority 110" in out
         assert "      preempt" in out
@@ -894,7 +899,7 @@ class TestVRRPGroups:
     def test_render_anycast_mode_surfaces_review_comment(self):
         """AOS-S has NO anycast / HSRP / CARP grammar.  Groups with
         non-``vrrp`` mode emit a review comment and don't produce
-        an ``ip vrrp vrid`` block."""
+        a ``vrrp vrid`` block (nor the global ``router vrrp``)."""
         tree = CanonicalIntent(
             vlans=[CanonicalVlan(
                 id=60,
@@ -913,7 +918,8 @@ class TestVRRPGroups:
             )],
         )
         out = ArubaAOSSCodec().render(tree)
-        assert "ip vrrp vrid" not in out
+        assert "vrrp vrid" not in out
+        assert "router vrrp" not in out
         assert "review" in out
         assert "'anycast'" in out
 
@@ -963,7 +969,7 @@ class TestVRRPGroups:
         raw = (
             'vlan 30\n'
             '   ip address 10.0.30.1/24\n'
-            '   ip vrrp vrid 3\n'
+            '   vrrp vrid 3\n'
             '      virtual-ip-address 10.0.30.254\n'
             '      authentication mode plaintext-password "SECRET"\n'
             '      enable\n'
@@ -974,6 +980,79 @@ class TestVRRPGroups:
         tree2 = codec.parse(codec.render(tree1))
         svi = next(i for i in tree2.interfaces if i.name == "Vlan30")
         assert svi.vrrp_groups[0].authentication == "plain:SECRET"
+
+    # ------------------- Real-grammar regressions (gap-hunt) -------------------
+
+    def test_parse_real_grammar_vrrp_vrid_no_ip_prefix(self):
+        """Real AOS-S running-config emits ``router vrrp`` + ``vrrp vrid
+        N`` (NO ``ip`` prefix) — verified against the AOS-S 16.10 CLI
+        reference + four operator captures.  The pre-gap-hunt parser
+        required ``ip vrrp vrid`` and dropped every real VRRP block."""
+        raw = (
+            "router vrrp\n"
+            "vlan 1\n"
+            "   ip address 10.40.0.2 255.255.255.0\n"
+            "   vrrp vrid 1\n"
+            "      owner\n"
+            "      virtual-ip-address 10.40.0.1 255.255.255.0\n"
+            "      enable\n"
+            "      exit\n"
+            "   exit\n"
+        )
+        tree = ArubaAOSSCodec().parse(raw)
+        svi = next(i for i in tree.interfaces if i.name == "Vlan1")
+        assert len(svi.vrrp_groups) == 1
+        g = svi.vrrp_groups[0]
+        assert g.group_id == 1
+        # ``owner`` → canonical priority ceiling 254 (model caps at 254;
+        # 255 reserved-but-unrepresentable).  Legacy ``<ip> <mask>`` VIP
+        # keeps the bare IP (mask dropped, not carried on the canonical).
+        assert g.priority == 254
+        assert g.virtual_ips == ["10.40.0.1"]
+
+    def test_parse_legacy_ip_vrrp_vrid_still_accepted(self):
+        """Back-compat: the older / mis-documented ``ip vrrp vrid``
+        form (what the codec itself emitted through v0.1.8) still
+        parses, so existing stored configs don't regress."""
+        raw = (
+            "vlan 9\n"
+            "   ip address 10.0.9.1/24\n"
+            "   ip vrrp vrid 9\n"
+            "      virtual-ip-address 10.0.9.254\n"
+            "      enable\n"
+            "      exit\n"
+            "   exit\n"
+        )
+        tree = ArubaAOSSCodec().parse(raw)
+        svi = next(i for i in tree.interfaces if i.name == "Vlan9")
+        assert svi.vrrp_groups[0].group_id == 9
+
+    def test_owner_maps_to_max_priority_254_and_round_trips(self):
+        """``owner`` parses to the canonical priority ceiling 254 (255
+        is unrepresentable).  Render emits ``priority 254`` (AOS-S
+        accepts an explicit priority; the canonical can't distinguish a
+        254-from-owner from an explicit 254), which re-parses to 254 —
+        round-trip stable."""
+        raw = (
+            "router vrrp\n"
+            "vlan 7\n"
+            "   ip address 10.0.7.1/24\n"
+            "   vrrp vrid 7\n"
+            "      owner\n"
+            "      virtual-ip-address 10.0.7.254\n"
+            "      enable\n"
+            "      exit\n"
+            "   exit\n"
+        )
+        codec = ArubaAOSSCodec()
+        tree = codec.parse(raw)
+        svi = next(i for i in tree.interfaces if i.name == "Vlan7")
+        assert svi.vrrp_groups[0].priority == 254
+        out = codec.render(tree)
+        assert "      priority 254" in out
+        reparsed = codec.parse(out)
+        svi2 = next(i for i in reparsed.interfaces if i.name == "Vlan7")
+        assert svi2.vrrp_groups[0].priority == 254
 
     # ----------------------------- Capabilities -----------------------------
 


### PR DESCRIPTION
## What

Corrects the `aruba_aoss` VRRP grammar to the **real ArubaOS-Switch form**. The
codec required `ip vrrp vrid <N>` on both parse and render — a grammar the
platform never emits — so **no real AOS-S VRRP capture could be parsed**. The
2026-06-15 `fixture-gap-hunt` flagged this as the worst-covered codec's primary
blocker and a prerequisite engineering task.

## Verification (the banner said don't patch on the claim alone)

The gap report explicitly warned this was a **grammar discrepancy to confirm
against the vendor CLI reference, not a confirmed bug**. Confirmed via the
official **AOS-S 16.10 "Basic configuration process"** CLI reference
([techdocs](https://arubanetworking.hpe.com/techdocs/AOS-S/16.10/MRG/KB/content/kb/bas-cnf-pro.htm))
+ four independent operator captures:

```
switch(config)# router vrrp
switch(config)# vlan 10
switch(vlan-10)# vrrp vrid 1          ← no "ip" prefix
switch(vlan-10-vrid-1)# owner | backup
switch(vlan-10-vrid-1)# virtual-ip-address 10.10.10.1
switch(vlan-10-vrid-1)# enable
```

## Changes

**Parse**
- `_VRRP_VRID_HEADER_RE` accepts `vrrp vrid` **and** the legacy/mis-documented
  `ip vrrp vrid` (optional `ip ` prefix — back-compat; the codec emitted it
  through v0.1.8).
- `_VRRP_VIRTUAL_IP_RE` tolerates the older K.15 `virtual-ip-address <ip> <mask>`
  two-token form (mask dropped; canonical carries the bare VIP).
- `owner` → canonical priority ceiling **254** (255 is reserved and
  unrepresentable — the model caps `priority` at 254); `backup` consumed.
- global `router vrrp` parses as a no-op.

**Render**
- emit a global `router vrrp` once before the VLAN blocks when any interface
  carries a classic-VRRP group;
- emit `vrrp vrid <N>` (no `ip`) inside the `vlan N` stanza.

## Tests / verification

- `+3` regression tests (real `vrrp vrid` grammar, legacy `ip vrrp vrid`
  back-compat, `owner`→254 round-trip); existing VRRP tests migrated to the real
  grammar. Full `tests/unit` + `tests/integration` green.
- **Cross-mesh neutral** — no aoss fixture exercises VRRP, and the comparison is
  on canonicals (not rendered text), so **CODEC_BUG stays flat at 5** and
  `CROSS_MESH_RESULTS.md` / `PHASE4_RECONCILIATION.md` are byte-identical to
  `main`.
- Docs corrected: `CAPABILITIES.md`, `WANTED.md`.

## Unblocks

A real AOS-S VRRP capture can now be imported. (Still donor-blocked on a *full*
running-config — public sources are forum snippets only — but the codec no
longer rejects the grammar.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
