### PR TITLE
fix(ui): UX PR-2 — a11y quick wins (toast, labels, jargon, badge tokens)

### DIFF
--- a/netcanon/templates/base.html
+++ b/netcanon/templates/base.html
@@ -529,6 +529,16 @@
     }
     #_job-progress-footer a { color:var(--accent); text-decoration:none; margin-right:auto; }
     #_job-progress-footer a:hover { text-decoration:underline; }
+    /* Toast container.  z-index sits ABOVE the config-viewer modal
+       (10000) so a toast fired while the viewer is open is not painted
+       behind it; shadow uses the theme token so it stays visible in
+       dark mode.  display is left to the inline style.display toggle in
+       showToast (hidden initially via the element's inline display:none). */
+    #_toast {
+      position:fixed; bottom:1.5rem; right:1.5rem; max-width:360px;
+      z-index:10001; padding:.75rem 1rem; border-radius:6px;
+      box-shadow:var(--shadow-lift); font-size:.9rem; line-height:1.4;
+    }
     /* Toast variants: theme-aware colour pairs driven by CSS vars
        so dark mode inherits the same semantic hues.  The showToast
        JS assigns one of these classes instead of setting inline
@@ -548,8 +558,7 @@
       <strong id="_job-progress-job-id"
               data-testid="job-id-display"></strong>
       <span id="_job-progress-summary"
-            data-testid="job-progress-summary"
-            aria-label="Job progress summary"></span>
+            data-testid="job-progress-summary"></span>
       <span id="_job-progress-status"
             data-testid="job-status-display"
             style="display:none"></span>
@@ -572,9 +581,7 @@
 
   <!-- Toast notification -->
   <div id="_toast" data-testid="toast" role="status" aria-live="polite" aria-atomic="true"
-       style="position:fixed;bottom:1.5rem;right:1.5rem;max-width:360px;z-index:9999;display:none;
-              padding:.75rem 1rem;border-radius:6px;box-shadow:0 2px 8px rgba(0,0,0,.25);
-              font-size:.9rem;line-height:1.4">
+       style="display:none">
     <span id="_toast-msg"></span>
   </div>
 
@@ -596,6 +603,15 @@
     var msgEl = document.getElementById('_toast-msg');
     toast.classList.remove('toast-info', 'toast-error', 'toast-success');
     toast.classList.add('toast-' + variant);
+    // Errors must interrupt the screen reader rather than queue behind
+    // polite output; info/success stay polite.  Toggle per message.
+    if (variant === 'error') {
+      toast.setAttribute('role', 'alert');
+      toast.setAttribute('aria-live', 'assertive');
+    } else {
+      toast.setAttribute('role', 'status');
+      toast.setAttribute('aria-live', 'polite');
+    }
     msgEl.textContent = msg;
     toast.style.display = '';
     clearTimeout(toast._t);

--- a/netcanon/templates/configs.html
+++ b/netcanon/templates/configs.html
@@ -34,6 +34,7 @@
       <button onclick="downloadConfig('{{ cfg.filename }}')"
               class="btn-secondary" data-testid="config-download-btn"
               style="font-size:.8rem;padding:.3rem .6rem;margin-left:.3rem"
+              aria-label="Download {{ cfg.filename }}"
               title="Download {{ cfg.filename }}">&#8595;</button>
       <button class="btn-secondary compare-btn"
               data-testid="config-compare-btn"
@@ -41,6 +42,7 @@
               data-type-key="{{ cfg.device_type }}"
               data-ext="{{ cfg.file_extension }}"
               style="font-size:.8rem;padding:.3rem .6rem;margin-left:.3rem"
+              aria-label="Compare {{ cfg.filename }} with another config"
               title="Compare this config with another">&#8644;</button>
       {% if open_in_editor %}
       <button class="btn-secondary"

--- a/netcanon/templates/devices.html
+++ b/netcanon/templates/devices.html
@@ -293,6 +293,7 @@
                     class="btn-secondary"
                     data-testid="device-config-download-btn"
                     style="font-size:.8rem;padding:.3rem .6rem;margin-left:.3rem"
+                    aria-label="Download {{ config.filename }}"
                     title="Download {{ config.filename }}">&#8595;</button>
           </td>
         </tr>

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -194,7 +194,7 @@
     background:rgba(255,255,255,.18); color:#fff;
   }
   .mig-rename-rail-btn .rail-badge-warn {
-    background:#fd7e14; color:#fff; font-weight:700;
+    background:var(--badge-partial-bg); color:var(--badge-partial-fg); font-weight:700;
     margin-left:.3rem; padding:.05rem .4rem; border-radius:8px;
     font-size:.68rem; font-family:monospace;
   }
@@ -309,7 +309,7 @@
     font-size:.78rem; padding:.25rem .6rem;
   }
   .mig-rename-open-btn .badge-count {
-    background:#fd7e14; color:#fff; border-radius:8px;
+    background:var(--badge-partial-bg); color:var(--badge-partial-fg); border-radius:8px;
     padding:.05rem .4rem; font-size:.7rem; font-weight:700;
     font-family:monospace;
   }
@@ -2085,7 +2085,7 @@
           + escapeHtml(label) + '.</strong> '
           + escapeHtml(vendorLabel) + ' parses + renders interfaces '
           + 'and VLANs but ' + escapeHtml(label) + ' are currently '
-          + 'Tier-3 passthrough (raw_sections).  Rename overrides '
+          + 'kept as an opaque Tier-3 pass-through, not translated.  Rename overrides '
           + 'will apply to the canonical tree but won\'t appear in '
           + 'the rendered output until the codec wires full '
           + 'round-trip support for this category.'


### PR DESCRIPTION
Second fix batch from the wide UI/UX review (`docs/reviews/2026-06-16-ux-review/`). Aria / attribute one-liners + token repoints — **no layout change**, all behaviour-preserving, all **live-verified** against the running app.

## Changes
| MF | Severity | What | File |
|----|----------|------|------|
| **MF-11** | minor (a11y) | Dropped the static `aria-label="Job progress summary"` that overrode the JS-populated live text ("3/4 complete") for screen readers. | `base.html` |
| **MF-10** | minor (a11y) | Error toasts now toggle `role="alert"`/`aria-live="assertive"` (interrupt) instead of `status`/`polite` (queue); info/success stay polite. | `base.html` |
| **MF-9** | minor (a11y) | `aria-label` (+ existing `title`) on the icon-only download (↓) / compare (⇄) buttons. | `configs.html`, `devices.html` |
| **MF-17** | minor | Moved the toast's inline styles into a `#_toast{}` rule; `z-index` 9999 → **10001** (above the 10000 config-viewer modal); `box-shadow` → `var(--shadow-lift)` (visible in dark mode). | `base.html` |
| **MF-15** | minor | Repointed the two `#fd7e14` rename-badge oranges → theme-aware `var(--badge-partial-bg/fg)` (previously ignored dark mode). | `migrate.html` |
| **MF-13** | minor | De-jargoned the unsupported-category banner — dropped the literal field name `Tier-3 passthrough (raw_sections)` for plain prose. | `migrate.html` |

> Note: the review also cited `jobs.html:118` for MF-9, but those action buttons already use **text** labels ("Download"/"Open") — no change needed there.

## Live verification (preview on :8765)
- **MF-17 / MF-10** — fired an error toast: `z-index 10001`, box-shadow set, `position:fixed`, `role="alert"` / `aria-live="assertive"`; info toast → `role="status"` / `aria-live="polite"`. ✅
- **MF-9** — `config-download-btn` → `aria-label="Download <file>"`; `config-compare-btn` → `aria-label="Compare <file> with another config"`. ✅
- **MF-11** — `#_job-progress-summary` present, `aria-label` absent. ✅
- **MF-15** — on `/migrate`, both `.badge-count` + `.rail-badge-warn` computed bg = `rgb(74,61,5)` (the dark `--badge-partial-bg` #4a3d05); no longer `rgb(253,126,20)`. ✅

## Gate
- `ruff check netcanon tests` — clean
- `pytest tests/integration` — all pass (1 skip)
- No console errors on any touched page
- No test pins the touched strings/attrs (grep-checked: `raw_sections` matches are the canonical field, not the UI banner)

Detail + `file:line` in `docs/reviews/2026-06-16-ux-review/{30-review-adversarial,99-synthesis}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)