### PR TITLE
feat(definitions): add backup defs for NX-OS, IOS-XR, AOS-CX, VyOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,21 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-16
+### Added
+- **Backup device definitions for NX-OS, IOS-XR, AOS-CX, and VyOS** —
+  closes the backup-vs-migrate coverage gap.  These four vendors had a
+  migration codec but no `definitions/` entry, so configs could be
+  *migrated* but not *backed up* from a live device.  New family bases:
+  `definitions/cisco/nx-os/10.x.yaml` (`type_key: CiscoNXOS`,
+  netmiko `cisco_nxos`), `definitions/cisco/ios-xr/7.x.yaml`
+  (`CiscoIOSXR`, `cisco_xr`), `definitions/aruba/aos-cx/10.x.yaml`
+  (`ArubaCX`, `aruba_aoscx`), and `definitions/vyos/vyos/1.x.yaml`
+  (`VyOS`, `vyos`, fetching `show configuration commands` set-form which
+  the vyos codec accepts).  Distinct `type_key`s avoid colliding with the
+  existing `Cisco` (IOS-XE) and `Aruba` (AOS-S) family bases.  Every
+  migration codec family now has a backup definition.  Each ships a
+  tested `show version` probe; per-definition unit tests under
+  `tests/unit/definitions/` lock in the collector wiring + probe regexes.
 
 Internal maintenance + refactor release.  **No change to migration
 output** — the codec work below is behaviour-preserving: the cross-mesh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ timestamp if your timezone matters for an audit.
   migration codec family now has a backup definition.  Each ships a
   tested `show version` probe; per-definition unit tests under
   `tests/unit/definitions/` lock in the collector wiring + probe regexes.
+  These four are **provisional**: the collection wiring is verified in
+  code and against sample output but has not yet been run against a live
+  device, so each carries a "NOT YET VALIDATED" marker in its `notes`
+  (surfaced in the `/definitions` Notes column).
 
 Internal maintenance + refactor release.  **No change to migration
 output** — the codec work below is behaviour-preserving: the cross-mesh

--- a/definitions/README.md
+++ b/definitions/README.md
@@ -199,6 +199,62 @@ only via `resolve()`.
   `netcanon/migration/codecs/arista_eos` for round-tripping
   ``show running-config``.
 
+### Cisco NX-OS 9.x / 10.x
+- `type_key: CiscoNXOS` — **not** `Cisco`.  The IOS-XE family base owns
+  the `Cisco` key, and `type_key`s must be unique (a collision silently
+  drops one definition).  NX-OS is a separate NOS, so it gets its own key.
+- `collector.netmiko_device_type: cisco_nxos` — netmiko disables paging
+  natively (NX-OS supports `terminal length 0`, unlike classic IOS/IOS-XE).
+- `connection.needs_enable: false` — the admin role lands straight in `#`.
+- `connection.cisco_more_paging: false` — the SPACE-injection flag is
+  IOS/IOS-XE-only and is ignored by the netmiko collector; do NOT add
+  `terminal length 0` to `commands.pre` (AGENTS.md hard rule — netmiko owns
+  paging).
+- `probe.command: show version` — captures `major.minor` from the modern
+  `NXOS: version 10.3(2)` / legacy `system: version 7.0(3)...` line, the
+  chassis SKU from the `cisco Nexus9000 <SKU> Chassis` line, and the
+  serial from `Processor Board ID`.
+- Pairs with the `cisco_nxos` migration codec.
+
+### Cisco IOS-XR 7.x
+- `type_key: CiscoIOSXR` — distinct from `Cisco`/`CiscoNXOS` for the same
+  uniqueness reason.
+- `collector.netmiko_device_type: cisco_xr` — netmiko disables paging
+  natively.
+- `connection.needs_enable: false` — IOS-XR has no enable mode (privilege
+  is task-group based); SSH lands in exec mode.
+- `connection.cisco_more_paging: false` — same rationale as NX-OS.
+- `probe.command: show version` — captures `major.minor` from
+  `Cisco IOS XR Software, Version 7.5.2` and the platform from the leading
+  `cisco ASR9K Series` / `cisco NCS-5501` processor line.
+- Pairs with the `cisco_iosxr` migration codec (ASR 9000 / NCS SP routers).
+
+### Aruba AOS-CX 10.x
+- `type_key: ArubaCX` — **not** `Aruba`.  `Aruba` belongs to the AOS-S
+  (ex-ProCurve) family base, a completely different NOS; AOS-CX is the
+  modern Linux-based switch OS.
+- `collector.netmiko_device_type: aruba_aoscx` — netmiko disables paging
+  natively (`no page`).
+- `connection.needs_enable: false` — SSH lands in manager `#`.
+- `connection.cisco_more_paging: false` — IOS/IOS-XE-only flag, ignored here.
+- `probe.command: show version` — captures `major.minor` from the
+  platform-prefixed `Version : FL.10.10.1000` line.  Model is not in
+  AOS-CX `show version` (it lives in `show system`), so it is not probed.
+- Pairs with the `aruba_aoscx` migration codec.
+
+### VyOS 1.3 / 1.4
+- `collector.netmiko_device_type: vyos` — netmiko's VyOS driver lands in
+  operational mode and disables the pager itself.
+- `connection.needs_enable: false` — no enable equivalent on VyOS.
+- `commands.config: "show configuration commands"` — emits flat `set ...`
+  lines (set-form).  The `vyos` migration codec accepts set-form natively
+  (its Phase-6 front-end converts it to the curly-brace tree before
+  parsing); `cat /config/config.boot` is an equivalent the codec also reads.
+- `file_extension: conf` — matches the `.conf` convention of the vyos
+  real-capture fixtures.
+- `probe.command: show version` — captures `major.minor` from
+  `Version: VyOS 1.4.0`, plus `Hardware model:` and `Hardware S/N:`.
+
 ---
 
 ## See also

--- a/definitions/README.md
+++ b/definitions/README.md
@@ -200,6 +200,9 @@ only via `resolve()`.
   ``show running-config``.
 
 ### Cisco NX-OS 9.x / 10.x
+- ⚠ **Not yet validated on live hardware** — the collection wiring is
+  verified in code and against sample `show version` output only; the
+  `/definitions` Notes column flags it.  Confirm on a real switch.
 - `type_key: CiscoNXOS` — **not** `Cisco`.  The IOS-XE family base owns
   the `Cisco` key, and `type_key`s must be unique (a collision silently
   drops one definition).  NX-OS is a separate NOS, so it gets its own key.
@@ -217,6 +220,9 @@ only via `resolve()`.
 - Pairs with the `cisco_nxos` migration codec.
 
 ### Cisco IOS-XR 7.x
+- ⚠ **Not yet validated on live hardware** — collection wiring verified in
+  code + against sample output only (Notes column flags it).  Confirm on a
+  real router.
 - `type_key: CiscoIOSXR` — distinct from `Cisco`/`CiscoNXOS` for the same
   uniqueness reason.
 - `collector.netmiko_device_type: cisco_xr` — netmiko disables paging
@@ -230,6 +236,9 @@ only via `resolve()`.
 - Pairs with the `cisco_iosxr` migration codec (ASR 9000 / NCS SP routers).
 
 ### Aruba AOS-CX 10.x
+- ⚠ **Not yet validated on live hardware** — collection wiring verified in
+  code + against sample output only (Notes column flags it).  Confirm on a
+  real switch.
 - `type_key: ArubaCX` — **not** `Aruba`.  `Aruba` belongs to the AOS-S
   (ex-ProCurve) family base, a completely different NOS; AOS-CX is the
   modern Linux-based switch OS.
@@ -243,6 +252,9 @@ only via `resolve()`.
 - Pairs with the `aruba_aoscx` migration codec.
 
 ### VyOS 1.3 / 1.4
+- ⚠ **Not yet validated on live hardware** — collection wiring verified in
+  code + against sample output only (Notes column flags it).  Confirm on a
+  real router.
 - `collector.netmiko_device_type: vyos` — netmiko's VyOS driver lands in
   operational mode and disables the pager itself.
 - `connection.needs_enable: false` — no enable equivalent on VyOS.

--- a/definitions/aruba/aos-cx/10.x.yaml
+++ b/definitions/aruba/aos-cx/10.x.yaml
@@ -1,0 +1,57 @@
+# Aruba AOS-CX 10.x  (CX 6000 / 8000 / 10000 series)
+#
+# Pairs with the migration codec at netcanon/migration/codecs/aruba_aoscx.
+# This file is what the backup pipeline uses to *fetch* the running-config
+# from a live AOS-CX switch.
+#
+# type_key is ArubaCX — NOT "Aruba".  The "Aruba" type_key belongs to the
+# AOS-S (ex-ProCurve) family base, which is a completely different NOS.
+# AOS-CX is the modern Linux-based switch OS and gets its own key.
+#
+# Paging — netmiko's `aruba_aoscx` driver disables paging itself at session
+# setup (AOS-CX uses `no page`).  cisco_more_paging (SPACE-injection) is
+# IOS/IOS-XE-only and ignored by the netmiko collector, so it stays false.
+
+vendor: Aruba
+os: AOS-CX
+version_match: "^10\\."       # advisory/future; AOS-CX 10.x trains (FL/GL/etc platform builds)
+type_key: ArubaCX
+priority: 10
+
+file_extension: cfg
+
+connection:
+  needs_enable: false         # AOS-CX SSH lands in manager '#'; no enable-mode escalation
+  cisco_more_paging: false    # netmiko aruba_aoscx disables paging natively (`no page`)
+  opnsense_shell_menu: false
+
+commands:
+  pre: []
+  config: "show running-config"
+  post: []
+
+prompts:
+  trailing:
+    - '^\S+[#>]\s*$'          # switch#  /  switch>
+
+collector:
+  strategy: netmiko
+  netmiko_device_type: aruba_aoscx
+
+probe:
+  # Pre-backup `show version` probe.  AOS-CX reports the firmware build on a
+  # `Version      : FL.10.10.1000` line (a two-letter platform prefix then
+  # the AOS-CX version).  Capture the 10.x major.minor so a future overlay
+  # (`os_version: "10.10"`) resolves.  Model is not in `show version` on
+  # AOS-CX (it lives in `show system`), so it is intentionally not probed
+  # here — version is the high-value fact for overlay selection.  Failure is
+  # non-fatal.
+  command: "show version"
+  patterns:
+    detected_os_version: 'Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)'
+
+notes: >
+  Aruba AOS-CX 10.x (CX 6000/8000/10000) — the modern Linux-based switch OS,
+  distinct from AOS-S (ex-ProCurve, the "Aruba" type_key).  Pairs with the
+  aruba_aoscx migration codec for round-tripping `show running-config`.
+  netmiko's `aruba_aoscx` driver handles paging natively; no enable mode.

--- a/definitions/aruba/aos-cx/10.x.yaml
+++ b/definitions/aruba/aos-cx/10.x.yaml
@@ -51,7 +51,12 @@ probe:
     detected_os_version: 'Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)'
 
 notes: >
-  Aruba AOS-CX 10.x (CX 6000/8000/10000) — the modern Linux-based switch OS,
-  distinct from AOS-S (ex-ProCurve, the "Aruba" type_key).  Pairs with the
-  aruba_aoscx migration codec for round-tripping `show running-config`.
-  netmiko's `aruba_aoscx` driver handles paging natively; no enable mode.
+  ⚠ NOT YET VALIDATED on a live device — the backup-collection wiring
+  (netmiko driver, config command, prompt patterns, probe regex) is
+  verified in code and against sample `show version` output only, never
+  run against real hardware.  Treat as provisional and confirm on a real
+  switch before relying on it.  Aruba AOS-CX 10.x (CX 6000/8000/10000) —
+  the modern Linux-based switch OS, distinct from AOS-S (ex-ProCurve, the
+  "Aruba" type_key).  Pairs with the aruba_aoscx migration codec for
+  round-tripping `show running-config`.  netmiko's `aruba_aoscx` driver
+  handles paging natively; no enable mode.

--- a/definitions/cisco/ios-xr/7.x.yaml
+++ b/definitions/cisco/ios-xr/7.x.yaml
@@ -54,7 +54,11 @@ probe:
     detected_model: '^cisco\s+(\S+)'
 
 notes: >
-  Cisco IOS-XR 7.x (ASR 9000 / NCS SP routers).  Pairs with the cisco_iosxr
-  migration codec for round-tripping `show running-config`.  netmiko's
-  `cisco_xr` driver handles paging natively; IOS-XR has no enable mode
-  (privilege is task-group based).
+  ⚠ NOT YET VALIDATED on a live device — the backup-collection wiring
+  (netmiko driver, config command, prompt patterns, probe regexes) is
+  verified in code and against sample `show version` output only, never
+  run against real hardware.  Treat as provisional and confirm on a real
+  router before relying on it.  Cisco IOS-XR 7.x (ASR 9000 / NCS SP
+  routers).  Pairs with the cisco_iosxr migration codec for round-tripping
+  `show running-config`.  netmiko's `cisco_xr` driver handles paging
+  natively; IOS-XR has no enable mode (privilege is task-group based).

--- a/definitions/cisco/ios-xr/7.x.yaml
+++ b/definitions/cisco/ios-xr/7.x.yaml
@@ -1,0 +1,60 @@
+# Cisco IOS-XR 7.x  (ASR 9000 / NCS service-provider routers)
+#
+# Pairs with the migration codec at netcanon/migration/codecs/cisco_iosxr.
+# This file is what the backup pipeline uses to *fetch* the running-config
+# from a live IOS-XR router.
+#
+# type_key is CiscoIOSXR — NOT "Cisco" (owned by the IOS-XE family base).
+# type_keys must be unique across the family-base set; IOS-XR is a distinct
+# NOS and gets its own key.
+#
+# Paging — netmiko's `cisco_xr` driver disables paging itself at session
+# setup (IOS-XR supports `terminal length 0` natively).  cisco_more_paging
+# (our SPACE-injection mechanism) is IOS/IOS-XE-only and ignored by the
+# netmiko collector, so it stays false.  Do NOT add `terminal length 0` to
+# commands.pre — netmiko owns paging.
+
+vendor: Cisco
+os: IOS-XR
+version_match: "^7\\."        # advisory/future; current IOS-XR 7.x train
+type_key: CiscoIOSXR
+priority: 10
+
+file_extension: cfg
+
+connection:
+  needs_enable: false         # IOS-XR SSH lands in exec mode; no enable-mode escalation
+  cisco_more_paging: false    # netmiko cisco_xr disables paging natively
+  opnsense_shell_menu: false
+
+commands:
+  pre: []
+  config: "show running-config"
+  post: []
+
+prompts:
+  trailing:
+    - '^RP/\S+:\S+#\s*$'      # RP/0/RP0/CPU0:hostname#
+    - '^\S+[#>]\s*$'          # generic fallback
+
+collector:
+  strategy: netmiko
+  netmiko_device_type: cisco_xr
+
+probe:
+  # Pre-backup `show version` probe.  Populates DeviceProfile.detected_facts
+  # and feeds DefinitionLoader.resolve().  Failure is non-fatal.
+  command: "show version"
+  patterns:
+    # `Cisco IOS XR Software, Version 7.5.2` (XR7 adds a trailing ` LNT`).
+    # Capture major.minor only to match an overlay's `os_version: "7.5"` pin.
+    detected_os_version: 'Cisco IOS XR Software, Version\s+(\d+\.\d+)'
+    # Platform from the leading `cisco ASR9K Series ...` / `cisco NCS-5501 ...`
+    # processor line.  Anchored multiline; first token after `cisco`.
+    detected_model: '^cisco\s+(\S+)'
+
+notes: >
+  Cisco IOS-XR 7.x (ASR 9000 / NCS SP routers).  Pairs with the cisco_iosxr
+  migration codec for round-tripping `show running-config`.  netmiko's
+  `cisco_xr` driver handles paging natively; IOS-XR has no enable mode
+  (privilege is task-group based).

--- a/definitions/cisco/nx-os/10.x.yaml
+++ b/definitions/cisco/nx-os/10.x.yaml
@@ -58,7 +58,12 @@ probe:
     detected_serial: 'Processor Board ID\s+(\S+)'
 
 notes: >
-  Cisco NX-OS 9.x / 10.x (Nexus 3000 / 9000).  Pairs with the cisco_nxos
-  migration codec for round-tripping `show running-config`.  netmiko's
-  `cisco_nxos` driver handles paging natively (it sends `terminal length 0`
-  at session setup); no enable mode on NX-OS.
+  ⚠ NOT YET VALIDATED on a live device — the backup-collection wiring
+  (netmiko driver, config command, prompt patterns, probe regexes) is
+  verified in code and against sample `show version` output only, never
+  run against real hardware.  Treat as provisional and confirm on a real
+  switch before relying on it.  Cisco NX-OS 9.x / 10.x (Nexus 3000 / 9000).
+  Pairs with the cisco_nxos migration codec for round-tripping
+  `show running-config`.  netmiko's `cisco_nxos` driver handles paging
+  natively (it sends `terminal length 0` at session setup); no enable
+  mode on NX-OS.

--- a/definitions/cisco/nx-os/10.x.yaml
+++ b/definitions/cisco/nx-os/10.x.yaml
@@ -1,0 +1,64 @@
+# Cisco NX-OS 9.x / 10.x  (Nexus 3000 / 9000 series)
+#
+# Pairs with the migration codec at netcanon/migration/codecs/cisco_nxos.
+# This file is what the backup pipeline uses to *fetch* the running-config
+# from a live Nexus switch so the codec has real text to round-trip.
+#
+# type_key is CiscoNXOS — NOT "Cisco".  The IOS-XE family base already owns
+# the "Cisco" type_key, and type_keys must be unique across the family-base
+# set (a collision would silently drop one definition).  NX-OS is a distinct
+# NOS with its own session behaviour, so it gets its own key.
+#
+# Paging — netmiko's `cisco_nxos` driver disables paging itself at session
+# setup (NX-OS supports `terminal length 0` natively, unlike classic IOS/
+# IOS-XE).  cisco_more_paging (our SPACE-injection mechanism) is documented
+# as IOS/IOS-XE-only and is ignored by the netmiko collector, so it stays
+# false here.  Do NOT add `terminal length 0` to commands.pre — netmiko owns
+# paging, and the AGENTS.md hard rule forbids us issuing it ourselves.
+
+vendor: Cisco
+os: NX-OS
+version_match: "^(9|10)\\."   # advisory/future; covers the current 9.x + 10.x trains
+type_key: CiscoNXOS
+priority: 10
+
+file_extension: cfg
+
+connection:
+  needs_enable: false         # NX-OS logs the admin role straight into '#'; no enable mode
+  cisco_more_paging: false    # netmiko cisco_nxos disables paging natively
+  opnsense_shell_menu: false
+
+commands:
+  pre: []
+  config: "show running-config"
+  post: []
+
+prompts:
+  trailing:
+    - '^\S+[#>]\s*$'          # switch#  /  switch(config)#  (no spaces → \S+ matches)
+
+collector:
+  strategy: netmiko
+  netmiko_device_type: cisco_nxos
+
+probe:
+  # Pre-backup `show version` probe.  Populates DeviceProfile.detected_facts
+  # and feeds DefinitionLoader.resolve() so a future version overlay (e.g.
+  # 10.3.yaml) is picked when the device reports it.  Failure is non-fatal.
+  command: "show version"
+  patterns:
+    # Modern NX-OS reports `  NXOS: version 10.3(2)`; older boxes report
+    # `  system:    version 7.0(3)I7(8)`.  Capture major.minor only so it
+    # matches an overlay's `os_version: "10.3"` pin.
+    detected_os_version: '(?:NXOS|system):\s+version\s+(\d+\.\d+)'
+    # Chassis SKU from the `cisco Nexus9000 C93180YC-EX Chassis` line.
+    detected_model: 'cisco Nexus\S*\s+(\S+)\s+[Cc]hassis'
+    # Serial from the `Processor Board ID FDO12345ABC` line (asset audit).
+    detected_serial: 'Processor Board ID\s+(\S+)'
+
+notes: >
+  Cisco NX-OS 9.x / 10.x (Nexus 3000 / 9000).  Pairs with the cisco_nxos
+  migration codec for round-tripping `show running-config`.  netmiko's
+  `cisco_nxos` driver handles paging natively (it sends `terminal length 0`
+  at session setup); no enable mode on NX-OS.

--- a/definitions/vyos/vyos/1.x.yaml
+++ b/definitions/vyos/vyos/1.x.yaml
@@ -1,0 +1,60 @@
+# VyOS 1.3 (equuleus) / 1.4 (sagitta)
+#
+# Pairs with the migration codec at netcanon/migration/codecs/vyos.  This
+# file is what the backup pipeline uses to *fetch* the configuration from a
+# live VyOS router/firewall (the OSS Vyatta-successor NOS).
+#
+# Config form — netmiko's `vyos` driver lands in operational mode.  We run
+# `show configuration commands`, which emits the config as flat `set ...`
+# lines (set-form).  The vyos codec accepts set-form natively (its Phase-6
+# `_setform_to_brace` front-end converts it before the brace-stack walker
+# runs), so the backup pairs cleanly with the codec.  `cat /config/config.boot`
+# (the curly-brace form) is an equivalent alternative the codec also accepts,
+# but `show configuration commands` is operational-mode-native and makes no
+# filesystem-path assumption.
+#
+# Paging — netmiko's `vyos` driver disables the operational pager itself.
+# cisco_more_paging (SPACE-injection) is IOS/IOS-XE-only and stays false.
+
+vendor: VyOS
+os: VyOS
+version_match: "^1\\."        # advisory/future; VyOS 1.3 / 1.4
+type_key: VyOS
+priority: 10
+
+file_extension: conf          # matches the .conf convention used by the vyos real-capture fixtures
+
+connection:
+  needs_enable: false         # VyOS SSH lands in operational mode ('$'); no enable equivalent
+  cisco_more_paging: false    # netmiko vyos disables the operational pager natively
+  opnsense_shell_menu: false
+
+commands:
+  pre: []
+  config: "show configuration commands"   # set-form; the vyos codec accepts it (Phase 6)
+  post: []
+
+prompts:
+  trailing:
+    - '^\S+@\S+:.*[$#]\s*$'   # vyos@hostname:~$  (operational mode; '#' if logged in as root)
+
+collector:
+  strategy: netmiko
+  netmiko_device_type: vyos
+
+probe:
+  # Pre-backup `show version` probe.  VyOS reports the release on a
+  # `Version:          VyOS 1.4.0` line and the platform on `Hardware model:`.
+  # Capture major.minor so a future overlay (`os_version: "1.4"`) resolves.
+  # Failure is non-fatal.
+  command: "show version"
+  patterns:
+    detected_os_version: 'Version:\s+VyOS\s+(\d+\.\d+)'
+    detected_model: '^Hardware model:\s+(.+?)\s*$'
+    detected_serial: '^Hardware S/N:\s+(\S+)'
+
+notes: >
+  VyOS 1.3 (equuleus) / 1.4 (sagitta).  Pairs with the vyos migration codec.
+  Backup uses `show configuration commands` (set-form) over netmiko's `vyos`
+  driver in operational mode; the codec converts set-form to its curly-brace
+  tree on parse.  No enable mode on VyOS.

--- a/definitions/vyos/vyos/1.x.yaml
+++ b/definitions/vyos/vyos/1.x.yaml
@@ -54,7 +54,12 @@ probe:
     detected_serial: '^Hardware S/N:\s+(\S+)'
 
 notes: >
-  VyOS 1.3 (equuleus) / 1.4 (sagitta).  Pairs with the vyos migration codec.
-  Backup uses `show configuration commands` (set-form) over netmiko's `vyos`
-  driver in operational mode; the codec converts set-form to its curly-brace
-  tree on parse.  No enable mode on VyOS.
+  ⚠ NOT YET VALIDATED on a live device — the backup-collection wiring
+  (netmiko driver, config command, prompt patterns, probe regexes) is
+  verified in code and against sample `show version` output only, never
+  run against real hardware.  Treat as provisional and confirm on a real
+  router before relying on it.  VyOS 1.3 (equuleus) / 1.4 (sagitta).
+  Pairs with the vyos migration codec.  Backup uses
+  `show configuration commands` (set-form) over netmiko's `vyos` driver in
+  operational mode; the codec converts set-form to its curly-brace tree on
+  parse.  No enable mode on VyOS.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -38,8 +38,12 @@ tests.  Backup-side device definitions are listed under
 | `opnsense`        | OPNsense      | `config.xml`              | bidirectional | certified |
 | `vyos`            | VyOS          | `config.boot` curly-brace **or** `set`-form text | bidirectional | certified (Phases 1-6 — `system host-name` + ethernet / loopback / dummy interfaces (address IPv4+IPv6 CIDR / `dhcp` / description / `disable` / mtu) + `vif` VLAN sub-interfaces (`ethN.<vid>`) + `protocols static` routes + `system login` local users + `system`/`service` ntp servers (bare + 1.4 block form) + `bonding` LAGs (`mode 802.3ad` LACP + both member forms) + `service snmp` (v1/v2c community / location / contact + v3 USM users) + VRF (`vrf name` routing-instances + per-interface `vrf` binding) + `interfaces vxlan` netdevs (one VNI each — vni / source / mcast or remote / port); round-trip-validated against a 10-config real corpus from 4 sources spanning VyOS 1.3/1.4/1.5 (`cisagov/prescup-challenges` MIT IPv4/OSPF + IPv6/BGP, `zhouleyan/wcni-kind` Apache-2.0 VXLAN pair, `scottlaird/vyos-parser` + `rapid7/metasploit-framework` for `service snmp`); accepts BOTH the native curly-brace `config.boot` AND `set`-form input (`show configuration commands`, converted to curly-brace up front; the probe disambiguates VyOS set-form from the `set`-form `juniper_junos` codec); per-VRF static routes + symmetric-IRB L3VNI remain later phases) |
 
-Backup-side device-definition YAMLs ship for the same vendor families
-plus per-OS-version overlays.  See
+Backup-side device-definition YAMLs ship for every codec family above
+(plus per-OS-version overlays), so any vendor you can migrate you can
+also back up.  Cisco and Aruba each span two NOSes with separate
+definitions — `Cisco` (IOS-XE) + `CiscoNXOS` + `CiscoIOSXR`, and `Aruba`
+(AOS-S) + `ArubaCX` (AOS-CX) — keyed distinctly because `type_key` must
+be unique.  See
 [`../definitions/README.md`](../definitions/README.md) for the
 authoring guide and the live `/definitions` page in the running app
 for the per-vendor inventory.  RESULTS.md is the source of truth for

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -39,11 +39,14 @@ tests.  Backup-side device definitions are listed under
 | `vyos`            | VyOS          | `config.boot` curly-brace **or** `set`-form text | bidirectional | certified (Phases 1-6 — `system host-name` + ethernet / loopback / dummy interfaces (address IPv4+IPv6 CIDR / `dhcp` / description / `disable` / mtu) + `vif` VLAN sub-interfaces (`ethN.<vid>`) + `protocols static` routes + `system login` local users + `system`/`service` ntp servers (bare + 1.4 block form) + `bonding` LAGs (`mode 802.3ad` LACP + both member forms) + `service snmp` (v1/v2c community / location / contact + v3 USM users) + VRF (`vrf name` routing-instances + per-interface `vrf` binding) + `interfaces vxlan` netdevs (one VNI each — vni / source / mcast or remote / port); round-trip-validated against a 10-config real corpus from 4 sources spanning VyOS 1.3/1.4/1.5 (`cisagov/prescup-challenges` MIT IPv4/OSPF + IPv6/BGP, `zhouleyan/wcni-kind` Apache-2.0 VXLAN pair, `scottlaird/vyos-parser` + `rapid7/metasploit-framework` for `service snmp`); accepts BOTH the native curly-brace `config.boot` AND `set`-form input (`show configuration commands`, converted to curly-brace up front; the probe disambiguates VyOS set-form from the `set`-form `juniper_junos` codec); per-VRF static routes + symmetric-IRB L3VNI remain later phases) |
 
 Backup-side device-definition YAMLs ship for every codec family above
-(plus per-OS-version overlays), so any vendor you can migrate you can
-also back up.  Cisco and Aruba each span two NOSes with separate
-definitions — `Cisco` (IOS-XE) + `CiscoNXOS` + `CiscoIOSXR`, and `Aruba`
-(AOS-S) + `ArubaCX` (AOS-CX) — keyed distinctly because `type_key` must
-be unique.  See
+(plus per-OS-version overlays).  Cisco and Aruba each span two NOSes with
+separate definitions — `Cisco` (IOS-XE) + `CiscoNXOS` + `CiscoIOSXR`, and
+`Aruba` (AOS-S) + `ArubaCX` (AOS-CX) — keyed distinctly because `type_key`
+must be unique.  **`CiscoNXOS`, `CiscoIOSXR`, `ArubaCX`, and `VyOS` are
+provisional**: their backup wiring is verified in code and against sample
+`show version` output, but has not yet been run against a live device —
+the `/definitions` Notes column flags each with a "NOT YET VALIDATED"
+warning.  See
 [`../definitions/README.md`](../definitions/README.md) for the
 authoring guide and the live `/definitions` page in the running app
 for the per-vendor inventory.  RESULTS.md is the source of truth for

--- a/tests/unit/definitions/test_aruba_aoscx_definition.py
+++ b/tests/unit/definitions/test_aruba_aoscx_definition.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for the shipped ``definitions/aruba/aos-cx/10.x.yaml`` definition.
+
+Locks in the backup-pipeline schema fields and asserts the type_key is
+distinct from the AOS-S ``Aruba`` family base (AOS-CX is a different NOS).
+Exercises the version probe against a realistic AOS-CX ``show version``
+fragment (the ``Version : FL.10.10.1000`` platform-prefixed line).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from netcanon.collectors.probe import PROBE_TIMESTAMP_KEY, parse_probe_output
+from netcanon.definitions.loader import DefinitionLoader
+from netcanon.definitions.schema import DeviceDefinition
+
+pytestmark = pytest.mark.unit
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFINITION_PATH = _REPO_ROOT / "definitions" / "aruba" / "aos-cx" / "10.x.yaml"
+
+
+def _load_definition() -> DeviceDefinition:
+    raw = yaml.safe_load(_DEFINITION_PATH.read_text(encoding="utf-8"))
+    return DeviceDefinition(**raw)
+
+
+_SHOW_VERSION_AOSCX = """\
+-----------------------------------------------------------------------------
+ArubaOS-CX
+(c) Copyright 2017-2023 Hewlett Packard Enterprise Development LP
+-----------------------------------------------------------------------------
+Version      : FL.10.10.1000
+Build Date   : 2023-05-09 17:00:00 PDT
+Build ID     : ArubaOS-CX:FL.10.10.1000:...
+"""
+
+
+class TestSchemaCompliance:
+    def test_definition_file_exists(self):
+        assert _DEFINITION_PATH.is_file()
+
+    def test_loads_under_pydantic_schema(self):
+        assert isinstance(_load_definition(), DeviceDefinition)
+
+    def test_vendor_and_os(self):
+        d = _load_definition()
+        assert d.vendor == "Aruba"
+        assert d.os == "AOS-CX"
+
+    def test_type_key_is_distinct_from_aos_s(self):
+        """AOS-CX must NOT reuse the ``Aruba`` type_key (owned by AOS-S /
+        ex-ProCurve) — they are different NOSes with different sessions."""
+        d = _load_definition()
+        assert d.type_key == "ArubaCX"
+
+    def test_file_extension_cfg(self):
+        assert _load_definition().file_extension == "cfg"
+
+    def test_loaded_via_definition_loader(self):
+        defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
+        assert "ArubaCX" in defs, sorted(defs.keys())
+        # Coexists with the AOS-S ``Aruba`` family base — no collision.
+        assert "Aruba" in defs
+        assert defs["ArubaCX"].os == "AOS-CX"
+        assert defs["Aruba"].os == "AOS-S"
+
+
+class TestCollectorWiring:
+    def test_strategy_is_netmiko(self):
+        assert _load_definition().collector.strategy == "netmiko"
+
+    def test_netmiko_device_type_is_aruba_aoscx(self):
+        assert _load_definition().collector.netmiko_device_type == "aruba_aoscx"
+
+
+class TestConnectionFlags:
+    def test_needs_enable_is_false(self):
+        """AOS-CX SSH lands in manager ``#``; no enable-mode escalation."""
+        assert _load_definition().connection.needs_enable is False
+
+    def test_cisco_more_paging_is_false(self):
+        """netmiko aruba_aoscx disables paging natively (``no page``)."""
+        assert _load_definition().connection.cisco_more_paging is False
+
+    def test_no_terminal_length_zero_in_pre(self):
+        d = _load_definition()
+        assert d.commands.pre == []
+        assert all("terminal length" not in c for c in d.commands.pre)
+
+
+class TestCommandsBlock:
+    def test_config_command_is_show_running_config(self):
+        assert _load_definition().commands.config == "show running-config"
+
+    def test_pre_and_post_are_empty(self):
+        d = _load_definition()
+        assert d.commands.pre == []
+        assert d.commands.post == []
+
+
+class TestPromptPatterns:
+    def test_trailing_matches_manager_and_operator_prompts(self):
+        import re
+
+        d = _load_definition()
+        compiled = [re.compile(p) for p in d.prompts.trailing]
+        assert any(p.match("switch#") for p in compiled)
+        assert any(p.match("switch>") for p in compiled)
+
+
+class TestProbeRegexes:
+    def test_probe_command_is_show_version(self):
+        assert _load_definition().probe.command == "show version"
+
+    def test_version_pattern_present(self):
+        assert "detected_os_version" in _load_definition().probe.patterns
+
+    def test_extracts_version_from_platform_prefixed_line(self):
+        """``Version : FL.10.10.1000`` → ``10.10`` (the two-letter platform
+        prefix is stripped, major.minor captured for overlay pins)."""
+        facts = parse_probe_output(_SHOW_VERSION_AOSCX, _load_definition().probe)
+        assert facts.get("detected_os_version") == "10.10"
+
+    def test_probe_timestamp_attached(self):
+        facts = parse_probe_output(_SHOW_VERSION_AOSCX, _load_definition().probe)
+        assert PROBE_TIMESTAMP_KEY in facts
+
+    def test_probe_misses_silently_on_empty_input(self):
+        assert parse_probe_output("", _load_definition().probe) == {}

--- a/tests/unit/definitions/test_aruba_aoscx_definition.py
+++ b/tests/unit/definitions/test_aruba_aoscx_definition.py
@@ -62,6 +62,11 @@ class TestSchemaCompliance:
     def test_file_extension_cfg(self):
         assert _load_definition().file_extension == "cfg"
 
+    def test_notes_flag_not_validated_on_live_hardware(self):
+        """Honesty marker surfaced in the /definitions Notes column —
+        the backup actuation has never run against real hardware."""
+        assert "NOT YET VALIDATED" in _load_definition().notes
+
     def test_loaded_via_definition_loader(self):
         defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
         assert "ArubaCX" in defs, sorted(defs.keys())

--- a/tests/unit/definitions/test_cisco_iosxr_definition.py
+++ b/tests/unit/definitions/test_cisco_iosxr_definition.py
@@ -64,6 +64,11 @@ class TestSchemaCompliance:
     def test_file_extension_cfg(self):
         assert _load_definition().file_extension == "cfg"
 
+    def test_notes_flag_not_validated_on_live_hardware(self):
+        """Honesty marker surfaced in the /definitions Notes column —
+        the backup actuation has never run against real hardware."""
+        assert "NOT YET VALIDATED" in _load_definition().notes
+
     def test_loaded_via_definition_loader(self):
         defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
         assert "CiscoIOSXR" in defs, sorted(defs.keys())

--- a/tests/unit/definitions/test_cisco_iosxr_definition.py
+++ b/tests/unit/definitions/test_cisco_iosxr_definition.py
@@ -1,0 +1,142 @@
+"""
+Unit tests for the shipped ``definitions/cisco/ios-xr/7.x.yaml`` definition.
+
+Locks in the backup-pipeline schema fields (collector strategy, netmiko
+device-type, paging mode, distinct type_key) and exercises the probe
+regex map against synthetic IOS-XR ``show version`` fragments spanning
+the ASR 9000 and NCS platform families.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from netcanon.collectors.probe import PROBE_TIMESTAMP_KEY, parse_probe_output
+from netcanon.definitions.loader import DefinitionLoader
+from netcanon.definitions.schema import DeviceDefinition
+
+pytestmark = pytest.mark.unit
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFINITION_PATH = _REPO_ROOT / "definitions" / "cisco" / "ios-xr" / "7.x.yaml"
+
+
+def _load_definition() -> DeviceDefinition:
+    raw = yaml.safe_load(_DEFINITION_PATH.read_text(encoding="utf-8"))
+    return DeviceDefinition(**raw)
+
+
+_SHOW_VERSION_ASR9K = """\
+Cisco IOS XR Software, Version 7.5.2 LNT
+Copyright (c) 2013-2022 by Cisco Systems, Inc.
+
+Build Information:
+ Built By     : builder
+cisco ASR9K Series (Intel 686 F6M14S) processor
+"""
+
+_SHOW_VERSION_NCS = """\
+Cisco IOS XR Software, Version 7.3.1
+cisco NCS-5501 () processor
+"""
+
+
+class TestSchemaCompliance:
+    def test_definition_file_exists(self):
+        assert _DEFINITION_PATH.is_file()
+
+    def test_loads_under_pydantic_schema(self):
+        assert isinstance(_load_definition(), DeviceDefinition)
+
+    def test_vendor_and_os(self):
+        d = _load_definition()
+        assert d.vendor == "Cisco"
+        assert d.os == "IOS-XR"
+
+    def test_type_key_is_distinct_from_cisco(self):
+        d = _load_definition()
+        assert d.type_key == "CiscoIOSXR"
+
+    def test_file_extension_cfg(self):
+        assert _load_definition().file_extension == "cfg"
+
+    def test_loaded_via_definition_loader(self):
+        defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
+        assert "CiscoIOSXR" in defs, sorted(defs.keys())
+        assert "Cisco" in defs  # coexists with IOS-XE family base
+        assert defs["CiscoIOSXR"].os == "IOS-XR"
+
+
+class TestCollectorWiring:
+    def test_strategy_is_netmiko(self):
+        assert _load_definition().collector.strategy == "netmiko"
+
+    def test_netmiko_device_type_is_cisco_xr(self):
+        assert _load_definition().collector.netmiko_device_type == "cisco_xr"
+
+
+class TestConnectionFlags:
+    def test_needs_enable_is_false(self):
+        """IOS-XR SSH lands in exec mode; no enable-mode escalation."""
+        assert _load_definition().connection.needs_enable is False
+
+    def test_cisco_more_paging_is_false(self):
+        assert _load_definition().connection.cisco_more_paging is False
+
+    def test_no_terminal_length_zero_in_pre(self):
+        d = _load_definition()
+        assert d.commands.pre == []
+        assert all("terminal length" not in c for c in d.commands.pre)
+
+
+class TestCommandsBlock:
+    def test_config_command_is_show_running_config(self):
+        assert _load_definition().commands.config == "show running-config"
+
+    def test_pre_and_post_are_empty(self):
+        d = _load_definition()
+        assert d.commands.pre == []
+        assert d.commands.post == []
+
+
+class TestPromptPatterns:
+    def test_trailing_matches_xr_exec_prompt(self):
+        import re
+
+        d = _load_definition()
+        compiled = [re.compile(p) for p in d.prompts.trailing]
+        assert any(p.match("RP/0/RP0/CPU0:router1#") for p in compiled)
+        assert any(p.match("router1#") for p in compiled)
+
+
+class TestProbeRegexes:
+    def test_probe_command_is_show_version(self):
+        assert _load_definition().probe.command == "show version"
+
+    def test_required_patterns_present(self):
+        patterns = _load_definition().probe.patterns
+        assert "detected_os_version" in patterns
+        assert "detected_model" in patterns
+
+    @pytest.mark.parametrize(
+        "sample,version,model",
+        [
+            (_SHOW_VERSION_ASR9K, "7.5", "ASR9K"),
+            (_SHOW_VERSION_NCS, "7.3", "NCS-5501"),
+        ],
+    )
+    def test_extracts_version_and_model(self, sample, version, model):
+        facts = parse_probe_output(sample, _load_definition().probe)
+        assert facts.get("detected_os_version") == version
+        assert facts.get("detected_model") == model
+
+    def test_probe_timestamp_attached(self):
+        facts = parse_probe_output(_SHOW_VERSION_ASR9K, _load_definition().probe)
+        assert PROBE_TIMESTAMP_KEY in facts
+
+    def test_probe_misses_silently_on_empty_input(self):
+        assert parse_probe_output("", _load_definition().probe) == {}

--- a/tests/unit/definitions/test_cisco_nxos_definition.py
+++ b/tests/unit/definitions/test_cisco_nxos_definition.py
@@ -77,6 +77,13 @@ class TestSchemaCompliance:
     def test_file_extension_cfg(self):
         assert _load_definition().file_extension == "cfg"
 
+    def test_notes_flag_not_validated_on_live_hardware(self):
+        """Honesty marker: the backup actuation has never been run against
+        a real device, only verified in code + against sample output.  The
+        Notes column surfaces this in the /definitions UI (warning-first so
+        it survives truncation).  Locked in so it can't silently drop."""
+        assert "NOT YET VALIDATED" in _load_definition().notes
+
     def test_loaded_via_definition_loader(self):
         defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
         assert "CiscoNXOS" in defs, sorted(defs.keys())

--- a/tests/unit/definitions/test_cisco_nxos_definition.py
+++ b/tests/unit/definitions/test_cisco_nxos_definition.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for the shipped ``definitions/cisco/nx-os/10.x.yaml`` definition.
+
+Locks in the schema fields the backup pipeline relies on (collector
+strategy, netmiko device-type, paging mode, distinct type_key) and
+exercises the probe regex map against synthetic-but-realistic NX-OS
+``show version`` fragments spanning the modern ``NXOS:`` and legacy
+``system:`` version lines.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from netcanon.collectors.probe import PROBE_TIMESTAMP_KEY, parse_probe_output
+from netcanon.definitions.loader import DefinitionLoader
+from netcanon.definitions.schema import DeviceDefinition
+
+pytestmark = pytest.mark.unit
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFINITION_PATH = _REPO_ROOT / "definitions" / "cisco" / "nx-os" / "10.x.yaml"
+
+
+def _load_definition() -> DeviceDefinition:
+    raw = yaml.safe_load(_DEFINITION_PATH.read_text(encoding="utf-8"))
+    return DeviceDefinition(**raw)
+
+
+# Synthetic ``show version`` outputs — realistic shapes drawn from Cisco
+# NX-OS docs, no real serials.  Modern boxes report ``NXOS: version``,
+# older ones ``system:    version``.
+
+_SHOW_VERSION_NXOS_10 = """\
+Cisco Nexus Operating System (NX-OS) Software
+Software
+  BIOS: version 07.69
+  NXOS: version 10.3(2)
+Hardware
+  cisco Nexus9000 C93180YC-EX Chassis
+  Intel(R) Xeon(R) CPU
+  Processor Board ID FDO12345ABC
+  Device name: leaf1
+"""
+
+_SHOW_VERSION_NXOS_LEGACY = """\
+Software
+  system:    version 7.0(3)I7(8)
+Hardware
+  cisco Nexus9000 C9396PX Chassis
+  Processor Board ID SAL1234ABCD
+"""
+
+
+class TestSchemaCompliance:
+    def test_definition_file_exists(self):
+        assert _DEFINITION_PATH.is_file()
+
+    def test_loads_under_pydantic_schema(self):
+        assert isinstance(_load_definition(), DeviceDefinition)
+
+    def test_vendor_and_os(self):
+        d = _load_definition()
+        assert d.vendor == "Cisco"
+        assert d.os == "NX-OS"
+
+    def test_type_key_is_distinct_from_cisco(self):
+        """NX-OS must NOT reuse the ``Cisco`` type_key (owned by IOS-XE);
+        a collision would silently drop one definition from load_all()."""
+        d = _load_definition()
+        assert d.type_key == "CiscoNXOS"
+
+    def test_file_extension_cfg(self):
+        assert _load_definition().file_extension == "cfg"
+
+    def test_loaded_via_definition_loader(self):
+        defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
+        assert "CiscoNXOS" in defs, sorted(defs.keys())
+        # Coexists with the IOS-XE ``Cisco`` family base — no collision.
+        assert "Cisco" in defs
+        assert defs["CiscoNXOS"].os == "NX-OS"
+
+
+class TestCollectorWiring:
+    def test_strategy_is_netmiko(self):
+        assert _load_definition().collector.strategy == "netmiko"
+
+    def test_netmiko_device_type_is_cisco_nxos(self):
+        assert _load_definition().collector.netmiko_device_type == "cisco_nxos"
+
+
+class TestConnectionFlags:
+    def test_needs_enable_is_false(self):
+        """NX-OS logs the admin role straight into ``#``; no enable mode."""
+        assert _load_definition().connection.needs_enable is False
+
+    def test_cisco_more_paging_is_false(self):
+        """netmiko cisco_nxos disables paging natively; the SPACE-injection
+        flag is IOS/IOS-XE-only and ignored by the netmiko collector."""
+        assert _load_definition().connection.cisco_more_paging is False
+
+    def test_no_terminal_length_zero_in_pre(self):
+        """AGENTS.md hard rule: we never issue ``terminal length 0`` —
+        netmiko owns paging."""
+        d = _load_definition()
+        assert d.commands.pre == []
+        assert all("terminal length" not in c for c in d.commands.pre)
+
+
+class TestCommandsBlock:
+    def test_config_command_is_show_running_config(self):
+        assert _load_definition().commands.config == "show running-config"
+
+    def test_pre_and_post_are_empty(self):
+        d = _load_definition()
+        assert d.commands.pre == []
+        assert d.commands.post == []
+
+
+class TestPromptPatterns:
+    def test_trailing_matches_exec_and_config_prompts(self):
+        import re
+
+        d = _load_definition()
+        compiled = [re.compile(p) for p in d.prompts.trailing]
+        assert any(p.match("leaf1#") for p in compiled)
+        assert any(p.match("leaf1(config)#") for p in compiled)
+
+
+class TestProbeRegexes:
+    def test_probe_command_is_show_version(self):
+        assert _load_definition().probe.command == "show version"
+
+    def test_required_patterns_present(self):
+        patterns = _load_definition().probe.patterns
+        assert "detected_os_version" in patterns
+        assert "detected_model" in patterns
+
+    @pytest.mark.parametrize(
+        "sample,version,model,serial",
+        [
+            (_SHOW_VERSION_NXOS_10, "10.3", "C93180YC-EX", "FDO12345ABC"),
+            (_SHOW_VERSION_NXOS_LEGACY, "7.0", "C9396PX", "SAL1234ABCD"),
+        ],
+    )
+    def test_extracts_facts(self, sample, version, model, serial):
+        facts = parse_probe_output(sample, _load_definition().probe)
+        assert facts.get("detected_os_version") == version
+        assert facts.get("detected_model") == model
+        assert facts.get("detected_serial") == serial
+
+    def test_probe_timestamp_attached(self):
+        facts = parse_probe_output(_SHOW_VERSION_NXOS_10, _load_definition().probe)
+        assert PROBE_TIMESTAMP_KEY in facts
+
+    def test_probe_misses_silently_on_empty_input(self):
+        assert parse_probe_output("", _load_definition().probe) == {}

--- a/tests/unit/definitions/test_vyos_definition.py
+++ b/tests/unit/definitions/test_vyos_definition.py
@@ -63,6 +63,11 @@ class TestSchemaCompliance:
         fixtures (tests/fixtures/real/vyos/*.conf)."""
         assert _load_definition().file_extension == "conf"
 
+    def test_notes_flag_not_validated_on_live_hardware(self):
+        """Honesty marker surfaced in the /definitions Notes column —
+        the backup actuation has never run against real hardware."""
+        assert "NOT YET VALIDATED" in _load_definition().notes
+
     def test_loaded_via_definition_loader(self):
         defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
         assert "VyOS" in defs, sorted(defs.keys())

--- a/tests/unit/definitions/test_vyos_definition.py
+++ b/tests/unit/definitions/test_vyos_definition.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for the shipped ``definitions/vyos/vyos/1.x.yaml`` definition.
+
+Locks in the backup-pipeline schema fields and the VyOS-specific choices:
+the set-form config command (``show configuration commands``, which the
+vyos migration codec accepts), the ``conf`` file extension matching the
+real-capture fixtures, and operational-mode session behaviour (no enable).
+Exercises the version probe against a realistic VyOS ``show version``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from netcanon.collectors.probe import PROBE_TIMESTAMP_KEY, parse_probe_output
+from netcanon.definitions.loader import DefinitionLoader
+from netcanon.definitions.schema import DeviceDefinition
+
+pytestmark = pytest.mark.unit
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFINITION_PATH = _REPO_ROOT / "definitions" / "vyos" / "vyos" / "1.x.yaml"
+
+
+def _load_definition() -> DeviceDefinition:
+    raw = yaml.safe_load(_DEFINITION_PATH.read_text(encoding="utf-8"))
+    return DeviceDefinition(**raw)
+
+
+_SHOW_VERSION_VYOS = """\
+Version:          VyOS 1.4.0
+Release train:    sagitta
+Built by:         Sentrium S.L.
+Build UUID:       abc-123
+Hardware vendor:  VMware, Inc.
+Hardware model:   VMware Virtual Platform
+Hardware S/N:     VMware-42abc
+Hardware UUID:    deadbeef-1234
+"""
+
+
+class TestSchemaCompliance:
+    def test_definition_file_exists(self):
+        assert _DEFINITION_PATH.is_file()
+
+    def test_loads_under_pydantic_schema(self):
+        assert isinstance(_load_definition(), DeviceDefinition)
+
+    def test_vendor_and_os(self):
+        d = _load_definition()
+        assert d.vendor == "VyOS"
+        assert d.os == "VyOS"
+
+    def test_type_key(self):
+        assert _load_definition().type_key == "VyOS"
+
+    def test_file_extension_conf(self):
+        """``conf`` matches the convention used by the vyos real-capture
+        fixtures (tests/fixtures/real/vyos/*.conf)."""
+        assert _load_definition().file_extension == "conf"
+
+    def test_loaded_via_definition_loader(self):
+        defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()
+        assert "VyOS" in defs, sorted(defs.keys())
+        assert defs["VyOS"].vendor == "VyOS"
+
+
+class TestCollectorWiring:
+    def test_strategy_is_netmiko(self):
+        assert _load_definition().collector.strategy == "netmiko"
+
+    def test_netmiko_device_type_is_vyos(self):
+        assert _load_definition().collector.netmiko_device_type == "vyos"
+
+
+class TestConnectionFlags:
+    def test_needs_enable_is_false(self):
+        """VyOS SSH lands in operational mode (``$``); no enable equivalent."""
+        assert _load_definition().connection.needs_enable is False
+
+    def test_cisco_more_paging_is_false(self):
+        assert _load_definition().connection.cisco_more_paging is False
+
+
+class TestCommandsBlock:
+    def test_config_command_is_show_configuration_commands(self):
+        """Set-form dump; the vyos codec's Phase-6 front-end accepts it."""
+        assert _load_definition().commands.config == "show configuration commands"
+
+    def test_pre_and_post_are_empty(self):
+        d = _load_definition()
+        assert d.commands.pre == []
+        assert d.commands.post == []
+
+
+class TestPromptPatterns:
+    def test_trailing_matches_operational_prompt(self):
+        import re
+
+        d = _load_definition()
+        compiled = [re.compile(p) for p in d.prompts.trailing]
+        assert any(p.match("vyos@vyos:~$") for p in compiled)
+
+
+class TestProbeRegexes:
+    def test_probe_command_is_show_version(self):
+        assert _load_definition().probe.command == "show version"
+
+    def test_required_patterns_present(self):
+        patterns = _load_definition().probe.patterns
+        assert "detected_os_version" in patterns
+        assert "detected_model" in patterns
+
+    def test_extracts_facts(self):
+        facts = parse_probe_output(_SHOW_VERSION_VYOS, _load_definition().probe)
+        assert facts.get("detected_os_version") == "1.4"
+        assert facts.get("detected_model") == "VMware Virtual Platform"
+        assert facts.get("detected_serial") == "VMware-42abc"
+
+    def test_probe_timestamp_attached(self):
+        facts = parse_probe_output(_SHOW_VERSION_VYOS, _load_definition().probe)
+        assert PROBE_TIMESTAMP_KEY in facts
+
+    def test_probe_misses_silently_on_empty_input(self):
+        assert parse_probe_output("", _load_definition().probe) == {}


### PR DESCRIPTION
## What

Adds backup device definitions for the four vendors that had a migration codec but no `definitions/` entry — so their configs could be **migrated** but not **backed up** from a live device. Closes the backup-vs-migrate coverage gap surfaced while fixing the `target_profiles` loader noise ([#109](https://github.com/netcanon/netcanon/pull/109)).

| File | type_key | netmiko device_type | config command |
|---|---|---|---|
| `definitions/cisco/nx-os/10.x.yaml` | `CiscoNXOS` | `cisco_nxos` | `show running-config` |
| `definitions/cisco/ios-xr/7.x.yaml` | `CiscoIOSXR` | `cisco_xr` | `show running-config` |
| `definitions/aruba/aos-cx/10.x.yaml` | `ArubaCX` | `aruba_aoscx` | `show running-config` |
| `definitions/vyos/vyos/1.x.yaml` | `VyOS` | `vyos` | `show configuration commands` |

**Every migration codec family now has a backup definition.**

## Design decisions (verified against the code, not assumed)

- **Distinct `type_key`s.** `Cisco` (IOS-XE) and `Aruba` (AOS-S) are already taken; `type_key` must be unique across the family-base set or one definition is silently dropped on collision. NX-OS / IOS-XR / AOS-CX are separate NOSes and get their own keys.
- **Paging.** `NetmikoCollector` never reads `cisco_more_paging` — it relies on netmiko's own `disable_paging` at connect. The flag is documented "Cisco IOS/IOS-XE only," so it's `false` for all four, and there's no `terminal length 0` in `commands.pre` (AGENTS.md hard rule — netmiko owns paging).
- **`needs_enable: false`** for all four: NX-OS/IOS-XR/AOS-CX land privileged on login; VyOS is operational mode with no enable equivalent.
- **VyOS** fetches `show configuration commands` (set-form) — the `vyos` codec accepts set-form natively via its Phase-6 front-end; `file_extension: conf` matches the vyos real-capture fixtures.
- All four netmiko `device_type` strings confirmed present in the installed netmiko.

## Verification

- New per-definition unit tests under `tests/unit/definitions/` (mirroring the Arista/Junos pattern): schema compliance, collector wiring, connection flags, config command, prompt patterns, and probe regexes. Probe regexes validated against realistic synthetic `show version` output (NX-OS modern `NXOS:` + legacy `system:`; IOS-XR ASR9K + NCS; AOS-CX `FL.10.10.x`; VyOS `1.4.0`).
- Boot-log repro on the shipped `definitions/` tree: **11** device families load (was 7), **0** validation warnings.
- `ruff` clean; full `tests/unit` + definitions/UI-routes/backup-probe integration tests green locally.

## Docs

`definitions/README.md` vendor notes (×4) + `docs/CAPABILITIES.md` backup/codec-parity note + `CHANGELOG.md` `[Unreleased]`.

## Scope

Pure additive data + tests + docs. No codec, collector, or schema code changed. Backup *collection* for these vendors is now wired and unit-covered; live-device validation against real NX-OS/XR/CX/VyOS hardware remains future work (as for every definition — we can't reach live boxes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)