### PR TITLE
refactor(codecs): add opt-in StanzaScanner, adopt in cisco_iosxr (Stage 2 PR 3)

### DIFF
--- a/netcanon/migration/codecs/_scanner.py
+++ b/netcanon/migration/codecs/_scanner.py
@@ -1,0 +1,87 @@
+"""Composable stanza-scan helper for the line-scan (CLI) codecs.
+
+Several codecs hand-roll the same control-flow skeleton: a *header* line
+opens a scratch accumulator, subsequent indented lines feed a per-attribute
+handler cascade, and a ``!`` or column-0 (dedented) line closes the stanza
+and materialises a canonical record.  :func:`scan_stanzas` factors out ONLY
+that loop; the vendor grammar — header regex, attribute cascade, scratch
+shape, and build step — stays in the codec via callables.  The scanner
+carries zero canonical-model knowledge, so the records it produces are
+identical to the hand-rolled loop it replaces.
+
+This is an OPT-IN utility, not a base class.  Codecs whose grammar does not
+fit the flat open/accumulate/close shape (brace-stack ``vyos``, XML
+``opnsense`` / ``cisco_iosxe``-NETCONF, set-form ``juniper_junos``, or the
+nested sub-blocks like NX-OS HSRP) keep their bespoke loop.
+
+Import as ``from .._scanner import scan_stanzas`` from inside a codec package.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+from typing import TypeVar
+
+_Scratch = TypeVar("_Scratch")
+_Result = TypeVar("_Result")
+
+
+def _default_terminator(line: str) -> bool:
+    """Close a stanza on a bare ``!`` or any non-indented (column-0) line.
+
+    Replicates the de-facto rule the CLI codecs hand-roll verbatim:
+    ``line.strip() == "!" or (line and not line[0].isspace())``.
+    """
+    return line.strip() == "!" or bool(line and not line[0].isspace())
+
+
+def scan_stanzas(
+    lines: Iterable[str],
+    *,
+    is_header: Callable[[str], re.Match[str] | None],
+    open_scratch: Callable[[re.Match[str]], _Scratch],
+    on_line: Callable[[str, _Scratch], None],
+    build: Callable[[_Scratch], _Result],
+    is_terminator: Callable[[str], bool] = _default_terminator,
+) -> list[_Result]:
+    """Drive the open/accumulate/close-on-terminator stanza loop.
+
+    For each line, in this order:
+
+    1. If ``is_header`` matches, flush any open stanza, then open a fresh
+       scratch via ``open_scratch(match)``.
+    2. Else if no stanza is open, skip the line.
+    3. Else if ``is_terminator`` says so, flush the open stanza.
+    4. Otherwise feed the line to ``on_line(line, scratch)`` to mutate the
+       current scratch in place.
+
+    A final flush closes the last stanza if the input ends without a
+    terminator.  ``build(scratch)`` turns each completed scratch into a
+    result; results are returned in input (stanza) order — the scanner never
+    sorts.
+    """
+    results: list[_Result] = []
+    current: _Scratch | None = None
+
+    def _flush() -> None:
+        nonlocal current
+        if current is not None:
+            results.append(build(current))
+            current = None
+
+    for line in lines:
+        match = is_header(line)
+        if match is not None:
+            _flush()
+            current = open_scratch(match)
+            continue
+        if current is None:
+            continue
+        if is_terminator(line):
+            _flush()
+            continue
+        on_line(line, current)
+
+    _flush()
+    return results

--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -87,6 +87,7 @@ from ...canonical.intent import (
 )
 from .._helpers import _is_link_local_v6, _mask_to_prefix
 from .._input_shape import detect_input_shape
+from .._scanner import scan_stanzas
 from ..base import ParseError
 
 logger = logging.getLogger(__name__)
@@ -338,43 +339,21 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
     handled by :func:`_parse_dot1q_vlans` (a separate scan) — it falls
     through this loop harmlessly.
     """
-    interfaces: list[CanonicalInterface] = []
-    current: dict | None = None
-
-    def _flush() -> None:
-        if current is not None:
-            interfaces.append(_build_canonical_interface(current))
-
-    for line in raw.splitlines():
-        m = _IFACE_RE.match(line)
-        if m:
-            _flush()
-            current = _new_iface_scratch(m.group(1))
-            continue
-
-        if current is None:
-            continue
-
-        # `!` terminator or any non-indented line closes the stanza.
-        if line.strip() == "!" or (line and not line[0].isspace()):
-            _flush()
-            current = None
-            continue
-
+    def _on_line(line: str, current: dict) -> None:
         dm = _DESC_RE.match(line)
         if dm:
             current["description"] = dm.group(1).strip()
-            continue
+            return
         if _SHUTDOWN_RE.match(line):
             current["enabled"] = False
-            continue
+            return
         mm = _MTU_RE.match(line)
         if mm:
             try:
                 current["mtu"] = int(mm.group(1))
             except ValueError:
                 pass
-            continue
+            return
         im = _IPV4_RE.match(line)
         if im:
             try:
@@ -385,7 +364,7 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
                 })
             except ParseError:
                 pass
-            continue
+            return
         v6m = _IPV6_RE.match(line)
         if v6m:
             addr = v6m.group(1)
@@ -403,18 +382,26 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
                 })
             except ValueError:
                 pass
-            continue
+            return
         bm = _BUNDLE_ID_RE.match(line)
         if bm:
             current["lag_member_of"] = f"Bundle-Ether{int(bm.group(1))}"
-            continue
+            return
         vm = _INDENTED_VRF_RE.match(line)
         if vm:
             current["vrf"] = vm.group(1)
-            continue
+            return
 
-    _flush()
-    return interfaces
+    # Loop skeleton (open on `interface`, close on `!`/dedent, flush at EOF)
+    # is the shared codecs/_scanner helper; the vendor regex cascade above
+    # stays here.  Behaviour-identical to the former hand-rolled loop.
+    return scan_stanzas(
+        raw.splitlines(),
+        is_header=_IFACE_RE.match,
+        open_scratch=lambda m: _new_iface_scratch(m.group(1)),
+        on_line=_on_line,
+        build=_build_canonical_interface,
+    )
 
 
 def _build_canonical_interface(raw: dict) -> CanonicalInterface:

--- a/tests/unit/migration/codecs/test_scanner.py
+++ b/tests/unit/migration/codecs/test_scanner.py
@@ -1,0 +1,88 @@
+"""Unit tests for the shared ``codecs/_scanner.scan_stanzas`` helper.
+
+Exercises the loop skeleton in isolation with a tiny synthetic grammar
+(``item <name>`` headers + indented ``attr <x>`` lines) so the control flow
+is pinned independently of any codec: open/accumulate/close-on-terminator,
+close-on-dedent, end-of-input flush, pre-header skipping, and a custom
+terminator.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from netcanon.migration.codecs._scanner import _default_terminator, scan_stanzas
+
+_HEADER = re.compile(r"^item (\w+)")
+
+
+def _open(m: re.Match[str]) -> dict:
+    return {"name": m.group(1), "attrs": []}
+
+
+def _on_line(line: str, scratch: dict) -> None:
+    stripped = line.strip()
+    if stripped.startswith("attr "):
+        scratch["attrs"].append(stripped.split(None, 1)[1])
+
+
+def _build(scratch: dict) -> tuple[str, tuple[str, ...]]:
+    return (scratch["name"], tuple(scratch["attrs"]))
+
+
+def _scan(text: str, **kw) -> list[tuple[str, tuple[str, ...]]]:
+    return scan_stanzas(
+        text.splitlines(),
+        is_header=_HEADER.match,
+        open_scratch=_open,
+        on_line=_on_line,
+        build=_build,
+        **kw,
+    )
+
+
+@pytest.mark.unit
+def test_two_stanzas_closed_by_bang() -> None:
+    text = "item a\n  attr x\n  attr y\n!\nitem b\n  attr z\n!\n"
+    assert _scan(text) == [("a", ("x", "y")), ("b", ("z",))]
+
+
+@pytest.mark.unit
+def test_close_on_dedent_without_bang() -> None:
+    # A non-indented, non-header line closes the open stanza.
+    text = "item a\n  attr x\nunrelated top-level\nitem b\n  attr y\n"
+    assert _scan(text) == [("a", ("x",)), ("b", ("y",))]
+
+
+@pytest.mark.unit
+def test_flush_at_end_of_input() -> None:
+    # Last stanza has no trailing terminator; the final flush still emits it.
+    assert _scan("item a\n  attr x\n") == [("a", ("x",))]
+
+
+@pytest.mark.unit
+def test_lines_before_first_header_are_skipped() -> None:
+    assert _scan("junk\n  more junk\nitem a\n  attr x\n!\n") == [("a", ("x",))]
+
+
+@pytest.mark.unit
+def test_empty_input() -> None:
+    assert _scan("") == []
+
+
+@pytest.mark.unit
+def test_custom_terminator() -> None:
+    text = "item a\n  attr x\nEND\nitem b\n  attr y\n"
+    out = _scan(text, is_terminator=lambda ln: "END" in ln)
+    assert out == [("a", ("x",)), ("b", ("y",))]
+
+
+@pytest.mark.unit
+def test_default_terminator_rules() -> None:
+    assert _default_terminator("!") is True
+    assert _default_terminator("   !  ") is True          # stripped bang
+    assert _default_terminator("interface Gi0/0") is True  # column-0 dedent
+    assert _default_terminator("  description x") is False  # indented body
+    assert _default_terminator("") is False                # blank line falls through


### PR DESCRIPTION
## What

**v0.2.0 Stage 2, PR 3** — the one *new* abstraction from the design verdict. Adds `codecs/_scanner.py::scan_stanzas()` — a composable function (NOT a base class) for the open/accumulate/close-on-terminator loop the line-scan codecs hand-roll.

The helper owns only the control flow (header opens a scratch, `!`/column-0 dedent closes + flushes, EOF flushes, input-order preserved — never sorts). The vendor grammar — header regex, the per-attribute cascade, scratch shape, and build step — stays in the codec via callables, so the helper carries **zero canonical-model knowledge** and produces records identical to the hand-rolled loop.

**`cisco_iosxr` is the reference adopter:** `_parse_interfaces` now delegates its loop to `scan_stanzas`, keeping its regex cascade verbatim inside an `_on_line` closure. The default terminator exactly replicates iosxr's `line.strip() == "!" or (line and not line[0].isspace())`.

## Scope / non-goals

Opt-in, one codec at a time. Archetypes that don't fit the flat shape stay bespoke and are **not** migrated: vyos brace-stack, opnsense / cisco_iosxe-NETCONF XML, juniper_junos set-form, and nested sub-blocks (NX-OS HSRP, IOS-XR 4-level vrf/af/RT).

## Verification

- New `tests/unit/migration/codecs/test_scanner.py` pins the loop in isolation: close-on-`!`, close-on-dedent, EOF flush, pre-header skip, custom terminator, `_default_terminator` rules.
- Full `pytest tests/unit tests/integration` → green; `compileall` clean; ruff CI gate clean.
- Cross-mesh: `CROSS_MESH_RESULTS.md` + `PHASE4_RECONCILIATION.md` **byte-identical**; **CODEC_BUG flat at 5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
