### PR TITLE
refactor(codecs): lift VLAN id-list helpers into _helpers.py (Stage 2 PR 1)

### DIFF
--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -103,3 +103,71 @@ def _prefix_to_mask(prefix: int, *, vendor: str) -> str:
         )
     mask_int = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF if prefix else 0
     return str(ipaddress.IPv4Address(mask_int))
+
+
+def _parse_vlan_list(text: str) -> list[int]:
+    """Parse a VLAN id-list like ``1,10,2000`` or ``10-20`` into a flat
+    list of ints.  Ranges are expanded inclusively.
+
+    Shared by the codecs whose id-lists use the Cisco-style comma/hyphen
+    grammar (``cisco_nxos``, ``cisco_iosxe_cli``, ``aruba_aoscx`` each
+    previously carried a byte-identical private copy).  The valid VLAN
+    space is clamped BEFORE the range is materialised so an out-of-bounds
+    span (e.g. ``1-9999999999``) cannot OOM the process; the valid
+    sub-range is preserved (lossless vs the downstream 1..4094 filter).
+    Non-numeric tokens are skipped.  The inverse is
+    :func:`_coalesce_vlan_ids`.
+    """
+    result: list[int] = []
+    for part in text.split(","):
+        part = part.strip()
+        if "-" in part:
+            lo, hi = part.split("-", 1)
+            try:
+                lo_i, hi_i = int(lo.strip()), int(hi.strip())
+            except ValueError:
+                continue
+            lo_i, hi_i = max(1, lo_i), min(4094, hi_i)
+            if lo_i <= hi_i:
+                result.extend(range(lo_i, hi_i + 1))
+        elif part.isdigit():
+            result.append(int(part))
+    return result
+
+
+def _run_token(lo: int, hi: int) -> str:
+    """Format a single consecutive run for :func:`_coalesce_vlan_ids`.
+
+    A two-wide run (``10,11``) stays comma-separated rather than
+    ``10-11`` — both re-parse identically, but the comma form matches the
+    show-output convention for adjacent pairs.
+    """
+    if hi == lo:
+        return str(lo)
+    if hi == lo + 1:
+        return f"{lo},{hi}"
+    return f"{lo}-{hi}"
+
+
+def _coalesce_vlan_ids(ids: list[int]) -> str:
+    """Coalesce a sorted, de-duplicated VLAN-id list into comma/hyphen form.
+
+    ``[1, 10, 11, 12, 20]`` → ``"1,10-12,20"``.  Consecutive runs of three
+    or more collapse to ``lo-hi``; the inverse of :func:`_parse_vlan_list`
+    so a ``vlan trunk allowed`` / id-list round-trips.  Shared by the
+    codecs that previously carried a byte-identical private copy
+    (``cisco_nxos``, ``aruba_aoscx``).  The caller is responsible for
+    sorting and de-duplicating *ids* first.
+    """
+    if not ids:
+        return ""
+    parts: list[str] = []
+    run_start = prev = ids[0]
+    for vid in ids[1:]:
+        if vid == prev + 1:
+            prev = vid
+            continue
+        parts.append(_run_token(run_start, prev))
+        run_start = prev = vid
+    parts.append(_run_token(run_start, prev))
+    return ",".join(parts)

--- a/tests/unit/migration/codecs/test_helpers_equivalence.py
+++ b/tests/unit/migration/codecs/test_helpers_equivalence.py
@@ -1,0 +1,125 @@
+"""Golden-equivalence tests for the shared VLAN-list helpers.
+
+v0.2.0 Stage 2, PR 1 is deliberately *additive*: it lifts the
+byte-identical private copies of the VLAN id-list parse / coalesce
+helpers into ``codecs/_helpers.py`` but DELETES no inline copy yet.
+
+These tests freeze the equivalence between the new shared helper and each
+surviving inline copy over a deliberate input sweep, so a later per-codec
+PR can delete an inline copy as a *proven* behaviour-preserving swap (the
+swap PR stays green by construction against this frozen golden).
+
+The arista_eos ``_expand_vlan_list`` near-twin is intentionally NOT
+converged here: it diverges on edge cases (it accepts ``int(chunk)``
+forms like ``"+10"`` that the canonical ``str.isdigit()`` gate rejects).
+The final test documents that divergence so a future contributor does not
+"finish the job" and silently change arista's behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs._helpers import (
+    _coalesce_vlan_ids,
+    _parse_vlan_list,
+)
+from netcanon.migration.codecs.arista_eos.parse import (
+    _expand_vlan_list as _arista_expand,
+)
+from netcanon.migration.codecs.aruba_aoscx.parse import (
+    _parse_vlan_list as _aoscx_parse,
+)
+from netcanon.migration.codecs.aruba_aoscx.render import (
+    _coalesce_vlan_ids as _aoscx_coalesce,
+)
+from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
+    _parse_vlan_list as _iosxe_parse,
+)
+from netcanon.migration.codecs.cisco_nxos.parse import (
+    _parse_vlan_list as _nxos_parse,
+)
+from netcanon.migration.codecs.cisco_nxos.render import (
+    _coalesce_vlan_ids as _nxos_coalesce,
+)
+
+# Inline copies that the shared _parse_vlan_list must reproduce exactly.
+_PARSE_INLINE_COPIES = (_nxos_parse, _iosxe_parse, _aoscx_parse)
+# Inline copies that the shared _coalesce_vlan_ids must reproduce exactly.
+_COALESCE_INLINE_COPIES = (_nxos_coalesce, _aoscx_coalesce)
+
+_PARSE_SWEEP = [
+    "1",
+    "0",
+    "4094",
+    "4095",
+    "10,20,30",
+    "10-20",
+    "1,10,2000",
+    "100-102",
+    "10-20,30,40-42",
+    " 10 , 20 ",
+    "",
+    "10,,20",
+    "abc",
+    "1,abc,3",
+    "5-3",            # inverted range -> empty
+    "1-9999999999",   # OOM-guard: clamp to 1..4094, no MemoryError
+    "0-5",            # low clamp -> 1..5
+    "4090-4100",      # high clamp -> 4090..4094
+]
+
+_COALESCE_SWEEP = [
+    [],
+    [1],
+    [1, 2],
+    [1, 2, 3],
+    [1, 10, 11, 12, 20],
+    [5],
+    [100, 101],
+    [4094],
+    [1, 2, 3, 5, 6, 7, 10],
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("text", _PARSE_SWEEP)
+def test_parse_vlan_list_matches_every_inline_copy(text: str) -> None:
+    expected = _parse_vlan_list(text)
+    for inline in _PARSE_INLINE_COPIES:
+        assert inline(text) == expected, (
+            f"{inline.__module__}._parse_vlan_list drifted from the shared "
+            f"helper on {text!r}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("ids", _COALESCE_SWEEP)
+def test_coalesce_vlan_ids_matches_every_inline_copy(ids: list[int]) -> None:
+    expected = _coalesce_vlan_ids(ids)
+    for inline in _COALESCE_INLINE_COPIES:
+        assert inline(ids) == expected, (
+            f"{inline.__module__}._coalesce_vlan_ids drifted from the shared "
+            f"helper on {ids!r}"
+        )
+
+
+@pytest.mark.unit
+def test_parse_coalesce_round_trip() -> None:
+    """coalesce(parse(x)) re-parses to the same id set (inverse pair)."""
+    for text in ("1,10-12,20", "100-102", "4090-4094"):
+        ids = _parse_vlan_list(text)
+        assert _parse_vlan_list(_coalesce_vlan_ids(ids)) == ids
+
+
+@pytest.mark.unit
+def test_arista_expand_divergence_is_documented() -> None:
+    """arista_eos._expand_vlan_list is a near-twin that is NOT converged.
+
+    It accepts ``int(chunk)`` forms the canonical ``str.isdigit()`` gate
+    rejects, so it must keep its own copy until that divergence is
+    deliberately reconciled.  This asserts the known difference so the
+    exclusion is intentional, not an oversight.
+    """
+    assert _parse_vlan_list("+10") == []
+    assert _arista_expand("+10") == [10]


### PR DESCRIPTION
## What

**v0.2.0 Stage 2, PR 1** of the codec-abstraction work. Per the design synthesis (run as a 20-agent design workflow), the verdict was **minimal shared utilities, NO base class** — the codec layer is too archetype-divergent (cli-line-scan / brace / XML / set-form) for a parse/render base without leaky abstractions. This PR is the **safety-contract** first step.

Lifts the byte-identical VLAN id-list helpers into `codecs/_helpers.py`:
- `_parse_vlan_list` — 3 byte-identical inline copies (`cisco_nxos`, `cisco_iosxe_cli`, `aruba_aoscx`).
- `_coalesce_vlan_ids` + `_run_token` (the inverse) — 2 byte-identical copies (`cisco_nxos`, `aruba_aoscx`).

## Additive only — deletes nothing

No inline copy is removed and no codec imports the new helper yet, so **every codec is byte-for-byte unchanged**. The new `tests/unit/migration/codecs/test_helpers_equivalence.py` freezes the golden equivalence between the shared helper and *every surviving inline copy* over a deliberate sweep (single/list/range, inverted range, OOM-clamp `1-9999999999`, low/high clamp, non-numeric junk). A later per-codec PR can then delete an inline copy as a **proven** behaviour-preserving swap — green by construction against this frozen golden.

## Verify-first notes (scope narrowed vs the design's optimistic list)

- `arista_eos._expand_vlan_list` is a **near-twin, intentionally NOT converged** — it accepts `int(chunk)` forms (e.g. `"+10"`) that the canonical `str.isdigit()` gate rejects. A test asserts the divergence so the exclusion is deliberate.
- `_quote_if_needed` (mikrotik vs junos) shares its escape body but the **quote-trigger differs** (`any(c in ...)` vs a regex) → not byte-identical → deferred, not lifted.
- `_split_subiface_name` has a **single** occurrence → not a duplication candidate.

## Verification

- New ruff CI gate: `ruff check` clean on the changed files.
- `pytest tests/unit/migration/codecs/test_helpers_equivalence.py` → 29 cases green; full `tests/unit tests/integration` → green.
- Cross-mesh: `CROSS_MESH_RESULTS.md` + `PHASE4_RECONCILIATION.md` **byte-identical**, **CODEC_BUG flat at 5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
