### PR TITLE
fix(ui): UX PR-1 — sanitize first-paint, migrate honesty copy, AA contrast tokens

### DIFF
--- a/netcanon/templates/base.html
+++ b/netcanon/templates/base.html
@@ -50,7 +50,10 @@
       --surface-hover:  #d0d0d8;
       --text-primary:   #222222;
       --text-muted:     #555555;
-      --text-faint:     #888888;
+      /* Faint text is still information-bearing (empty-state "what
+         next" messages, job metadata, timestamps).  #6e6e6e clears
+         WCAG-AA (5.1:1 on white); the old #888888 was 3.5:1. */
+      --text-faint:     #6e6e6e;
       --border:         #eeeeee;
       --border-strong:  #cccccc;
 
@@ -63,9 +66,15 @@
       --nav-accent:     #7eb8f7;
       --nav-accent-hov: #a8d0ff;
 
-      /* Accent + focus ring — same colour the nav uses for its
-         active-page underline; shared with input:focus outlines. */
+      /* Accent — the nav's active-page underline colour.  Light
+         (#7eb8f7) on white is only ~2:1, so it is NOT used for the
+         focus ring (see --focus-ring below). */
       --accent:         #7eb8f7;
+      /* Focus ring — dedicated token that clears the WCAG 3:1 UI
+         minimum against the input surface.  Light mode needs a
+         darker blue (#2563eb ≈ 5.2:1 on white); dark mode keeps the
+         light accent (~7.5:1 on the dark surface). */
+      --focus-ring:     #2563eb;
 
       /* Primary button — shares the nav's dark navy. */
       --btn-primary-bg:       #1a1a2e;
@@ -123,7 +132,9 @@
       --surface-hover:  #333344;
       --text-primary:   #e8e8ea;
       --text-muted:     #b0b0b8;
-      --text-faint:     #808088;
+      /* Lifted to clear WCAG-AA (~6:1 on the dark surface); old
+         #808088 was ~3.6:1.  See light-mode --text-faint note. */
+      --text-faint:     #9a9aa4;
       --border:         #333338;
       --border-strong:  #555560;
 
@@ -134,6 +145,9 @@
       --nav-accent-hov: #a8d0ff;
 
       --accent:         #7eb8f7;
+      /* On the dark surface the light accent itself clears 3:1
+         (~7.5:1), so the focus ring reuses it. */
+      --focus-ring:     #7eb8f7;
 
       --btn-primary-bg:       #2e2e50;   /* lifted for visibility */
       --btn-primary-bg-hover: #3e3e68;
@@ -254,7 +268,7 @@
     .form-group { display: flex; flex-direction: column; gap: .25rem; }
     label { font-size: .8rem; font-weight: 600; color: var(--text-muted); }
     input, select, textarea { padding: .4rem .6rem; border: 1px solid var(--border-strong); border-radius: 4px; font-size: .9rem; background: var(--surface); color: var(--text-primary); }
-    input:focus, select:focus, textarea:focus { outline: 2px solid var(--accent); border-color: transparent; }
+    input:focus, select:focus, textarea:focus { outline: 2px solid var(--focus-ring); border-color: transparent; }
     button { padding: .45rem 1rem; border: none; border-radius: 4px; cursor: pointer; font-size: .9rem; font-weight: 600; }
     button:disabled { opacity: .6; cursor: not-allowed; }
     .btn-primary { background: var(--btn-primary-bg); color: var(--btn-primary-fg); }

--- a/netcanon/templates/configs.html
+++ b/netcanon/templates/configs.html
@@ -3,6 +3,11 @@
 
 {% block content %}
 <h1>Stored Configurations</h1>
+<p style="color:var(--text-muted);font-size:.9rem;margin:.25rem 0 1rem">
+  Configs captured from your devices (via Backup) or uploaded here. This is
+  the hub that feeds the rest of the app — view or download any file, compare
+  two with Diff, or send one through Migrate to translate it to another vendor.
+</p>
 
 {% if configs %}
 <table data-testid="configs-table">

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -472,6 +472,12 @@
                 title="Download as file">&#8595; Download</button>
       </div>
     </div>
+    <p data-testid="migrate-output-review-note"
+       style="color:var(--text-muted);font-size:.8rem;margin:0 0 .5rem">
+      Review before applying — Netcanon translates configs but does not
+      deploy them, and only fields with a supported path on the target are
+      carried across.
+    </p>
     <pre class="mig-output" id="mig-output"
          data-testid="migrate-output"></pre>
   </div>
@@ -1513,7 +1519,9 @@
     var v = job.validation;
     if (!v) return '<em>No validation report.</em>';
     if (v.severity === 'ok') {
-      return '<div>&#10003; Validation OK — every path round-trips cleanly.</div>';
+      return '<div>&#10003; Validation OK — every field that translates maps '
+           + 'to a supported path on the target. Review before applying; '
+           + 'Netcanon has no deploy path.</div>';
     }
     var lines = v.reasons.map(function(r) {
       return '<li>' + escapeHtml(r) + '</li>';

--- a/netcanon/templates/sanitize.html
+++ b/netcanon/templates/sanitize.html
@@ -124,8 +124,11 @@
   </div>
 </form>
 
-<!-- Results region -->
-<div id="san-result" data-testid="sanitize-result" class="hidden">
+<!-- Results region.  Hidden via inline style (not a `.hidden` class —
+     there is no global `.hidden{display:none}` rule, which previously
+     left the empty result scaffold visible on first load).  The JS
+     reveal below flips `style.display`, mirroring migrate's #mig-result. -->
+<div id="san-result" data-testid="sanitize-result" style="display:none">
   <div class="san-result-section">
     <div id="san-status-summary" data-testid="sanitize-status-summary"
          style="font-family:monospace;font-size:.82rem;color:var(--text-faint);margin-bottom:.5rem"></div>
@@ -381,7 +384,7 @@
       // Both succeeded — render.
       var auditJson = await auditResp.json();
       var sanitizedText = outputResp ? await outputResp.text() : null;
-      result.classList.remove('hidden');
+      result.style.display = '';
       var dt = (performance.now() - t0).toFixed(0);
       statusSum.textContent =
         'Sanitized in ' + dt + 'ms — ' + auditJson.total


### PR DESCRIPTION
First fix batch from the wide UI/UX review (`docs/reviews/2026-06-16-ux-review/`, verdict **GO-WITH-FIXES**). This is the highest-ROI / lowest-risk slice — **CSS / copy / token only**, all behaviour-preserving, all **live-verified against the running app** (local preview, both themes).

## Changes
| MF | Severity | What | File |
|----|----------|------|------|
| **MF-1** | major | `/sanitize` result region was `class="hidden"`, but no global `.hidden{display:none}` rule exists → the empty result scaffold (grey cards + empty "Substitution audit" table) rendered **visible on first load**. Switched to inline `style="display:none"` + `style.display=''` reveal (mirrors migrate's `#mig-result`). | `sanitize.html` |
| **MF-2** | major (honesty) | The OK validation banner claimed *"every path round-trips cleanly"* — a same-vendor fidelity term that overclaims on a cross-vendor result and reads as deploy-safe. Netcanon has **no deploy path**. Rescoped the banner + added a persistent review-before-deploy note in the Rendered-output header. | `migrate.html` |
| **MF-3** | major (a11y) | `--text-faint` (#888 light / #808088 dark) failed WCAG-AA for the info-bearing empty-state/metadata text it colours; the `--accent` input focus ring failed the 3:1 UI minimum on light surfaces. Darkened/lightened `--text-faint` and added a dedicated `--focus-ring` token in both theme blocks. | `base.html` |
| **MF-20** | minor | Configs page lacked the orienting lead paragraph the other pages have. | `configs.html` |

## Live verification (preview on :8765)
- **MF-1** — `#san-result` first load: `display:none`, `offsetHeight 0` (was `block`, 257px). ✅
- **MF-2** — drove a real `cisco_iosxe` round-trip → OK banner renders *"Validation OK — every field that translates maps to a supported path on the target. Review before applying; Netcanon has no deploy path."* with `mig-banner-ok` class preserved; review note visible. ✅
- **MF-3** — measured computed tokens against actual surfaces: `--text-faint` 5.10:1 light / 5.98:1 dark (both clear AA 4.5:1); `--focus-ring` 5.17:1 light / 8.01:1 dark (both clear 3:1). ✅
- **MF-20** — orienting lead `<p>` visible after the `<h1>`. ✅

## Gate
- `ruff check netcanon tests` — clean
- `pytest tests/integration` — all pass (1 skip)
- No console errors on any touched page
- e2e (`tests/e2e`) not runnable locally (Playwright browser launch fails at the session fixture, unrelated to this change) — runs in CI

Detail + `file:line` in `docs/reviews/2026-06-16-ux-review/{30-review-adversarial,99-synthesis}.md`. Subsequent batches (PR-2…PR-6) land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)