### PR TITLE
fix(fortigate): preserve SNMPv3 auth-proto sha224 on round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **fortigate_cli SNMPv3 `auth-proto sha224` no longer silently
+  upgraded to `sha256`.**  The FortiGate render map coerced canonical
+  `auth_protocol="sha224"` to the FortiOS token `sha256`, even though
+  FortiOS 7.x natively accepts `sha224` (the parse map already mapped
+  `sha224 → sha224` faithfully).  On a same-vendor round-trip the value
+  was silently mangled — and the coercion contradicted the
+  junos→fortigate expectation YAML, which already declared `sha224`
+  preserved.  Render now maps `sha224 → sha224`, so the full SHA-2 auth
+  family round-trips losslessly.  Surfaced + verified during the
+  2026-06-15 `fixture-gap-hunt` codec-bug verification pass; render-side
+  one-line fix, CODEC_BUG flat at 5 (no mesh source emits `sha224` into
+  a FortiGate target).
+
 * **aruba_aoss VRRP grammar corrected to the real AOS-S form.**  The
   parser required `ip vrrp vrid <N>` and the renderer emitted it, but
   real ArubaOS-Switch uses a global `router vrrp` enable plus

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -788,11 +788,13 @@ def render_intent(tree: Any) -> str:
         # presence (noAuthNoPriv / auth-no-priv / auth-priv — the
         # three FortiOS-accepted values).  Canonical priv_protocol
         # back to FortiOS: aes128 → aes; aes256 / aes192 / des
-        # preserved.  Unknown / empty auth_protocol → sha fallback
-        # to satisfy FortiOS validation when security-level implies
-        # auth.
+        # preserved.  Canonical auth_protocol maps 1:1 to the FortiOS
+        # token — md5 / sha / sha224 / sha256 / sha384 / sha512 are
+        # all natively accepted, so each is preserved verbatim.
+        # Unknown / empty auth_protocol → sha fallback to satisfy
+        # FortiOS validation when security-level implies auth.
         _CAN_TO_FG_AUTH = {
-            "md5": "md5", "sha": "sha", "sha224": "sha256",
+            "md5": "md5", "sha": "sha", "sha224": "sha224",
             "sha256": "sha256", "sha384": "sha384", "sha512": "sha512",
         }
         _CAN_TO_FG_PRIV = {

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -8984,7 +8984,7 @@ Traceback (most recent call last):
     rendered = target_codec.render(canonical_source)
   File "netcanon\migration\codecs\fortigate_cli\codec.py", line 334, in render
     return render_intent(tree)
-  File "netcanon\migration\codecs\fortigate_cli\render.py", line 944, in render_intent
+  File "netcanon\migration\codecs\fortigate_cli\render.py", line 946, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)
   File "netcanon\migration\codecs\fortigate_cli\parse.py", line 87, in _prefix_to_mask
     raise RenderError(

--- a/tests/unit/migration/codecs/fortigate_cli/test_render_snmp.py
+++ b/tests/unit/migration/codecs/fortigate_cli/test_render_snmp.py
@@ -136,6 +136,58 @@ def test_fortigate_renders_snmp_v3_user_no_priv() -> None:
     assert "        set auth-proto md5" in out
 
 
+def test_fortigate_renders_snmp_v3_user_sha224_preserved() -> None:
+    """Regression: FortiOS natively accepts the full SHA-2 auth family,
+    so a canonical ``auth_protocol='sha224'`` must render as
+    ``set auth-proto sha224`` — NOT be silently upgraded to sha256.
+
+    The render map previously coerced ``sha224 -> sha256``, which
+    contradicted both the parse map (``sha224 -> sha224``) and the
+    declared junos->fortigate expectation, mangling the value on a
+    same-vendor round-trip."""
+    intent = CanonicalIntent()
+    intent.snmp = CanonicalSNMP(
+        v3_users=[
+            CanonicalSNMPv3User(
+                name="sha224user",
+                auth_protocol="sha224",
+                auth_passphrase="ENC opaque-auth-blob",
+                priv_protocol="aes256",
+                priv_passphrase="ENC opaque-priv-blob",
+            ),
+        ],
+    )
+    out = render_intent(intent)
+
+    assert "        set auth-proto sha224" in out
+    assert "        set auth-proto sha256" not in out
+
+
+def test_fortigate_snmp_v3_sha224_round_trips() -> None:
+    """End-to-end: a FortiGate config carrying ``set auth-proto sha224``
+    survives parse -> render -> parse with the auth protocol intact."""
+    cfg = (
+        "config system snmp user\n"
+        '    edit "sha224user"\n'
+        "        set security-level auth-priv\n"
+        "        set auth-proto sha224\n"
+        '        set auth-pwd "ENC opaque-auth-blob"\n'
+        "        set priv-proto aes256\n"
+        '        set priv-pwd "ENC opaque-priv-blob"\n'
+        "    next\n"
+        "end\n"
+    )
+    intent = parse_intent(cfg)
+    assert intent.snmp is not None
+    assert intent.snmp.v3_users[0].auth_protocol == "sha224"
+
+    rendered = render_intent(intent)
+    assert "        set auth-proto sha224" in rendered
+
+    back = parse_intent(rendered)
+    assert back.snmp.v3_users[0].auth_protocol == "sha224"
+
+
 def test_fortigate_no_snmp_emits_nothing() -> None:
     """Regression guard: when ``intent.snmp`` is None the renderer
     must NOT emit any ``config system snmp`` block."""


### PR DESCRIPTION
## What

The FortiGate render map `_CAN_TO_FG_AUTH` coerced canonical `auth_protocol="sha224"` to the FortiOS token `sha256`, silently mangling the value on a same-vendor `parse → render → parse` round-trip.

FortiOS 7.x natively accepts `sha224` (the parse map already maps `sha224 → sha224`), and the `juniper_junos__fortigate_cli` cross-vendor expectation YAML already declared `sha224` preserved — so the coercion was both lossy and self-contradictory.

## Fix

One-line render-side change: `_CAN_TO_FG_AUTH["sha224"]` now maps to `sha224` (was `sha256`). The full SHA-2 auth family (`md5/sha/sha224/sha256/sha384/sha512`) now round-trips losslessly. Render docstring clarified to state the 1:1 auth-protocol mapping.

Two regression tests added in `tests/unit/migration/codecs/fortigate_cli/test_render_snmp.py`:
- `test_fortigate_renders_snmp_v3_user_sha224_preserved` — render emits `set auth-proto sha224`, not `sha256`.
- `test_fortigate_snmp_v3_sha224_round_trips` — end-to-end parse→render→parse preserves `sha224`.

## Provenance

Confirmed a genuine code bug (vs. fixture-gap) during the 2026-06-15 `fixture-gap-hunt` codec-bug verification pass. One of **2 confirmed real bugs** out of 4 suspects; the other (cisco_nxos VXLAN `mcast-group` not harvested on parse) lands as a separate PR. The two non-bugs (juniper_junos VRRP `priority-cost` — declared lossy; cisco_iosxr 4-segment port — clean same-vendor round-trip) need no change.

## Invariants

- Full local gate green (`tests/unit tests/integration tests/unit/migration/test_real_captures.py`).
- **CODEC_BUG flat at 5** — no mesh source emits `sha224` into a FortiGate target, so cross-mesh is unchanged. `PHASE4_RECONCILIATION.md` byte-identical; the only `CROSS_MESH_RESULTS.md` delta is a +2-line traceback line-number shift from the added render docstring (an expected-RenderError cell, not a fidelity change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)