### PR TITLE
refactor(codecs): swap nxos/iosxe_cli/aoscx to shared VLAN-list helpers (Stage 2 PR 2)

### DIFF
--- a/netcanon/migration/codecs/aruba_aoscx/parse.py
+++ b/netcanon/migration/codecs/aruba_aoscx/parse.py
@@ -83,7 +83,7 @@ from ...canonical.intent import (
     CanonicalVlan,
     CanonicalVxlan,
 )
-from .._helpers import _is_link_local_v6, _normalise_mac_to_colon_hex
+from .._helpers import _is_link_local_v6, _normalise_mac_to_colon_hex, _parse_vlan_list
 from .._input_shape import detect_input_shape
 from ..base import ParseError
 from . import port_names as _port_names
@@ -292,28 +292,6 @@ def _default_enabled(iface_name: str) -> bool:
     ``shutdown`` / ``no shutdown`` line in the stanza overrides this.
     """
     return _port_names.classify_port_name(iface_name).kind == "loopback"
-
-
-def _parse_vlan_list(text: str) -> list[int]:
-    """Parse a VLAN id-list like ``101-102`` or ``10,20,30`` into a flat
-    list of ints.  Ranges are expanded inclusively (mirrors cisco_nxos)."""
-    result: list[int] = []
-    for part in text.split(","):
-        part = part.strip()
-        if "-" in part:
-            lo, hi = part.split("-", 1)
-            try:
-                lo_i, hi_i = int(lo.strip()), int(hi.strip())
-            except ValueError:
-                continue
-            # Clamp to the valid VLAN space before materializing so a huge
-            # span cannot OOM the process (valid sub-range preserved).
-            lo_i, hi_i = max(1, lo_i), min(4094, hi_i)
-            if lo_i <= hi_i:
-                result.extend(range(lo_i, hi_i + 1))
-        elif part.isdigit():
-            result.append(int(part))
-    return result
 
 
 def _lag_sort_key(name: str) -> tuple[int, int]:

--- a/netcanon/migration/codecs/aruba_aoscx/render.py
+++ b/netcanon/migration/codecs/aruba_aoscx/render.py
@@ -45,6 +45,7 @@ import ipaddress
 import re
 
 from ...canonical.intent import CanonicalIntent
+from .._helpers import _coalesce_vlan_ids
 
 #: Synthesised AOS-CX release stamped into the ``!Version`` banner.
 #: Cosmetic — the parsed ``source_version`` is metadata only and not
@@ -316,42 +317,6 @@ def _render_interface(
             block.append(f"    lacp mode {mode}")
 
     return block
-
-
-def _coalesce_vlan_ids(ids: list[int]) -> str:
-    """Coalesce a sorted, de-duplicated VLAN-id list into AOS-CX form.
-
-    ``[1, 10, 11, 12, 20]`` → ``"1,10-12,20"``.  Consecutive runs of
-    three or more collapse to ``lo-hi``; the inverse of
-    :func:`parse._parse_vlan_list` so the ``vlan trunk allowed`` list
-    round-trips.
-    """
-    if not ids:
-        return ""
-    parts: list[str] = []
-    run_start = prev = ids[0]
-    for vid in ids[1:]:
-        if vid == prev + 1:
-            prev = vid
-            continue
-        parts.append(_run_token(run_start, prev))
-        run_start = prev = vid
-    parts.append(_run_token(run_start, prev))
-    return ",".join(parts)
-
-
-def _run_token(lo: int, hi: int) -> str:
-    """Format a single run for :func:`_coalesce_vlan_ids`.
-
-    A two-wide run (``10,11``) stays comma-separated rather than
-    ``10-11`` — both re-parse identically, but the comma form matches the
-    show-output convention for adjacent pairs.
-    """
-    if hi == lo:
-        return str(lo)
-    if hi == lo + 1:
-        return f"{lo},{hi}"
-    return f"{lo}-{hi}"
 
 
 #: Interface-kind render order: SVIs, then physical, then LAGs, then the

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -63,6 +63,7 @@ from .._helpers import (
     _is_link_local_v6,
     _mask_to_prefix,
     _normalise_mac_to_colon_hex,
+    _parse_vlan_list,
 )
 from .._input_shape import detect_input_shape
 from ..base import ParseError
@@ -1053,29 +1054,6 @@ def _build_canonical_interface(raw: dict[str, Any]) -> CanonicalInterface:
         tunnel_type=raw.get("tunnel_type", ""),
         vrrp_groups=vrrp_groups,
     )
-
-
-def _parse_vlan_list(text: str) -> list[int]:
-    """Parse a Cisco VLAN list like '10,20,30-40' into a flat list of ints."""
-    result: list[int] = []
-    for part in text.split(","):
-        part = part.strip()
-        if "-" in part:
-            lo, hi = part.split("-", 1)
-            try:
-                lo_i, hi_i = int(lo.strip()), int(hi.strip())
-            except ValueError:
-                continue
-            # Clamp to the valid VLAN space BEFORE materializing the range so
-            # an out-of-bounds span (e.g. `1-9999999999`) cannot OOM the
-            # process; the valid sub-range is preserved (lossless vs the
-            # downstream 1..4094 filter).
-            lo_i, hi_i = max(1, lo_i), min(4094, hi_i)
-            if lo_i <= hi_i:
-                result.extend(range(lo_i, hi_i + 1))
-        elif part.isdigit():
-            result.append(int(part))
-    return result
 
 
 def _parse_vlans(raw: str) -> list[CanonicalVlan]:

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -66,7 +66,11 @@ from ...canonical.intent import (
     CanonicalVRRPGroup,
     CanonicalVxlan,
 )
-from .._helpers import _is_link_local_v6, _normalise_mac_to_colon_hex
+from .._helpers import (
+    _is_link_local_v6,
+    _normalise_mac_to_colon_hex,
+    _parse_vlan_list,
+)
 from .._input_shape import detect_input_shape
 from ..base import ParseError
 
@@ -941,28 +945,6 @@ def _parse_lags(raw: str) -> list[CanonicalLAG]:
             lag.mode = mode_by_lag[lag_name]
         lags.append(lag)
     return lags
-
-
-def _parse_vlan_list(text: str) -> list[int]:
-    """Parse an NX-OS VLAN id-list like ``1,10,2000`` or ``10-20`` into a
-    flat list of ints.  Ranges are expanded inclusively."""
-    result: list[int] = []
-    for part in text.split(","):
-        part = part.strip()
-        if "-" in part:
-            lo, hi = part.split("-", 1)
-            try:
-                lo_i, hi_i = int(lo.strip()), int(hi.strip())
-            except ValueError:
-                continue
-            # Clamp to the valid VLAN space before materializing so a huge
-            # span cannot OOM the process (valid sub-range preserved).
-            lo_i, hi_i = max(1, lo_i), min(4094, hi_i)
-            if lo_i <= hi_i:
-                result.extend(range(lo_i, hi_i + 1))
-        elif part.isdigit():
-            result.append(int(part))
-    return result
 
 
 def _parse_vlans(raw: str) -> list[CanonicalVlan]:

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import re
 
 from ...canonical.intent import CanonicalIntent, CanonicalRoutingInstance
+from .._helpers import _coalesce_vlan_ids
 from . import port_names as _port_names
 
 #: Synthesised NX-OS release stamped into the banner.  Cosmetic — the
@@ -457,27 +458,6 @@ def _render_interface(iface, lag_mode_by_name: dict) -> list[str]:
     return block
 
 
-def _coalesce_vlan_ids(ids: list[int]) -> str:
-    """Coalesce a sorted, de-duplicated VLAN-id list into NX-OS form.
-
-    ``[1, 10, 11, 12, 20]`` → ``"1,10-12,20"``.  Consecutive runs of
-    three or more collapse to ``lo-hi``; the inverse of
-    :func:`parse._parse_vlan_list` so the id-list round-trips.
-    """
-    if not ids:
-        return ""
-    parts: list[str] = []
-    run_start = prev = ids[0]
-    for vid in ids[1:]:
-        if vid == prev + 1:
-            prev = vid
-            continue
-        parts.append(_run_token(run_start, prev))
-        run_start = prev = vid
-    parts.append(_run_token(run_start, prev))
-    return ",".join(parts)
-
-
 def _mac_to_dotted_triplet(mac: str) -> str:
     """Convert a canonical colon-hex MAC to NX-OS dotted-triplet form.
 
@@ -493,20 +473,6 @@ def _mac_to_dotted_triplet(mac: str) -> str:
     if len(hex_only) != 12:
         return ""
     return f"{hex_only[0:4]}.{hex_only[4:8]}.{hex_only[8:12]}"
-
-
-def _run_token(lo: int, hi: int) -> str:
-    """Format a single run for :func:`_coalesce_vlan_ids`.
-
-    A two-wide run (``10,11``) stays comma-separated rather than
-    ``10-11`` — both re-parse identically, but the comma form matches
-    NX-OS show-output convention for adjacent pairs.
-    """
-    if hi == lo:
-        return str(lo)
-    if hi == lo + 1:
-        return f"{lo},{hi}"
-    return f"{lo}-{hi}"
 
 
 #: Interface-kind render order (``02-codec-architecture.md`` § 4.1):


### PR DESCRIPTION
## What

**v0.2.0 Stage 2, PR 2** — the *proven swap* following PR 1's additive lift. Deletes the byte-identical inline VLAN-list copies and imports the shared versions from `codecs/_helpers.py`:

- `_parse_vlan_list` — `cisco_nxos`, `cisco_iosxe_cli`, `aruba_aoscx` (parse.py)
- `_coalesce_vlan_ids` + its private `_run_token` — `cisco_nxos`, `aruba_aoscx` (render.py)

**Net −131 LOC** (5 files, +9/−140).

## Why it's safe

PR 1's `test_helpers_equivalence.py` already proves the shared helpers are **byte-identical** to each inline copy over an input sweep. Call-site names are unchanged (the shared functions keep the same names), so no call site moves. `_run_token` was verified used **only** by `_coalesce_vlan_ids` in both render files. `arista_eos._expand_vlan_list` and `_quote_if_needed` stay in-codec (documented non-twins).

## Verification

- Full `pytest tests/unit tests/integration` → green.
- Cross-mesh: `CROSS_MESH_RESULTS.md` + `PHASE4_RECONCILIATION.md` **byte-identical**; **CODEC_BUG flat at 5**.
- ruff CI gate clean; `compileall` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
