### PR TITLE
fix(deps): declare tzlocal explicitly and exclude the yanked 5.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,15 @@ dependencies = [
     "python-multipart>=0.0.9",
     "aiofiles>=23.0.0",
     "apscheduler>=3.10.4",
+    # Hard runtime dep of apscheduler (imported at scheduler startup).
+    # Declared explicitly — and pinned away from the yanked 5.4.2 — so a
+    # bad upstream tzlocal release can't silently break app boot through
+    # the transitive path.  5.4.2 was yanked upstream ("didn't work": a
+    # ~4.8 KB stub wheel that installs but imports as ModuleNotFoundError)
+    # and, being the highest version, briefly broke CI before the yank
+    # propagated.  TODO(post-release app-wide dependency review): re-check
+    # for a newer valid tzlocal and relax/raise this constraint.
+    "tzlocal>=5.0,!=5.4.2",
     "cryptography>=41.0.0",
     "keyring>=24.0.0",
     # XML parsing of operator-uploaded configs (OPNsense config.xml +


### PR DESCRIPTION
## Dependency hygiene — pin `tzlocal` away from the yanked 5.4.2

`apscheduler` imports `tzlocal` at scheduler startup, making it a **hard
runtime dependency** of the app — yet it was only transitive and undeclared.

### What happened
`tzlocal 5.4.2` was published as a ~4.8 KB stub wheel that **installs but
ships no importable module** (`ModuleNotFoundError: No module named
'tzlocal'`). Being the highest version (PEP 440: `5.4.2 > 5.4`), pip
selected it in fresh installs, and every CI job that imports the app failed
at boot:
```
apscheduler/schedulers/base.py:11: from tzlocal import get_localzone
E   ModuleNotFoundError: No module named 'tzlocal'
```
Upstream has since **yanked 5.4.2** ("didn't work"), which self-healed CI —
but the build shouldn't rely on an upstream yank.

### Fix
Declare `tzlocal` as a direct dependency and exclude the bad release:
`tzlocal>=5.0,!=5.4.2`. This immunises the build against a repeat (future
bad release, or a mirror still serving 5.4.2) and documents the incident.
An inline `TODO` flags re-checking for a newer valid `tzlocal` during the
post-release app-wide dependency review.

Dependency declaration only — no code change. Latest good upstream is 5.4
(local resolves to the known-good 5.3.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)