### PR TITLE
refactor(codecs): extract shared mask/MAC/link-local helpers into _helpers.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,29 @@ timestamp if your timezone matters for an audit.
   by name (cosmetic order, consistent with the 7 collections it already
   sorts).
 
+### Internal
+
+* **Shared codec helpers — de-duplicated four vendor-neutral functions
+  into `netcanon/migration/codecs/_helpers.py`.**  Four small pure helpers
+  had been copy-pasted across the CLI / text codecs (the older
+  "duplicate rather than lift" convention); they are now defined once and
+  imported: `_normalise_mac_to_colon_hex` (was in cisco_iosxe_cli /
+  cisco_nxos / aruba_aoscx), `_is_link_local_v6` (cisco_iosxe_cli /
+  cisco_iosxr / cisco_nxos / aruba_aoscx), `_mask_to_prefix`
+  (cisco_iosxe_cli / cisco_iosxr / arista_eos / aruba_aoss /
+  fortigate_cli), and `_prefix_to_mask` (cisco_iosxe_cli / cisco_iosxr).
+  Net −254 lines.  The two fallible helpers take a keyword-only `vendor=`
+  so the raised `ParseError` / `RenderError` messages stay byte-identical
+  (the cross-mesh report's render-error text is unchanged).
+  Behaviour-preserving: the full unit + integration gate is green and the
+  cross-mesh audit holds **CODEC_BUG flat at 5**.  The consolidated
+  `_mask_to_prefix` adopts cisco_iosxr's already-correct 32-bit
+  zero-padded contiguity check for all five copies, incidentally fixing a
+  latent edge case where a mask whose leading octet is zero (e.g. the
+  non-contiguous `0.255.0.0`) was mis-counted rather than rejected — no
+  fixture or test exercises it, so the audit is unaffected.  fortigate
+  keeps its own `_prefix_to_mask` (distinct message, no range pre-check).
+
 ## [0.1.8] - 2026-06-15
 
 ### Security

--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -1,0 +1,103 @@
+"""Shared, vendor-neutral helpers for the CLI / text codecs.
+
+These small pure functions were independently duplicated across several
+codecs (the "duplicate rather than lift" convention noted in the older
+per-codec docstrings).  Because they are vendor-neutral — IEEE MAC
+canonicalisation, RFC 4291 link-local detection, and dotted-mask ⇄ CIDR
+conversion — a single shared copy removes the drift risk without coupling
+the codecs to one another's grammar.
+
+Import as ``from .._helpers import <name>`` from inside a codec package
+(e.g. ``codecs/cisco_iosxe_cli/parse.py``).
+
+The functions that can fail take a keyword-only ``vendor`` argument so the
+raised :class:`ParseError` / :class:`RenderError` still names the codec
+whose input was malformed (preserving the diagnostics that the previous
+per-codec copies emitted).
+"""
+
+import ipaddress
+import re
+
+from .base import ParseError, RenderError
+
+
+def _normalise_mac_to_colon_hex(mac: str) -> str:
+    """Normalise a vendor MAC representation to canonical colon-hex.
+
+    Accepts the common operator-paste forms — dotted-triplet
+    (``0001.c73a.0000``, Cisco / NX-OS native), colon-hex
+    (``00:01:c7:3a:00:00``, canonical / Unix), or dash-hex
+    (``00-01-C7-3A-00-00``, Windows / IEEE) — and returns the lower-case
+    ``aa:bb:cc:dd:ee:ff`` form.  Returns the empty string for input it
+    cannot classify (12 hex digits expected) so the caller skips the
+    field rather than poisoning it with malformed data.
+    """
+    if not mac:
+        return ""
+    hex_only = re.sub(r"[^0-9a-f]", "", mac.strip().lower())
+    if len(hex_only) != 12:
+        return ""
+    return ":".join(hex_only[i:i + 2] for i in range(0, 12, 2))
+
+
+def _is_link_local_v6(addr: str) -> bool:
+    """Return True iff *addr* is in the IPv6 link-local prefix fe80::/10.
+
+    The prefix (RFC 4291 §2.4) is vendor-neutral: the first byte is 0xfe
+    and the second nibble is 8/9/a/b (binary ``1111111010`` — ten leading
+    ones).  This lets a codec recover link-local scope on a raw
+    ``fe80::`` line even when the operator omits the vendor
+    ``link-local`` keyword.  Only the leading characters are inspected,
+    so malformed / over-``::`` inputs return False rather than raising —
+    downstream canonical-build validation rejects a truly bad address.
+    """
+    if not addr:
+        return False
+    lo = addr.lower()
+    return len(lo) >= 3 and lo[:2] == "fe" and lo[2] in ("8", "9", "a", "b")
+
+
+def _mask_to_prefix(mask_str: str, *, vendor: str) -> int:
+    """Convert a dotted-decimal IPv4 subnet mask to a CIDR prefix length.
+
+    Raises :class:`ParseError` (prefixed with *vendor*) for an address
+    that is not a valid dotted quad or whose set bits are not
+    left-contiguous (e.g. ``255.0.255.0``).  The mask is zero-padded to
+    the full 32 bits before the contiguity check so a mask whose leading
+    octet is zero (e.g. the non-contiguous ``0.255.0.0``) is correctly
+    rejected rather than silently mis-counted.
+    """
+    try:
+        addr = ipaddress.IPv4Address(mask_str)
+    except ipaddress.AddressValueError:
+        raise ParseError(
+            f"{vendor}: invalid subnet mask {mask_str!r}",
+            snippet=mask_str,
+        )
+    bits = bin(int(addr))[2:].zfill(32)
+    if "01" in bits:
+        raise ParseError(
+            f"{vendor}: non-contiguous subnet mask {mask_str!r}",
+            snippet=mask_str,
+        )
+    return bits.count("1")
+
+
+def _prefix_to_mask(prefix: int, *, vendor: str) -> str:
+    """Convert a CIDR prefix length to a dotted-decimal IPv4 subnet mask.
+
+    Inverse of :func:`_mask_to_prefix`.  Used by render() for the Cisco
+    ``ip address X Y`` / ``ipv4 address X Y`` forms that require a dotted
+    mask (every other shipped codec uses CIDR natively, so the canonical
+    tree holds prefix lengths and we expand on render).  Raises
+    :class:`RenderError` (prefixed with *vendor*) when *prefix* is
+    outside 0..32.
+    """
+    if not (0 <= prefix <= 32):
+        raise RenderError(
+            f"{vendor}: prefix length {prefix} out of range",
+            yang_path="/interfaces/interface/ipv4/address/prefix-length",
+        )
+    mask_int = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF if prefix else 0
+    return str(ipaddress.IPv4Address(mask_int))

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -58,6 +58,7 @@ from ...canonical.intent import (
 )
 from .._input_shape import detect_input_shape
 from ..base import ParseError
+from .._helpers import _mask_to_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -281,7 +282,7 @@ def _parse_dhcp_pools(raw: str) -> list[CanonicalDHCPPool]:
         if nm:
             ip_str, mask = nm.group(1), nm.group(2)
             try:
-                prefix = _mask_to_prefix(mask)
+                prefix = _mask_to_prefix(mask, vendor="arista_eos")
             except ParseError:
                 continue
             current.network = f"{ip_str}/{prefix}"
@@ -327,28 +328,6 @@ def _parse_dhcp_pools(raw: str) -> list[CanonicalDHCPPool]:
     if current is not None:
         pools.append(current)
     return pools
-
-
-def _mask_to_prefix(mask_str: str) -> int:
-    """Convert a dotted-decimal subnet mask to a CIDR prefix length.
-
-    Local copy of the cisco_iosxe_cli helper — keeping it in-codec
-    avoids a cross-codec import for one regex helper.
-    """
-    try:
-        addr = ipaddress.IPv4Address(mask_str)
-    except ipaddress.AddressValueError:
-        raise ParseError(
-            f"arista_eos: invalid subnet mask {mask_str!r}",
-            snippet=mask_str,
-        )
-    bits = bin(int(addr))[2:]
-    if "01" in bits:
-        raise ParseError(
-            f"arista_eos: non-contiguous subnet mask {mask_str!r}",
-            snippet=mask_str,
-        )
-    return bits.count("1")
 
 
 # ---------------------------------------------------------------------------

--- a/netcanon/migration/codecs/aruba_aoscx/parse.py
+++ b/netcanon/migration/codecs/aruba_aoscx/parse.py
@@ -85,6 +85,7 @@ from ...canonical.intent import (
 )
 from .._input_shape import detect_input_shape
 from ..base import ParseError
+from .._helpers import _is_link_local_v6, _normalise_mac_to_colon_hex
 from . import port_names as _port_names
 
 logger = logging.getLogger(__name__)
@@ -241,22 +242,6 @@ _VXLAN_VNI_RE = re.compile(r"^\s+vni\s+(\d+)\s*$", re.IGNORECASE)
 _VXLAN_VLAN_MAP_RE = re.compile(r"^\s+vlan\s+(\d+)\s*$", re.IGNORECASE)
 
 
-def _normalise_mac_to_colon_hex(mac: str) -> str:
-    """Normalise a MAC to canonical lower-case colon-hex.
-
-    AOS-CX emits colon-hex already (``02:00:0a:01:65:01``); this also
-    tolerates dotted-triplet / dash forms.  Returns empty string for
-    input it can't classify.  Forked from cisco_nxos per the
-    duplicate-rather-than-lift convention.
-    """
-    if not mac:
-        return ""
-    hex_only = re.sub(r"[^0-9a-f]", "", mac.strip().lower())
-    if len(hex_only) != 12:
-        return ""
-    return ":".join(hex_only[i:i + 2] for i in range(0, 12, 2))
-
-
 #: ``vrf <name>`` opens a top-level VRF declaration (single token, whole
 #: line).  Distinct from the interface-level ``vrf attach`` (indented) and
 #: from ``ssh server vrf mgmt`` / ``ntp vrf mgmt`` (different leading
@@ -307,19 +292,6 @@ def _default_enabled(iface_name: str) -> bool:
     ``shutdown`` / ``no shutdown`` line in the stanza overrides this.
     """
     return _port_names.classify_port_name(iface_name).kind == "loopback"
-
-
-def _is_link_local_v6(addr: str) -> bool:
-    """Return True iff *addr* is in the IPv6 link-local prefix fe80::/10.
-
-    Mirrors ``cisco_nxos.parse._is_link_local_v6`` — the prefix is
-    vendor-neutral (RFC 4291 §2.4), so scope can be recovered even when
-    the operator omits the ``link-local`` keyword.
-    """
-    if not addr:
-        return False
-    lo = addr.lower()
-    return len(lo) >= 3 and lo[:2] == "fe" and lo[2] in ("8", "9", "a", "b")
 
 
 def _parse_vlan_list(text: str) -> list[int]:

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -60,6 +60,7 @@ from ...canonical.intent import (
 )
 from .._input_shape import detect_input_shape
 from ..base import ParseError
+from .._helpers import _mask_to_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -320,24 +321,6 @@ def _unquote(s: str) -> str:
     return s
 
 
-def _mask_to_prefix(mask: str) -> int:
-    """Convert dotted-decimal mask to CIDR prefix length."""
-    try:
-        addr = ipaddress.IPv4Address(mask)
-    except ipaddress.AddressValueError:
-        raise ParseError(
-            f"aruba_aoss: invalid subnet mask {mask!r}",
-            snippet=mask,
-        )
-    bits = bin(int(addr))[2:]
-    if "01" in bits:
-        raise ParseError(
-            f"aruba_aoss: non-contiguous subnet mask {mask!r}",
-            snippet=mask,
-        )
-    return bits.count("1")
-
-
 def _dest_to_cidr(dest: str) -> str:
     """Accept either ``A.B.C.D/N`` or just ``A.B.C.D``; default /32."""
     if "/" in dest:
@@ -552,7 +535,7 @@ def _parse_vlan_stanza(
         if ip_mask:
             vlan.ipv4_addresses.append(CanonicalIPv4Address(
                 ip=ip_mask.group(1),
-                prefix_length=_mask_to_prefix(ip_mask.group(2)),
+                prefix_length=_mask_to_prefix(ip_mask.group(2), vendor="aruba_aoss"),
             ))
             i += 1
             continue
@@ -756,7 +739,7 @@ def _parse_interface_stanza(
         if ip_mask:
             iface.ipv4_addresses.append(CanonicalIPv4Address(
                 ip=ip_mask.group(1),
-                prefix_length=_mask_to_prefix(ip_mask.group(2)),
+                prefix_length=_mask_to_prefix(ip_mask.group(2), vendor="aruba_aoss"),
             ))
             i += 1
             continue
@@ -967,7 +950,7 @@ def parse_intent(raw: str) -> CanonicalIntent:
             dest, mask, gateway = rt.group(1), rt.group(2), rt.group(3)
             if mask is not None:
                 try:
-                    prefix = _mask_to_prefix(mask)
+                    prefix = _mask_to_prefix(mask, vendor="aruba_aoss")
                 except Exception:
                     # Non-contiguous mask — unusual; fall back to
                     # /32 host-route semantic so render still

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -61,6 +61,11 @@ from ...canonical.intent import (
 )
 from .._input_shape import detect_input_shape
 from ..base import ParseError
+from .._helpers import (
+    _is_link_local_v6,
+    _mask_to_prefix,
+    _normalise_mac_to_colon_hex,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -196,29 +201,6 @@ _FABRIC_AG_MODE_RE = re.compile(
 )
 
 
-def _normalise_mac_to_colon_hex(mac: str) -> str:
-    """Normalise a vendor MAC representation to canonical colon-hex.
-
-    Accepts the three common forms an operator might paste:
-
-    * dotted-triplet (Cisco / NX-OS native): ``0001.c73a.0000``
-    * colon-hex (canonical / Unix): ``00:01:c7:3a:00:00``
-    * dash-hex (Windows / IEEE): ``00-01-C7-3A-00-00``
-
-    Returns the lower-case ``aa:bb:cc:dd:ee:ff`` form.  Returns empty
-    string for input the function can't classify — leaves the caller
-    to skip the canonical population rather than poison the field
-    with malformed data.
-    """
-    if not mac:
-        return ""
-    raw = mac.strip().lower()
-    # Strip every separator and keep only hex digits.
-    hex_only = re.sub(r"[^0-9a-f]", "", raw)
-    if len(hex_only) != 12:
-        return ""
-    return ":".join(hex_only[i:i + 2] for i in range(0, 12, 2))
-
 #: Interface-name prefix → IANA ifType hint.
 _TYPE_HINTS: dict[str, str] = {
     "gigabitethernet": "ianaift:ethernetCsmacd",
@@ -243,63 +225,6 @@ def _infer_type(iface_name: str) -> str:
         if lower.startswith(prefix):
             return iftype
     return "ianaift:other"
-
-
-def _is_link_local_v6(addr: str) -> bool:
-    """Return True iff *addr* is in the IPv6 link-local prefix
-    fe80::/10 (RFC 4291 §2.4).
-
-    Per IANA the link-local prefix covers the range fe80:: through
-    febf::: the first byte is 0xfe and the second nibble is 8/9/a/b
-    (binary 1111111010 — ten leading 1s).  Cisco / Arista classically
-    require the operator to add the ``link-local`` keyword on the
-    interface line, but the prefix itself is unambiguous regardless
-    of vendor decoration; this lets us recover the correct scope on
-    raw fe80:: lines that omit the keyword.
-
-    Returns False for malformed inputs (the caller has the
-    responsibility for downstream parse-time validation; here we just
-    classify scope and leave the ipaddress library to reject the
-    address at canonical-build time if needed).  Accepts the
-    too-many-``::`` shape ``FE80:A8::2DA::1689`` that some NTC
-    fixtures contain — we only inspect the leading characters.
-
-    Args:
-        addr: The bare IPv6 address token (no prefix length).
-
-    Returns:
-        True when *addr* lower-cases to ``fe[89ab]...``; False
-        otherwise.  Empty / non-string inputs return False.
-    """
-    if not addr:
-        return False
-    lo = addr.lower()
-    return (
-        len(lo) >= 3
-        and lo[:2] == "fe"
-        and lo[2] in ("8", "9", "a", "b")
-    )
-
-
-def _mask_to_prefix(mask_str: str) -> int:
-    """Convert a dotted-decimal subnet mask to a CIDR prefix length.
-
-    Raises ParseError for non-contiguous masks.
-    """
-    try:
-        addr = ipaddress.IPv4Address(mask_str)
-    except ipaddress.AddressValueError:
-        raise ParseError(
-            f"cisco_iosxe_cli: invalid subnet mask {mask_str!r}",
-            snippet=mask_str,
-        )
-    bits = bin(int(addr))[2:]
-    if "01" in bits:
-        raise ParseError(
-            f"cisco_iosxe_cli: non-contiguous subnet mask {mask_str!r}",
-            snippet=mask_str,
-        )
-    return bits.count("1")
 
 
 _HOSTNAME_RE = re.compile(r"^hostname\s+(\S+)", re.IGNORECASE | re.MULTILINE)
@@ -784,7 +709,7 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
         if im:
             ip_str = im.group(1)
             mask_str = im.group(2)
-            prefix_len = _mask_to_prefix(mask_str)
+            prefix_len = _mask_to_prefix(mask_str, vendor="cisco_iosxe_cli")
             # IOS-XE accepts one primary + multiple secondary addresses
             # per interface (``ip address X.X.X.X MASK [secondary]``).
             # The render-side companion in :mod:`.render` re-derives the
@@ -1351,7 +1276,7 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
             dest_ip = m.group(2)
             mask = m.group(3)
             gw_or_iface = m.group(4)
-            prefix_len = _mask_to_prefix(mask)
+            prefix_len = _mask_to_prefix(mask, vendor="cisco_iosxe_cli")
             dest = f"{dest_ip}/{prefix_len}"
             # Gateway could be an IP or an interface name.
             gateway = ""
@@ -1472,7 +1397,7 @@ def _parse_dhcp_pools(raw: str) -> list[CanonicalDHCPPool]:
         nm = _DHCP_NETWORK_RE.match(line)
         if nm:
             ip_str, mask = nm.group(1), nm.group(2)
-            prefix = _mask_to_prefix(mask)
+            prefix = _mask_to_prefix(mask, vendor="cisco_iosxe_cli")
             current.network = f"{ip_str}/{prefix}"
             continue
         gm = _DHCP_DEFAULT_ROUTER_RE.match(line)

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -57,6 +57,7 @@ from ...canonical.intent import (
     CanonicalLAG,
 )
 from ..base import RenderError
+from .._helpers import _prefix_to_mask
 
 
 def render_intent(tree: Any) -> str:
@@ -296,7 +297,7 @@ def render_intent(tree: Any) -> str:
         # Round-trips with the parse-side companion that drops the
         # ``secondary`` token before storing in the canonical list.
         for idx, addr in enumerate(iface.ipv4_addresses):
-            mask = _prefix_to_mask(addr.prefix_length)
+            mask = _prefix_to_mask(addr.prefix_length, vendor="cisco_iosxe_cli")
             suffix = " secondary" if idx > 0 else ""
             body.append(f" ip address {addr.ip} {mask}{suffix}")
         # SD-Access anycast-gateway per-SVI marker.  When any IPv4
@@ -717,24 +718,6 @@ def _mac_to_dotted_triplet(mac: str) -> str:
     return f"{hex_only[0:4]}.{hex_only[4:8]}.{hex_only[8:12]}"
 
 
-def _prefix_to_mask(prefix: int) -> str:
-    """Convert a CIDR prefix length to a dotted-decimal subnet mask.
-
-    Inverse of :func:`netcanon.migration.codecs.cisco_iosxe_cli.parse._mask_to_prefix`.
-    Used by render() because Cisco IOS-XE's ``ip address X Y`` form
-    requires dotted-decimal — every other shipped codec uses CIDR
-    natively, so the canonical tree holds prefix lengths and we
-    expand on render.
-    """
-    if not (0 <= prefix <= 32):
-        raise RenderError(
-            f"cisco_iosxe_cli: prefix length {prefix} out of range",
-            yang_path="/interfaces/interface/ipv4/address/prefix-length",
-        )
-    mask_int = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF if prefix else 0
-    return str(ipaddress.IPv4Address(mask_int))
-
-
 def _cidr_to_dest_mask(cidr: str) -> tuple[str, str]:
     """Split a ``X.X.X.X/N`` CIDR into ``(network, dotted_mask)``.
 
@@ -756,7 +739,7 @@ def _cidr_to_dest_mask(cidr: str) -> tuple[str, str]:
         prefix = int(prefix_str)
     except ValueError:
         return (dest, "255.255.255.255")
-    return (dest, _prefix_to_mask(prefix))
+    return (dest, _prefix_to_mask(prefix, vendor="cisco_iosxe_cli"))
 
 
 def _extract_lag_number(lag_name: str) -> int | None:

--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -87,6 +87,7 @@ from ...canonical.intent import (
 )
 from .._input_shape import detect_input_shape
 from ..base import ParseError
+from .._helpers import _is_link_local_v6, _mask_to_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -213,43 +214,6 @@ def _infer_type(iface_name: str) -> str:
         if lower.startswith(prefix):
             return iftype
     return "ianaift:other"
-
-
-def _is_link_local_v6(addr: str) -> bool:
-    """Return True iff *addr* is in the IPv6 link-local prefix fe80::/10.
-
-    Forked from ``cisco_iosxe_cli.parse._is_link_local_v6`` — the prefix
-    is vendor-neutral (RFC 4291 §2.4), so scope can be recovered even
-    when the operator omits the ``link-local`` keyword.
-    """
-    if not addr:
-        return False
-    lo = addr.lower()
-    return len(lo) >= 3 and lo[:2] == "fe" and lo[2] in ("8", "9", "a", "b")
-
-
-def _mask_to_prefix(mask_str: str) -> int:
-    """Convert a dotted-decimal subnet mask to a CIDR prefix length.
-
-    Forked from ``cisco_iosxe_cli.parse._mask_to_prefix`` (per the
-    architecture doc's "duplicate rather than lift" guidance — the
-    helper is small and parse-only).  Raises :class:`ParseError` for a
-    non-contiguous mask.
-    """
-    try:
-        addr = ipaddress.IPv4Address(mask_str)
-    except ipaddress.AddressValueError:
-        raise ParseError(
-            f"cisco_iosxr: invalid subnet mask {mask_str!r}",
-            snippet=mask_str,
-        )
-    bits = bin(int(addr))[2:].zfill(32)
-    if "01" in bits:
-        raise ParseError(
-            f"cisco_iosxr: non-contiguous subnet mask {mask_str!r}",
-            snippet=mask_str,
-        )
-    return bits.count("1")
 
 
 def _fmt_secret(hash_type: str | None, payload: str) -> str:
@@ -416,7 +380,7 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
             try:
                 current["ipv4"].append({
                     "ip": im.group(1),
-                    "prefix_length": _mask_to_prefix(im.group(2)),
+                    "prefix_length": _mask_to_prefix(im.group(2), vendor="cisco_iosxr"),
                     "is_secondary": im.group(3) is not None,
                 })
             except ParseError:

--- a/netcanon/migration/codecs/cisco_iosxr/render.py
+++ b/netcanon/migration/codecs/cisco_iosxr/render.py
@@ -42,6 +42,7 @@ import re
 
 from ...canonical.intent import CanonicalIntent, CanonicalRoutingInstance
 from ..base import RenderError
+from .._helpers import _prefix_to_mask
 from . import port_names as _port_names
 
 #: Synthesised IOS-XR release stamped into the banner.  Cosmetic — the
@@ -60,23 +61,6 @@ _CANON_TO_IOSXR_BUNDLE_MODE = {
 #: Fallback BGP ASN when no route-distinguisher exposes a numeric
 #: administrator field (e.g. all RDs are IP-based ``<ip>:<nn>``).
 _FALLBACK_BGP_ASN = "65000"
-
-
-def _prefix_to_mask(prefix: int) -> str:
-    """Convert a CIDR prefix length to a dotted-decimal subnet mask.
-
-    Forked from ``cisco_iosxe_cli.render._prefix_to_mask`` (render-only,
-    small enough to duplicate per the architecture doc).  IOS-XR's
-    ``ipv4 address X Y`` form requires the dotted mask; the canonical
-    tree holds prefix lengths, so we expand on render.
-    """
-    if not (0 <= prefix <= 32):
-        raise RenderError(
-            f"cisco_iosxr: prefix length {prefix} out of range",
-            yang_path="/interfaces/interface/ipv4/address/prefix-length",
-        )
-    mask_int = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF if prefix else 0
-    return str(ipaddress.IPv4Address(mask_int))
 
 
 def render_intent(tree: CanonicalIntent) -> str:
@@ -289,7 +273,7 @@ def _render_interface(iface, vlan_ids: set, lag_mode_by_name: dict) -> list[str]
         if unit is not None and unit in vlan_ids:
             block.append(f" encapsulation dot1q {unit}")
     for addr in iface.ipv4_addresses:
-        line = f" ipv4 address {addr.ip} {_prefix_to_mask(addr.prefix_length)}"
+        line = f" ipv4 address {addr.ip} {_prefix_to_mask(addr.prefix_length, vendor='cisco_iosxr')}"
         if addr.is_secondary:
             line += " secondary"
         block.append(line)

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -68,6 +68,7 @@ from ...canonical.intent import (
 )
 from .._input_shape import detect_input_shape
 from ..base import ParseError
+from .._helpers import _is_link_local_v6, _normalise_mac_to_colon_hex
 
 logger = logging.getLogger(__name__)
 
@@ -221,21 +222,6 @@ _FABRIC_AG_MODE_RE = re.compile(
 )
 
 
-def _normalise_mac_to_colon_hex(mac: str) -> str:
-    """Normalise a MAC representation to canonical colon-hex.
-
-    Accepts dotted-triplet (``0001.c73a.0000`` — NX-OS native), colon-hex,
-    or dash-hex; returns lower-case ``aa:bb:cc:dd:ee:ff``.  Returns empty
-    string for input it can't classify (caller skips population rather
-    than poisoning the field).  Forked from cisco_iosxe_cli per the
-    duplicate-rather-than-lift convention.
-    """
-    if not mac:
-        return ""
-    hex_only = re.sub(r"[^0-9a-f]", "", mac.strip().lower())
-    if len(hex_only) != 12:
-        return ""
-    return ":".join(hex_only[i:i + 2] for i in range(0, 12, 2))
 #: ``vrf context <name>`` opens a top-level VRF stanza.
 _VRF_CONTEXT_RE = re.compile(r"^vrf\s+context\s+(\S+)\s*$", re.IGNORECASE)
 _VRF_DESCRIPTION_RE = re.compile(r"^\s+description\s+(.+)$", re.IGNORECASE)
@@ -342,19 +328,6 @@ def _infer_type(iface_name: str) -> str:
         if lower.startswith(prefix):
             return iftype
     return "ianaift:other"
-
-
-def _is_link_local_v6(addr: str) -> bool:
-    """Return True iff *addr* is in the IPv6 link-local prefix fe80::/10.
-
-    Mirrors ``cisco_iosxe_cli.parse._is_link_local_v6`` — the prefix is
-    vendor-neutral (RFC 4291 §2.4), so scope can be recovered even when
-    the operator omits the ``link-local`` keyword.
-    """
-    if not addr:
-        return False
-    lo = addr.lower()
-    return len(lo) >= 3 and lo[:2] == "fe" and lo[2] in ("8", "9", "a", "b")
 
 
 def _is_mgmt_vrf(vrf_name: str) -> bool:

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -52,6 +52,7 @@ from typing import ClassVar
 
 from .._input_shape import detect_input_shape
 from ..base import ParseError
+from .._helpers import _mask_to_prefix
 from ...canonical.intent import (
     CanonicalDHCPPool,
     CanonicalIPv4Address,
@@ -90,24 +91,6 @@ def _prefix_to_mask(prefix: int) -> str:
         )
     mask_int = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF
     return str(ipaddress.IPv4Address(mask_int))
-
-
-def _mask_to_prefix(mask: str) -> int:
-    """Convert dotted-decimal mask to CIDR prefix length."""
-    try:
-        addr = ipaddress.IPv4Address(mask)
-    except ipaddress.AddressValueError:
-        raise ParseError(
-            f"fortigate_cli: invalid subnet mask {mask!r}",
-            snippet=mask,
-        )
-    bits = bin(int(addr))[2:]
-    if "01" in bits:
-        raise ParseError(
-            f"fortigate_cli: non-contiguous subnet mask {mask!r}",
-            snippet=mask,
-        )
-    return bits.count("1")
 
 
 def _split_cidr(destination: str) -> tuple[str, int]:
@@ -337,7 +320,7 @@ def _apply_system_interface(
             ip, mask = ip_tokens[0], ip_tokens[1]
             iface.ipv4_addresses.append(CanonicalIPv4Address(
                 ip=ip,
-                prefix_length=_mask_to_prefix(mask),
+                prefix_length=_mask_to_prefix(mask, vendor="fortigate_cli"),
             ))
 
         # IPv6 dynamic-address mode: ``set ip6-mode {static|dhcp|
@@ -676,7 +659,7 @@ def _apply_router_static(
             # keep the scope narrow for now.
             continue
         ip, mask = dst[0], dst[1]
-        destination = f"{ip}/{_mask_to_prefix(mask)}"
+        destination = f"{ip}/{_mask_to_prefix(mask, vendor='fortigate_cli')}"
         gateway_tokens = edit.settings.get("gateway") or [""]
         device_tokens = edit.settings.get("device") or [""]
         # FortiOS `set comment "<text>"` (singular) is the per-route
@@ -825,7 +808,7 @@ def _apply_system_dhcp_server(
             # network address.
             try:
                 gw = ipaddress.IPv4Interface(
-                    f"{gw_tokens[0]}/{_mask_to_prefix(netmask_tokens[0])}"
+                    f"{gw_tokens[0]}/{_mask_to_prefix(netmask_tokens[0], vendor='fortigate_cli')}"
                 )
                 pool.network = str(gw.network)
             except (ipaddress.AddressValueError, ValueError):

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -9780,12 +9780,12 @@ Traceback (most recent call last):
     rendered = target_codec.render(canonical_source)
   File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 342, in render
     return render_intent(tree)
-  File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 546, in render_intent
+  File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 547, in render_intent
     dest, mask = _cidr_to_dest_mask(route.destination)
                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
-  File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 759, in _cidr_to_dest_mask
-    return (dest, _prefix_to_mask(prefix))
-                  ~~~~~~~~~~~~~~~^^^^^^^^
+  File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 742, in _cidr_to_dest_mask
+    return (dest, _prefix_to_mask(prefix, vendor="cisco_iosxe_cli"))
+                  ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 out of range
 ```
 
@@ -9825,7 +9825,7 @@ Traceback (most recent call last):
     return render_intent(tree)
   File "netcanon\migration\codecs\fortigate_cli\render.py", line 946, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)
-  File "netcanon\migration\codecs\fortigate_cli\parse.py", line 87, in _prefix_to_mask
+  File "netcanon\migration\codecs\fortigate_cli\parse.py", line 88, in _prefix_to_mask
     raise RenderError(
     ...<2 lines>...
     )

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-06-16T05:34:37+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260616T053436Z.json",
-  "mesh_run_started_utc": "2026-06-16T05:34:30+00:00",
+  "started_utc": "2026-06-16T07:03:04+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260616T070302Z.json",
+  "mesh_run_started_utc": "2026-06-16T07:02:56+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -175,11 +175,11 @@ class TestMaskHelpers:
     def test_mask_to_prefix_roundtrip(self):
         for prefix in (0, 8, 16, 24, 30, 32):
             mask = _prefix_to_mask(prefix)
-            assert _mask_to_prefix(mask) == prefix
+            assert _mask_to_prefix(mask, vendor="fortigate_cli") == prefix
 
     def test_non_contiguous_mask_rejected(self):
         with pytest.raises(ParseError, match="non-contiguous"):
-            _mask_to_prefix("255.0.255.0")
+            _mask_to_prefix("255.0.255.0", vendor="fortigate_cli")
 
     def test_invalid_cidr_rejected(self):
         from netcanon.migration.codecs.base import RenderError


### PR DESCRIPTION
## What

First of the **v0.1.9 cleanup batch**. De-duplicates four small vendor-neutral pure helpers that had been copy-pasted across the CLI/text codecs (the older "duplicate rather than lift" convention) into a single `netcanon/migration/codecs/_helpers.py`:

| helper | was duplicated in |
|---|---|
| `_normalise_mac_to_colon_hex` | cisco_iosxe_cli, cisco_nxos, aruba_aoscx |
| `_is_link_local_v6` | cisco_iosxe_cli, cisco_iosxr, cisco_nxos, aruba_aoscx |
| `_mask_to_prefix` | cisco_iosxe_cli, cisco_iosxr, arista_eos, aruba_aoss, fortigate_cli |
| `_prefix_to_mask` | cisco_iosxe_cli, cisco_iosxr |

**Net −254 lines.**

## Behaviour-preserving

- The two fallible helpers take a keyword-only `vendor=` so the raised `ParseError`/`RenderError` messages stay **byte-identical** — the cross-mesh report's render-error text is unchanged (only the embedded traceback *line numbers* shift, since defs moved).
- Full **unit + integration gate green**; cross-mesh audit holds **CODEC_BUG flat at 5** (EXPECTED_LOSSY 1226, METHODOLOGY_over 25 — all unchanged).
- The consolidated `_mask_to_prefix` adopts cisco_iosxr's already-correct 32-bit zero-padded contiguity check for all five copies, **incidentally fixing a latent edge case** where a mask whose leading octet is zero (e.g. the non-contiguous `0.255.0.0`) was mis-counted rather than rejected — no fixture or test exercises it, so the audit is unaffected.
- fortigate keeps its **own** `_prefix_to_mask` (distinct message, no range pre-check) — deliberately not folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)