### PR TITLE
fix(ui): UX PR-3 — async edges (double-submit guard, full job-id deep-link, jobs refresh)

### DIFF
--- a/netcanon/templates/_partials/job-progress.js
+++ b/netcanon/templates/_partials/job-progress.js
@@ -117,7 +117,7 @@
 
       if (isTerminal(job.status)) {
         footEl.style.display = 'flex';
-        viewEl.href = '/jobs#' + job.id.substring(0, 8);
+        viewEl.href = '/jobs#' + job.id;  // full id — the /jobs deep-link matches on the complete job id
       } else {
         footEl.style.display = 'none';
       }

--- a/netcanon/templates/configs.html
+++ b/netcanon/templates/configs.html
@@ -153,12 +153,15 @@ function attachDeleteListener(btn) {
 
     confirmEl.querySelector('[data-testid="config-delete-confirm-btn"]')
       .addEventListener('click', async function() {
+        this.disabled = true;  // guard against double-click while in flight
         try {
           var res = await fetch(
             '/api/v1/configs/' + encodeURIComponent(fn),
             { method: 'DELETE' }
           );
-          if (res.ok || res.status === 204) {
+          // 404 after a successful delete (double-click / already gone) is a
+          // success, not a failure — the file is no longer there either way.
+          if (res.ok || res.status === 204 || res.status === 404) {
             self.closest('tr').remove();
             if (!document.querySelector('[data-testid="config-row"]')) {
               location.reload();

--- a/netcanon/templates/jobs.html
+++ b/netcanon/templates/jobs.html
@@ -34,9 +34,13 @@
   .btn-link-btn:hover { background:var(--btn-secondary-bg-hover); }
 </style>
 
-<div style="display:flex;align-items:baseline;gap:1rem;margin-bottom:1.25rem">
+<div style="display:flex;align-items:baseline;gap:1rem;margin-bottom:1.25rem;flex-wrap:wrap">
   <h1 style="margin-bottom:0">Backup Jobs</h1>
   <span style="font-size:.85rem;color:var(--text-faint)">{{ jobs|length }} job{{ 's' if jobs|length != 1 else '' }}</span>
+  <button type="button" class="btn-secondary" data-testid="jobs-refresh-btn"
+          onclick="window.location.reload()"
+          style="font-size:.8rem;padding:.25rem .7rem">&#8635; Refresh</button>
+  <span style="font-size:.78rem;color:var(--text-faint)">This list does not auto-update &mdash; refresh to see new results.</span>
 </div>
 
 {% if not jobs %}
@@ -51,7 +55,7 @@
 {% set duration_secs = ((job.completed_at - job.created_at).total_seconds() | int) if job.completed_at else none %}
 
 <div class="job-card" data-testid="job-card" data-job-id="{{ job.id }}"
-     id="job-{{ job.id[:8] }}">
+     id="job-{{ job.id }}">
 
   <div class="job-card-header" data-testid="job-card-header"
        onclick="toggleJob(this)">
@@ -119,7 +123,7 @@
                     data-testid="job-config-download-btn"
                     class="btn-link-btn">Download</button>
             {% if open_in_editor %}
-            <button onclick="openJobConfig('{{ result.config_record.filename }}')"
+            <button onclick="openJobConfig('{{ result.config_record.filename }}', this)"
                     data-testid="job-config-open-btn"
                     class="btn-link-btn">Open</button>
             {% endif %}
@@ -158,7 +162,10 @@ function toggleJob(header) {
   chevron.classList.toggle('open', open);
 }
 
-/* Open all jobs that match the URL hash (e.g. /jobs#a1b2c3d4) */
+/* Open the job that matches the URL hash (e.g. /jobs#<full-job-id>).
+ * The fragment carries the FULL id so it is unambiguous; a miss means
+ * the job aged out of the in-memory store, so we say so rather than
+ * silently no-op. */
 document.addEventListener('DOMContentLoaded', function() {
   var hash = window.location.hash.replace('#', '');
   if (hash) {
@@ -167,18 +174,23 @@ document.addEventListener('DOMContentLoaded', function() {
       var header = card.querySelector('[data-testid="job-card-header"]');
       if (header) toggleJob(header);
       card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } else {
+      showToast('Job ' + hash.substring(0, 8) + '… not found — it may have '
+        + 'aged out of the in-memory job store.', 'info');
     }
   }
 });
 
 {% if open_in_editor %}
-function openJobConfig(filename) {
+function openJobConfig(filename, btn) {
+  if (btn) btn.disabled = true;  // guard against double-click while in flight
   fetch('/api/v1/configs/' + encodeURIComponent(filename) + '/open', { method: 'POST' })
     .then(function(r) {
       if (r.status === 204) showToast('Opened ' + filename, 'success');
       else r.json().then(function(d) { showToast('Error: ' + formatApiError(d, r.statusText), 'error'); });
     })
-    .catch(function(e) { showToast('Network error: ' + e.message, 'error'); });
+    .catch(function(e) { showToast('Network error: ' + e.message, 'error'); })
+    .finally(function() { if (btn) btn.disabled = false; });
 }
 {% endif %}
 </script>

--- a/netcanon/templates/schedules.html
+++ b/netcanon/templates/schedules.html
@@ -131,7 +131,7 @@
       </td>
       <td data-testid="schedule-interval">{{ format_interval(sched.interval_minutes) }}</td>
       <td>
-        <button onclick="toggleSchedule('{{ sched.id }}')"
+        <button onclick="toggleSchedule('{{ sched.id }}', this)"
                 data-testid="schedule-toggle-btn"
                 class="badge {% if sched.enabled %}enabled-badge{% else %}disabled-badge{% endif %}"
                 style="border:none;cursor:pointer;padding:.25rem .6rem">
@@ -156,7 +156,7 @@
       </td>
       <td data-testid="schedule-last-job">
         {% if sched.last_job_id %}
-          <a href="/jobs#{{ sched.last_job_id[:8] }}"
+          <a href="/jobs#{{ sched.last_job_id }}"
              style="font-family:monospace;font-size:.82rem">
             {{ sched.last_job_id[:8] }}&hellip;
           </a>
@@ -171,7 +171,7 @@
         <span class="sched-confirm" style="display:none;gap:.35rem">
           Delete?
           <button data-testid="schedule-delete-confirm-btn"
-                  onclick="confirmDeleteSchedule('{{ sched.id }}')"
+                  onclick="confirmDeleteSchedule('{{ sched.id }}', this)"
                   class="btn-danger" style="font-size:.8rem">Yes</button>
           <button data-testid="schedule-delete-cancel-btn"
                   onclick="cancelDeleteSchedule(this)"
@@ -254,17 +254,20 @@ schedForm.addEventListener('submit', async function(e) {
 });
 
 /* ── Toggle enable/disable ── */
-async function toggleSchedule(schedId) {
+async function toggleSchedule(schedId, btn) {
+  if (btn) btn.disabled = true;  // guard against double-click while in flight
   try {
     var res = await fetch('/api/v1/schedules/' + schedId + '/toggle', { method: 'POST' });
     if (!res.ok) {
       var d = await res.json().catch(function() { return {}; });
       showToast('Error: ' + formatApiError(d, res.statusText), 'error');
+      if (btn) btn.disabled = false;
       return;
     }
-    window.location.reload();
+    window.location.reload();  // success path reloads; no need to re-enable
   } catch (err) {
     showToast('Network error: ' + err.message, 'error');
+    if (btn) btn.disabled = false;
   }
 }
 
@@ -281,10 +284,13 @@ function cancelDeleteSchedule(btn) {
   confirm.previousElementSibling.style.display = '';
 }
 
-async function confirmDeleteSchedule(schedId) {
+async function confirmDeleteSchedule(schedId, btn) {
+  if (btn) btn.disabled = true;  // guard against double-click while in flight
   try {
     var res = await fetch('/api/v1/schedules/' + schedId, { method: 'DELETE' });
-    if (res.status === 204) {
+    // 404 after a successful delete (double-click / already gone) is a
+    // success, not a failure — the schedule is no longer there either way.
+    if (res.status === 204 || res.status === 404) {
       showToast('Schedule deleted', 'success');
       var row = document.querySelector('[data-schedule-id="' + schedId + '"]');
       if (row) row.remove();
@@ -293,9 +299,11 @@ async function confirmDeleteSchedule(schedId) {
     } else {
       var d = await res.json().catch(function() { return {}; });
       showToast('Error: ' + formatApiError(d, res.statusText), 'error');
+      if (btn) btn.disabled = false;
     }
   } catch (err) {
     showToast('Network error: ' + err.message, 'error');
+    if (btn) btn.disabled = false;
   }
 }
 </script>

--- a/tests/testid_reference.md
+++ b/tests/testid_reference.md
@@ -198,7 +198,7 @@ dispatches `CustomEvent`s on `document` that page-level code can listen for:
 | `job-progress-device-duration`   | `<span>`   | "N.Ns" once device reaches terminal state |
 | `job-progress-device-error`      | `<div>`    | Only rendered when `data-status="failed"`; truncated error with `title` |
 | `job-progress-footer`            | `<div>`    | Appears only after job reaches terminal state |
-| `job-progress-view-link`         | `<a>`      | Deep link to `/jobs#<job-id-short>` |
+| `job-progress-view-link`         | `<a>`      | Deep link to `/jobs#<full-job-id>` |
 | `job-progress-dismiss`           | `<button>` | Hides panel AND clears the localStorage key |
 
 ## Config viewer modal (`base.html` — global)
@@ -314,7 +314,7 @@ The page exposes four sections — one `section-*` testid per container.
 | `data-testid`             | Element | Notes |
 |---------------------------|---------|-------|
 | `no-jobs-msg`             | `<p>`   | Shown when no jobs exist |
-| `job-card`                | `<div>` | One collapsible card per job; also has `data-job-id` and `id="job-{id[:8]}"` for anchor linking |
+| `job-card`                | `<div>` | One collapsible card per job; also has `data-job-id` and `id="job-{full-id}"` for anchor linking |
 | `job-card-header`         | `<div>` | Clickable header row; calls `toggleJob()` to expand/collapse body |
 | `job-id-text`             | `<span>`| First 8 chars of job UUID + "…" |
 | `job-status`              | `<span>`| Status badge (`pending`, `running`, `completed`, `partial`, `failed`) |
@@ -385,7 +385,7 @@ exist yet.
 | `schedule-toggle-btn`          | `<button>` | Styled badge; click to toggle enabled/disabled; reloads page |
 | `schedule-next-run`            | `<td>`  | Next scheduled run (localised by JS); also has `data-utc` |
 | `schedule-last-run`            | `<td>`  | Last run timestamp (localised by JS); "Never" when never run; also has `data-utc` |
-| `schedule-last-job`            | `<td>`  | Link to last job card (`/jobs#{id[:8]}`); "—" if none |
+| `schedule-last-job`            | `<td>`  | Link to last job card (`/jobs#{full-id}`, shows first 8 chars); "—" if none |
 | `schedule-delete-btn`          | `<button>` | Shows inline confirm — does NOT call `confirm()` |
 | `schedule-delete-confirm-btn`  | `<button>` | "Yes" — confirms deletion |
 | `schedule-delete-cancel-btn`   | `<button>` | "No" — cancels and restores Delete button |


### PR DESCRIPTION
Third fix batch from the wide UI/UX review (`docs/reviews/2026-06-16-ux-review/`). Small behaviour-preserving JS hardening on the async surfaces — all **live-verified** against the running app (18 real jobs in the dev instance).

## Changes
| MF | Severity | What | File(s) |
|----|----------|------|---------|
| **MF-16** | minor | Disable inline per-row buttons while their request is in flight (double-click race guard); treat `404`-on-delete-after-success as success (no false "delete failed" toast). Handlers now receive `this`, re-enable on error/catch. | `configs.html`, `schedules.html`, `jobs.html` |
| **MF-18** | minor | `/jobs#` fragment + job-card `id` now carry the **full** job id (was 8-char prefix → non-unique + silent no-op on miss). A miss now shows an info toast ("…may have aged out"). All three `/jobs#` producers updated in lockstep. | `jobs.html`, `schedules.html`, `_partials/job-progress.js` |
| **MF-19** | minor | "Refresh" button + "does not auto-update" hint on the `/jobs` header (server-rendered list, never polls). Manual refresh — **not** interval polling (right-sized for a single-operator tool). | `jobs.html` |

## Live verification (preview on :8765, 18 real jobs)
- **MF-19** — `jobs-refresh-btn` present ("↻ Refresh") + hint "This list does not auto-update — refresh to see new results." ✅
- **MF-18 full id** — first card `id="job-bb69c721-db44-4930-9c4a-e8752b6e6238"` (full UUID). ✅
- **MF-18 valid deep-link** — load `/jobs#<full-id>` → card found + body expanded, no toast. ✅
- **MF-18 miss** — load `/jobs#deadbeef-…` → info toast "Job deadbeef… not found — it may have aged out of the in-memory job store." (toast displays: synchronous check `display:block`, `z-index 10001`). ✅
- **MF-16** — `toggleSchedule`/`confirmDeleteSchedule` now arity-2; toggle onclick passes `this`. No console errors on any page. ✅

## Gate
- `ruff check netcanon tests` — clean
- `pytest tests/integration` — all pass (1 skip)
- No test breaks: `test_progress_panel.py` only asserts `href.startswith("/jobs#")` (still true); synced `tests/testid_reference.md` to the full-id form.

Detail + `file:line` in `docs/reviews/2026-06-16-ux-review/{30-review-adversarial,99-synthesis}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)