### PR TITLE
chore: add `from __future__ import annotations` to remaining modules

### DIFF
--- a/netcanon/__init__.py
+++ b/netcanon/__init__.py
@@ -24,3 +24,5 @@ Or programmatically (e.g. in tests):
     from netcanon.config import Settings
     app = create_app(Settings(configs_dir=tmp_path))
 """
+
+from __future__ import annotations

--- a/netcanon/api/__init__.py
+++ b/netcanon/api/__init__.py
@@ -1,1 +1,3 @@
 """FastAPI router modules for the Netcanon REST API."""
+
+from __future__ import annotations

--- a/netcanon/api/deps.py
+++ b/netcanon/api/deps.py
@@ -13,6 +13,8 @@ Usage::
         ...
 """
 
+from __future__ import annotations
+
 from fastapi import Request
 
 from ..definitions.loader import DefinitionLoader

--- a/netcanon/api/routes/__init__.py
+++ b/netcanon/api/routes/__init__.py
@@ -1,1 +1,3 @@
 """API route modules — imported and included by the application factory."""
+
+from __future__ import annotations

--- a/netcanon/api/routes/definitions.py
+++ b/netcanon/api/routes/definitions.py
@@ -6,6 +6,8 @@ refresh the in-memory registry after editing YAML files without
 restarting the server.
 """
 
+from __future__ import annotations
+
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request

--- a/netcanon/collectors/__init__.py
+++ b/netcanon/collectors/__init__.py
@@ -13,6 +13,8 @@ Adding a new strategy
 4. Document the strategy in ``collectors/README.md``.
 """
 
+from __future__ import annotations
+
 from .base import BaseCollector, get_collector
 from .netmiko_collector import NetmikoCollector
 from .paramiko_collector import ParamikoShellCollector

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -9,6 +9,8 @@ prefix, e.g.::
 Pydantic-settings automatically reads ``.env`` files if present.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Literal
 

--- a/netcanon/definitions/__init__.py
+++ b/netcanon/definitions/__init__.py
@@ -10,6 +10,8 @@ and the web UI.
 See ``definitions/README.md`` for the file format and extension guide.
 """
 
+from __future__ import annotations
+
 from .loader import DefinitionLoader
 from .schema import (
     CollectorConfig,

--- a/netcanon/definitions/loader.py
+++ b/netcanon/definitions/loader.py
@@ -51,6 +51,8 @@ Usage::
     definition = loader.resolve("Cisco", os_version="17.12")  # overlay-aware
 """
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 

--- a/netcanon/definitions/schema.py
+++ b/netcanon/definitions/schema.py
@@ -21,6 +21,8 @@ defence-in-depth.  Single-token CamelCase keys (``Cisco``, ``Aruba``,
 ``Juniper`` ...) are the established convention.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Literal
 

--- a/netcanon/migration/canonical/__init__.py
+++ b/netcanon/migration/canonical/__init__.py
@@ -9,3 +9,5 @@ was not adopted — ``loader.py`` remains an unused stub kept for a stable
 import path — so validation is the model's own Pydantic constraints,
 not external YANG-schema validation.
 """
+
+from __future__ import annotations

--- a/netcanon/migration/codecs/__init__.py
+++ b/netcanon/migration/codecs/__init__.py
@@ -1,5 +1,7 @@
 """Vendor-adapter package.  Each sub-module registers its adapter."""
 
+from __future__ import annotations
+
 from .base import CodecBase, CodecError, ParseError, RenderError
 from .registry import get_codec, list_codecs, register
 

--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -16,6 +16,8 @@ whose input was malformed (preserving the diagnostics that the previous
 per-codec copies emitted).
 """
 
+from __future__ import annotations
+
 import ipaddress
 import re
 

--- a/netcanon/migration/codecs/_mock/__init__.py
+++ b/netcanon/migration/codecs/_mock/__init__.py
@@ -13,6 +13,8 @@ exercising the full parse → validate → render loop end-to-end without
 requiring libyang or any real device.
 """
 
+from __future__ import annotations
+
 from .codec import MockCodec
 
 __all__ = ["MockCodec"]

--- a/netcanon/migration/codecs/arista_eos/__init__.py
+++ b/netcanon/migration/codecs/arista_eos/__init__.py
@@ -42,6 +42,8 @@ Certainty: ``certified`` — validated against real-capture fixtures;
     see ``tests/fixtures/real/RESULTS.md`` for the per-fixture matrix.
 """
 
+from __future__ import annotations
+
 from .codec import AristaEOSCodec
 
 __all__ = ["AristaEOSCodec"]

--- a/netcanon/migration/codecs/aruba_aoscx/__init__.py
+++ b/netcanon/migration/codecs/aruba_aoscx/__init__.py
@@ -32,6 +32,8 @@ Certainty: ``certified`` — Phase 1 (Tier-1: hostname, basic-L3
     ``docs/fixture-research-2015/11-aruba_aoscx.md``.
 """
 
+from __future__ import annotations
+
 from .codec import ArubaAOSCXCodec
 
 __all__ = ["ArubaAOSCXCodec"]

--- a/netcanon/migration/codecs/aruba_aoss/__init__.py
+++ b/netcanon/migration/codecs/aruba_aoss/__init__.py
@@ -55,6 +55,8 @@ Certainty: ``certified`` — validated against real-capture fixtures
     see ``tests/fixtures/real/RESULTS.md`` for the per-fixture matrix.
 """
 
+from __future__ import annotations
+
 from .codec import ArubaAOSSCodec
 
 __all__ = ["ArubaAOSSCodec"]

--- a/netcanon/migration/codecs/cisco_iosxe/__init__.py
+++ b/netcanon/migration/codecs/cisco_iosxe/__init__.py
@@ -36,6 +36,8 @@ Certainty: ``best_effort`` — Phase-0.5 NETCONF stub; render covers
     ``tests/fixtures/real/RESULTS.md`` for the under-development matrix.
 """
 
+from __future__ import annotations
+
 from .codec import CiscoIOSXECodec
 
 __all__ = ["CiscoIOSXECodec"]

--- a/netcanon/migration/codecs/cisco_iosxe_cli/__init__.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/__init__.py
@@ -27,6 +27,8 @@ Certainty: ``certified`` — validated against real-capture fixtures;
     see ``tests/fixtures/real/RESULTS.md`` for the per-fixture matrix.
 """
 
+from __future__ import annotations
+
 from .codec import CiscoIOSXECLICodec
 
 __all__ = ["CiscoIOSXECLICodec"]

--- a/netcanon/migration/codecs/cisco_iosxr/__init__.py
+++ b/netcanon/migration/codecs/cisco_iosxr/__init__.py
@@ -28,6 +28,8 @@ Certainty: ``certified`` — all four phases complete: interfaces +
     round-trips cleanly.  See ``docs/v0.2.0-planning/04-iosxr-codec/``.
 """
 
+from __future__ import annotations
+
 from .codec import CiscoIOSXRCodec
 
 __all__ = ["CiscoIOSXRCodec"]

--- a/netcanon/migration/codecs/cisco_nxos/__init__.py
+++ b/netcanon/migration/codecs/cisco_nxos/__init__.py
@@ -24,6 +24,8 @@ Certainty: ``certified`` — all four phases complete (L1/L3 + L2
     remain unsupported.  See ``docs/v0.2.0-planning/03-nxos-codec/``.
 """
 
+from __future__ import annotations
+
 from .codec import CiscoNXOSCodec
 
 __all__ = ["CiscoNXOSCodec"]

--- a/netcanon/migration/codecs/fortigate_cli/__init__.py
+++ b/netcanon/migration/codecs/fortigate_cli/__init__.py
@@ -47,6 +47,8 @@ Certainty: ``certified`` — three real captures across FortiOS 7.2.13
     ``tests/fixtures/real/RESULTS.md``.
 """
 
+from __future__ import annotations
+
 from .codec import FortiGateCLICodec
 
 __all__ = ["FortiGateCLICodec"]

--- a/netcanon/migration/codecs/juniper_junos/__init__.py
+++ b/netcanon/migration/codecs/juniper_junos/__init__.py
@@ -71,6 +71,8 @@ Certainty: ``certified`` — validated against real-capture fixtures;
     see ``tests/fixtures/real/RESULTS.md`` for the per-fixture matrix.
 """
 
+from __future__ import annotations
+
 from .codec import JunosCodec
 
 __all__ = ["JunosCodec"]

--- a/netcanon/migration/codecs/mikrotik_routeros/__init__.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/__init__.py
@@ -35,6 +35,8 @@ Certainty: ``certified`` — validated against real-capture fixtures
     ``tests/fixtures/real/RESULTS.md`` for the per-fixture matrix.
 """
 
+from __future__ import annotations
+
 from .codec import MikroTikRouterOSCodec
 
 __all__ = ["MikroTikRouterOSCodec"]

--- a/netcanon/migration/codecs/opnsense/__init__.py
+++ b/netcanon/migration/codecs/opnsense/__init__.py
@@ -38,6 +38,8 @@ Certainty: ``certified`` — validated against real-capture fixtures;
     see ``tests/fixtures/real/RESULTS.md`` for the per-fixture matrix.
 """
 
+from __future__ import annotations
+
 from .codec import OPNsenseCodec
 
 __all__ = ["OPNsenseCodec"]

--- a/netcanon/migration/codecs/vyos/__init__.py
+++ b/netcanon/migration/codecs/vyos/__init__.py
@@ -31,6 +31,8 @@ Certainty: ``certified`` — Phase 1 (Tier-1: ``system host-name``;
     ``config`` input follows in a later phase.
 """
 
+from __future__ import annotations
+
 from .codec import VyOSCodec
 
 __all__ = ["VyOSCodec"]

--- a/netcanon/models/__init__.py
+++ b/netcanon/models/__init__.py
@@ -1,5 +1,7 @@
 """Domain models for devices, backup jobs, and stored configuration records."""
 
+from __future__ import annotations
+
 from .backup import BackupJob, BackupResult, ConfigRecord, JobStatus
 from .device import BackupRequest, DeviceCredentials, DeviceTarget
 from .diff import CompatibilityReport, DiffGroup, DiffLine, DiffReport, DiffRequest

--- a/netcanon/models/backup.py
+++ b/netcanon/models/backup.py
@@ -7,6 +7,8 @@ each device is processed.  Callers poll ``GET /api/v1/backups/{job_id}``
 for status.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 from typing import Literal

--- a/netcanon/models/device.py
+++ b/netcanon/models/device.py
@@ -6,6 +6,8 @@ They are accepted as request bodies from API callers and the interactive
 web form, never persisted to disk (credentials are in-memory only).
 """
 
+from __future__ import annotations
+
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from .validators import validate_host as _validate_host

--- a/netcanon/models/validators.py
+++ b/netcanon/models/validators.py
@@ -5,6 +5,8 @@ Centralised here so that ``device.py`` and ``device_profile.py`` share
 the same hostname/IP validation logic without duplication.
 """
 
+from __future__ import annotations
+
 import ipaddress
 import re
 

--- a/netcanon/security/__init__.py
+++ b/netcanon/security/__init__.py
@@ -1,1 +1,3 @@
 """Security utilities for Netcanon."""
+
+from __future__ import annotations

--- a/netcanon/services/__init__.py
+++ b/netcanon/services/__init__.py
@@ -1,1 +1,3 @@
 """Stateless service-layer helpers used by API routes and UI views."""
+
+from __future__ import annotations

--- a/netcanon/storage/__init__.py
+++ b/netcanon/storage/__init__.py
@@ -7,6 +7,8 @@ is the default for v1.  Future implementations (database, object storage)
 only need to satisfy the same interface.
 """
 
+from __future__ import annotations
+
 from .base import BaseConfigStore
 from .file_store import FileConfigStore
 

--- a/netcanon/storage/base.py
+++ b/netcanon/storage/base.py
@@ -5,6 +5,8 @@ Any storage backend must implement all four methods.  The interface is
 intentionally narrow to keep implementations simple and swappable.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path

--- a/netcanon/storage/file_store.py
+++ b/netcanon/storage/file_store.py
@@ -55,6 +55,8 @@ skips files matching ``*.meta.json`` so they aren't enumerated as
 configs in their own right.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import re

--- a/netcanon/tools/__init__.py
+++ b/netcanon/tools/__init__.py
@@ -11,3 +11,5 @@ sanitization rules track codec evolution automatically: a new field
 on :class:`netcanon.migration.canonical.intent.CanonicalIntent` becomes
 visible to the sanitizer in the same wave it ships.
 """
+
+from __future__ import annotations

--- a/tests/fixtures/iosxe/__init__.py
+++ b/tests/fixtures/iosxe/__init__.py
@@ -3,3 +3,5 @@
 Files are real-shaped (namespace declarations, envelope, subinterfaces)
 but every IP, hostname, and description is synthetic / sanitised.
 """
+
+from __future__ import annotations

--- a/tests/fixtures/opnsense/__init__.py
+++ b/tests/fixtures/opnsense/__init__.py
@@ -1,1 +1,3 @@
 """Sanitised OPNsense config.xml samples for translator tests."""
+
+from __future__ import annotations

--- a/tests/fixtures/ssh_responses.py
+++ b/tests/fixtures/ssh_responses.py
@@ -10,6 +10,8 @@ the underlying SSH transport — including the trailing prompt line that a
 prompt-stripping layer would remove.
 """
 
+from __future__ import annotations
+
 CISCO_RUNNING_CONFIG = """\
 Building configuration...
 

--- a/tests/unit/migration/__init__.py
+++ b/tests/unit/migration/__init__.py
@@ -1,1 +1,3 @@
 """Unit tests for the translator / migration engine (Phase 0)."""
+
+from __future__ import annotations

--- a/tests/unit/migration/codecs/mikrotik_routeros/test_bridge_declaration_and_svi.py
+++ b/tests/unit/migration/codecs/mikrotik_routeros/test_bridge_declaration_and_svi.py
@@ -34,6 +34,8 @@ must exist before the child is committed.  See RouterOS VLAN docs:
 https://help.mikrotik.com/docs/spaces/ROS/pages/328068/VLAN
 """
 
+from __future__ import annotations
+
 import pytest
 from netcanon.migration.canonical.port_names import PortIdentity
 from netcanon.migration.canonical.intent import (

--- a/tests/unit/migration/codecs/mikrotik_routeros/test_loopback_tunnel_and_static_route.py
+++ b/tests/unit/migration/codecs/mikrotik_routeros/test_loopback_tunnel_and_static_route.py
@@ -48,6 +48,8 @@ RouterOS doc references (cited in render.py comments):
   https://wiki.mikrotik.com/wiki/Manual:IP/Route
 """
 
+from __future__ import annotations
+
 import pytest
 from netcanon.migration.canonical.intent import (
     CanonicalInterface,

--- a/tests/unit/migration/codecs/mikrotik_routeros/test_multi_module_port_names.py
+++ b/tests/unit/migration/codecs/mikrotik_routeros/test_multi_module_port_names.py
@@ -34,6 +34,8 @@ the per-PORT numbering (the bit before the dash) is still flat.
 that ships SFP28 (CCR2004-1G-12S+2XS).
 """
 
+from __future__ import annotations
+
 import pytest
 from netcanon.migration.canonical.intent import (
     CanonicalInterface,

--- a/tests/unit/migration/codecs/mikrotik_routeros/test_render_cross_vendor_names.py
+++ b/tests/unit/migration/codecs/mikrotik_routeros/test_render_cross_vendor_names.py
@@ -11,6 +11,8 @@ interface that isn't already owned by the VLAN, bridge, or LAG
 sections, and confirm the round-trip preserves attributes.
 """
 
+from __future__ import annotations
+
 import pytest
 from netcanon.migration.canonical.intent import (
     CanonicalInterface,

--- a/tests/unit/migration/codecs/mikrotik_routeros/test_vlan_parent_and_user_emit.py
+++ b/tests/unit/migration/codecs/mikrotik_routeros/test_vlan_parent_and_user_emit.py
@@ -50,6 +50,8 @@ These tests pin:
    has no global domain command.
 """
 
+from __future__ import annotations
+
 import pytest
 from netcanon.migration.canonical.intent import (
     CanonicalInterface,


### PR DESCRIPTION
## What

Pure-additive PEP 563 sweep: adds `from __future__ import annotations` to the **45** `.py` modules that still lacked it (307 already had it). First import after the module docstring, before any other import.

## Why

Stage 1 of the v0.2.0 tooling baseline. Standardising the future-import everywhere lets the upcoming ruff config turn on `isort.required-imports = ["from __future__ import annotations"]` (rule I002) and pass repo-wide with zero further churn, and lets annotations be written without import-time forward-ref gymnastics in later refactors.

## Scope notes

- **22 empty / comment-only files skipped** (e.g. package-marker `__init__.py`), which matches ruff I002's own skip-empty behaviour — so PR (b) stays consistent.
- Insertion point computed via `ast` (after docstring / shebang, before first statement) — not a blind line-1 prepend.

## Verification

- `py -m compileall netcanon tests` — clean (catches any misplaced future-import as a SyntaxError).
- `py -m pytest tests/unit tests/integration` — green (exit 0).
- Regenerated cross-mesh + phase4: **`CROSS_MESH_RESULTS.md` and `PHASE4_RECONCILIATION.md` byte-identical**, `CODEC_BUG` flat at **5**. Confirms zero behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
