### PR TITLE
fix(fortigate): clamp VRRP priority into [1,254] so `set priority 255` doesn't crash parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,18 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **fortigate_cli VRRP `set priority 255` no longer crashes the parser.**
+  FortiOS permits VRRP priority 1-255 (255 is the address-owner
+  sentinel), but `CanonicalVRRPGroup.priority` caps at 254 (`le=254` —
+  255 is RFC-reserved / unrepresentable).  The parser passed the raw int
+  straight into the model, so a legitimate master config carrying `set
+  priority 255` raised an unhandled pydantic `ValidationError` (a
+  500-class parse crash) rather than parsing cleanly.  Parse now clamps
+  the priority into `[1, 254]`, mirroring the aruba_aoss `owner` → 254
+  mapping.  Surfaced during the 2026-06-15 `fixture-gap-hunt` while
+  smoke-testing a real FortiGate VRRP pair; +1 regression test,
+  cross-mesh-neutral (CODEC_BUG flat at 5).
+
 * **cisco_iosxe_cli no longer mis-detects bannerless NX-OS / AOS-CX
   configs as IOS-XE.**  A containerlab / golden-config capture lacking
   its vendor banner (`!Command: show running-config` for NX-OS,

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -477,6 +477,14 @@ def _apply_system_interface(
                         priority = int(priority_tokens[0])
                     except ValueError:
                         pass
+                # FortiOS permits VRRP priority 1-255; 255 is the
+                # address-owner sentinel that ``CanonicalVRRPGroup.priority``
+                # caps at 254 (``le=254`` — 255 is RFC-reserved /
+                # unrepresentable).  Clamp into [1, 254] so a legitimate
+                # ``set priority 255`` master config does NOT raise a raw
+                # pydantic ValidationError (a 500-class parse crash) —
+                # mirrors the aruba_aoss ``owner`` -> 254 mapping.
+                priority = max(1, min(priority, 254))
                 preempt_tokens = vrrp_edit.settings.get("preempt")
                 # FortiOS default for preempt is ``enable`` when the knob
                 # is absent — matches the canonical default (``True``).

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -638,6 +638,30 @@ end
         assert group.preempt is True
         assert group.advertisement_interval == 1
 
+    def test_priority_255_master_clamped_not_crash(self):
+        """A legitimate FortiOS VRRP master (``set priority 255`` — the
+        address-owner sentinel; FortiOS permits 1-255) must parse without
+        raising.  ``CanonicalVRRPGroup.priority`` caps at 254 (``le=254``),
+        so the parser clamps 255 -> 254 rather than letting pydantic raise
+        a 500-class ValidationError."""
+        raw = """\
+config system interface
+    edit "vlan20"
+        set ip 10.0.20.1 255.255.255.0
+        config vrrp
+            edit 5
+                set vrip 10.0.20.254
+                set priority 255
+                set preempt enable
+            next
+        end
+    next
+end
+"""
+        tree = FortiGateCLICodec().parse(raw)  # must NOT raise
+        iface = next(i for i in tree.interfaces if i.name == "vlan20")
+        assert iface.vrrp_groups[0].priority == 254
+
     def test_preempt_disable_maps_to_false(self):
         raw = """\
 config system interface


### PR DESCRIPTION
## What

FortiOS permits VRRP priority **1-255** (255 = the address-owner sentinel), but `CanonicalVRRPGroup.priority` caps at 254 (`le=254` — 255 is RFC-reserved / unrepresentable). The parser passed the raw int straight into the pydantic model, so a legitimate FortiGate **master** config carrying `set priority 255` raised an unhandled `ValidationError` — a **500-class parse crash** — instead of parsing cleanly.

## Fix

`_apply_system_interface` now clamps the parsed VRRP priority into `[1, 254]`, mirroring the aruba_aoss `owner → 254` mapping. +1 regression test (`set priority 255` → `priority == 254`, no raise).

## Provenance

Surfaced during the 2026-06-15 `fixture-gap-hunt` while smoke-testing a real FortiGate VRRP pair (the [community.fortinet.com](https://community.fortinet.com/t5/FortiGate/Technical-Tip-FortiGate-VRRP-configuration-and-debug/ta-p/197015) capture's PRIMARY unit uses `set priority 255`). The fixture itself was held back (weak coverage + forum transcription), but the **crash it exposed is worth fixing on its own** — any real FortiGate master config would hit it.

## Invariants

- Full local gate green; focused VRRP suite green.
- No fixture exercises this, so cross-mesh `CROSS_MESH_RESULTS.md` + `PHASE4_RECONCILIATION.md` are **byte-identical**; **CODEC_BUG flat at 5**. Pure robustness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)