### PR TITLE
fix(ui): UX PR-5 — keyboard operability (disclosures + rename modal)

### DIFF
--- a/netcanon/templates/_partials/job-progress.js
+++ b/netcanon/templates/_partials/job-progress.js
@@ -125,6 +125,7 @@
 
     /** Expand/collapse the body section. */
     window.toggleJobProgress = function() {
+      var header  = document.getElementById('_job-progress-header');
       var body    = document.getElementById('_job-progress-body');
       var foot    = document.getElementById('_job-progress-footer');
       var chevron = document.getElementById('_job-progress-chevron');
@@ -135,6 +136,7 @@
       if (!open) foot.style.display = 'none';
       else if (foot.getAttribute('data-should-show') === '1') foot.style.display = 'flex';
       chevron.classList.toggle('open', open);
+      if (header) header.setAttribute('aria-expanded', open ? 'true' : 'false');
     };
 
     /** Dismiss the panel; clears persisted state. */

--- a/netcanon/templates/base.html
+++ b/netcanon/templates/base.html
@@ -554,7 +554,10 @@
        style="display:none">
     <div id="_job-progress-header"
          data-testid="job-progress-header"
-         onclick="toggleJobProgress()">
+         role="button" tabindex="0" aria-expanded="true"
+         aria-controls="_job-progress-body"
+         onclick="toggleJobProgress()"
+         onkeydown="if((event.key==='Enter'||event.key===' ')&&event.target===this){event.preventDefault();toggleJobProgress();}">
       <strong id="_job-progress-job-id"
               data-testid="job-id-display"></strong>
       <span id="_job-progress-summary"

--- a/netcanon/templates/devices.html
+++ b/netcanon/templates/devices.html
@@ -122,7 +122,9 @@
        data-port="{{ profile.port }}">
 
     <div class="device-card-header" data-testid="device-card-header"
-         onclick="toggleDevice(this)">
+         role="button" tabindex="0" aria-expanded="false"
+         onclick="toggleDevice(this)"
+         onkeydown="if((event.key==='Enter'||event.key===' ')&&event.target===this){event.preventDefault();toggleDevice(this);}">
 
       <strong data-testid="device-name">{{ profile.name }}</strong>
       <span class="badge" data-testid="device-type"
@@ -348,6 +350,7 @@ function toggleDevice(header) {
   var open    = body.style.display === 'none';
   body.style.display = open ? '' : 'none';
   chevron.classList.toggle('open', open);
+  header.setAttribute('aria-expanded', open ? 'true' : 'false');
 }
 
 /* ── Toggle inline edit panel ── */

--- a/netcanon/templates/jobs.html
+++ b/netcanon/templates/jobs.html
@@ -58,7 +58,9 @@
      id="job-{{ job.id }}">
 
   <div class="job-card-header" data-testid="job-card-header"
-       onclick="toggleJob(this)">
+       role="button" tabindex="0" aria-expanded="false"
+       onclick="toggleJob(this)"
+       onkeydown="if((event.key==='Enter'||event.key===' ')&&event.target===this){event.preventDefault();toggleJob(this);}">
 
     <span class="job-id" data-testid="job-id-text">{{ job.id[:8] }}&hellip;</span>
 
@@ -160,6 +162,7 @@ function toggleJob(header) {
   var open    = body.style.display === 'none';
   body.style.display = open ? '' : 'none';
   chevron.classList.toggle('open', open);
+  header.setAttribute('aria-expanded', open ? 'true' : 'false');
 }
 
 /* Open the job that matches the URL hash (e.g. /jobs#<full-job-id>).

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -2352,6 +2352,9 @@
       return;
     }
     var modal = document.getElementById('mig-rename-modal');
+    // Remember what opened the modal so focus can return there on close
+    // (keyboard/SR users land back where they were).
+    modal._returnFocus = document.activeElement;
     modal.classList.add('open');
     modal.style.display = 'flex';
     // Restore persisted overrides for this (source, target, hostname)
@@ -2395,13 +2398,38 @@
     renderPerPaneFitCheck();
     renderRenamePreview();
     renderRenameSummary();
+    // Move focus into the dialog so SR announces it and keyboard users
+    // can Tab through + Esc out (mirrors kbd-cheatsheet.js).
+    var closeBtn = modal.querySelector(
+      '[data-testid="migrate-rename-modal-close"]'
+    );
+    if (closeBtn) closeBtn.focus();
   };
 
   window.closeRenameModal = function() {
     var modal = document.getElementById('mig-rename-modal');
     modal.classList.remove('open');
     modal.style.display = 'none';
+    // Return focus to whatever opened the modal (a11y: don't strand
+    // keyboard/SR focus on the now-hidden dialog).
+    var ret = modal._returnFocus;
+    modal._returnFocus = null;
+    if (ret && typeof ret.focus === 'function') {
+      try { ret.focus(); } catch (_) { /* element gone — ignore */ }
+    }
   };
+
+  // Esc closes the rename modal.  Focus management only — the modal is
+  // intentionally non-blocking + draggable (aria-modal="false"), so we
+  // deliberately do NOT install a focus trap.
+  document.addEventListener('keydown', function(e) {
+    if (e.key !== 'Escape') return;
+    var modal = document.getElementById('mig-rename-modal');
+    if (modal && modal.classList.contains('open')) {
+      e.preventDefault();
+      closeRenameModal();
+    }
+  });
 
   window.renameModalResetAll = function() {
     _renameUserMap = {};

--- a/tests/testid_reference.md
+++ b/tests/testid_reference.md
@@ -315,7 +315,7 @@ The page exposes four sections — one `section-*` testid per container.
 |---------------------------|---------|-------|
 | `no-jobs-msg`             | `<p>`   | Shown when no jobs exist |
 | `job-card`                | `<div>` | One collapsible card per job; also has `data-job-id` and `id="job-{full-id}"` for anchor linking |
-| `job-card-header`         | `<div>` | Clickable header row; calls `toggleJob()` to expand/collapse body |
+| `job-card-header`         | `<div>` | Disclosure header row (`role="button"`, focusable, `aria-expanded`); click or Enter/Space calls `toggleJob()` to expand/collapse body |
 | `job-id-text`             | `<span>`| First 8 chars of job UUID + "…" |
 | `job-status`              | `<span>`| Status badge (`pending`, `running`, `completed`, `partial`, `failed`) |
 | `job-success-count`       | `<span>`| `success / total` with ✓ (all-success), ⚠ (partial) or ✗ (all-fail) indicator |
@@ -417,7 +417,7 @@ exist yet.
 | `devices-section`              | `<section>` | Wraps all device cards |
 | `no-devices-msg`               | `<p>` | Shown when no profiles exist |
 | `device-card`                  | `<div>` | One collapsible card per profile; also has `data-device-id` and `data-profile` (JSON) |
-| `device-card-header`           | `<div>` | Clickable header; `toggleDevice()` to show/hide config history |
+| `device-card-header`           | `<div>` | Disclosure header (`role="button"`, focusable, `aria-expanded`); click or Enter/Space calls `toggleDevice()` to show/hide config history |
 | `device-name`                  | `<strong>` | Profile name |
 | `device-type`                  | `<span>` | Type key badge |
 | `device-host`                  | `<span>` | Host / IP |


### PR DESCRIPTION
Fifth fix batch from the wide UI/UX review (`docs/reviews/2026-06-16-ux-review/`) — the keyboard/SR gaps. Behaviour-preserving for mouse users; all **live-verified**.

## Changes
| MF | Severity | What | File(s) |
|----|----------|------|---------|
| **MF-4** | major (a11y) | The 3 disclosure headers were `<div onclick>` — not focusable, no role/state. Added `role="button" tabindex="0" aria-expanded` + Enter/Space keydown (guarded with `event.target===this` so a keypress on an inner Backup/Edit/Delete button doesn't bubble up and double-toggle the card). Toggle fns sync `aria-expanded`; job-progress header also gets `aria-controls`. | `jobs.html`, `devices.html`, `base.html`, `_partials/job-progress.js` |
| **MF-6** | major (a11y) | Rename modal had no Esc/focus-on-open/focus-restore. On open: store opener + focus close button; document Esc handler closes; on close: restore focus. Mirrors `kbd-cheatsheet.js`. **No focus trap** — modal is intentionally non-blocking + draggable (`aria-modal="false"`). | `migrate.html` |

Kept the disclosure headers as `<div role="button">` (not real `<button>`) so the flex layout + existing CSS are untouched.

## Live verification (preview on :8765)
- **MF-4 jobs** — `job-card-header`: `role=button`, `tabIndex 0`, focusable; Enter toggles body `none`↔`block` + `aria-expanded` `false`↔`true`. ✅
- **MF-4 devices** — `device-card-header`: same, Space expands (`aria-expanded`→`true`). ✅
- **MF-4 job-progress** — header `role=button`, `tabindex 0`, `aria-expanded`, `aria-controls="_job-progress-body"`. ✅
- **MF-6** — focus lands on close button on open; Escape closes (`.open` removed, `display:none`); focus restored to the opener. ✅
- No console errors.

## Gate
- `ruff check netcanon tests` — clean
- `pytest tests/integration` — all pass (1 skip)
- No test breaks: e2e rename-modal tests still click the close button; disclosure headers stay `<div>` (synced `tests/testid_reference.md` to note keyboard operability).

Detail + `file:line` in `docs/reviews/2026-06-16-ux-review/{30-review-adversarial,99-synthesis}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)