### PR TITLE
fix(ui): UX PR-4 — themed 404/500 error pages (MF-5)

### DIFF
--- a/netcanon/api/routes/ui.py
+++ b/netcanon/api/routes/ui.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 import heapq
 import logging
 from collections import defaultdict
+from http import HTTPStatus
 from pathlib import Path
 
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.templating import Jinja2Templates
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +71,100 @@ def _format_interval(minutes: int) -> str:
 
 
 _templates.env.globals["format_interval"] = _format_interval
+
+
+# ---------------------------------------------------------------------------
+# Error pages (404 / 500)
+# ---------------------------------------------------------------------------
+#
+# A mistyped URL or an uncaught server error used to drop the operator
+# onto a raw JSON body (``{"detail":"Not Found"}``) with no nav and no
+# theme.  These handlers render a themed ``error.html`` (extends
+# ``base.html``) for *browser* navigations while preserving the JSON
+# contract for the API surface and programmatic clients.
+
+_ERROR_MESSAGES = {
+    404: (
+        "We couldn't find that page. It may have moved, or the link "
+        "was mistyped."
+    ),
+    500: (
+        "Something went wrong on our end. The error has been logged; "
+        "try again, or head back to the dashboard."
+    ),
+}
+_DEFAULT_ERROR_MESSAGE = "An unexpected error occurred."
+
+
+def _wants_html(request: Request) -> bool:
+    """True when the themed error page (not JSON) is the right response.
+
+    Browser navigations to a non-API path send ``Accept: text/html``;
+    they get the page.  Anything under ``/api/`` — and any programmatic
+    client whose ``Accept`` is ``*/*`` or ``application/json`` (incl.
+    the test harness's default) — keeps the JSON ``{"detail": ...}``
+    contract untouched.
+    """
+    if request.url.path.startswith("/api/"):
+        return False
+    return "text/html" in request.headers.get("accept", "")
+
+
+def _status_phrase(status_code: int) -> str:
+    """Human phrase for an HTTP status (``404`` → ``"Not Found"``)."""
+    try:
+        return HTTPStatus(status_code).phrase
+    except ValueError:
+        return "Error"
+
+
+def _render_error_page(request: Request, status_code: int) -> Response:
+    return _templates.TemplateResponse(
+        request,
+        "error.html",
+        {
+            "status_code": status_code,
+            "status_text": _status_phrase(status_code),
+            "message": _ERROR_MESSAGES.get(status_code, _DEFAULT_ERROR_MESSAGE),
+        },
+        status_code=status_code,
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Wire the themed 404/500 handlers onto *app*.
+
+    Called from ``create_app`` after the routers are mounted.  Lives
+    here (not in ``main.py``) so it can reuse this module's configured
+    ``Jinja2Templates`` instance and its registered globals.
+    """
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_exception_handler(
+        request: Request, exc: StarletteHTTPException
+    ) -> Response:
+        if _wants_html(request):
+            return _render_error_page(request, exc.status_code)
+        # Preserve FastAPI's default JSON shape for the API surface.
+        return JSONResponse(
+            {"detail": exc.detail},
+            status_code=exc.status_code,
+            headers=getattr(exc, "headers", None),
+        )
+
+    @app.exception_handler(Exception)
+    async def _unhandled_exception_handler(
+        request: Request, exc: Exception
+    ) -> Response:
+        # The traceback is logged here (with the request path) and again
+        # by the framework when it re-raises; we never echo it to the
+        # client.
+        logger.exception("Unhandled error serving %s", request.url.path)
+        if _wants_html(request):
+            return _render_error_page(request, 500)
+        return JSONResponse(
+            {"detail": "Internal Server Error"}, status_code=500
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/netcanon/main.py
+++ b/netcanon/main.py
@@ -305,6 +305,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(docs_router.router)  # custom Swagger UI at /docs (no prefix)
     app.include_router(ui_router.router)  # UI routes at root (/, /jobs, …)
 
+    # Themed 404/500 pages for browser navigations (API surface keeps
+    # its JSON error contract — see ui._wants_html).  Registered last so
+    # it wraps the fully-mounted router set.
+    ui_router.register_exception_handlers(app)
+
     return app
 
 

--- a/netcanon/templates/error.html
+++ b/netcanon/templates/error.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}{{ status_code }} {{ status_text }} — Netcanon{% endblock %}
+
+{% block content %}
+{# Minimal themed error page (404 / 500) so a mistyped URL or an
+   uncaught server error keeps the operator inside the nav-wrapped
+   shell instead of dropping them onto a raw JSON body.  The message
+   is generic by design — we never echo exception detail here (the
+   full traceback lives in the server log). #}
+<div data-testid="error-page"
+     style="max-width:640px;margin:3rem auto;text-align:center">
+  <div data-testid="error-status-code"
+       style="font-size:3.5rem;font-weight:700;font-family:monospace;
+              color:var(--text-faint);line-height:1">{{ status_code }}</div>
+  <h1 style="margin:.5rem 0 .25rem">{{ status_text }}</h1>
+  <p style="color:var(--text-muted);margin:.5rem 0 1.5rem">{{ message }}</p>
+  <a href="/" class="btn-primary" data-testid="error-home-link"
+     style="display:inline-block;text-decoration:none;
+            padding:.5rem 1.1rem;border-radius:4px">
+    &#8592; Back to Dashboard
+  </a>
+</div>
+{% endblock %}

--- a/tests/integration/test_error_pages.py
+++ b/tests/integration/test_error_pages.py
@@ -1,0 +1,83 @@
+"""
+Integration tests for the themed 404/500 error pages (UX review MF-5).
+
+A mistyped URL or an uncaught server error must keep a *browser* user
+inside the nav-wrapped themed shell (``error.html``) instead of dropping
+them onto a raw JSON body — while the API surface and programmatic
+clients keep their ``{"detail": ...}`` JSON contract untouched.
+
+The browser-vs-JSON branch is driven by ``ui._wants_html``:
+``Accept: text/html`` on a non-``/api/`` path → HTML page; everything
+else (``*/*``, ``application/json``, or any ``/api/`` path) → JSON.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+_HTML = {"accept": "text/html"}
+
+
+class TestNotFoundPage:
+    """``404`` — unmatched routes."""
+
+    def test_browser_404_renders_themed_html(self, client):
+        resp = client.get("/this-page-does-not-exist", headers=_HTML)
+        assert resp.status_code == 404
+        assert resp.headers["content-type"].startswith("text/html")
+        body = resp.text
+        # Extends base.html → the nav shell is present.
+        assert 'data-testid="nav-home"' in body
+        assert 'data-testid="error-page"' in body
+        assert 'data-testid="error-home-link"' in body
+        assert "404" in body
+        # Never renders the raw JSON detail body to a browser.
+        assert '{"detail"' not in body
+
+    def test_api_style_404_keeps_json(self, client):
+        # Default Accept (*/*) — programmatic clients keep the JSON contract.
+        resp = client.get("/this-page-does-not-exist")
+        assert resp.status_code == 404
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.json() == {"detail": "Not Found"}
+
+    def test_api_path_404_is_json_even_for_browser(self, client):
+        # An /api/ path stays JSON even when the client accepts HTML —
+        # the API namespace is a machine contract, not a browseable page.
+        resp = client.get("/api/v1/this-endpoint-does-not-exist", headers=_HTML)
+        assert resp.status_code == 404
+        assert resp.headers["content-type"].startswith("application/json")
+
+
+class TestServerErrorPage:
+    """``500`` — uncaught exceptions (never echo the exception detail)."""
+
+    def test_browser_500_renders_themed_html(self, test_app):
+        @test_app.get("/__boom_html__", include_in_schema=False)
+        async def _boom():  # pragma: no cover - body never returns
+            raise RuntimeError("kaboom-secret-detail")
+
+        with TestClient(test_app, raise_server_exceptions=False) as c:
+            resp = c.get("/__boom_html__", headers=_HTML)
+        assert resp.status_code == 500
+        assert resp.headers["content-type"].startswith("text/html")
+        body = resp.text
+        assert 'data-testid="error-page"' in body
+        assert "500" in body
+        # The exception type/message must not leak to the client.
+        assert "kaboom-secret-detail" not in body
+        assert "RuntimeError" not in body
+
+    def test_api_style_500_keeps_json(self, test_app):
+        @test_app.get("/__boom_json__", include_in_schema=False)
+        async def _boom():  # pragma: no cover - body never returns
+            raise RuntimeError("kaboom-secret-detail")
+
+        with TestClient(test_app, raise_server_exceptions=False) as c:
+            resp = c.get("/__boom_json__")  # default Accept: */*
+        assert resp.status_code == 500
+        assert resp.json() == {"detail": "Internal Server Error"}
+        assert "kaboom-secret-detail" not in resp.text


### PR DESCRIPTION
Fourth fix batch from the wide UI/UX review (`docs/reviews/2026-06-16-ux-review/`) — the second **live-verified** blocker. A mistyped URL or an uncaught server error used to drop the operator onto a raw, nav-less `{"detail":"Not Found"}` JSON body. Now a minimal themed `error.html` (extends `base.html` → inherits nav + theme) is served for browser navigations, while the API surface keeps its JSON contract.

## Changes
- **`netcanon/templates/error.html`** (new) — status code + phrase + generic message + "← Back to Dashboard". **Never echoes exception detail.**
- **`ui.register_exception_handlers(app)`** — a `StarletteHTTPException` (404) handler + a generic `Exception` (500) handler. Both branch on `_wants_html`:
  - browser navigation (`Accept: text/html`, non-`/api/` path) → themed page
  - API surface / programmatic clients (`*/*`, `application/json`, or any `/api/` path) → unchanged `{"detail": ...}` JSON
  - The 500 handler logs the traceback (with request path) but the framework still re-raises, so `TestClient(raise_server_exceptions=True)` is unaffected.
- **`main.py`** — calls `register_exception_handlers(app)` after mounting routers.
- **Desktop parity** ✅ — `netcanon_desktop/app.py:58` builds its embedded server via the same `create_app()`, so the pages reach the desktop automatically (AGENTS.md Feature-Parity).

## Live verification (preview on :8765)
- **Browser 404** — `/totally-bogus-typo-url` → themed page: `nav-home` present, `error-page` rendered, "404 Not Found" title, "← Back to Dashboard" → `/`, **no raw JSON**. (Was: `{"detail":"Not Found"}`, no nav.) ✅
- **API 404** — `fetch('/api/v1/this-endpoint-does-not-exist')` → `application/json`, `{"detail":"Not Found"}`. ✅
- **API path + `Accept: text/html`** → still `application/json` (API namespace is a machine contract). ✅
- No console errors.

## Gate
- `ruff check netcanon tests` — clean · `compileall netcanon` — clean
- `pytest tests/integration` — all pass (1 skip), incl. 5 new `test_error_pages.py` cases (browser 404 HTML, API 404 JSON, /api/ path JSON, browser 500 HTML no-leak, API 500 JSON)

Detail + `file:line` in `docs/reviews/2026-06-16-ux-review/{30-review-adversarial,99-synthesis}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)