### PR TITLE
fix(nxos): harvest VXLAN member-vni mcast-group on parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **cisco_nxos VXLAN `mcast-group` now harvested on parse.**  The
+  capability matrix declared `/vxlan-vnis/mcast-group` **supported** and
+  the renderer emitted `member vni <vni>` + `mcast-group <ip>`, but the
+  parser's `_parse_vxlan` never read the `member vni` lines — so the L2
+  overlay multicast group was dropped 100% on the first parse, and a
+  supported surface silently round-tripped to empty.  Parse now harvests
+  `mcast-group` onto `CanonicalVxlan.mcast_group` in **both** real NX-OS
+  grammar forms (inline `member vni N mcast-group X` and the own-sub-line
+  `mcast-group X`), skipping `member vni N associate-vrf` (the L3VNI
+  binding, harvested from `vrf context`).  Surfaced + verified during the
+  2026-06-15 `fixture-gap-hunt` codec-bug verification pass; parse-side
+  fix, CODEC_BUG flat at 5 and every cross-mesh artifact byte-identical
+  (no existing NX-OS fixture carries `mcast-group`).  Unblocks importing
+  the akarneliuk / networklessons real VXLAN multicast captures the gap
+  report identified.
+
 * **fortigate_cli SNMPv3 `auth-proto sha224` no longer silently
   upgraded to `sha256`.**  The FortiGate render map coerced canonical
   `auth_protocol="sha224"` to the FortiOS token `sha256`, even though

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -280,6 +280,23 @@ _VN_SEGMENT_RE = re.compile(r"^\s+vn-segment\s+(\d+)\s*$", re.IGNORECASE)
 _NVE_SOURCE_IF_RE = re.compile(
     r"^\s+source-interface\s+(\S+)\s*$", re.IGNORECASE,
 )
+#: ``member vni <vni> [mcast-group <ip>]`` inside ``interface nve1`` → an
+#: L2 VNI's overlay multicast group.  Two real grammar forms exist: the
+#: inline form (group 2 captures the address on the same line) and the
+#: own-sub-line form where ``mcast-group`` lands on the next indented line
+#: (see _NVE_MCAST_RE).  ``member vni N associate-vrf`` (the L3VNI binding)
+#: matches with group 2 empty and is skipped — the L3VNI is harvested from
+#: ``vrf context X / vni N`` instead.
+_NVE_MEMBER_VNI_RE = re.compile(
+    r"^\s+member\s+vni\s+(\d+)"
+    r"(?:\s+mcast-group\s+(\d+\.\d+\.\d+\.\d+)|\s+associate-vrf)?\s*$",
+    re.IGNORECASE,
+)
+#: ``mcast-group <ip>`` on its own indented line, following a ``member vni``
+#: line (the own-sub-line form) → attaches to the current member VNI.
+_NVE_MCAST_RE = re.compile(
+    r"^\s+mcast-group\s+(\d+\.\d+\.\d+\.\d+)\s*$", re.IGNORECASE,
+)
 #: ``vlan 1,10,2000`` / ``vlan 10-20`` — comma + range list (unique to
 #: NX-OS / Arista in this codebase).
 _VLAN_TOP_RE = re.compile(r"^vlan\s+([\d,\-]+)\s*$", re.IGNORECASE)
@@ -1090,9 +1107,13 @@ def _parse_vxlan(raw: str) -> list[CanonicalVxlan]:
     CanonicalVxlan per-switch convention).  L3VNIs (``vrf context X /
     vni N``) are NOT L2 records — they live on
     :attr:`CanonicalRoutingInstance.l3_vni` (harvested by
-    :func:`_parse_routing_instances`).  The ``interface nve1`` member-vni
-    / suppress-arp / ingress-replication sub-flags are parse-discard (v1
-    assumes modern BGP-EVPN head-end replication; declared lossy).
+    :func:`_parse_routing_instances`).  The ``interface nve1`` ``member
+    vni N`` lines carry the L2 overlay multicast group (``mcast-group``),
+    harvested onto :attr:`CanonicalVxlan.mcast_group` in either the inline
+    (``member vni N mcast-group X``) or the own-sub-line form; the
+    ``suppress-arp`` / ``ingress-replication`` sub-flags remain
+    parse-discard (v1 assumes modern BGP-EVPN head-end replication;
+    declared lossy).
     """
     # Pass 1: vlan_id → vni from ``vlan N / vn-segment <vni>``.
     vn_by_vlan: dict[int, int] = {}
@@ -1111,25 +1132,51 @@ def _parse_vxlan(raw: str) -> list[CanonicalVxlan]:
             if line and not line[0].isspace():
                 current_id = None
 
-    # Pass 2: switch-level VTEP source-interface from ``interface nve1``.
+    # Pass 2: switch-level VTEP source-interface + per-VNI overlay
+    # multicast group from ``interface nve1``.  ``member vni N`` carries
+    # the L2 ``mcast-group`` in either the inline form or an own-sub-line
+    # ``mcast-group X``; ``member vni N associate-vrf`` is the L3VNI
+    # binding and is skipped here (harvested from ``vrf context``).
     source_iface = ""
+    mcast_by_vni: dict[int, str] = {}
     in_nve = False
+    current_member_vni: int | None = None
     for line in raw.splitlines():
         im = _IFACE_RE.match(line)
         if im:
             in_nve = im.group(1).lower().startswith("nve")
+            current_member_vni = None
             continue
         if line and not line[0].isspace():
             in_nve = False
+            current_member_vni = None
             continue
-        if in_nve:
-            sm = _NVE_SOURCE_IF_RE.match(line)
-            if sm:
-                source_iface = sm.group(1)
+        if not in_nve:
+            continue
+        sm = _NVE_SOURCE_IF_RE.match(line)
+        if sm:
+            source_iface = sm.group(1)
+            continue
+        mm = _NVE_MEMBER_VNI_RE.match(line)
+        if mm:
+            if mm.group(2):  # inline ``member vni N mcast-group X``
+                mcast_by_vni[int(mm.group(1))] = mm.group(2)
+                current_member_vni = int(mm.group(1))
+            elif "associate-vrf" in line.lower():  # L3VNI — not an L2 record
+                current_member_vni = None
+            else:  # bare L2 member; an mcast-group may follow on the next line
+                current_member_vni = int(mm.group(1))
+            continue
+        cm = _NVE_MCAST_RE.match(line)
+        if cm and current_member_vni is not None:
+            mcast_by_vni[current_member_vni] = cm.group(1)
 
     return [
         CanonicalVxlan(
-            vlan_id=vid, vni=vn_by_vlan[vid], source_interface=source_iface,
+            vlan_id=vid,
+            vni=vn_by_vlan[vid],
+            source_interface=source_iface,
+            mcast_group=mcast_by_vni.get(vn_by_vlan[vid], ""),
         )
         for vid in sorted(vn_by_vlan)
     ]

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -871,6 +871,37 @@ interface nve1
 """
 
 
+# Exercises BOTH real NX-OS multicast grammars in one capture: the inline
+# ``member vni N mcast-group X`` (vni 10010) and the own-sub-line form
+# where ``mcast-group`` lands on the next indented line (vni 10020), plus
+# an ``associate-vrf`` L3VNI member (50001) that must NOT acquire an
+# mcast-group or become an L2 record.
+_VXLAN_MCAST_CONFIG = """\
+!Command: show running-config
+hostname MCAST1
+feature nv overlay
+feature vn-segment-vlan-based
+vlan 10
+  name WEB
+  vn-segment 10010
+vlan 20
+  name APP
+  vn-segment 10020
+vrf context TENANT-A
+  vni 50001
+interface loopback0
+  ip address 10.255.0.1/32
+interface nve1
+  no shutdown
+  host-reachability protocol bgp
+  source-interface loopback0
+  member vni 10010 mcast-group 239.1.1.10
+  member vni 10020
+    mcast-group 239.1.1.20
+  member vni 50001 associate-vrf
+"""
+
+
 class TestPhase4VXLAN:
     @pytest.fixture
     def tree(self, codec):
@@ -945,6 +976,37 @@ class TestPhase4VXLAN:
         out = codec.render(tree)
         assert "  member vni 10030" in out
         assert "    mcast-group 239.1.1.30" in out
+
+    def test_mcast_group_parse_inline(self, codec):
+        # Regression (gap-hunt): the inline ``member vni N mcast-group X``
+        # form was never harvested — a matrix-`supported` surface lost
+        # 100% of its data on parse.
+        tree = codec.parse(_VXLAN_MCAST_CONFIG)
+        v = next(v for v in tree.vxlan_vnis if v.vni == 10010)
+        assert v.mcast_group == "239.1.1.10"
+
+    def test_mcast_group_parse_own_subline(self, codec):
+        # The own-sub-line form (``mcast-group`` on the next indented
+        # line) must harvest to the preceding ``member vni`` too.
+        tree = codec.parse(_VXLAN_MCAST_CONFIG)
+        v = next(v for v in tree.vxlan_vnis if v.vni == 10020)
+        assert v.mcast_group == "239.1.1.20"
+
+    def test_associate_vrf_member_carries_no_mcast(self, codec):
+        # The L3VNI ``member vni 50001 associate-vrf`` must not become an
+        # L2 vxlan record nor steal an mcast-group from a sibling.
+        tree = codec.parse(_VXLAN_MCAST_CONFIG)
+        assert 50001 not in {v.vni for v in tree.vxlan_vnis}
+
+    def test_mcast_group_round_trips(self, codec):
+        tree = codec.parse(_VXLAN_MCAST_CONFIG)
+        second = codec.parse(codec.render(tree))
+
+        def mc(t):
+            return sorted((v.vni, v.mcast_group) for v in t.vxlan_vnis)
+
+        assert mc(tree) == [(10010, "239.1.1.10"), (10020, "239.1.1.20")]
+        assert mc(second) == mc(tree)
 
     def test_phase4_matrix_graduated(self, codec):
         caps = codec.capabilities


### PR DESCRIPTION
## What

The capability matrix declares `/vxlan-vnis/mcast-group` **supported** and the renderer emits `member vni <vni>` + `mcast-group <ip>`, but the parser's `_parse_vxlan` never read the `member vni` lines. The L2 overlay multicast group was dropped **100% on the first parse** — a supported surface silently round-tripping to empty (the parse→render→parse stability check masked it: both parses gave `""`).

## Fix

Parse-side only. `_parse_vxlan` now harvests `mcast-group` onto `CanonicalVxlan.mcast_group` in **both** real NX-OS grammar forms:
- inline — `member vni 100010 mcast-group 239.11.11.10`
- own-sub-line — `member vni 10010` then an indented `mcast-group 239.1.1.1`

It skips `member vni N associate-vrf` (the L3VNI binding, harvested from `vrf context X / vni N`), so an L3VNI member never becomes an L2 record nor steals an mcast-group from a sibling.

4 regression tests added in `TestPhase4VXLAN` (inline parse, own-sub-line parse, associate-vrf guard, round-trip).

## Provenance

Confirmed a genuine code bug (vs. fixture-gap) during the 2026-06-15 `fixture-gap-hunt` codec-bug verification pass. **2 of 2** confirmed real bugs from that pass (sibling to the fortigate sha224 fix [netcanon#72](https://github.com/netcanon/netcanon/pull/72)). The two non-bugs (juniper_junos VRRP `priority-cost` — declared lossy; cisco_iosxr 4-segment port — clean same-vendor round-trip) need no change.

## Invariants

- Full local gate green (`tests/unit tests/integration tests/unit/migration/test_real_captures.py`).
- **CODEC_BUG flat at 5** — `CROSS_MESH_RESULTS.md` **and** `PHASE4_RECONCILIATION.md` byte-identical (no existing NX-OS fixture carries `mcast-group`; render already emitted it symmetrically, so same-vendor canonical round-trip is now lossless and mesh-neutral).
- Unblocks importing the akarneliuk / networklessons real VXLAN multicast captures the gap report identified (rank 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)