### PR TITLE
chore(workflows): reusable ultracode blackboard runner + agent-workflow doctrine

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -1,0 +1,88 @@
+# .claude/workflows — reusable ultracode workflows
+
+Reusable `Workflow`-tool scripts for this repo. **Invoke them by `scriptPath`** (not `name:` — the `name:`
+registry is reserved for built-in/plugin workflows like `deep-research` / `code-review`; custom files here are
+addressed by their path). The binding process they implement is
+[docs/agent-workflow.md](../../docs/agent-workflow.md).
+
+## `blackboard.js` — the file-per-agent blackboard (the consistent ultracode pattern)
+
+Every ultracode run uses this runner so the discipline never has to be re-hand-rolled (and can't drift). It
+bakes in the load-bearing contract:
+
+- **Read-only agents, one report file each.** Each agent writes EXACTLY ONE long-form report (its `id`.md under
+  the run dir) and is otherwise strictly read-only — no source/test/fixture/doc edits, no git/regen/build, no
+  actuation, and never touches the uncommitted `docs/codebase-review/` PII dossier. The contract preamble is
+  prepended to every agent prompt automatically.
+- **File-based peer comms.** Later-phase agents read earlier phases' report files (`readsPrior: true`, or an
+  explicit per-agent `reads: [id,…]`).
+- **Short returns.** Agents return only a pointer/summary (`report_file`, `headline`, `key_points`; reviewers
+  return `verdict` + `must_fixes`). The depth lives in the markdown files, so the main thread's context stays
+  light.
+- **Opus by default** for every agent (override per-agent/phase with `model`).
+
+### The main thread owns the bookends (NOT the runner — it has no filesystem access)
+
+1. **Before invoking:** write `<dir>/00-blackboard.md` — the seed: mission, hard constraints, file roster. Use
+   the template in [docs/agent-workflow.md](../../docs/agent-workflow.md) (§ Ultracode runs).
+2. **Invoke** the runner (see below).
+3. **After it returns:** read the `NN-*.md` report files, write `<dir>/99-synthesis.md` (reconciled decisions +
+   the buildable-now contract, applying the review's must-fixes), then build/verify/commit. Agents NEVER
+   actuate — the main thread is the sole actor that runs tests / regen / live preview and commits (pseudonym
+   identity, explicit staging, confirm-before-merge — see [../../AGENTS.md](../../AGENTS.md)).
+
+### Invocation
+
+```
+// main thread, before the call: Write <repo>/docs/reviews/<UTC-date>-<slug>/00-blackboard.md (the seed)
+Workflow({ scriptPath: "<repo>/.claude/workflows/blackboard.js", args: {
+  dir: "<absolute-repo-path>/docs/reviews/<UTC-date>-<slug>",  // ABSOLUTE; date-stamped + slug
+  slug: "ux-review",
+  mission: "one-line mission (logged at start)",
+  phases: [
+    { title: "Research", agents: [
+      { id: "10-research-x", label: "R1:x", task: "<run-specific prompt body>" },
+      { id: "11-research-y", label: "R2:y", task: "…" },
+    ] },
+    { title: "Design", readsPrior: true, agents: [
+      { id: "20-design-a", label: "D1:a", task: "…" },
+    ] },
+    { title: "Review", readsPrior: true, review: true, agents: [
+      { id: "30-review", label: "V1", task: "…" },
+    ] },
+  ],
+} })
+```
+
+### `args` contract
+
+| key | required | meaning |
+|---|---|---|
+| `dir` | yes | ABSOLUTE run-folder path (`<repo>/docs/reviews/<UTC-date>-<slug>`). The runner has no FS access, so the caller computes it (matches the caller's path separator automatically). |
+| `slug` | no | short topic label for the progress narrator. |
+| `mission` | no | one-line mission, `log()`-ed at start. |
+| `phases[]` | yes | ordered phases; each runs as a `parallel()` barrier. |
+| `phases[].title` | yes | progress group + the phase tag. |
+| `phases[].readsPrior` | no | `true` → every agent reads ALL earlier-phase report files. |
+| `phases[].review` | no | `true` → agents use the `REVIEW_SUMMARY` schema (verdict + must_fixes). |
+| `phases[].model` | no | model for the whole phase (default `opus`). |
+| `agents[].id` | yes | report filename stem; numeric-prefixed + **unique** (it IS the agent's only write target). |
+| `agents[].task` | yes | the run-specific prompt body (the read-only contract is prepended for you). |
+| `agents[].label` | no | progress label (default = `id`). |
+| `agents[].reads` | no | explicit `[id,…]` peer reports to read (overrides `readsPrior`). |
+| `agents[].model` | no | per-agent model override. |
+
+Returns `{ dir, files:{id→path}, phases:[{title, results:[{id,file,summary}]}], review }`.
+
+### Iterate / resume
+
+Edit `blackboard.js` (or the per-run caller) and re-invoke with `scriptPath` + `resumeFromRunId` — unchanged
+agents return cached results. Note: `Date.now()`/`new Date()` are unavailable in workflow scripts (they break
+resume), which is why the caller stamps the date into `dir`.
+
+## Lineage
+
+This runner formalizes netcanon's own multi-agent methodology — the `docs/security-triage/` and `docs/docs-audit/`
+sister-processes (snapshot → cluster → parallel read-only agents → orchestrator synthesis → main-thread
+actuation). It was hardened into a reusable runner in a sibling project and brought back here so every future
+ultracode run inherits the same discipline by construction rather than by memory.

--- a/.claude/workflows/blackboard.js
+++ b/.claude/workflows/blackboard.js
@@ -1,0 +1,138 @@
+// Reusable file-per-agent BLACKBOARD runner for netcanon ultracode runs.
+//
+// Why this exists: every ultracode run should follow the SAME netcanon blackboard discipline
+// (docs/agent-workflow.md) instead of being hand-rolled each time. This runner bakes in the
+// load-bearing contract so it can't drift: each agent is READ-ONLY except its ONE long-form
+// report file; agents read peers' reports for cross-phase comms; agents return only a short
+// pointer/summary; the MAIN THREAD seeds 00-blackboard.md and (after the run) synthesizes +
+// verifies + commits. Parameterized entirely by `args` (see .claude/workflows/README.md).
+//
+// Invoke:  Workflow({ scriptPath: "<repo>/.claude/workflows/blackboard.js", args: { dir, slug, mission, phases:[...] } })
+//   - Invoke by scriptPath (NOT name: -- the name: registry is reserved for built-in/plugin workflows).
+//   - The MAIN THREAD writes <dir>/00-blackboard.md (the seed: mission + constraints + roster)
+//     BEFORE invoking, and reads the <dir>/NN-*.md reports + writes 99-synthesis.md AFTER.
+//
+// args = {
+//   dir:     ABSOLUTE path of the run folder, e.g. "<repo>/docs/reviews/<UTC-date>-<slug>"  (REQUIRED)
+//   slug:    short topic label (for the progress narrator)                                   (optional)
+//   mission: one-line mission (logged at start)                                              (optional)
+//   phases: [ {                                                                              (REQUIRED, >=1)
+//     title:      "Research" | "Design" | "Review" | ...  (progress group + the phase tag)
+//     readsPrior: true  -> every agent in this phase is told to read ALL earlier-phase reports
+//     review:     true  -> agents use the REVIEW_SUMMARY schema (verdict + must_fixes)
+//     model:      override model for the whole phase (default per-agent / 'opus')
+//     agents: [ {
+//       id:    report filename stem, numeric-prefixed + unique, e.g. "10-research-templates"
+//              (-> <dir>/10-research-templates.md ; this is the agent's ONLY write)
+//       task:  the run-specific prompt body (the READ-ONLY contract is prepended automatically)
+//       label: progress label (default = id)
+//       reads: explicit [id,...] peer reports to read (overrides phase.readsPrior)
+//       model: per-agent model override
+//     }, ... ]
+//   }, ... ]
+// }
+//
+// Returns: { dir, files:{id->path}, phases:[{title, results:[{id,file,summary}]}], review }
+
+export const meta = {
+  name: 'blackboard',
+  description: 'Reusable file-per-agent blackboard runner for netcanon ultracode runs: read-only agents each write ONE long-form report under the run dir, read peers reports for cross-phase comms, return a short pointer/summary. Main thread seeds 00-blackboard.md then synthesizes + verifies + commits. Parameterized by args (.claude/workflows/README.md).',
+}
+
+// ---- the ENFORCED, consistent contract (baked in so every ultracode run is identical) ----
+const RO = [
+  "You are an agent in netcanon's ultracode BLACKBOARD process (docs/agent-workflow.md).",
+  "OUTPUT RULE: you write EXACTLY ONE file -- your own long-form report at the path given below. That report file IS your deliverable; write it thoroughly (headings, tables, rationale, citations to file:line, concrete names/code/markup sketches). Otherwise you are STRICTLY READ-ONLY: do NOT edit/create/delete ANY other file, do NOT touch source/tests/fixtures/docs, do NOT run git, the regen tools (tools/run_full_mesh.py / tools/run_phase4_reconciliation.py), any build/commit/tag, or any state-changing command, and do NOT start the app or actuate anything. NEVER read or write under docs/codebase-review/ (uncommitted PII dossier). The MAIN THREAD alone synthesizes, verifies (tests / regen / live preview), and commits.",
+  "After writing your report file, RETURN only the small structured summary the schema asks for (a pointer + a few key points). The depth lives in the FILE; the return is for orchestration only.",
+  "FIRST read AGENTS.md (the repo doctrine) and the run's seed (00-blackboard.md, path below) for the mission + hard constraints + file roster. Then read the source/peer files you need.",
+].join("\n");
+
+const SUMMARY = { type:"object", additionalProperties:false, properties:{
+  report_file:{type:"string"},
+  headline:{type:"string"},
+  key_points:{type:"array", items:{type:"string"}},
+  buildable_now:{type:"array", items:{type:"string"}},
+  over_engineering_flags:{type:"array", items:{type:"string"}}
+}, required:["report_file","headline","key_points"] };
+
+const REVIEW_SUMMARY = { type:"object", additionalProperties:false, properties:{
+  report_file:{type:"string"},
+  verdict:{type:"string", enum:["GO","GO-WITH-FIXES","NO-GO"]},
+  must_fixes:{type:"array", items:{type:"object", additionalProperties:false, properties:{
+    id:{type:"string"}, target:{type:"string"}, issue:{type:"string"}, fix:{type:"string"},
+    severity:{type:"string", enum:["blocker","major","minor"]} }, required:["issue","fix","severity"] }},
+  over_engineering_flags:{type:"array", items:{type:"string"}},
+  buildable_now_confirmed:{type:"array", items:{type:"string"}}
+}, required:["report_file","verdict","must_fixes","buildable_now_confirmed"] };
+
+// ---- arg validation (LOUD + synchronous, BEFORE any agent spawns) ----
+// NB: validation must NOT live inside a parallel() thunk -- a thunk that throws resolves to null
+// silently, so a bad config would be swallowed instead of failing the run. Validate up front.
+// `args` may arrive as a real object OR (depending on how the caller passed it) as a JSON STRING -- the
+// Workflow tool warns a stringified value reaches the script as one string. Tolerate both so the runner is
+// robust regardless of how it is invoked.
+let A = args;
+if (typeof A === 'string') {
+  try { A = JSON.parse(A); }
+  catch (e) { throw new Error("blackboard: args arrived as a string that is not valid JSON: " + e.message); }
+}
+if (!A || typeof A !== 'object' || Array.isArray(A)) throw new Error("blackboard: args object required (see .claude/workflows/README.md)");
+const dir = A.dir;
+if (!dir || typeof dir !== 'string') throw new Error("blackboard: args.dir (absolute run-folder path) is required");
+const phases = A.phases || [];
+if (!Array.isArray(phases) || !phases.length) throw new Error("blackboard: args.phases (>= 1 phase) is required");
+const seen = {};
+for (const ph of phases) {
+  if (!ph || !ph.title) throw new Error("blackboard: each phase needs a title");
+  const list = ph.agents || [];
+  if (!Array.isArray(list) || !list.length) throw new Error("blackboard: phase '" + ph.title + "' has no agents");
+  for (const a of list) {
+    if (!a || !a.id) throw new Error("blackboard: every agent needs an id (it is the report filename)");
+    if (!a.task) throw new Error("blackboard: agent '" + a.id + "' needs a task");
+    if (seen[a.id]) throw new Error("blackboard: duplicate agent id '" + a.id + "' -- ids are report filenames, must be unique");
+    seen[a.id] = true;
+  }
+}
+
+const SEP = dir.indexOf("\\") >= 0 ? "\\" : "/";        // match the caller's path style (Windows vs POSIX)
+const pathFor = (id) => dir + SEP + id + ".md";
+const seed = pathFor("00-blackboard");
+
+if (A.mission) log("blackboard [" + (A.slug || "run") + "]: " + A.mission);
+
+const prior = [];                                        // accumulated report paths for peer-reads
+const out = { dir: dir, files: {}, phases: [], review: null };
+
+for (const ph of phases) {
+  phase(ph.title);
+  const reading = prior.slice();                         // snapshot of all earlier-phase report files
+  const list = ph.agents;
+  const thunks = list.map((a) => () => {
+    const file = pathFor(a.id);
+    out.files[a.id] = file;
+    let reads = [];
+    if (Array.isArray(a.reads)) reads = a.reads.map(pathFor);
+    else if (ph.readsPrior) reads = reading;
+    const prompt = RO
+      + "\n\nSEED (read first): " + seed
+      + "\n\nYOUR REPORT FILE (your ONLY write): " + file
+      + (reads.length ? "\n\nFIRST read these peer reports for context: " + reads.join(" , ") : "")
+      + "\n\nTASK:\n" + a.task
+      + "\n\nDELIVERABLE: the full long-form report written to your report file above; THEN return the summary.";
+    return agent(prompt, {
+      label: a.label || a.id,
+      phase: ph.title,
+      model: a.model || ph.model || 'opus',
+      schema: ph.review ? REVIEW_SUMMARY : SUMMARY,
+    }).then((summary) => ({ id: a.id, file: file, summary: summary }));
+  });
+  const results = await parallel(thunks);
+  out.phases.push({ title: ph.title, results: results });
+  for (const a of list) prior.push(pathFor(a.id));       // visible to the next phase's peer-reads
+  if (ph.review) {
+    const got = results.filter(Boolean).map((x) => x.summary).filter(Boolean);
+    if (got.length) out.review = got.length === 1 ? got[0] : got;
+  }
+}
+
+return out;

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,13 @@ configs/
 .fernet_key
 **/.fernet_key
 
-# AI-assistant tooling — local session state, never committed
-.claude/
+# AI-assistant tooling — local session state, never committed.
+# EXCEPTION: .claude/workflows/ holds reusable, version-controlled Workflow
+# scripts (the ultracode blackboard runner) — shared tooling, not session
+# state, so it IS tracked.  User-local config (settings.local.json,
+# launch.json) stays ignored via the .claude/* glob.
+.claude/*
+!.claude/workflows/
 .cursor/
 .aider*/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,6 +346,30 @@ tests use these exclusively — never CSS classes or element structure.  See
 
 ---
 
+## Ultracode runs (multi-agent reviews)
+
+Multi-agent reviews, audits, and research follow netcanon's two-stage process:
+**read-only agents each write one report into `docs/reviews/<UTC-date>-<slug>/`
+→ the main thread reconciles into a synthesis + fix-plan and is the sole actor
+that verifies and commits.** The full process, run-folder convention, seed
+template, cluster taxonomy, and dispatch heuristics live in
+[`docs/agent-workflow.md`](docs/agent-workflow.md) (the
+[`docs/security-triage/`](docs/security-triage/) and
+[`docs/docs-audit/`](docs/docs-audit/) processes are worked instances).
+
+**Ultracode runs use the reusable file-per-agent blackboard runner**
+([`.claude/workflows/blackboard.js`](.claude/workflows/blackboard.js), via the
+`Workflow` tool with `scriptPath: .claude/workflows/blackboard.js`) — never
+hand-rolled. Each agent writes ONE long-form report under the run dir, reads
+peers' reports for cross-phase comms, and returns only a short pointer/summary;
+the main thread writes the `00-blackboard.md` seed up front and the
+`99-synthesis.md` reconciliation after, then actuates under the Hard Rules
+above (pseudonym identity, explicit staging, the cross-mesh proof bar,
+confirm-before-merge). The runner bakes the read-only contract in so it can't
+drift. See [`docs/agent-workflow.md`](docs/agent-workflow.md) § Ultracode runs.
+
+---
+
 ## See also
 
 - [`README.md`](README.md) — project orientation and quickstart
@@ -361,6 +385,7 @@ tests use these exclusively — never CSS classes or element structure.  See
 - [`docs/HOW_WE_TEST.md`](docs/HOW_WE_TEST.md) — operator-facing narrative of the cross-mesh audit + 8-class variance taxonomy; update if a new test layer or audit category lands
 - [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) — diagnostic flowchart for "my translation didn't go cleanly" (Tier-3 vs Lossy vs CODEC_BUG)
 - [`BUG_REPORTING.md`](BUG_REPORTING.md) — operator-facing fixture-submission + bug-report workflow (sanitise → verify → submit); references the Phase 4.5 sanitiser
+- [`docs/agent-workflow.md`](docs/agent-workflow.md) — the binding multi-agent / ultracode process (read-only agents → orchestrator synthesis → main-thread actuation) + the reusable `.claude/workflows/blackboard.js` runner; security-triage and docs-audit are worked instances
 - [`docs/security-triage/`](docs/security-triage/) — process + per-run evidence trail for triaging Code Scanning / Dependabot / secret-scanning alert waves; cluster taxonomy + read-only Stage-1 agents + orchestrator-applied dismissals
 - [`docs/docs-audit/`](docs/docs-audit/) — sister process to security-triage applied to documentation hygiene; 6-cluster taxonomy (interlinking / user-docs / developer-docs / codec-docstrings / platform-docstrings / tests-changelog); read-only Stage-1 Opus 4.7 1M agents + orchestrator-executed Stage-2 fixes
 - [`tests/README.md`](tests/README.md) — test-suite layout and mocking strategy

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,164 @@
+# Distributed agent work — how we run reviews, audits & research
+
+This is the **binding process** for any multi-agent review, audit, or research task in netcanon. It is the
+project's own methodology — the [`docs/security-triage/`](security-triage/) and [`docs/docs-audit/`](docs-audit/)
+sister-processes are worked instances of it — now formalized behind a single reusable runner so the discipline
+is inherited by construction rather than re-derived from memory each time.
+
+The one-line shape:
+
+> **snapshot → cluster scope → parallel read-only agents → orchestrator synthesis → fix-plan → main-thread
+> actuation → evidence-trail commit**
+
+## The load-bearing rule: read-only agents, main thread actuates
+
+- **Stage-1 agents are strictly read-only.** An agent may read anything; it may **write ONLY its one designated
+  report file** under the run folder. No source/test/fixture/doc edits, no `git add`/commit/tag, no running the
+  regen tools (`tools/run_full_mesh.py` / `tools/run_phase4_reconciliation.py`), no starting the app, no
+  actuation of any kind. It must never read or write under `docs/codebase-review/` (the uncommitted PII
+  dossier). No worktree isolation is needed precisely *because* agents cannot edit (saves disk + dispatch cost).
+- **The orchestrator (main thread) is the only actor that validates and actuates.** It reads the agents'
+  reports, reconciles them into a synthesis + fix-plan, then applies fixes, runs the gate, and commits — itself,
+  or by dispatching **Stage-2 implementation agents** *only* where the fix scope genuinely warrants it (and
+  those use worktree isolation if they edit shared files in parallel).
+
+Research fans out cheaply and safely; mutation is centralized and verified. This is the same split the
+security-triage and docs-audit processes already use.
+
+## Ultracode runs — the Workflow-tool blackboard (the consistent mechanism)
+
+Ultracode runs (the `ultracode` keyword opts a turn into multi-agent orchestration) operationalize the process
+above through the **`Workflow` tool** + the reusable runner
+[../.claude/workflows/blackboard.js](../.claude/workflows/blackboard.js) (invoked by **`scriptPath`** —
+`Workflow({ scriptPath: "<repo>/.claude/workflows/blackboard.js", args })`; the `name:` registry is reserved
+for built-in/plugin workflows). **This runner is the only sanctioned shape** — it bakes the load-bearing rule
+in (read-only agents, one report file each, main thread actuates) so the discipline can't be re-hand-rolled or
+drift. The `args` contract + invocation recipe live in
+[../.claude/workflows/README.md](../.claude/workflows/README.md); this section is the convention it implements.
+
+**Run folder** = `docs/reviews/<UTC-date>-<slug>/` (the topical `-<slug>` distinguishes a focused
+research+design run from a whole-repo audit, which may drop the slug — same family, phase-appropriate file
+names):
+
+```
+docs/reviews/<UTC-date>-<slug>/
+  00-blackboard.md            # SEED — the MAIN THREAD writes this BEFORE the run: mission, hard constraints, roster
+  10-research-<x>.md          # Stage-1 research agents (10s) — each its ONLY write
+  11-research-<y>.md
+  20-design-<a>.md            # Stage-1 design agents (20s) — read the 10s for peer comms
+  21-design-<b>.md
+  30-review-adversarial.md    # adversarial review (30s) — reads all 10s + 20s
+  99-synthesis.md             # SYNTHESIS — the MAIN THREAD writes this AFTER: reconciled decisions + buildable-now
+```
+
+- **Numeric prefixes encode phase order** (10s research → 20s design → 30s review); the prefix is the agent's
+  `id` *and* its report filename. Phases run as `parallel()` barriers; later phases read earlier reports for
+  comms.
+- **The runner has NO filesystem access** — it only orchestrates agents. So the **main thread owns the
+  bookends**: write `00-blackboard.md` (the seed) before invoking, `99-synthesis.md` after, and then
+  fix / verify / commit — the sole actuator. Agents write only their one `NN-*.md`.
+- **Agents return only a pointer/summary**; the long-form analysis lives in the file (keeps the main thread
+  light). Reviewers return a verdict + severity-tagged must-fixes.
+- **Opus for every agent** (the runner's default) — long-context retention + design/audit quality. Never
+  under-model a design/audit/research agent.
+
+### The `00-blackboard.md` seed template (the main thread fills + writes this before invoking)
+
+```markdown
+# Blackboard — <mission title> (<UTC-date>)
+
+**Process:** netcanon file-per-agent blackboard. Read-only agents each write EXACTLY ONE report in this dir; the
+main thread seeds this file + writes 99-synthesis.md + is the sole actor that verifies/commits.
+
+## Mission
+<what this run examines/decides — 1-3 bullets>
+
+## Hard constraints (apply to every report)
+<the non-negotiables for THIS run — e.g. behaviour-preserving (cross-mesh CODEC_BUG flat at 5; artifacts
+byte-identical); no over-engineering; the pseudonym/PII commit rules; matrix-honesty (declare what you drop)>
+
+## File roster
+| File | Phase | Author | Covers |
+|---|---|---|---|
+| 00-blackboard.md | seed | main thread | this protocol + mission + constraints |
+| 10-research-<x>.md | research | R1 | ... |
+| 30-review-adversarial.md | review | V1 | GO/NO-GO + must-fixes |
+| 99-synthesis.md | synthesis | main thread | reconciled decisions + buildable-now contract |
+
+## Decisions already locked (context)
+<prior decisions the agents should treat as fixed>
+```
+
+### Evidence-trail conventions
+
+- Folder name carries the **UTC date** of the run (matches commit/GitHub timestamps).
+- Numeric prefixes encode pipeline order: `00-` seed, `10/20/30-` Stage-1 outputs by phase, `99-` synthesis.
+- These folders are **EXPECTED-STALE**: a later audit must never flag a past run's evidence as drift. They are
+  a frozen record, not live docs.
+- Agents hand off purely via their `NN-*.md`; the orchestrator reconciles in `99-synthesis.md`.
+
+## Agent report format
+
+A research/design agent's report is long-form prose + tables (headings, rationale, `file:line` citations,
+concrete code/markup sketches). A reviewer's report is a verdict table the orchestrator can reconcile fast:
+
+```
+| # | Path:Line | Severity | Finding | Verdict (CONFIRMED/DISMISSED) | Fix shape |
+```
+
+Pick severity tags that fit the run. For a UX/UI review: **BROKEN / CONFUSING / INCONSISTENT / A11Y / POLISH**.
+For a docs/scaffolding review: **WRONG / MISSING / INCOMPLETE / STYLE / EXPECTED-STALE** (the last = a
+deliberate pattern, not a defect).
+
+## Cluster taxonomy (how work is scoped & parallelized)
+
+Group work by the **kind of investigation** it needs, not by file type — that is what makes it parallelizable.
+Labels should be **stable across runs** so future searches find prior investigations under the same name. Each
+agent owns a **non-overlapping scope**. The cluster set is run-type-specific; representative netcanon clusters:
+
+| Run type | Typical clusters |
+|---|---|
+| **Codec / fidelity** | per-codec round-trip + cross-mesh CODEC_BUG; canonical-model surface coverage; matrix-honesty (declare-what-you-drop) |
+| **Docs** | interlinking & structure; user-facing accuracy; developer-facing accuracy; codec/platform docstrings; tests + CHANGELOG (see `docs/docs-audit/`) |
+| **Security** | attack-surface alerts; pattern-class alerts; workflow/secret handling (see `docs/security-triage/`) |
+| **UX / UI** | information architecture & navigation; state coverage (loading/empty/error/success); accessibility & semantics; consistency & visual system; microcopy & honesty (limitation messages match `docs/CAPABILITIES.md`) |
+
+## Dispatch heuristics
+
+- **Model:** Opus for the read-only investigation agents (long-context retention across many files); the
+  orchestrator runs on the main thread.
+- **Parallelism:** one agent per cluster, dispatched together. More agents ≠ faster when each cluster is
+  file-bounded — and harder to reconcile.
+- **File-overlap check before dispatch:** if two Stage-2 agents would need to *edit* the same file, serialize
+  them or split the file. Stage-1 is read-only so overlap is harmless.
+- **Keep findings in files, not the main thread.** Agents write full detail to their report file and return
+  only a short summary + the path, so the main thread's context stays light (the whole point of off-thread
+  research).
+
+## When to invoke vs. inline
+
+- **Invoke the full process** on a *wave*: a UX/scaffolding/doc audit, a pre-release gate, a post-large-change
+  sweep, or a periodic cadence.
+- **For a one-off** finding or small fix, just fix it inline — don't spin up the process.
+
+## Stage 2 (actuation) — netcanon rules
+
+The orchestrator executes fixes **one logical theme per PR/commit**, with rationale-first commit messages. Each
+behaviour-affecting change is gated on the netcanon proof bar before commit:
+
+> ruff clean → `compileall` → `pytest tests/unit tests/integration` green → (for codec changes) regen
+> `run_full_mesh --matrix` + `run_phase4_reconciliation`, confirm **CODEC_BUG flat at 5** and
+> `CROSS_MESH_RESULTS.md` / `PHASE4_RECONCILIATION.md` byte-identical → prune the regen `*Z.json` + revert
+> `_phase4_runs/latest.json`. For UI changes, add live preview verification (visual testing catches what CI
+> doesn't).
+
+Standing actuation constraints (see [`../AGENTS.md`](../AGENTS.md) § Hard Rules): commit under the pseudonym
+identity with the `Co-Authored-By` trailer; stage files explicitly (never `git add -A` — the `docs/codebase-review/`
+dossier must stay uncommitted); branch before committing; confirm before each merge; a release tag = publish and
+needs explicit user go-ahead. Stage-2 agents are spawned only for genuinely multi-file fixes.
+
+## See also
+- [`../AGENTS.md`](../AGENTS.md) — contributor directives + Hard Rules + the Documentation Sync Checklist
+- [`METHODOLOGY.md`](METHODOLOGY.md) — the matrix-honesty discipline the audits enforce
+- [`security-triage/`](security-triage/) — worked instance: Code Scanning / Dependabot alert-wave triage
+- [`docs-audit/`](docs-audit/) — worked instance: documentation-hygiene sweep


### PR DESCRIPTION
## Bring the ultracode blackboard protocol home

Formalizes netcanon's own multi-agent methodology — the
[`docs/security-triage/`](docs/security-triage/) and [`docs/docs-audit/`](docs/docs-audit/)
sister-processes — behind a single **reusable runner**, so every future ultracode run inherits the
same *read-only agents → main-thread actuates* discipline by construction rather than by memory.
(Brought home from a sibling project that had hardened this same netcanon methodology into a runner.)

### What lands
- **`.claude/workflows/blackboard.js`** — the file-per-agent blackboard `Workflow` runner (invoked by
  `scriptPath`). Read-only agents each write ONE long-form report under the run dir, read peers' reports
  for cross-phase comms, and return a short pointer/summary; Opus by default. The read-only contract (no
  edits, no git/regen/build/actuation, never touch `docs/codebase-review/`) is prepended to every agent
  prompt so it can't drift.
- **`.claude/workflows/README.md`** — the `args` contract + invocation recipe.
- **`docs/agent-workflow.md`** — the binding process: run-folder convention
  (`docs/reviews/<UTC-date>-<slug>/`), the `00-blackboard.md` seed template, cluster taxonomy, dispatch
  heuristics, and the netcanon Stage-2 actuation rules (pseudonym identity, explicit staging, the
  cross-mesh proof bar, confirm-before-merge).
- **`AGENTS.md`** — new "Ultracode runs" doctrine section + See-also link.
- **`.gitignore`** — scoped exception so `.claude/workflows/` (shared tooling) is tracked while
  user-local `.claude` config stays ignored.

Docs / tooling only — **no runtime change** (no `netcanon/` or `tests/` files touched; the ruff gate and
cross-mesh invariant are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)