### PR TITLE
fix(definitions): stop DefinitionLoader validating target_profiles/ as device defs

### DIFF
--- a/netcanon/definitions/loader.py
+++ b/netcanon/definitions/loader.py
@@ -63,13 +63,29 @@ from .schema import DeviceDefinition
 
 logger = logging.getLogger(__name__)
 
+#: Immediate-child directory names under ``definitions_dir`` that hold
+#: YAML owned by a *different* loader and a *different* schema, and must
+#: NOT be validated as ``DeviceDefinition`` files.  ``target_profiles/``
+#: holds Tier-3 port-rename profiles loaded by
+#: :func:`netcanon.migration.target_profiles.load_profiles_dir` (a
+#: ``TargetProfile`` is shaped nothing like a ``DeviceDefinition`` — no
+#: ``os`` / ``type_key`` / ``connection`` / ``commands``).  Because
+#: ``load_all`` scans recursively, without this exclusion every
+#: target-profile file fails ``DeviceDefinition`` validation and emits a
+#: spurious WARNING at boot — noise that would mask a genuine bad
+#: definition.  See ``netcanon/main.py`` where both loaders are wired to
+#: the same ``definitions_dir`` root.
+_RESERVED_SUBDIRS: frozenset[str] = frozenset({"target_profiles"})
+
 
 class DefinitionLoader:
     """Loads and validates device definitions from a YAML file tree.
 
     Args:
         definitions_dir: Root of the definition tree.  All ``*.yaml``
-            files found recursively are candidates for loading.
+            files found recursively are candidates for loading, except
+            those under a reserved sibling subdirectory (see
+            :data:`_RESERVED_SUBDIRS`, e.g. ``target_profiles/``).
 
     Raises:
         FileNotFoundError: If ``definitions_dir`` does not exist.
@@ -89,7 +105,12 @@ class DefinitionLoader:
         This keeps backwards compatibility with callers that treat
         ``load_all()`` as "one entry per type_key".
 
-        Files are parsed in two passes:
+        Files under a reserved sibling subdirectory (see
+        :data:`_RESERVED_SUBDIRS`, e.g. ``target_profiles/``) are skipped
+        entirely — they belong to a different loader/schema and would
+        otherwise log spurious validation warnings at boot.
+
+        Remaining files are parsed in two passes:
 
         1. All files are read and validated against ``DeviceDefinition``.
            Failures emit a ``WARNING`` log and are skipped.
@@ -113,7 +134,11 @@ class DefinitionLoader:
                 f"Definitions directory not found: {self._dir.resolve()}"
             )
 
-        yaml_files = sorted(self._dir.rglob("*.yaml"))
+        yaml_files = [
+            path
+            for path in sorted(self._dir.rglob("*.yaml"))
+            if not self._in_reserved_subdir(path)
+        ]
         if not yaml_files:
             raise RuntimeError(
                 f"No *.yaml definition files found under: {self._dir.resolve()}"
@@ -272,6 +297,23 @@ class DefinitionLoader:
 
         definition.source_file = path
         return definition
+
+    def _in_reserved_subdir(self, path: Path) -> bool:
+        """True when *path* lives under a reserved sibling subdirectory.
+
+        Reserved subdirs (see :data:`_RESERVED_SUBDIRS`) hold YAML owned
+        by a different loader/schema and must be skipped so they don't
+        fail ``DeviceDefinition`` validation.  Matching is on any path
+        component relative to ``self._dir``, so an arbitrarily nested
+        ``target_profiles/.../x.yaml`` is excluded too.
+        """
+        try:
+            rel = path.relative_to(self._dir)
+        except ValueError:
+            # Not under our root (shouldn't happen for rglob results) —
+            # don't exclude it.
+            return False
+        return any(part in _RESERVED_SUBDIRS for part in rel.parts)
 
 
 def _highest_priority(

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -6,6 +6,7 @@ two-pass loader: parse → sort by priority → apply in order.
 """
 from __future__ import annotations
 
+import logging
 import textwrap
 from pathlib import Path
 
@@ -95,6 +96,19 @@ MISSING_COMMANDS = textwrap.dedent("""\
     collector:
       strategy: netmiko
       netmiko_device_type: bad_device
+""")
+
+# Shaped like a real definitions/target_profiles/*.yaml — a TargetProfile,
+# NOT a DeviceDefinition (no os/type_key/connection/commands).  Validating
+# it as a DeviceDefinition would fail; the loader must skip it instead.
+TARGET_PROFILE = textwrap.dedent("""\
+    vendor: opnsense
+    model: generic
+    display_name: "OPNsense generic"
+    device_class: firewall
+    ports:
+      - {id: "em0", kind: physical}
+      - {id: "em1", kind: physical}
 """)
 
 
@@ -451,3 +465,70 @@ class TestResolveLongestMatch:
         # tier-2 match (os_version=17.12, model=None) is preferred.
         assert hit is not None
         assert hit.notes == "overlay 17.12"
+
+
+# ---------------------------------------------------------------------------
+# Reserved sibling subdirectories (target_profiles/) are skipped
+# ---------------------------------------------------------------------------
+
+
+class TestLoaderReservedSubdirs:
+    """``target_profiles/`` under the definitions root holds TargetProfile
+    YAML owned by a different loader/schema.  ``load_all`` scans
+    recursively, so without an explicit exclusion those files fail
+    ``DeviceDefinition`` validation and emit a WARNING per file at boot.
+    The loader must skip the reserved subdir silently."""
+
+    def test_target_profiles_subdir_is_skipped(self, tmp_path: Path):
+        (tmp_path / "cisco.yaml").write_text(VALID_CISCO, encoding="utf-8")
+        tp = tmp_path / "target_profiles"
+        tp.mkdir()
+        (tp / "opnsense_generic.yaml").write_text(TARGET_PROFILE, encoding="utf-8")
+        profiles = DefinitionLoader(tmp_path).load_all()
+        # The real device def loads; the target profile is not mistaken
+        # for one (its vendor would key as "opnsense" / etc.).
+        assert "Cisco" in profiles
+        assert "opnsense" not in profiles
+        assert "generic" not in profiles
+
+    def test_target_profiles_emit_no_validation_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        (tmp_path / "cisco.yaml").write_text(VALID_CISCO, encoding="utf-8")
+        tp = tmp_path / "target_profiles"
+        tp.mkdir()
+        for i in range(3):
+            (tp / f"profile{i}.yaml").write_text(TARGET_PROFILE, encoding="utf-8")
+        with caplog.at_level(logging.WARNING, logger="netcanon.definitions.loader"):
+            DefinitionLoader(tmp_path).load_all()
+        assert "Validation error" not in caplog.text
+        assert "target_profiles" not in caplog.text
+
+    def test_nested_target_profiles_also_skipped(self, tmp_path: Path):
+        (tmp_path / "cisco.yaml").write_text(VALID_CISCO, encoding="utf-8")
+        nested = tmp_path / "target_profiles" / "vendor"
+        nested.mkdir(parents=True)
+        (nested / "deep.yaml").write_text(TARGET_PROFILE, encoding="utf-8")
+        profiles = DefinitionLoader(tmp_path).load_all()
+        assert "Cisco" in profiles
+        assert "opnsense" not in profiles
+
+    def test_only_target_profiles_raises_no_valid_definitions(
+        self, tmp_path: Path
+    ):
+        """A root holding *only* reserved-subdir files has no device
+        definitions — same RuntimeError as a genuinely empty tree."""
+        tp = tmp_path / "target_profiles"
+        tp.mkdir()
+        (tp / "opnsense_generic.yaml").write_text(TARGET_PROFILE, encoding="utf-8")
+        with pytest.raises(RuntimeError, match=r"No \*.yaml"):
+            DefinitionLoader(tmp_path).load_all()
+
+    def test_non_reserved_subdir_still_loads(self, tmp_path: Path):
+        """Exclusion is scoped to the reserved name only — other nested
+        dirs (e.g. cisco/ios-xe/) keep loading recursively."""
+        sub = tmp_path / "cisco" / "ios-xe"
+        sub.mkdir(parents=True)
+        (sub / "17.x.yaml").write_text(VALID_CISCO, encoding="utf-8")
+        profiles = DefinitionLoader(tmp_path).load_all()
+        assert "Cisco" in profiles


### PR DESCRIPTION
## What

`DefinitionLoader.load_all()` scans the definitions tree with `rglob("*.yaml")`, so it descended into `definitions/target_profiles/` and tried to validate each Tier-3 port-rename profile against the `DeviceDefinition` schema. Those files are `TargetProfile`-shaped (no `os` / `type_key` / `connection` / `commands`), so **every one failed validation and logged a WARNING at boot** — 54 spurious validation blocks (~216 log lines) on the shipped tree.

## Why it's harmless today but worth fixing

The target profiles are owned by a **separate** loader — `migration.target_profiles.load_profiles_dir`, which uses a non-recursive `glob` and the correct schema — and they load fine. So there was no functional impact: the Migrate UI's 54 target profiles work, and no device definition is dropped.

But 54 scary validation tracebacks at every startup is exactly the noise that would bury a *genuine* bad device definition. This is the out-of-scope observation logged during the UX review.

## Fix

- Add a documented module-level `_RESERVED_SUBDIRS = frozenset({"target_profiles"})` — immediate-child dirs under `definitions_dir` owned by a different loader/schema.
- `load_all()` skips any path under a reserved subdir (matched on any relative path component, so nested files are excluded too).
- **Recursion for real nested per-vendor definitions** (`cisco/ios-xe/17.x.yaml`, etc.) **is unchanged.**

## Verification

- New `TestLoaderReservedSubdirs` (5 cases): target_profiles skipped, **no** validation WARNING emitted, nested target_profiles also skipped, a root with *only* reserved files raises the existing `No *.yaml` RuntimeError, non-reserved nested dirs still load.
- Boot-log repro against the **shipped** `definitions/` tree before/after:
  - before: 54 `Validation error` WARNING blocks, all `target_profiles/*.yaml`
  - after: **0** warnings; all 7 device families load; all 54 target profiles still load via their own loader.
- `ruff` clean; full `tests/unit` + definitions/UI-routes integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)