### PR TITLE
chore(lint): resolve remaining ruff findings -> clean baseline

### DIFF
--- a/netcanon/api/routes/_migration_helpers.py
+++ b/netcanon/api/routes/_migration_helpers.py
@@ -59,7 +59,7 @@ def resolve_adapter_or_422(name: str, side: str):
         raise HTTPException(
             status_code=422,
             detail=f"unknown {side} adapter: {exc}",
-        )
+        ) from exc
 
 
 def resolve_input_text(
@@ -86,11 +86,11 @@ def resolve_input_text(
         return body.raw_text or ""
     try:
         return storage.get_content(body.source_filename or "")
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
             detail=f"source_filename not found: {body.source_filename!r}",
-        )
+        ) from exc
 
 
 def get_target_profiles(request: Request) -> dict[str, TargetProfile]:

--- a/netcanon/api/routes/configs.py
+++ b/netcanon/api/routes/configs.py
@@ -84,9 +84,11 @@ def get_config(
         content = storage.get_content(filename)
         logger.debug("Served config %r (%d bytes)", filename, len(content))
         return content
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         logger.warning("Config not found: %r", filename)
-        raise HTTPException(status_code=404, detail=f"Config not found: {filename!r}")
+        raise HTTPException(
+            status_code=404, detail=f"Config not found: {filename!r}"
+        ) from exc
 
 
 @router.delete(
@@ -109,9 +111,11 @@ def delete_config(
     try:
         storage.delete(filename)
         logger.info("Deleted config %r", filename)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         logger.warning("Delete requested for missing config: %r", filename)
-        raise HTTPException(status_code=404, detail=f"Config not found: {filename!r}")
+        raise HTTPException(
+            status_code=404, detail=f"Config not found: {filename!r}"
+        ) from exc
 
 
 @router.post(
@@ -167,9 +171,11 @@ def open_config(
 
     try:
         path = storage.resolve_path(filename)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         logger.warning("Open requested for missing config: %r", filename)
-        raise HTTPException(status_code=404, detail=f"Config not found: {filename!r}")
+        raise HTTPException(
+            status_code=404, detail=f"Config not found: {filename!r}"
+        ) from exc
 
     try:
         if sys.platform == "win32":
@@ -182,7 +188,7 @@ def open_config(
             import subprocess
             subprocess.run(["xdg-open", str(path)], check=True)
         logger.info("Opened config %r in default editor", filename)
-    except NotImplementedError:
+    except NotImplementedError as exc:
         # os.startfile is Windows-only; the linux/darwin branches above use
         # subprocess so this typically fires only on exotic platforms.
         raise HTTPException(
@@ -192,7 +198,7 @@ def open_config(
                 f"platform ({sys.platform!r}).  Use the download link to "
                 f"fetch the file instead."
             ),
-        )
+        ) from exc
     except Exception as exc:
         # Full exception detail is logged server-side (exc_info=True).
         # Don't echo raw OS exception text to the HTTP client — operator
@@ -204,7 +210,7 @@ def open_config(
                 f"The OS refused to open {filename!r} in the default "
                 f"editor.  Check the server log for the underlying error."
             ),
-        )
+        ) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -168,7 +168,7 @@ def get_codec_capabilities(name: str) -> CapabilityMatrix:
     try:
         adapter = get_codec(name)
     except LookupError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return adapter.capabilities
 
 
@@ -619,11 +619,11 @@ def detect_source_codec(
     else:
         try:
             raw = storage.get_content(body.source_filename or "")
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
             raise HTTPException(
                 status_code=404,
                 detail=f"source_filename not found: {body.source_filename!r}",
-            )
+            ) from exc
     return detect_codec(raw, min_confidence=body.min_confidence)
 
 

--- a/netcanon/api/routes/sanitize.py
+++ b/netcanon/api/routes/sanitize.py
@@ -67,7 +67,7 @@ async def post_sanitize(
         raise HTTPException(
             status_code=400,
             detail=f"Failed to parse upload as {source_vendor!r}: {e}",
-        )
+        ) from e
 
     if dry_run:
         return JSONResponse({

--- a/netcanon/collectors/paramiko_collector.py
+++ b/netcanon/collectors/paramiko_collector.py
@@ -195,14 +195,15 @@ class ParamikoShellCollector(BaseCollector):
             initial = self._drain(shell)
 
             # OPNsense console menu — send "8" to enter shell
-            if definition.connection.opnsense_shell_menu:
-                if "8) Shell" in initial or "Enter an option:" in initial:
-                    logger.debug(
-                        "OPNsense menu detected on %s — sending '8'", device.host
-                    )
-                    shell.send("8\n")
-                    time.sleep(3)
-                    self._drain(shell)
+            if definition.connection.opnsense_shell_menu and (
+                "8) Shell" in initial or "Enter an option:" in initial
+            ):
+                logger.debug(
+                    "OPNsense menu detected on %s — sending '8'", device.host
+                )
+                shell.send("8\n")
+                time.sleep(3)
+                self._drain(shell)
 
             for cmd in definition.commands.pre:
                 logger.debug("Pre-command: %s", cmd)
@@ -296,16 +297,17 @@ class ParamikoShellCollector(BaseCollector):
             time.sleep(2)
             initial = self._drain(shell)
 
-            if definition.connection.opnsense_shell_menu:
-                if "8) Shell" in initial or "Enter an option:" in initial:
-                    logger.debug(
-                        "OPNsense menu detected on %s during probe — "
-                        "sending '8'",
-                        device.host,
-                    )
-                    shell.send("8\n")
-                    time.sleep(3)
-                    self._drain(shell)
+            if definition.connection.opnsense_shell_menu and (
+                "8) Shell" in initial or "Enter an option:" in initial
+            ):
+                logger.debug(
+                    "OPNsense menu detected on %s during probe — "
+                    "sending '8'",
+                    device.host,
+                )
+                shell.send("8\n")
+                time.sleep(3)
+                self._drain(shell)
 
             time.sleep(1)
             self._drain(shell)

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -165,7 +165,9 @@ class CanonicalIPv6Address(BaseModel):
 
 
 class CanonicalInterface(BaseModel):
-    """A network interface — physical, VLAN SVI, LAG, loopback, tunnel (Tier 1 — auto-translatable cross-vendor primitive).
+    """A network interface — physical, VLAN SVI, LAG, loopback, tunnel.
+
+    Tier 1 — auto-translatable cross-vendor primitive.
 
     Attributes:
         name: Vendor-native name (opaque).  For renamed MikroTik ports
@@ -359,7 +361,9 @@ class CanonicalDHCPPool(BaseModel):
 
 
 class CanonicalSNMPv3User(BaseModel):
-    """An SNMPv3 User-based Security Model (USM) user (Tier 2 — translate-with-review; per-vendor hash + key grammar diverges).
+    """An SNMPv3 User-based Security Model (USM) user.
+
+    Tier 2 — translate-with-review; per-vendor hash + key grammar diverges.
 
     The v3 identity unit — where SNMPv1/v2c identity is a shared
     community string, v3 identity is a named user with per-user
@@ -484,7 +488,9 @@ class CanonicalLAG(BaseModel):
 
 
 class CanonicalVRRPGroup(BaseModel):
-    """A classic FHRP redundancy group on an interface — VRRP / HSRP / CARP (Tier 2 — FHRP redundancy; cross-vendor grammar diverges).
+    """A classic FHRP redundancy group on an interface — VRRP / HSRP / CARP.
+
+    Tier 2 — FHRP redundancy; cross-vendor grammar diverges.
 
     Models the universal L3 redundancy primitive across the shipped
     bidirectional codecs.  Every vendor has equivalent grammar; the

--- a/netcanon/migration/canonical/port_names.py
+++ b/netcanon/migration/canonical/port_names.py
@@ -529,7 +529,7 @@ def _strip_dropped_ports(
         vlan.untagged_ports = [
             p for p in vlan.untagged_ports if p not in dropped
         ]
-    intent.lags = [l for l in intent.lags if l.name not in dropped]
+    intent.lags = [lag for lag in intent.lags if lag.name not in dropped]
     for lag in intent.lags:
         lag.members = [m for m in lag.members if m not in dropped]
     intent.static_routes = [

--- a/netcanon/migration/canonical/transforms.py
+++ b/netcanon/migration/canonical/transforms.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 
 import re
 
-from .intent import CanonicalIntent, CanonicalVlan
+from .intent import CanonicalIntent, CanonicalInterface, CanonicalVlan
 
 # Splits a port name into a tuple of (str, int, str, int, ...) for
 # natural sort.  Used by :func:`project_vlan_to_switchport` so
@@ -154,8 +154,7 @@ def project_switchport_to_vlan(intent: CanonicalIntent) -> None:
         elif mode == "trunk":
             allowed_set = set(iface.trunk_allowed_vlans)
             is_trunk_all = (
-                allowed_set == _TRUNK_ALL_RANGE_FULL
-                or allowed_set == _TRUNK_ALL_RANGE_OPERATIONAL
+                allowed_set in (_TRUNK_ALL_RANGE_FULL, _TRUNK_ALL_RANGE_OPERATIONAL)
             )
             if is_trunk_all:
                 # Trunk-all sentinel: do NOT synthesise 4094 phantom

--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -72,11 +72,11 @@ def _mask_to_prefix(mask_str: str, *, vendor: str) -> int:
     """
     try:
         addr = ipaddress.IPv4Address(mask_str)
-    except ipaddress.AddressValueError:
+    except ipaddress.AddressValueError as e:
         raise ParseError(
             f"{vendor}: invalid subnet mask {mask_str!r}",
             snippet=mask_str,
-        )
+        ) from e
     bits = bin(int(addr))[2:].zfill(32)
     if "01" in bits:
         raise ParseError(

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -210,8 +210,14 @@ class AristaEOSCodec(CodecBase):
             # ── Tier-1 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
             UnsupportedPath(
                 path="/routing/bgp",
                 reason=(

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -641,7 +641,6 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
     }
 
     current_iface: CanonicalInterface | None = None
-    current_iface_is_l3 = False   # set via ``no switchport``
     current_vlan: CanonicalVlan | None = None
 
     lines = raw.splitlines()
@@ -651,7 +650,6 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
         if not stripped or stripped.startswith("!"):
             # End-of-stanza delimiter.  Close whichever is open.
             current_iface = None
-            current_iface_is_l3 = False
             current_vlan = None
             continue
 
@@ -678,7 +676,6 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
                     sentinel = CanonicalInterface(name=name, enabled=True)
                     sentinel.interface_type = _infer_iface_type(name)
                     current_iface = sentinel
-                    current_iface_is_l3 = False
                     current_vlan = None
                     continue
                 iface = iface_by_name.get(name)
@@ -690,7 +687,6 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
                     iface_by_name[name] = iface
                     intent.interfaces.append(iface)
                 current_iface = iface
-                current_iface_is_l3 = False
                 current_vlan = None
                 continue
             if vlan_m:
@@ -714,13 +710,8 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
                 current_iface, stripped, lag_members, intent,
                 vxlan_state,
             )
-            # Track L3 flip so subsequent ``ip address`` lines are
-            # understood as routed rather than SVI-like.
-            if stripped == "no switchport":
-                current_iface_is_l3 = True
-        elif current_vlan is not None:
-            if stripped.startswith("name "):
-                current_vlan.name = stripped.split(None, 1)[1].strip()
+        elif current_vlan is not None and stripped.startswith("name "):
+            current_vlan.name = stripped.split(None, 1)[1].strip()
 
     # GAP-EVPN-2 post-pass: stamp every CanonicalVxlan record we
     # produced with the switch-level source-interface + udp-port we
@@ -745,7 +736,7 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
     for chan_id, members in lag_members.items():
         lag_name = f"Port-Channel{chan_id}"
         existing = next(
-            (l for l in intent.lags if l.name == lag_name), None,
+            (lag for lag in intent.lags if lag.name == lag_name), None,
         )
         if existing is None:
             intent.lags.append(CanonicalLAG(
@@ -1180,7 +1171,7 @@ def _apply_iface_subcommand(
     # ``docs/v0.2.0-planning/01-vrrp-canonical/03-parse-render-
     # touchpoints.md`` § "2. arista_eos" for the field-by-field
     # mapping.
-    if line.startswith("vrrp ") or line.startswith("no vrrp "):
+    if line.startswith(("vrrp ", "no vrrp ")):
         # ``vrrp <gid> ipv4 <ip>`` (modern) or ``vrrp <gid> ip <ip>`` (legacy).
         m = re.match(
             r"^vrrp\s+(\d+)\s+(?:ipv4|ip)\s+(\S+)\s*$", line,

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -253,14 +253,38 @@ class ArubaAOSCXCodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/domain", reason="Render emits no system domain-name; intent.domain is dropped on migration."),
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/dns-server", reason="Render emits no name-server config; intent.dns_servers are dropped on migration."),
-            UnsupportedPath(path="/system/ntp-server", reason="Render emits no NTP config; intent.ntp_servers are dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/dhcp-servers/pool", reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/host", reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/key", reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration."),
+            UnsupportedPath(
+                path="/system/domain",
+                reason="Render emits no system domain-name; intent.domain is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/dns-server",
+                reason="Render emits no name-server config; intent.dns_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/ntp-server",
+                reason="Render emits no NTP config; intent.ntp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/dhcp-servers/pool",
+                reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/host",
+                reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/key",
+                reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration.",
+            ),
             # ── SNMP trap hosts (deferred — `snmp-server host` grammar) ──
             UnsupportedPath(
                 path="/snmp/trap-host",

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -201,11 +201,27 @@ class ArubaAOSSCodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/domain", reason="Render emits no system domain-name; intent.domain is dropped on migration."),
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/dhcp-servers/pool", reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration."),
-            UnsupportedPath(path="/routing-instances/instance", reason="Render emits no VRF/routing-instance construct; intent.routing_instances are dropped on migration."),
+            UnsupportedPath(
+                path="/system/domain",
+                reason="Render emits no system domain-name; intent.domain is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/dhcp-servers/pool",
+                reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/routing-instances/instance",
+                reason="Render emits no VRF/routing-instance construct; "
+                "intent.routing_instances are dropped on migration.",
+            ),
             UnsupportedPath(
                 path="/filter/rule",
                 reason=(

--- a/netcanon/migration/codecs/aruba_aoss/render.py
+++ b/netcanon/migration/codecs/aruba_aoss/render.py
@@ -168,9 +168,7 @@ def _has_renderable_body(iface: Any) -> bool:
         return True
     if iface.voice_vlan is not None:
         return True
-    if iface.lag_member_of:
-        return True
-    return False
+    return bool(iface.lag_member_of)
 
 
 #: Hash algorithms AOS-S accepts in the ``password manager user-name
@@ -289,9 +287,7 @@ def _is_collapsible_aos_prefix(prefix: str) -> bool:
         return True
     if re.match(r"^\d+/[A-Za-z]?$", prefix):
         return True
-    if prefix.lower() == "trk":
-        return True
-    return False
+    return prefix.lower() == "trk"
 
 
 def _format_port_list(ports: list[str]) -> str:
@@ -339,7 +335,7 @@ def _format_port_list(ports: list[str]) -> str:
         run_start = nums[0]
         prev = nums[0]
         run: list[int] = [nums[0]]
-        def flush(start: int, end: int) -> str:
+        def flush(start: int, end: int, prefix: str) -> str:
             if start == end:
                 return f"{prefix}{start}"
             return f"{prefix}{start}-{prefix}{end}"
@@ -348,11 +344,11 @@ def _format_port_list(ports: list[str]) -> str:
                 run.append(n)
                 prev = n
             else:
-                parts.append(flush(run_start, prev))
+                parts.append(flush(run_start, prev, prefix))
                 run_start = n
                 prev = n
                 run = [n]
-        parts.append(flush(run_start, prev))
+        parts.append(flush(run_start, prev, prefix))
     return ",".join(parts)
 
 
@@ -619,11 +615,10 @@ def render_intent(tree: Any) -> str:
             if addrs:
                 absorbed_iface_names.add(svi_iface.name)
         id_match = iface_by_vlan_id.get(vlan.id)
-        if not addrs:
-            if id_match is not None:
-                addrs = list(id_match.ipv4_addresses)
-                if addrs:
-                    absorbed_iface_names.add(id_match.name)
+        if not addrs and id_match is not None:
+            addrs = list(id_match.ipv4_addresses)
+            if addrs:
+                absorbed_iface_names.add(id_match.name)
         for addr in addrs:
             lines.append(
                 f"   ip address {addr.ip}/{addr.prefix_length}"
@@ -768,9 +763,8 @@ def render_intent(tree: Any) -> str:
         # need post-deploy editing.  Native-shape names with empty
         # bodies are KEPT for round-trip stability (matches Junos
         # treatment of ``ge-0/0/0``-shape stubs).
-        if not _IS_AOS_PHYSICAL_PORT_RE.match(iface.name):
-            if not _has_renderable_body(iface):
-                continue
+        if not _IS_AOS_PHYSICAL_PORT_RE.match(iface.name) and not _has_renderable_body(iface):
+            continue
         physical_ifaces.append(iface)
     seen_names: dict[str, list[Any]] = {}
     name_order: list[str] = []

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -85,7 +85,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from xml.etree import ElementTree as ET
 
 from defusedxml.common import DefusedXmlException
@@ -110,6 +110,9 @@ from ....models.migration import (
 )
 from ..base import CodecBase, ParseError, RenderError
 from ..registry import register
+
+if TYPE_CHECKING:
+    from ...canonical.intent import CanonicalIntent, CanonicalInterface
 
 logger = logging.getLogger(__name__)
 
@@ -244,12 +247,30 @@ class CiscoIOSXECodec(CodecBase):
             #    adversarial review #9): the stub already carries the
             #    underscore field-markers below for run_full_mesh, but the
             #    live classifier needs the exact granular walker strings. ──
-            UnsupportedPath(path="/system/domain", reason="Phase 0.5 stub render emits only interfaces; intent.domain dropped on render."),
-            UnsupportedPath(path="/system/timezone", reason="Phase 0.5 stub render emits only interfaces; intent.timezone dropped on render."),
-            UnsupportedPath(path="/system/syslog-server", reason="Phase 0.5 stub render emits only interfaces; intent.syslog_servers dropped on render."),
-            UnsupportedPath(path="/dhcp-servers/pool", reason="Phase 0.5 stub render emits only interfaces; intent.dhcp_servers dropped on render."),
-            UnsupportedPath(path="/radius-servers/server/host", reason="Phase 0.5 stub render emits only interfaces; RADIUS host dropped on render."),
-            UnsupportedPath(path="/radius-servers/server/key", reason="Phase 0.5 stub render emits only interfaces; RADIUS shared secret dropped on render."),
+            UnsupportedPath(
+                path="/system/domain",
+                reason="Phase 0.5 stub render emits only interfaces; intent.domain dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Phase 0.5 stub render emits only interfaces; intent.timezone dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Phase 0.5 stub render emits only interfaces; intent.syslog_servers dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/dhcp-servers/pool",
+                reason="Phase 0.5 stub render emits only interfaces; intent.dhcp_servers dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/host",
+                reason="Phase 0.5 stub render emits only interfaces; RADIUS host dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/key",
+                reason="Phase 0.5 stub render emits only interfaces; RADIUS shared secret dropped on render.",
+            ),
             # ── Granular xpaths (match _walk_canonical's emitted shapes
             # so validate_against classifies render-time leaves as
             # unsupported when source-side data is present). ──
@@ -802,7 +823,7 @@ def _find_interfaces(root: ET.Element) -> ET.Element | None:
     if _strip_ns(root.tag) == "interfaces":
         return root
     # Dig through common NETCONF envelopes.
-    for path in ("./data/interfaces", "./{*}data/{*}interfaces"):
+    for _path in ("./data/interfaces", "./{*}data/{*}interfaces"):
         # ElementTree's wildcard `{*}` requires Python 3.8+ for findall,
         # but stability matters — fall back to hand-walk.
         pass
@@ -900,12 +921,12 @@ def _parse_config(el: ET.Element, iface_idx: int = 0) -> dict[str, Any]:
         elif tag == "mtu":
             try:
                 out["mtu"] = int((child.text or "0").strip())
-            except ValueError:
+            except ValueError as e:
                 raise ParseError(
                     f"cisco_iosxe: non-integer mtu {child.text!r}",
                     path=f"/interfaces/interface[{iface_idx}]/config/mtu",
                     snippet=(child.text or "")[:120],
-                )
+                ) from e
     return out
 
 
@@ -966,13 +987,13 @@ def _parse_ipv4(el: ET.Element, iface_idx: int = 0) -> dict[str, Any]:
                         )
                         try:
                             pl = int(pl_text)
-                        except ValueError:
+                        except ValueError as e:
                             raise ParseError(
                                 f"cisco_iosxe: non-integer prefix-length "
                                 f"{c.text!r}",
                                 path=pl_path,
                                 snippet=pl_text[:120],
-                            )
+                            ) from e
                         # IPv4 prefix length is a YANG inet:ipv4-prefix,
                         # formally 0..32.  Silently accepting 99 or -1
                         # lets a bogus input reach render time where
@@ -1030,13 +1051,13 @@ def _parse_ipv6(el: ET.Element, iface_idx: int = 0) -> dict[str, Any]:
                         )
                         try:
                             pl = int(pl_text)
-                        except ValueError:
+                        except ValueError as e:
                             raise ParseError(
                                 f"cisco_iosxe: non-integer ipv6 "
                                 f"prefix-length {c.text!r}",
                                 path=pl_path,
                                 snippet=pl_text[:120],
-                            )
+                            ) from e
                         if not 0 <= pl <= 128:
                             raise ParseError(
                                 f"cisco_iosxe: prefix-length {pl} out of "
@@ -1198,7 +1219,7 @@ def _iface_dict_to_canonical(raw: dict[str, Any]) -> CanonicalInterface:
 #: the name suffix.  Mirrors the cisco_iosxe_cli sibling parser's
 #: ``_SVI_NAME_RE``; kept independently here to avoid a cross-codec
 #: import.
-import re as _re
+import re as _re  # noqa: E402
 
 _SVI_NAME_RE = _re.compile(r"^Vlan(\d+)$", _re.IGNORECASE)
 

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -222,8 +222,14 @@ class CiscoIOSXECLICodec(CodecBase):
             # ── Tier-1 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
             UnsupportedPath(
                 path="/interfaces/interface/subinterfaces/subinterface/ipv6",
                 reason="Phase 0.5 scope — IPv4 only.",

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -29,7 +29,8 @@ This codec lands in four phases (see
 Phase 1: hostname, domain, interfaces (4-segment physical / Loopback /
 MgmtEth / Bundle-Ether / sub-interfaces, with IPv4 dotted-mask + IPv6
 CIDR + description / admin-state / mtu), and default-VRF ``router
-static`` routes.  Phase 2 adds: top-level ``vrf <name>`` stanzas + ``import|export route-target`` blocks → routing-instances; the
+static`` routes.  Phase 2 adds: top-level ``vrf <name>`` stanzas +
+``import|export route-target`` blocks → routing-instances; the
 route-distinguisher harvested from / rendered to ``router bgp <asn> /
 vrf <name> / rd`` (IOS-XR keeps the RD in the BGP process, not the
 ``vrf`` stanza — declared lossy); per-interface ``vrf <name>``
@@ -211,13 +212,34 @@ class CiscoIOSXRCodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/dns-server", reason="Render emits no name-server config; intent.dns_servers are dropped on migration."),
-            UnsupportedPath(path="/system/ntp-server", reason="Render emits no NTP config; intent.ntp_servers are dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/dhcp-servers/pool", reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/host", reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/key", reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration."),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/dns-server",
+                reason="Render emits no name-server config; intent.dns_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/ntp-server",
+                reason="Render emits no NTP config; intent.ntp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/dhcp-servers/pool",
+                reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/host",
+                reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/key",
+                reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration.",
+            ),
             # ── SNMP — out of the v1 XR scope ──
             UnsupportedPath(
                 path="/snmp/community",

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -328,14 +328,38 @@ class CiscoNXOSCodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/domain", reason="Render emits no system domain-name; intent.domain is dropped on migration."),
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/dns-server", reason="Render emits no name-server config; intent.dns_servers are dropped on migration."),
-            UnsupportedPath(path="/system/ntp-server", reason="Render emits no NTP config; intent.ntp_servers are dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/dhcp-servers/pool", reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/host", reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/key", reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration."),
+            UnsupportedPath(
+                path="/system/domain",
+                reason="Render emits no system domain-name; intent.domain is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/dns-server",
+                reason="Render emits no name-server config; intent.dns_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/ntp-server",
+                reason="Render emits no NTP config; intent.ntp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/dhcp-servers/pool",
+                reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/host",
+                reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/key",
+                reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration.",
+            ),
             # ── IPv6 anycast — IPv4 DAG is supported; v6 form deferred ──
             UnsupportedPath(
                 path="/interfaces/interface/ipv6/address/virtual-gateway-address",

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -239,9 +239,20 @@ class FortiGateCLICodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/routing-instances/instance", reason="Render emits no VRF/routing-instance construct (VDOMs not modelled); intent.routing_instances are dropped on migration."),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/routing-instances/instance",
+                reason="Render emits no VRF/routing-instance construct "
+                "(VDOMs not modelled); intent.routing_instances are "
+                "dropped on migration.",
+            ),
             UnsupportedPath(
                 path="/filter/rule",
                 reason=(

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -238,9 +238,8 @@ def _parse_blocks(raw: str) -> list[_ConfigBlock]:
     # Any unclosed containers at EOF — best-effort rescue.
     while stack:
         top = stack.pop()
-        if isinstance(top, _ConfigBlock):
-            if not stack:
-                blocks.append(top)
+        if isinstance(top, _ConfigBlock) and not stack:
+            blocks.append(top)
 
     return blocks
 

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -874,9 +874,10 @@ def render_intent(tree: Any) -> str:
                     algorithm, _payload = classify_hash(
                         user.hashed_password,
                     )
-                    out.append(
-                        f"        {format_review_comment(user.name, algorithm, comment_syntax='hash', target_label='FortiOS')}"
+                    review_comment = format_review_comment(
+                        user.name, algorithm, comment_syntax="hash", target_label="FortiOS"
                     )
+                    out.append(f"        {review_comment}")
             # Map canonical privilege back to accprofile.
             accprofile = (
                 "super_admin" if user.privilege_level == 15

--- a/netcanon/migration/codecs/fortigate_cli/vlan_heuristics.py
+++ b/netcanon/migration/codecs/fortigate_cli/vlan_heuristics.py
@@ -80,9 +80,7 @@ def looks_like_vlan_iface(name: str) -> bool:
     if _VLAN_NAME_RE.match(name):
         return True
     m = _DOTTED_VLAN_RE.match(name)
-    if m and not _NON_VLAN_DOTTED_PARENT_RE.match(m.group(1)):
-        return True
-    return False
+    return bool(m and not _NON_VLAN_DOTTED_PARENT_RE.match(m.group(1)))
 
 
 def vlan_id_for(
@@ -162,7 +160,7 @@ def infer_iface_type(name: str) -> str:
     lower = name.lower()
     if _ETHERNET_NAME_RE.match(lower):
         return "ianaift:ethernetCsmacd"
-    if lower.startswith("agg") or lower.startswith("trunk"):
+    if lower.startswith(("agg", "trunk")):
         return "ianaift:ieee8023adLag"
     if lower.startswith("loopback"):
         return "ianaift:softwareLoopback"

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -135,7 +135,8 @@ class JunosCodec(CodecBase):
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             "/routing/static-route",
-            "/routing/static-route/vrf",   # v0.2.0 — per-VRF binding (set routing-instances <NAME> routing-options static)
+            # v0.2.0 — per-VRF binding (set routing-instances <NAME> routing-options static)
+            "/routing/static-route/vrf",
             "/snmp/community",
             "/snmp/location",
             "/snmp/contact",
@@ -212,9 +213,18 @@ class JunosCodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/host", reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/key", reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration."),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/host",
+                reason="Render emits no AAA radius-server config; RADIUS host is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/key",
+                reason="Render emits no AAA radius-server config; the RADIUS shared secret is dropped on migration.",
+            ),
             UnsupportedPath(
                 path="/routing/bgp",
                 reason=(

--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -495,7 +495,7 @@ def parse_intent(raw: str) -> CanonicalIntent:
         # Don't accumulate duplicates if the same LAG already exists
         # (defensive for groups + apply-groups composition).
         existing = next(
-            (l for l in intent.lags if l.name == ae_name), None,
+            (lag for lag in intent.lags if lag.name == ae_name), None,
         )
         if existing is None:
             intent.lags.append(
@@ -620,9 +620,7 @@ def parse_intent(raw: str) -> CanonicalIntent:
         # (Aruba / OPNsense render paths) see the full anycast
         # surface.
         irb_v4_anycast = irb_entry.get("ipv4_anycast", {})
-        irb_v6_anycast = irb_entry.get("ipv6_anycast", {})
         irb_v4_mac = irb_entry.get("v4_mac", "")
-        irb_v6_mac = irb_entry.get("v6_mac", "")
         for ip, prefix in irb_entry.get("ipv4", []):
             existing_addrs = {
                 (a.ip, a.prefix_length) for a in vlan.ipv4_addresses
@@ -852,7 +850,7 @@ def _looks_like_blockform(raw: str) -> bool:
     # detection on block-form configs that lead with a comment).
     cleaned = _BLOCKFORM_COMMENT_RE.sub("", raw)
     stripped = cleaned.lstrip()
-    if stripped.startswith("set ") or stripped.startswith("version "):
+    if stripped.startswith(("set ", "version ")):
         return False
     # At least one opening curly on a line that isn't a comment.
     has_open_brace = bool(re.search(r"\{\s*$", cleaned, re.MULTILINE))
@@ -2026,30 +2024,29 @@ def _apply_routing_instances(
     # ``discard`` / ``reject`` and explicit ``rib <name>`` forms are not
     # modelled, same as the global routing table.  (v0.2.0 — graduates
     # /routing/static-route/vrf from lossy to supported.)
-    if head == "routing-options":
-        if (
-            len(rest) >= 6
-            and rest[1] == "static"
-            and rest[2] == "route"
-            and "/" in rest[3]
-            and rest[4] == "next-hop"
-        ):
-            dest = rest[3]
-            gateway = rest[5]
-            already = any(
-                r.destination == dest
-                and r.gateway == gateway
-                and r.vrf == ri_name
-                for r in intent.static_routes
-            )
-            if not already:
-                intent.static_routes.append(CanonicalStaticRoute(
-                    destination=dest,
-                    gateway=gateway,
-                    interface="",
-                    vrf=ri_name,
-                ))
-            return
+    if head == "routing-options" and (
+        len(rest) >= 6
+        and rest[1] == "static"
+        and rest[2] == "route"
+        and "/" in rest[3]
+        and rest[4] == "next-hop"
+    ):
+        dest = rest[3]
+        gateway = rest[5]
+        already = any(
+            r.destination == dest
+            and r.gateway == gateway
+            and r.vrf == ri_name
+            for r in intent.static_routes
+        )
+        if not already:
+            intent.static_routes.append(CanonicalStaticRoute(
+                destination=dest,
+                gateway=gateway,
+                interface="",
+                vrf=ri_name,
+            ))
+        return
         # Non-static routing-options (``rib`` / ``autonomous-system`` /
         # etc.) fall through to routing-instance materialisation +
         # parse-and-ignore below — unchanged from prior behaviour.
@@ -2286,7 +2283,6 @@ def _apply_snmp_v3(tokens: list[str], intent: CanonicalIntent) -> None:
     ):
         name = tokens[3]
         attr = tokens[4]
-        value = tokens[5] if len(tokens) >= 6 else ""
         # Drop the trailing ``authentication-key`` / ``privacy-key``
         # sentinel if present (``authentication-sha
         # authentication-key "<hash>"`` lands as 6 tokens).
@@ -2488,7 +2484,7 @@ def _infer_iface_type(name: str) -> str:
         return "ianaift:softwareLoopback"
     if lower.startswith("ae"):
         return "ianaift:ieee8023adLag"
-    if lower.startswith("irb") or lower.startswith("vlan."):
+    if lower.startswith(("irb", "vlan.")):
         return "ianaift:l3ipvlan"
     if lower.startswith(("gr-", "ip-", "st0")):
         return "ianaift:tunnel"

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -203,10 +203,23 @@ class MikroTikRouterOSCodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/domain", reason="Render emits no system domain-name; intent.domain is dropped on migration."),
-            UnsupportedPath(path="/system/timezone", reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/routing-instances/instance", reason="Render emits no VRF/routing-instance construct; intent.routing_instances are dropped on migration."),
+            UnsupportedPath(
+                path="/system/domain",
+                reason="Render emits no system domain-name; intent.domain is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/routing-instances/instance",
+                reason="Render emits no VRF/routing-instance construct; "
+                "intent.routing_instances are dropped on migration.",
+            ),
             UnsupportedPath(
                 path="/filter/rule",
                 reason=(

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -812,12 +812,12 @@ def _parse_ip_address(
         ip_str, prefix_str = addr.split("/", 1)
         try:
             prefix_len = int(prefix_str)
-        except ValueError:
+        except ValueError as e:
             raise ParseError(
                 f"mikrotik_routeros: invalid CIDR prefix {prefix_str!r}",
                 path=f"/ip address/{iface_name}",
                 snippet=line[:120],
-            )
+            ) from e
         # Route VIP rows to the VRRP scratch — don't materialise a
         # phantom CanonicalInterface for ``vrrpN`` pseudo-names.
         if vrrp_scratch is not None and iface_name in vrrp_scratch:
@@ -1223,9 +1223,7 @@ def _looks_like_vlan_iface(name: str) -> bool:
         return True
     # Subinterface unit form: anything with a dot followed by digits.
     # Junos `ge-0/0/0.10`, IOS `GigabitEthernet0/0/0.100`, etc.
-    if re.search(r"\.\d+$", name):
-        return True
-    return False
+    return bool(re.search(r"\.\d+$", name))
 
 
 def _looks_like_bridge_iface(name: str) -> bool:

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -141,7 +141,8 @@ class OPNsenseCodec(CodecBase):
             "/interfaces/interface/ipv4/address/prefix-length",
             "/interfaces/interface/ipv6/address/ip",         # GAP-EVPN-3
             "/interfaces/interface/ipv6/address/prefix-length",  # GAP-EVPN-3
-            "/interfaces/interface/dhcp-client-v6",          # OPNsense <ipaddrv6>{dhcp6|slaac|track6|6rd|6to4}</ipaddrv6>
+            # OPNsense <ipaddrv6>{dhcp6|slaac|track6|6rd|6to4}</ipaddrv6>
+            "/interfaces/interface/dhcp-client-v6",
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             # Tier 2 — SNMP (OPNsense snmpd plugin)
@@ -209,10 +210,23 @@ class OPNsenseCodec(CodecBase):
             #    `severity: ok` (2026-06 adversarial review #9).  NB: domain +
             #    dns DO round-trip (declared supported); ntp does NOT (render
             #    emits no timeservers), so it moves here from supported. ──
-            UnsupportedPath(path="/system/timezone", reason="Render emits no time-zone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/ntp-server", reason="Render emits no <system><timeservers>; intent.ntp_servers are dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no remote-syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/routing-instances/instance", reason="Render emits no VRF/routing-instance construct; intent.routing_instances are dropped on migration."),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no time-zone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/ntp-server",
+                reason="Render emits no <system><timeservers>; intent.ntp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no remote-syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/routing-instances/instance",
+                reason="Render emits no VRF/routing-instance construct; "
+                "intent.routing_instances are dropped on migration.",
+            ),
             UnsupportedPath(
                 path="/filter/rule",
                 reason=(

--- a/netcanon/migration/codecs/opnsense/parse.py
+++ b/netcanon/migration/codecs/opnsense/parse.py
@@ -548,12 +548,12 @@ def _parse_interface_zone_canonical(el: ET.Element) -> CanonicalInterface | None
                 ip=ipaddr_el.text.strip(),
                 prefix_length=int(subnet_el.text.strip()),
             ))
-        except ValueError:
+        except ValueError as e:
             raise ParseError(
                 f"opnsense: non-integer <subnet> {subnet_el.text!r}",
                 path=f"/interfaces/{el.tag}/subnet",
                 snippet=(subnet_el.text or "")[:120],
-            )
+            ) from e
     # GAP-EVPN-3: ``<ipaddrv6>X</ipaddrv6>`` + ``<subnetv6>N</subnetv6>``.
     # OPNsense uses the same shape as IPv4 but with the v6 suffix.
     # Non-static keywords (``dhcp6``, ``track6``, ``slaac``, ``6rd``,
@@ -593,12 +593,12 @@ def _parse_interface_zone_canonical(el: ET.Element) -> CanonicalInterface | None
                 prefix_length=int(subnetv6_el.text.strip()),
                 scope=scope,
             ))
-        except ValueError:
+        except ValueError as e:
             raise ParseError(
                 f"opnsense: non-integer <subnetv6> {subnetv6_el.text!r}",
                 path=f"/interfaces/{el.tag}/subnetv6",
                 snippet=(subnetv6_el.text or "")[:120],
-            )
+            ) from e
     return iface
 
 
@@ -629,12 +629,12 @@ def _parse_interface_zone(el: ET.Element) -> dict[str, Any] | None:
                 continue
             try:
                 iface["subnet"] = int(text)
-            except ValueError:
+            except ValueError as e:
                 raise ParseError(
                     f"opnsense: non-integer <subnet> {text!r}",
                     path=f"/interfaces/{el.tag}/subnet",
                     snippet=text[:120],
-                )
+                ) from e
             found_any = True
         elif py_key == "enable":
             # OPNsense uses an empty <enable/> element as a flag (no

--- a/netcanon/migration/codecs/opnsense/render.py
+++ b/netcanon/migration/codecs/opnsense/render.py
@@ -581,7 +581,7 @@ def _vlan_parent_default(intent: CanonicalIntent) -> str:
         lname = iface.name.lower()
         if lname.startswith("vlan"):
             continue
-        if lname.startswith("loopback") or lname.startswith("lo"):
+        if lname.startswith(("loopback", "lo")):
             continue
         if iface.name == "oobm":
             continue

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -274,13 +274,34 @@ class VyOSCodec(CodecBase):
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
-            UnsupportedPath(path="/system/domain", reason="Render emits no system domain-name; intent.domain is dropped on migration."),
-            UnsupportedPath(path="/system/timezone", reason="Render emits no time-zone stanza; intent.timezone is dropped on migration."),
-            UnsupportedPath(path="/system/dns-server", reason="Render emits no name-server config; intent.dns_servers are dropped on migration."),
-            UnsupportedPath(path="/system/syslog-server", reason="Render emits no syslog config; intent.syslog_servers are dropped on migration."),
-            UnsupportedPath(path="/dhcp-servers/pool", reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/host", reason="Render emits no RADIUS config; RADIUS host is dropped on migration."),
-            UnsupportedPath(path="/radius-servers/server/key", reason="Render emits no RADIUS config; the RADIUS shared secret is dropped on migration."),
+            UnsupportedPath(
+                path="/system/domain",
+                reason="Render emits no system domain-name; intent.domain is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/timezone",
+                reason="Render emits no time-zone stanza; intent.timezone is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/dns-server",
+                reason="Render emits no name-server config; intent.dns_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/system/syslog-server",
+                reason="Render emits no syslog config; intent.syslog_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/dhcp-servers/pool",
+                reason="Render emits no DHCP server pool; intent.dhcp_servers are dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/host",
+                reason="Render emits no RADIUS config; RADIUS host is dropped on migration.",
+            ),
+            UnsupportedPath(
+                path="/radius-servers/server/key",
+                reason="Render emits no RADIUS config; the RADIUS shared secret is dropped on migration.",
+            ),
             # VLAN database — VyOS has no top-level VLAN table.
             UnsupportedPath(
                 path="/vlans/vlan/id",

--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -436,10 +436,7 @@ def parse_intent(raw: str) -> CanonicalIntent:
     for raw_line in raw.splitlines():
         line = raw_line.strip()
         if (
-            not line
-            or line.startswith("//")
-            or line.startswith("/*")
-            or line.startswith("*")
+            not line or line.startswith(("//", "/*", "*"))
         ):
             continue
 

--- a/netcanon/migration/codecs/vyos/render.py
+++ b/netcanon/migration/codecs/vyos/render.py
@@ -366,7 +366,7 @@ def _render_service(snmp) -> list[str]:
     body.extend(_render_snmp_v3(snmp.v3_users))
     if not body:
         return []
-    return ["service {", "    snmp {"] + body + ["    }", "}"]
+    return ["service {", "    snmp {", *body, "    }", "}"]
 
 
 def _render_vrf(instances: list) -> list[str]:

--- a/netcanon/models/__init__.py
+++ b/netcanon/models/__init__.py
@@ -22,10 +22,14 @@ from .migration import (
 
 __all__ = [
     "BackupJob",
-    "BackupResult",
     "BackupRequest",
+    "BackupResult",
+    "CapabilityMatrix",
+    # Migration models (Phase 0)
+    "CodecInfo",
     "CompatibilityReport",
     "ConfigRecord",
+    "DeviceClass",
     "DeviceCredentials",
     "DeviceTarget",
     "DiffGroup",
@@ -33,10 +37,6 @@ __all__ = [
     "DiffReport",
     "DiffRequest",
     "JobStatus",
-    # Migration models (Phase 0)
-    "CodecInfo",
-    "CapabilityMatrix",
-    "DeviceClass",
     "LossyPath",
     "MigrationJob",
     "MigrationJobStatus",

--- a/netcanon/services/diff.py
+++ b/netcanon/services/diff.py
@@ -106,7 +106,7 @@ def compute_diff(
         compat = CompatibilityReport(
             compatible=False,
             severity="block",
-            reasons=compat.reasons + ["force=true override applied by caller"],
+            reasons=[*compat.reasons, "force=true override applied by caller"],
         )
 
     left_lines = left_text.splitlines()

--- a/netcanon/services/egress.py
+++ b/netcanon/services/egress.py
@@ -48,9 +48,7 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     if ip.is_loopback or ip.is_link_local:
         return True
     mapped = getattr(ip, "ipv4_mapped", None)
-    if mapped is not None and (mapped.is_loopback or mapped.is_link_local):
-        return True
-    return False
+    return bool(mapped is not None and (mapped.is_loopback or mapped.is_link_local))
 
 
 def assert_egress_allowed(host: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,18 @@ ignore = [
     # prose; RUF002/RUF003 would demand replacing every one of them.
     "RUF002",
     "RUF003",
+    # `try/except: pass` is idiomatic and often clearer (and faster) than
+    # `contextlib.suppress`; not worth churning the codebase for.
+    "SIM105",
+    # Ternary-over-if/else frequently hurts readability for non-trivial arms.
+    "SIM108",
+    # Naming an unpacked-but-unused value can document intent; the `_`-prefix
+    # demand is pure cosmetics.
+    "RUF059",
+    # `class X(str, Enum)` -> `StrEnum` changes `str(member)` semantics across
+    # Python versions; these enums feed render output, so the mixin form is
+    # deliberate. Do NOT auto-migrate.
+    "UP042",
 ]
 
 [tool.ruff.lint.isort]
@@ -225,3 +237,13 @@ extend-immutable-calls = [
 # Package re-exports: `from .codec import XCodec` is intentional even when
 # the symbol is only surfaced via `__all__`.
 "__init__.py" = ["F401"]
+# Test-scaffold conventions differ from production standards:
+#   RUF012 - mutable class attrs on throwaway fake/helper classes
+#   B905   - `zip()` in assertions (lengths are fixture-controlled)
+#   B017   - `pytest.raises(Exception)` is sometimes the intended assertion
+#   RUF043 - `pytest.raises(match=...)` non-raw patterns
+#   E741   - single-letter loop vars (`l`) in compact test bodies
+"tests/**" = ["RUF012", "B905", "B017", "RUF043", "E741"]
+# Swagger-UI customization page: the body is a large embedded CSS/HTML
+# blob where long style rules are intrinsic, not code to wrap.
+"netcanon/api/routes/docs.py" = ["E501"]

--- a/tests/desktop/test_window.py
+++ b/tests/desktop/test_window.py
@@ -48,7 +48,6 @@ class TestWebViewWindowCreate:
         win, ns = created_win
         view_instance = ns.QWebEngineView.return_value
         view_instance.load.assert_called_once()
-        url_arg = view_instance.load.call_args[0][0]
         # QUrl was called with the correct URL string
         ns.QUrl.assert_called_once_with("http://127.0.0.1:8765")
 

--- a/tests/e2e/test_diff.py
+++ b/tests/e2e/test_diff.py
@@ -73,7 +73,7 @@ class TestDiffPageUI:
         ensure_n_configs_of_type(page, "Cisco", 1)
         ensure_n_configs_of_type(page, "OPNsense", 1)
         records = page.request.get("/api/v1/configs/").json()
-        cisco = [r for r in records if r["device_type"] == "Cisco"][0]
+        cisco = next(r for r in records if r["device_type"] == "Cisco")
         page.goto("/configs")
         ConfigsPage(page).open_compare_for(cisco["filename"])
         picker = ComparePicker(page)
@@ -107,8 +107,8 @@ class TestDiffPageContent:
         ensure_n_configs_of_type(page, "Cisco", 1)
         ensure_n_configs_of_type(page, "OPNsense", 1)
         records = page.request.get("/api/v1/configs/").json()
-        cisco = [r for r in records if r["device_type"] == "Cisco"][0]
-        opn = [r for r in records if r["device_type"] == "OPNsense"][0]
+        cisco = next(r for r in records if r["device_type"] == "Cisco")
+        opn = next(r for r in records if r["device_type"] == "OPNsense")
         page.goto(f"/configs/{cisco['filename']}/vs/{opn['filename']}")
         diff = DiffPage(page)
         assert diff.banner_severity() == "block"
@@ -118,8 +118,8 @@ class TestDiffPageContent:
         ensure_n_configs_of_type(page, "Cisco", 1)
         ensure_n_configs_of_type(page, "OPNsense", 1)
         records = page.request.get("/api/v1/configs/").json()
-        cisco = [r for r in records if r["device_type"] == "Cisco"][0]
-        opn = [r for r in records if r["device_type"] == "OPNsense"][0]
+        cisco = next(r for r in records if r["device_type"] == "Cisco")
+        opn = next(r for r in records if r["device_type"] == "OPNsense")
         page.goto(
             f"/configs/{cisco['filename']}/vs/{opn['filename']}?force=true"
         )

--- a/tests/e2e/test_pages.py
+++ b/tests/e2e/test_pages.py
@@ -9,7 +9,6 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from tests.e2e.helpers import (
-    ConfigsPage,
     DefinitionsPage,
 )
 
@@ -51,7 +50,6 @@ class TestConfigsPage:
     def test_empty_configs_message(self, page: Page, base_url: str):
         """On a fresh server the configs page shows the empty-state message."""
         page.goto("/configs")
-        configs_page = ConfigsPage(page)
         # The live server is session-scoped, so other tests may have already
         # added configs — we just check the page renders without errors.
         expect(page.locator("h1")).to_have_text("Stored Configurations")

--- a/tests/fixtures/definitions.py
+++ b/tests/fixtures/definitions.py
@@ -31,91 +31,91 @@ def make_cisco_definition(**overrides) -> DeviceDefinition:
 
         defn = make_cisco_definition(priority=99)
     """
-    kwargs: dict = dict(
-        vendor="Cisco",
-        os="IOS-XE",
-        type_key="Cisco",
-        priority=10,
-        file_extension="cfg",
-        connection=ConnectionConfig(needs_enable=True, cisco_more_paging=True),
-        commands=CommandConfig(
+    kwargs: dict = {
+        "vendor": "Cisco",
+        "os": "IOS-XE",
+        "type_key": "Cisco",
+        "priority": 10,
+        "file_extension": "cfg",
+        "connection": ConnectionConfig(needs_enable=True, cisco_more_paging=True),
+        "commands": CommandConfig(
             pre=[],
             config="show running-config",
             post=[],
         ),
-        prompts=PromptConfig(trailing=[r"^\S+[#>]\s*$"]),
-        collector=CollectorConfig(
+        "prompts": PromptConfig(trailing=[r"^\S+[#>]\s*$"]),
+        "collector": CollectorConfig(
             strategy="netmiko",
             netmiko_device_type="cisco_xe",
         ),
-        notes="Cisco IOS-XE test definition.",
-    )
+        "notes": "Cisco IOS-XE test definition.",
+    }
     kwargs.update(overrides)
     return DeviceDefinition(**kwargs)
 
 
 def make_fortigate_definition(**overrides) -> DeviceDefinition:
     """Return a minimal valid Fortigate FortiOS ``DeviceDefinition``."""
-    kwargs: dict = dict(
-        vendor="Fortigate",
-        os="FortiOS",
-        type_key="Fortigate",
-        priority=10,
-        file_extension="cfg",
-        connection=ConnectionConfig(),
-        commands=CommandConfig(
+    kwargs: dict = {
+        "vendor": "Fortigate",
+        "os": "FortiOS",
+        "type_key": "Fortigate",
+        "priority": 10,
+        "file_extension": "cfg",
+        "connection": ConnectionConfig(),
+        "commands": CommandConfig(
             pre=["config system console", "set output standard", "end"],
             config="show full-configuration",
             post=["config system console", "set output more", "end"],
         ),
-        prompts=PromptConfig(trailing=[r"^\S+\s+[#]\s*$"]),
-        collector=CollectorConfig(
+        "prompts": PromptConfig(trailing=[r"^\S+\s+[#]\s*$"]),
+        "collector": CollectorConfig(
             strategy="netmiko",
             netmiko_device_type="fortinet",
         ),
-        notes="Fortigate FortiOS test definition.",
-    )
+        "notes": "Fortigate FortiOS test definition.",
+    }
     kwargs.update(overrides)
     return DeviceDefinition(**kwargs)
 
 
 def make_opnsense_definition(**overrides) -> DeviceDefinition:
     """Return a minimal valid OPNsense ``DeviceDefinition``."""
-    kwargs: dict = dict(
-        vendor="OPNsense",
-        os="OPNsense",
-        type_key="OPNsense",
-        priority=10,
-        file_extension="xml",
-        connection=ConnectionConfig(opnsense_shell_menu=True),
-        commands=CommandConfig(
+    kwargs: dict = {
+        "vendor": "OPNsense",
+        "os": "OPNsense",
+        "type_key": "OPNsense",
+        "priority": 10,
+        "file_extension": "xml",
+        "connection": ConnectionConfig(opnsense_shell_menu=True),
+        "commands": CommandConfig(
             config="cat /conf/config.xml",
             post=["exit"],
         ),
-        prompts=PromptConfig(trailing=[r"^root@\S+:.*[#$]\s*$"]),
-        collector=CollectorConfig(strategy="paramiko_shell"),
-        notes="OPNsense test definition.",
-    )
+        "prompts": PromptConfig(trailing=[r"^root@\S+:.*[#$]\s*$"]),
+        "collector": CollectorConfig(strategy="paramiko_shell"),
+        "notes": "OPNsense test definition.",
+    }
     kwargs.update(overrides)
     return DeviceDefinition(**kwargs)
 
 
 def make_mikrotik_definition(**overrides) -> DeviceDefinition:
     """Return a minimal valid MikroTik RouterOS ``DeviceDefinition``."""
-    kwargs: dict = dict(
-        vendor="MikroTik",
-        os="RouterOS",
-        type_key="MikroTik",
-        priority=10,
-        file_extension="rsc",
-        connection=ConnectionConfig(),
-        commands=CommandConfig(config="/export verbose"),
-        prompts=PromptConfig(trailing=[r"^\[.+\]\s*>\s*$"]),
-        collector=CollectorConfig(
+    kwargs: dict = {
+        "vendor": "MikroTik",
+        "os": "RouterOS",
+        "type_key": "MikroTik",
+        "priority": 10,
+        "file_extension": "rsc",
+        "connection": ConnectionConfig(),
+        "commands": CommandConfig(config="/export verbose"),
+        "prompts": PromptConfig(trailing=[r"^\[.+\]\s*>\s*$"]),
+        "collector": CollectorConfig(
             strategy="netmiko",
             netmiko_device_type="mikrotik_routeros",
         ),
-        notes="MikroTik RouterOS test definition.",
-    )
+        "notes": "MikroTik RouterOS test definition.",
+    }
     kwargs.update(overrides)
     return DeviceDefinition(**kwargs)

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -9778,7 +9778,7 @@ One section per non-OK synthetic cell (133 total).  Sections are ordered by sour
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 666, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 343, in render
+  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 349, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 546, in render_intent
     dest, mask = _cidr_to_dest_mask(route.destination)
@@ -9821,9 +9821,9 @@ netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 ou
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 666, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 335, in render
+  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 346, in render
     return render_intent(tree)
-  File "netcanon\migration\codecs\fortigate_cli\render.py", line 949, in render_intent
+  File "netcanon\migration\codecs\fortigate_cli\render.py", line 950, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)
   File "netcanon\migration\codecs\fortigate_cli\parse.py", line 88, in _prefix_to_mask
     raise RenderError(

--- a/tests/integration/test_backups_arista.py
+++ b/tests/integration/test_backups_arista.py
@@ -49,7 +49,7 @@ spanning-tree mode mstp
 !
 no aaa root
 !
-username admin privilege 15 secret sha512 $6$fakehash$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+username admin privilege 15 secret sha512 $6$fakehash$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 !
 vlan 100
    name Tenant_100

--- a/tests/integration/test_dark_mode_coverage.py
+++ b/tests/integration/test_dark_mode_coverage.py
@@ -99,7 +99,7 @@ class TestBannerPaletteTokens:
         # request returns the error path but the <style> block is still
         # in the response.  Fall back to a direct template route check
         # if the diff endpoint requires real records.
-        resp = client.get("/configs")  # configs.html doesn't have diff CSS
+        client.get("/configs")  # configs.html doesn't have diff CSS
         # Instead, check the underlying diff.html template via a route
         # that triggers it.  The diff route is /configs/{left}/vs/{right}
         # which 404s without records — but the response body still

--- a/tests/unit/api/test_migration_helpers.py
+++ b/tests/unit/api/test_migration_helpers.py
@@ -63,8 +63,8 @@ class _DictStore(BaseConfigStore):
     def get_content(self, filename: str) -> str:
         try:
             return self._files[filename]
-        except KeyError:
-            raise FileNotFoundError(filename)
+        except KeyError as e:
+            raise FileNotFoundError(filename) from e
 
     def delete(self, filename: str) -> None:  # pragma: no cover - unused
         raise NotImplementedError

--- a/tests/unit/migration/test_client_port_classify_drift.py
+++ b/tests/unit/migration/test_client_port_classify_drift.py
@@ -133,9 +133,7 @@ def _py_looks_like_uplink(name: str) -> bool:
         return True
     if re.match(r"^(sfp|sfp-sfpplus|sfpplus|qsfpplus)\d", name, re.IGNORECASE):
         return True
-    if re.match(r"^wan\d*$", name, re.IGNORECASE):
-        return True
-    return False
+    return bool(re.match(r"^wan\d*$", name, re.IGNORECASE))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -394,7 +394,8 @@ end
         second = c.parse(c.render(first))
         def norm(i):
             d = i.model_dump()
-            for k in ('source_vendor','source_format','source_version'): d.pop(k,None)
+            for k in ('source_vendor', 'source_format', 'source_version'):
+                d.pop(k, None)
             return d
         assert norm(first) == norm(second)
 

--- a/tests/unit/migration/test_snmp_names.py
+++ b/tests/unit/migration/test_snmp_names.py
@@ -128,7 +128,7 @@ class TestSimpleRename:
         matches.  ``applied`` captures the rewrite anyway (semantic
         parity with the sibling orchestrators)."""
         intent = _tree_with_snmp(community="public")
-        result = translate_snmp_community(
+        translate_snmp_community(
             intent, rename_map={"public": "public"},
         )
         # No collision warning — single-slot domain.  applied is

--- a/tests/unit/migration/test_snmpv3_user_names.py
+++ b/tests/unit/migration/test_snmpv3_user_names.py
@@ -35,7 +35,7 @@ def _intent_with_v3(*names: str) -> CanonicalIntent:
     only rename is visibly distinct from attribute mutation."""
     intent = CanonicalIntent()
     intent.snmp = CanonicalSNMP()
-    for i, name in enumerate(names):
+    for _i, name in enumerate(names):
         intent.snmp.v3_users.append(CanonicalSNMPv3User(
             name=name,
             group=f"grp-{name}",

--- a/tests/unit/migration/test_vlan_names.py
+++ b/tests/unit/migration/test_vlan_names.py
@@ -141,7 +141,7 @@ class TestDropSemantics:
                 voice_vlan=200,
             ),
         ]
-        result = translate_vlan_ids(intent, rename_map={200: None})
+        translate_vlan_ids(intent, rename_map={200: None})
         iface = intent.interfaces[0]
         assert iface.voice_vlan is None
         assert iface.access_vlan == 50  # untouched

--- a/tests/unit/test_api_errors.py
+++ b/tests/unit/test_api_errors.py
@@ -258,12 +258,12 @@ def test_netmiko_timeout_peeks_gaierror_under_chain():
     try:
         try:
             raise underlying
-        except socket.gaierror:
+        except socket.gaierror as chain:
             # This mirrors Netmiko's own raise-inside-except, which
             # sets __context__ to ``underlying`` automatically.
             raise NetmikoTimeoutException(
                 "TCP connection to device failed.\n\nCommon causes..."
-            )
+            ) from chain
     except NetmikoTimeoutException as exc:
         out = translate_backup_error(exc, host="not.a.real.host.invalid")
     assert "DNS lookup failed" in out
@@ -283,10 +283,10 @@ def test_netmiko_timeout_peeks_noValidConnectionsError_under_chain():
     try:
         try:
             raise underlying
-        except paramiko.ssh_exception.NoValidConnectionsError:
+        except paramiko.ssh_exception.NoValidConnectionsError as chain:
             raise NetmikoTimeoutException(
                 "TCP connection to device failed.\n\nCommon causes..."
-            )
+            ) from chain
     except NetmikoTimeoutException as exc:
         out = translate_backup_error(exc, host="127.0.0.1")
     assert "Connection refused" in out
@@ -303,10 +303,10 @@ def test_netmiko_timeout_peeks_TimeoutError_under_chain():
     try:
         try:
             raise underlying
-        except TimeoutError:
+        except TimeoutError as chain:
             raise NetmikoTimeoutException(
                 "TCP connection to device failed.\n\nCommon causes..."
-            )
+            ) from chain
     except NetmikoTimeoutException as exc:
         out = translate_backup_error(exc, host="192.0.2.1")
     # Both messages mention "timed out"; the precise distinction is

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -49,7 +49,6 @@ def reset_module():
 class TestKeyInitialisation:
     def test_generates_key_when_none_exists(self):
         """First run: no key in keyring → new key generated and stored."""
-        key = _make_fernet_key()
         with (
             patch("keyring.get_password", return_value=None),
             patch("keyring.set_password") as mock_set,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -70,11 +70,11 @@ class TestDeviceCredentials:
 
 class TestDeviceTarget:
     def _make(self, **kwargs) -> DeviceTarget:
-        defaults = dict(
-            type_key="Cisco",
-            host="192.168.1.1",
-            credentials=DeviceCredentials(username="admin", password="pw"),
-        )
+        defaults = {
+            "type_key": "Cisco",
+            "host": "192.168.1.1",
+            "credentials": DeviceCredentials(username="admin", password="pw"),
+        }
         defaults.update(kwargs)
         return DeviceTarget(**defaults)
 
@@ -303,12 +303,12 @@ class TestBackupResult:
 
 class TestBackupJob:
     def _make_job(self, **kwargs) -> BackupJob:
-        defaults = dict(
-            id="test-uuid-1234",
-            status=JobStatus.pending,
-            created_at=datetime(2026, 4, 14, 12, 0, 0, tzinfo=UTC),
-            total_devices=2,
-        )
+        defaults = {
+            "id": "test-uuid-1234",
+            "status": JobStatus.pending,
+            "created_at": datetime(2026, 4, 14, 12, 0, 0, tzinfo=UTC),
+            "total_devices": 2,
+        }
         defaults.update(kwargs)
         return BackupJob(**defaults)
 

--- a/tests/unit/test_schedule_models.py
+++ b/tests/unit/test_schedule_models.py
@@ -25,12 +25,12 @@ pytestmark = pytest.mark.unit
 
 class TestScheduleDevice:
     def _make(self, **kwargs) -> ScheduleDevice:
-        defaults = dict(
-            type_key="Cisco",
-            host="192.168.1.1",
-            username="admin",
-            password="secret",
-        )
+        defaults = {
+            "type_key": "Cisco",
+            "host": "192.168.1.1",
+            "username": "admin",
+            "password": "secret",
+        }
         defaults.update(kwargs)
         return ScheduleDevice(**defaults)
 
@@ -165,11 +165,11 @@ class TestBackupSchedule:
         )
 
     def _make(self, **kwargs) -> BackupSchedule:
-        defaults = dict(
-            name="Weekly Backup",
-            interval_minutes=10080,
-            devices=[self._make_device()],
-        )
+        defaults = {
+            "name": "Weekly Backup",
+            "interval_minutes": 10080,
+            "devices": [self._make_device()],
+        }
         defaults.update(kwargs)
         return BackupSchedule(**defaults)
 
@@ -220,12 +220,12 @@ class TestBackupSchedule:
 
 class TestBackupJobScheduleFields:
     def _make_job(self, **kwargs) -> BackupJob:
-        defaults = dict(
-            id="test-uuid-abcd",
-            status=JobStatus.pending,
-            created_at=datetime(2026, 4, 14, 12, 0, 0, tzinfo=UTC),
-            total_devices=1,
-        )
+        defaults = {
+            "id": "test-uuid-abcd",
+            "status": JobStatus.pending,
+            "created_at": datetime(2026, 4, 14, 12, 0, 0, tzinfo=UTC),
+            "total_devices": 1,
+        }
         defaults.update(kwargs)
         return BackupJob(**defaults)
 

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -130,17 +130,17 @@ class TestPromptConfig:
 
 def _valid_definition_kwargs() -> dict:
     """Return keyword arguments for a valid Cisco DeviceDefinition."""
-    return dict(
-        vendor="Cisco",
-        os="IOS-XE",
-        type_key="Cisco",
-        connection=ConnectionConfig(needs_enable=True),
-        commands=CommandConfig(config="show running-config"),
-        collector=CollectorConfig(
+    return {
+        "vendor": "Cisco",
+        "os": "IOS-XE",
+        "type_key": "Cisco",
+        "connection": ConnectionConfig(needs_enable=True),
+        "commands": CommandConfig(config="show running-config"),
+        "collector": CollectorConfig(
             strategy="netmiko",
             netmiko_device_type="cisco_xe",
         ),
-    )
+    }
 
 
 class TestDeviceDefinition:

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -181,7 +181,7 @@ class TestStartupMigration:
     def test_flat_files_content_preserved_after_migration(self, tmp_path: Path):
         flat = tmp_path / "Cisco_10-0-0-1_20260414_120000.cfg"
         flat.write_text("preserved content", encoding="utf-8")
-        store = FileConfigStore(tmp_path)
+        FileConfigStore(tmp_path)
         moved = tmp_path / "Cisco" / "10-0-0-1" / "Cisco_10-0-0-1_20260414_120000.cfg"
         assert moved.read_text(encoding="utf-8") == "preserved content"
 


### PR DESCRIPTION
## What

Stage 1(c) of the v0.2.0 tooling baseline — resolves the **311 manual-judgment** ruff findings left by PR (b). `ruff check netcanon tests` now reports **All checks passed!** (clean baseline, ready for the CI gate in the next PR).

## Code fixes

- **B904** — exception chaining (`raise … from e`) across `api/routes/*` + codec parse paths.
- **F841** — unused-variable removal; notably a fully-dead `current_iface_is_l3` tracking flag in `arista_eos/parse.py` (4 writes, **0 reads** — a latent no-op whose comment claimed it gated `ip address` handling).
- **F821** — type-only imports under `TYPE_CHECKING` (`cisco_iosxe/codec.py` defers its `canonical.intent` import for circular-import reasons) + `CanonicalInterface` added to the `transforms.py` module import.
- **E741** — ambiguous `l` → `lag` (3 production sites).
- **E501** — capability-matrix `UnsupportedPath(…)` declarations wrapped to multi-line (55), docstring/comment reflow, one f-string extracted to a local. Net: 70 → 0.
- **SIM102 / B023** — nested-`if` collapse; the `aruba_aoss` `flush` closure now takes `prefix` as an explicit parameter.

## Config refinements (with rationale in pyproject)

- **Global ignore:** `SIM105`/`SIM108`/`RUF059` (opinionated, low-value) + `UP042` (StrEnum migration changes `str()` semantics that feed render output).
- **`tests/**` per-file ignore:** `RUF012`/`B905`/`B017`/`RUF043`/`E741` — test-scaffold conventions, 0 occurrences in production.
- **`api/routes/docs.py`:** `E501` ignored (Swagger-UI CSS/HTML blob).

## Verification

- `ruff check netcanon tests` → **clean**; `compileall` → clean.
- `pytest tests/unit tests/integration` → green (exit 0).
- Regenerated cross-mesh + phase4: **CODEC_BUG flat at 5**, `EXPECTED_LOSSY` 1226, `PHASE4_RECONCILIATION.md` unchanged. `CROSS_MESH_RESULTS.md` changed only in **3 embedded-traceback line numbers** (the `from e` additions landed on raises not exercised by the mesh). Net behaviour change: zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
