### PR TITLE
chore(release): cut v0.1.9 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-06-16
+
 ### Added
 
 * **Real-capture corpus: JNPRAutomate MNHA vSRX fixture** —


### PR DESCRIPTION
## v0.1.9 release cut

Rolls the `[Unreleased]` section into **`[0.1.9] - 2026-06-16`** (fresh empty `[Unreleased]` left on top). Version is setuptools_scm-derived from the tag, so this is a CHANGELOG-only change — no manual version bump.

### What's in v0.1.9

**2026-06 fixture-gap-hunt** (PRs #68–#81, already merged): real codec fixes (nxos VXLAN mcast-group / dual-AF route-target dedup / flood-list, fortigate sha224 + priority-255 clamp, aoss VRRP, IOS-XE-probe NX-OS/AOS-CX deferral, comparator `is_secondary` + fortigate vlan-heuristic honesty) + vetted real-capture fixtures (canu AOS-CX, akarneliuk NX-OS EVPN-VXLAN, JNPRAutomate MNHA vSRX).

**v0.1.9 cleanup batch** (this session):
- **#82** — extracted shared `_helpers.py` (mask/MAC/link-local), `−254 LOC` de-duplicated across 7 codecs; behaviour-preserving, CODEC_BUG flat at 5.
- **#83** — removed a dead `TYPE_CHECKING` block + two stale skipped e2e tests.

CODEC_BUG invariant held flat at **5** throughout.

### Release flow (tag = publish — maintainer-owned)

After merge:
```
git tag -a v0.1.9 <merge-commit>
git push origin v0.1.9    # fires PyPI + Docker + desktop-MSI publish on the v*.*.* glob
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)