### PR TITLE
fix(ui): UX PR-6 — forms + tables a11y sweep (scope, skip-link, labels, terminology)

### DIFF
--- a/netcanon/templates/_partials/local-user-rename-table.js
+++ b/netcanon/templates/_partials/local-user-rename-table.js
@@ -71,10 +71,10 @@
     table.setAttribute('data-testid', 'migrate-rename-local-users-table');
     var thead = document.createElement('thead');
     thead.innerHTML = '<tr>'
-      + '<th>Source username</th>'
-      + '<th>Auto target</th>'
-      + '<th>Override</th>'
-      + '<th style="width:1.5rem">⚠</th>'
+      + '<th scope="col">Source username</th>'
+      + '<th scope="col">Auto target</th>'
+      + '<th scope="col">Override</th>'
+      + '<th scope="col" style="width:1.5rem">⚠</th>'
       + '</tr>';
     table.appendChild(thead);
 

--- a/netcanon/templates/_partials/rename-table.js
+++ b/netcanon/templates/_partials/rename-table.js
@@ -205,10 +205,10 @@
       table.className = 'mig-rename-table';
       var thead = document.createElement('thead');
       thead.innerHTML = '<tr>'
-        + '<th>Source</th>'
-        + '<th>Auto target</th>'
-        + '<th>Override</th>'
-        + '<th style="width:1.5rem">⚠</th>'
+        + '<th scope="col">Source</th>'
+        + '<th scope="col">Auto target</th>'
+        + '<th scope="col">Override</th>'
+        + '<th scope="col" style="width:1.5rem">⚠</th>'
         + '</tr>';
       table.appendChild(thead);
 

--- a/netcanon/templates/_partials/snmp-rename-table.js
+++ b/netcanon/templates/_partials/snmp-rename-table.js
@@ -68,10 +68,10 @@
     table.setAttribute('data-testid', 'migrate-rename-snmp-table');
     var thead = document.createElement('thead');
     thead.innerHTML = '<tr>'
-      + '<th>Source community</th>'
-      + '<th>Auto target</th>'
-      + '<th>Override</th>'
-      + '<th style="width:1.5rem"></th>'
+      + '<th scope="col">Source community</th>'
+      + '<th scope="col">Auto target</th>'
+      + '<th scope="col">Override</th>'
+      + '<th scope="col" style="width:1.5rem"></th>'
       + '</tr>';
     table.appendChild(thead);
 

--- a/netcanon/templates/_partials/snmpv3-user-rename-table.js
+++ b/netcanon/templates/_partials/snmpv3-user-rename-table.js
@@ -73,10 +73,10 @@
     table.setAttribute('data-testid', 'migrate-rename-snmpv3-table');
     var thead = document.createElement('thead');
     thead.innerHTML = '<tr>'
-      + '<th>Source v3 username</th>'
-      + '<th>Auto target</th>'
-      + '<th>Override</th>'
-      + '<th style="width:1.5rem">⚠</th>'
+      + '<th scope="col">Source v3 username</th>'
+      + '<th scope="col">Auto target</th>'
+      + '<th scope="col">Override</th>'
+      + '<th scope="col" style="width:1.5rem">⚠</th>'
       + '</tr>';
     table.appendChild(thead);
 

--- a/netcanon/templates/_partials/vlan-rename-table.js
+++ b/netcanon/templates/_partials/vlan-rename-table.js
@@ -70,10 +70,10 @@
     table.setAttribute('data-testid', 'migrate-rename-vlans-table');
     var thead = document.createElement('thead');
     thead.innerHTML = '<tr>'
-      + '<th>Source VLAN</th>'
-      + '<th>Auto target</th>'
-      + '<th>Override</th>'
-      + '<th style="width:1.5rem">⚠</th>'
+      + '<th scope="col">Source VLAN</th>'
+      + '<th scope="col">Auto target</th>'
+      + '<th scope="col">Override</th>'
+      + '<th scope="col" style="width:1.5rem">⚠</th>'
       + '</tr>';
     table.appendChild(thead);
 

--- a/netcanon/templates/base.html
+++ b/netcanon/templates/base.html
@@ -357,9 +357,25 @@
     }
     .kbd-sep { color:var(--text-faint); font-size:.75rem;
                padding:0 .1rem; }
+    /* Visually-hidden-until-focused utility + the skip-link that uses
+       it.  The skip-link is the first focusable element on every page
+       so keyboard users can jump past the 10-link nav straight to the
+       page content. */
+    .sr-only {
+      position:absolute; width:1px; height:1px; padding:0; margin:-1px;
+      overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;
+    }
+    .skip-link:focus {
+      position:fixed; top:.5rem; left:.5rem; width:auto; height:auto;
+      margin:0; padding:.5rem .9rem; clip:auto; overflow:visible;
+      z-index:10002; background:var(--surface); color:var(--text-primary);
+      border:2px solid var(--focus-ring); border-radius:4px;
+      text-decoration:none; font-weight:600;
+    }
   </style>
 </head>
 <body>
+  <a href="#main" class="sr-only skip-link" data-testid="skip-link">Skip to main content</a>
   <nav data-testid="nav">
     <a href="/" class="brand" data-testid="nav-brand">Netcanon</a>
     <a href="/"            data-testid="nav-home"        {% if active_page == 'home' %}class="active" aria-current="page"{% endif %}>Dashboard</a>
@@ -390,7 +406,7 @@
       <span class="sun"  aria-hidden="true">&#x2600;</span>
     </button>
   </nav>
-  <main>
+  <main id="main">
     {% block content %}{% endblock %}
   </main>
 

--- a/netcanon/templates/configs.html
+++ b/netcanon/templates/configs.html
@@ -13,8 +13,8 @@
 <table data-testid="configs-table">
   <thead>
     <tr>
-      <th>Filename</th><th>Device Type</th><th>Host</th>
-      <th>Captured</th><th>Size</th><th>Actions</th>
+      <th scope="col">Filename</th><th scope="col">Device Type</th><th scope="col">Host</th>
+      <th scope="col">Captured</th><th scope="col">Size</th><th scope="col">Actions</th>
     </tr>
   </thead>
   <tbody>

--- a/netcanon/templates/definitions.html
+++ b/netcanon/templates/definitions.html
@@ -303,8 +303,8 @@
     <table data-testid="definitions-table">
       <thead>
         <tr>
-          <th>Type Key</th><th>Vendor</th><th>OS</th>
-          <th>Collection</th><th>File Ext</th><th>Priority</th><th>Notes</th>
+          <th scope="col">Type Key</th><th scope="col">Vendor</th><th scope="col">OS</th>
+          <th scope="col">Collection</th><th scope="col">File Ext</th><th scope="col">Priority</th><th scope="col">Notes</th>
         </tr>
       </thead>
       <tbody>
@@ -370,8 +370,8 @@
     <table data-testid="overlays-table">
       <thead>
         <tr>
-          <th>Type Key</th><th>OS Version</th><th>Model</th>
-          <th>Priority</th><th>File</th>
+          <th scope="col">Type Key</th><th scope="col">OS Version</th><th scope="col">Model</th>
+          <th scope="col">Priority</th><th scope="col">File</th>
         </tr>
       </thead>
       <tbody>
@@ -616,8 +616,8 @@
                style="margin-top:.25rem">
           <thead>
             <tr>
-              <th>Codec</th><th>Direction</th><th>Certainty</th>
-              <th>Input format</th><th>Paths</th>
+              <th scope="col">Codec</th><th scope="col">Direction</th><th scope="col">Certainty</th>
+              <th scope="col">Input format</th><th scope="col">Paths</th>
             </tr>
           </thead>
           <tbody>

--- a/netcanon/templates/devices.html
+++ b/netcanon/templates/devices.html
@@ -269,10 +269,10 @@
       <table style="margin-top:.25rem">
         <thead>
           <tr>
-            <th>Filename</th>
-            <th>Captured</th>
-            <th>Size</th>
-            <th>Actions</th>
+            <th scope="col">Filename</th>
+            <th scope="col">Captured</th>
+            <th scope="col">Size</th>
+            <th scope="col">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/netcanon/templates/index.html
+++ b/netcanon/templates/index.html
@@ -13,7 +13,8 @@
       <div class="form-row device-entry" data-testid="device-entry">
         <div class="form-group" style="flex:0 0 auto;min-width:160px">
           <label>Device Profile</label>
-          <select name="device_profile_id" data-testid="device-profile-select">
+          <select name="device_profile_id" data-testid="device-profile-select"
+                  aria-label="Device Profile">
             <option value="">— new device —</option>
             {% for profile in device_profiles %}
             <option value="{{ profile.id }}"
@@ -29,6 +30,7 @@
         <div class="form-group">
           <label>Device Type</label>
           <select name="type_key" data-testid="device-type-select"
+                  aria-label="Device Type"
                   title="Vendor + OS family that determines how Netcanon connects (Paramiko shell vs Netmiko), what config command to run, and how to parse the output.">
             {% for key, def in definitions.items() | sort %}
             <option value="{{ key }}"
@@ -42,18 +44,21 @@
           <label>Host / IP</label>
           <input name="host" type="text" placeholder="192.168.1.1"
                  data-testid="device-host-input" required
+                 aria-label="Host or IP address"
                  title="IPv4 (192.168.1.1), IPv6 (2001:db8::1), or RFC-1123 hostname (core-sw-01.example.com).">
         </div>
         <div class="form-group">
           <label>Username</label>
           <input name="username" type="text" placeholder="admin"
                  data-testid="device-username-input" required
+                 aria-label="Username"
                  title="SSH login. Common defaults: admin (most vendors), netadmin (Aruba), root (OPNsense). Use a service account in production.">
         </div>
         <div class="form-group">
           <label>Password</label>
           <input name="password" type="password"
                  data-testid="device-password-input" required
+                 aria-label="Password"
                  title="SSH password. Encrypted at rest with Fernet — see SECURITY.md → Credential Storage for the resolution chain.">
         </div>
         <!-- Enable password: shown only when the selected definition requires it -->
@@ -61,6 +66,7 @@
           <label>Enable Password</label>
           <input name="enable_password" type="password"
                  placeholder="optional" data-testid="device-enable-input"
+                 aria-label="Enable Password"
                  title="Privileged-mode (enable / superuser) password. Only required when the selected Device Type's definition sets needs_enable=true (Cisco IOS, FortiOS, …). Auto-shows when needed.">
         </div>
         <!-- Port collapsed under Advanced; rarely needs changing from 22 -->
@@ -106,7 +112,7 @@
          {% if not recent_jobs %}style="display:none"{% endif %}>
     <thead>
       <tr>
-        <th>Job ID</th><th>Status</th><th>Success / Total</th><th>Created</th>
+        <th scope="col">Job ID</th><th scope="col">Status</th><th scope="col">Success / Total</th><th scope="col">Created</th>
       </tr>
     </thead>
     <tbody id="jobs-tbody">

--- a/netcanon/templates/jobs.html
+++ b/netcanon/templates/jobs.html
@@ -100,11 +100,11 @@
     <table class="job-results-table">
       <thead>
         <tr>
-          <th>Device Type</th>
-          <th>Host</th>
-          <th>Result</th>
-          <th>Config file</th>
-          <th>Duration</th>
+          <th scope="col">Device Type</th>
+          <th scope="col">Host</th>
+          <th scope="col">Result</th>
+          <th scope="col">Config file</th>
+          <th scope="col">Duration</th>
         </tr>
       </thead>
       <tbody>

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -327,14 +327,14 @@
 <form id="mig-form" class="mig-form" data-testid="migrate-form">
   <div class="mig-pair-row">
     <div class="form-group">
-      <label for="mig-source">Source adapter</label>
+      <label for="mig-source">Source vendor</label>
       <select id="mig-source" name="source"
               data-testid="migrate-source-select" required
               title="What format your input is in. Cisco IOS-XE expects CLI text (show running-config); OPNsense expects XML (config.xml); Junos expects 'set'-form or block-form; FortiOS expects CLI (show full-configuration)."></select>
     </div>
     <span class="mig-arrow" aria-hidden="true">&rarr;</span>
     <div class="form-group">
-      <label for="mig-target">Target adapter</label>
+      <label for="mig-target">Target vendor</label>
       <select id="mig-target" name="target"
               data-testid="migrate-target-select" required
               title="What format Netcanon renders. Same-vendor (round-trip) and cross-vendor both supported. Capability gaps + Tier-3 sections that don't translate are surfaced inline after the run."></select>
@@ -372,13 +372,13 @@
     <textarea class="mig-raw" id="mig-raw" name="raw_text"
               data-testid="migrate-raw-input"
               spellcheck="false"
-              placeholder="Pick a source adapter above and a matching sample will appear here."></textarea>
+              placeholder="Pick a source vendor above and a matching sample will appear here."></textarea>
     <div style="display:flex;gap:.5rem;margin-top:.35rem">
       <button type="button" class="btn-secondary"
               data-testid="migrate-load-sample-btn"
               onclick="loadSampleForSourceAdapter()"
               style="font-size:.75rem;padding:.2rem .6rem">
-        Load sample for source adapter
+        Load sample for source vendor
       </button>
       <span style="font-size:.72rem;color:var(--text-faint);align-self:center">
         overwrites the textarea
@@ -1001,7 +1001,7 @@
   function applyPlaceholder(entry) {
     var ta = document.getElementById('mig-raw');
     ta.placeholder = entry.sample
-      ? 'Sample for this source adapter — click "Load sample" below to populate.'
+      ? 'Sample for this source vendor — click "Load sample" below to populate.'
       : 'No sample available for this input format.';
   }
 
@@ -1032,7 +1032,7 @@
     if (compatExts.length === 0) {
       warnEl.style.display = '';
       warnEl.innerHTML =
-        '⚠ Source adapter <code>' + escapeHtml(entry.codec)
+        '⚠ Source vendor <code>' + escapeHtml(entry.codec)
         + '</code> does not read files from the backup store. Pasting '
         + 'via the textarea is likely to work better.';
       return;

--- a/netcanon/templates/sanitize.html
+++ b/netcanon/templates/sanitize.html
@@ -171,10 +171,10 @@
              style="margin-top:.5rem">
         <thead>
           <tr>
-            <th>Category</th>
-            <th>Field</th>
-            <th>Original</th>
-            <th>Redacted</th>
+            <th scope="col">Category</th>
+            <th scope="col">Field</th>
+            <th scope="col">Original</th>
+            <th scope="col">Redacted</th>
           </tr>
         </thead>
         <tbody id="san-audit-tbody"></tbody>

--- a/netcanon/templates/schedules.html
+++ b/netcanon/templates/schedules.html
@@ -114,13 +114,13 @@
   <table data-testid="schedules-table">
     <thead>
       <tr>
-        <th>Name</th>
-        <th>Interval</th>
-        <th>Status</th>
-        <th>Next run</th>
-        <th>Last run</th>
-        <th>Last job</th>
-        <th>Actions</th>
+        <th scope="col">Name</th>
+        <th scope="col">Interval</th>
+        <th scope="col">Status</th>
+        <th scope="col">Next run</th>
+        <th scope="col">Last run</th>
+        <th scope="col">Last job</th>
+        <th scope="col">Actions</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Final fix batch from the wide UI/UX review (`docs/reviews/2026-06-16-ux-review/`) — **completes the MF-1…MF-20 fix-plan**. Mechanical, multi-site, behaviour-preserving; live-verified.

## Changes
| MF | Severity | What | File(s) |
|----|----------|------|---------|
| **MF-8** | minor (a11y) | `scope="col"` on all **49** column `<th>` (44 static + 5 built in the rename-table JS partials); visually-hidden-until-focused **skip-link** as `<body>`'s first child → new `id="main"` on `<main>`, plus the `.sr-only` utility. | `base.html` + all table templates/partials |
| **MF-12** | minor (a11y) | Accessible names for the dashboard backup-form controls. The device-entry row is JS-cloned (`cloneNode`), so static `for`/`id` would collide and wrapping would break the stacked flex layout — used `aria-label` on each of the 6 controls (visible `<label>` stays as caption). | `index.html` |
| **MF-14** | minor | Converge the Migrate flow's visible "Source/Target adapter" → "Source/Target vendor" (matches Sanitize). Labels + JS-set placeholder + file-store warning + Load-sample button. Routes/testids/API fields (`source`/`target`, `entry.codec`) unchanged. | `migrate.html` |

## Live verification (preview on :8765)
- **MF-8 scope** — all 6 `configs-table` `<th>` resolve `scope="col"` (confirmed across templates: 0 bare `<th>` remain, 49 scoped). ✅
- **MF-8 skip-link** — present, **first focusable**, hidden by default (`.sr-only`, rect 1×1), `href="#main"`; `main#main` exists. The reveal-on-focus rule (`.skip-link:focus { width:auto; position:fixed; z-index:10002 }`) is present + correct; its visual reveal can't be observed in the headless preview because the tab lacks window focus (`document.hasFocus()===false` → `:focus` pseudo doesn't engage — same env limitation as `preview_screenshot` hanging). ✅
- **MF-12** — all 6 dashboard controls report `aria-label` (Device Profile / Device Type / Host or IP address / Username / Password / Enable Password). ✅
- **MF-14** — migrate labels now "Source vendor"/"Target vendor"; placeholder + Load-sample button + warning all say "vendor". ✅
- No console errors.

## Gate
- `ruff check netcanon tests` — clean
- `pytest tests/integration` — all pass (1 skip)
- No test breaks: `test_migration_api.py` asserts "source adapter" in a **server-side API error** (unchanged Python); doc/testid references describe the control's internal role, not the visible label.

> Implementation note: the `scope="col"` sweep was applied with a reviewed bulk `sed` (44 identical edits across 12 files); the full diff was reviewed and line-ending-only noise on untouched files reverted.

Detail + `file:line` in `docs/reviews/2026-06-16-ux-review/{30-review-adversarial,99-synthesis}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)