### PR TITLE
docs(security): SOPS evaluation (NO-GO) + plaintext-configs honesty pass

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -167,6 +167,37 @@ transparent and logged at `INFO`.
 concern only.  Credential fields are **never logged** (verified by
 `tests/unit/test_logging_config.py`).
 
+### Backup artifacts are stored in plaintext (deliberate; use an encrypted volume)
+
+Credential *fields* are encrypted (above), but the **fetched device
+configurations themselves** are written to `configs/<type>/<host>/*.{ext}`
+**verbatim, in plaintext** (`netcanon/services/backup_runner.py`).  A running
+config routinely contains device-side secrets — `$9$` / type-7 / `$6$` password
+hashes, SNMP / RADIUS / IKE keys.  This is deliberate: a backup is only useful
+if it is the real, complete config, and the directory is meant to be
+human-readable / diffable.  Netcanon does **not** encrypt or redact stored
+backups at rest (the sanitiser is an on-demand, bug-reporting-only tool — it
+never runs on the backup-write path).
+
+**Recommended at-rest control: an OS-level encrypted volume** — BitLocker (on by
+default on the Windows 11 desktop target), LUKS, or an encrypted cloud volume
+(EBS / PV) holding `NETCANON_DATA_DIR`.  One layer covers `configs/`, the
+credential JSON, **and** the Tier-3 `.fernet_key`, with no application
+complexity.  Its ceiling is honest: an encrypted volume protects an **offline**
+copy (stolen disk, leaked volume tarball) — it does *not* defend a read by a
+process on the live, mounted host, nor a config an operator deliberately copies
+off the box.
+
+> **Why not SOPS / app-level file encryption?**  SOPS's value is keeping the
+> decryption key on a *different host* than the ciphertext (the model the sibling
+> Kontroll project uses for its multi-service control plane).  Netcanon is a
+> local-first single app — desktop / server / Docker / MSI all co-locate the
+> process, the key, and the ciphertext on one machine — so SOPS cannot deliver
+> that separation, and the one decoupled posture it could offer (an off-host key)
+> is exactly what Tier 1 (`NETCANON_FERNET_KEY`) already provides.  SOPS is an
+> operator-side delivery option for the Tier-1 key, **not** a netcanon feature.
+> (Evaluated 2026-06-17 — see `docs/reviews/2026-06-17-sops-evaluation/`.)
+
 ---
 
 ## Credential Exposure in the Browser
@@ -503,6 +534,7 @@ regulated environments.
 | SSH host-key not verified by default | A MITM on the management path could harvest the SSH password + enable secret on first connect | Yes (default) / opt-in hardening available | Default `ssh_host_key_checking=auto_add` trusts any key (legacy; assumes a trusted management VLAN).  Set `NETCANON_SSH_HOST_KEY_CHECKING=tofu` (record first key under `{data_dir}/known_hosts`, reject later changes) or `reject` (only known hosts) to harden.  Netmiko collectors map the strict modes onto the OS `~/.ssh/known_hosts` (no custom-store API). |
 | Banner / comment text not sanitised | Operator-submitted bug reports may leak banner content | Documented | Sanitiser is canonical-model-driven; banner text is parse-and-ignored.  See `BUG_REPORTING.md`; hand-redact banners before submission. |
 | IPv6-public redaction not implemented | Operator-submitted public IPv6 addresses pass through verbatim | Documented | v0.1.0 limitation; sanitiser is IPv4-only.  Hand-redact public IPv6 before submission. |
+| Backup artifacts (`configs/`) stored plaintext | Fetched device configs contain device secrets (`$9$`/type-7/`$6$`, SNMP/RADIUS/IKE) written verbatim | Yes (deliberate) | A backup must be the real, complete, diffable config; recommended at-rest control is an OS-encrypted volume (covers `configs/` + the key in one layer; offline-threat only).  See "Credential Storage → Backup artifacts" |
 
 ---
 

--- a/docs/reviews/2026-06-17-sops-evaluation/00-blackboard.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/00-blackboard.md
@@ -1,0 +1,76 @@
+# Blackboard — Should netcanon adopt SOPS secret management? (2026-06-17)
+
+**Process:** netcanon file-per-agent blackboard. Read-only agents each write EXACTLY ONE report in this dir;
+the main thread seeds this file + writes `99-synthesis.md` + is the sole actor that verifies/commits. Agents
+must never read or write under `docs/codebase-review/` (the uncommitted PII dossier).
+
+## Mission
+
+Decide **whether and how** netcanon should add [SOPS](https://github.com/getsops/sops)-based secret management,
+mirroring the sibling **Kontroll** project (which uses SOPS for its deploy-stack secrets). Specifically:
+
+- **Is there a *practical* use case for SOPS in netcanon** — a real threat it uniquely mitigates given how
+  netcanon actually stores secrets and is actually run? Or is it Kontroll-shaped tooling that doesn't fit a
+  local-first single application?
+- **If yes**, what does adoption concretely look like (what gets encrypted, where the key lives per run-mode,
+  the decrypt-at-load flow, packaging/ops cost)?
+- Return a clear **GO / NO-GO / GO-WITH-NARROW-SCOPE** verdict the main thread can act on — including the
+  honest "do nothing / use a lighter alternative" outcome if that's correct.
+
+This is a **design/research run only** — no code changes this run. The deliverable is this dossier + a
+synthesis recommendation.
+
+## Hard constraints (apply to every report)
+
+- **Verify-first, cite `file:line`.** Every claim about how netcanon stores/handles a secret MUST be grounded in
+  the actual code (e.g. the device-profile store's on-disk format) — do NOT assume "it's plaintext" or "it's
+  encrypted"; open the file and confirm. Same for Kontroll's SOPS mechanics.
+- **Right-size / anti-over-engineering is a first-class outcome.** netcanon is a *local-first single app*
+  (PySide6 desktop + FastAPI server + Docker + Windows MSI), NOT a multi-service Ansible-deployed stack like
+  Kontroll. Weigh SOPS's real operational cost (age/gpg key mgmt, binary deps in Docker/MSI, dev/test friction)
+  against the actual threat. "This is security theater here / NO-GO" is a fully valid, even expected, verdict if
+  the runtime decryption key co-locates with the ciphertext in every real run-mode.
+- **netcanon ≠ Kontroll.** Explicitly separate what transfers from Kontroll's SOPS usage vs what is
+  Kontroll-specific (Ansible render-time decrypt, multi-service `.env` composition, a control-VM with the age
+  key). Don't cargo-cult.
+- **Threat model must be explicit.** Name the attacker/scenario SOPS would defend against (data-dir read access?
+  backup-artifact exfil? an accidental `git commit` of secrets? a stolen disk image?) and test each alternative
+  against *that same* scenario per run-mode.
+- **Standing actuation rules** (context, not this run): pseudonym commits + `Co-Authored-By` trailer; explicit
+  staging (the PII dossier stays uncommitted); no agent actuates — the main thread alone verifies/commits.
+
+## Decisions already locked (context the agents treat as fixed)
+
+- netcanon handles **device credentials** (SSH passwords + enable/`secret`) and a prior remediation already
+  landed: `DeviceProfilePublic` is WRITE-ONLY (creds scrubbed from API reads) + server-side backup-credential
+  resolution (the #53–#65 review era). Backup **artifacts themselves** (the fetched device configs) routinely
+  contain secrets (hashed/encrypted passwords, SNMP/RADIUS keys).
+- Run modes that all must keep working: **PySide6 desktop shell**, **FastAPI/uvicorn server**, **Docker image**,
+  **Windows MSI**. The decryption-key-availability story differs per mode and is the load-bearing design
+  constraint.
+- **Kontroll** (`~/Desktop/kontroll`) uses SOPS: encrypted
+  `instance/secrets/*.sops.yml`, a `.sops.yaml` ruleset, decrypt-by-name via `ansible/filter_plugins/
+  kontroll_sops.py` + `kontroll_token.py`, render-time `.env` composition (`scripts/gen-secret-env.py`,
+  `ansible/playbooks/deploy-stack.yml`), and a recent `docs/reviews/2026-06-17-secret-injection/` design review.
+  This whole evaluation was triggered while wiring a PVE/scratch-VM workflow into netcanon the way Kontroll does
+  it — Kontroll keeps its PVE token in SOPS; the question is whether netcanon should follow suit for its secrets.
+- This is **independent of** the scratch-VM/PVE-token handling for the dogfood lab (that token lives in a
+  gitignored `local/` regardless); this run is about netcanon's *own product* secret handling.
+
+## File roster
+
+| File | Phase | Author | Covers |
+|---|---|---|---|
+| 00-blackboard.md | seed | main thread | this protocol + mission + constraints |
+| 10-research-secret-census.md | research | R1 | every secret/credential netcanon handles + how it's stored at rest TODAY (device-profile store format, backup artifacts, egress allow-list, host-key TOFU, config/env) — `file:line` |
+| 11-research-kontroll-sops-precedent.md | research | R2 | how SOPS works in Kontroll (key backend, decrypt-by-name, render-time injection, ops cost from its secret-injection review); what transfers vs is Kontroll-specific |
+| 12-research-runtime-deployment.md | research | R3 | how netcanon is run/deployed per mode (desktop/server/docker/MSI) + where a decryption key could live in each; Python secret-mgmt alternatives (OS keyring, age/pyage, cryptography/Fernet, pydantic SecretStr, encrypted volume) |
+| 20-design-sops-integration.md | design | D1 | IF adopted: concrete SOPS integration — what's encrypted, key location per run-mode, decrypt-at-load flow, rotation, dev/test story, Docker/MSI packaging of sops+age |
+| 21-design-threat-and-alternatives.md | design | D2 | explicit threat model + head-to-head of SOPS vs the lighter alternatives against that threat per run-mode; recommended best-fit |
+| 30-review-adversarial.md | review | V1 | GO/NO-GO/GO-WITH-SCOPE + must-answers; steelman both sides; fact-check the census + the runtime key-colocation claim |
+| 99-synthesis.md | synthesis | main thread | reconciled verdict + (if GO) buildable-now scope, or the honest NO-GO + the lighter recommendation |
+
+## Severity tags for the reviewer
+
+`OVER-ENGINEERING` · `THREAT-MISMATCH` · `RUNTIME-BLOCKER` (key co-locates → no real protection in that mode) ·
+`VIABLE` (a use case that genuinely holds) · `POLISH`.

--- a/docs/reviews/2026-06-17-sops-evaluation/10-research-secret-census.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/10-research-secret-census.md
@@ -1,0 +1,257 @@
+# 10 — Secret / Credential Census (netcanon AS-IS, at rest)
+
+**Author:** R1 (research) · **Run:** 2026-06-17 SOPS evaluation · **Status:** read-only census, every claim cited to `file:line`.
+
+This is the factual spine for the design + review phases. The single load-bearing
+finding for the SOPS verdict is at the bottom (§7): in **every zero-config run mode the
+Fernet key co-locates with the ciphertext it protects**, and in the OS-keyring mode it is
+out-of-band. There is no run mode where SOPS would add a key-separation property that
+netcanon's existing 3-tier scheme doesn't already offer (env var) or can't (file fallback).
+
+---
+
+## 1. What secrets netcanon actually handles
+
+netcanon handles exactly **two classes** of secret material, plus one supporting key:
+
+1. **Device login credentials it is given** — SSH `username`/`password` + Cisco `enable`
+   secret, supplied by the operator to back up a device. netcanon *owns* these and is
+   responsible for storing them. (`netcanon/models/device.py:29-31`,
+   `netcanon/models/device_profile.py:53-65`)
+2. **Device-side secrets inside the fetched configs** — the backup artifacts contain the
+   target device's own hashed/encrypted passwords (`$9$…`, type-7, `$6$…`), SNMP community
+   strings, RADIUS/TACACS keys, IKE/IPsec pre-shared keys, etc. netcanon does **not** own
+   these — it transcribes whatever the device emits. (See §5.)
+3. **The Fernet symmetric key** that encrypts class (1) at rest — a derived/supporting
+   secret, not operator-facing. (`netcanon/security/credentials.py`)
+
+There are **no** API tokens, cloud credentials, signing keys, or service-account secrets in
+netcanon's own product surface (the PVE/scratch-VM token discussed in the seed is dogfood-lab
+infrastructure, gitignored under `local/`, explicitly out of scope per `00-blackboard.md:57-58`).
+
+---
+
+## 2. Device credentials — the only secret netcanon encrypts at rest
+
+### 2.1 In-memory model: `SecretStr` masking only, NOT encryption
+
+- The **request/transport** model `DeviceCredentials` types `password` / `enable_password`
+  as pydantic `SecretStr` (`netcanon/models/device.py:11,30-31`). This masks `repr()`/log/JSON
+  output **in memory only** — it is not encryption and never reaches disk in this form.
+- The **persisted** model `DeviceProfile` stores credentials as **plain `str`**
+  (`netcanon/models/device_profile.py:59-60`), with the docstring explicitly stating
+  "plaintext in memory; encrypted on disk" (`device_profile.py:9-12,34`). So the in-memory
+  representation of a *persisted* profile is plaintext `str`, NOT `SecretStr`. The `SecretStr`
+  only exists on the transport path (`DeviceCredentials`), and the backup route re-wraps the
+  plaintext profile password back into `SecretStr` when resolving credentials
+  (`netcanon/api/routes/backups.py:128-136`).
+
+**Conclusion:** `SecretStr` contributes nothing to at-rest protection here; it is a
+log/repr hygiene measure only. The at-rest protection is Fernet (next).
+
+### 2.2 On-disk format: Fernet-encrypted inside otherwise-plaintext JSON — CONFIRMED
+
+`FileDeviceProfileStore.save()` writes one JSON file per profile to `{data_dir}/devices/{id}.json`:
+
+- It dumps the full model to JSON, then **overwrites** the `password` field (and
+  `enable_password` if present) with `encrypt(...)` before writing
+  (`netcanon/storage/device_profile_store.py:64-67`).
+- `encrypt()` returns a Fernet token: `_get_fernet().encrypt(plaintext.encode()).decode()`
+  — a base64url string of the form `gAAAAA…` (`netcanon/security/credentials.py:227-233`).
+- Everything **else** in the file (id, name, type_key, **host**, port, **username**, notes,
+  os_version, model, detected_facts, created_at) is **plaintext JSON**. Only the two password
+  fields are ciphertext.
+- Write is atomic temp-then-rename (`device_profile_store.py:69-73`).
+
+`load_all()` reads the JSON back, decrypts the two credential fields via
+`migrate_credential_fields(...)` → `decrypt_field(...)`, and re-hydrates a `DeviceProfile`
+with plaintext credentials (`device_profile_store.py:99-125`,
+`netcanon/security/migration.py:18-35`, `credentials.py:246-263`).
+
+**Test-verified, not aspirational:** `tests/unit/test_device_profile_store.py:124-133`
+(`test_password_is_encrypted_on_disk`) saves a profile then asserts the plaintext password
+string does **not** appear in the on-disk JSON bytes. The encrypt/decrypt round-trip and the
+random-IV property are also tested in `tests/unit/test_credentials.py:107-149`.
+
+### 2.3 Legacy plaintext migration (one-shot, transparent)
+
+On load, any credential field that fails Fernet decryption (`InvalidToken`) is assumed to be
+a legacy pre-encryption plaintext value, returned as-is, and the file is immediately re-saved
+encrypted (`device_profile_store.py:104-118`, `credentials.py:246-263`,
+`migration.py:27-35`). Documented in the module docstring (`device_profile_store.py:11-15`)
+and `SECURITY.md:155-161`.
+
+---
+
+## 3. The Fernet key — where it lives per resolution tier (THE load-bearing fact)
+
+The key is resolved lazily, first-hit-wins, by `_resolve_key()`
+(`netcanon/security/credentials.py:156-211`):
+
+| Tier | Source | Resolved by | Key on disk in data-dir? | Key co-located with ciphertext? |
+|---|---|---|---|---|
+| **1** | `NETCANON_FERNET_KEY` env var | `credentials.py:163-167` | **No** | **No** — out-of-band (orchestrator/env) |
+| **2** | OS keyring (Win DPAPI / macOS Keychain / Linux SecretService) | `credentials.py:169-190` (`_read_keyring`/`_write_keyring` 82-114) | **No** | **No** — out-of-band (OS secret store) |
+| **3** | File fallback `$NETCANON_DATA_DIR/.fernet_key` | `credentials.py:192-211` (`_read_key_file`/`_write_key_file` 117-153) | **Yes**, plaintext 44-char base64 | **YES** — same volume as `devices/*.json` |
+
+Key facts to carry forward:
+
+- **Tier 3 is the zero-config bootstrap.** If neither the env var nor a usable keyring backend
+  exists, a fresh key is generated and written **plaintext** to `$NETCANON_DATA_DIR/.fernet_key`
+  with best-effort `chmod 0o600` (a **no-op on Windows** — `credentials.py:125-153`). A
+  `WARNING` log fires (`credentials.py:204-210`). This is the **typical Docker / headless**
+  path when the operator doesn't inject the env var.
+- The key-file directory is `Path(os.environ.get("NETCANON_DATA_DIR", "data"))`
+  (`credentials.py:70-79`) — i.e. the **same data root** that holds `devices/`, `schedules/`,
+  `jobs/`, and (by default) `configs/`. So in Tier 3 the decryption key sits **right next to**
+  the ciphertext it decrypts.
+- `.fernet_key` is gitignored (`.gitignore:23-28`, both `.fernet_key` and `**/.fernet_key`),
+  so it won't be committed, but it is present in any data-dir read / disk image / volume snapshot.
+- Key-loss == credential-loss is an accepted risk (`SECURITY.md:502`); profiles are
+  re-enterable.
+
+This 3-tier scheme is the existing answer to "where does the key live per run mode" — and it
+**already** offers the env-var separation that SOPS-with-an-external-key-backend would offer
+(Tier 1), and the OS-keyring separation desktop already uses (Tier 2). The design/review
+phases should weigh SOPS against *this*, not against a strawman plaintext store.
+
+---
+
+## 4. Schedule store — same credential treatment (legacy inline lists only)
+
+`FileScheduleStore` writes `{data_dir}/schedules/{id}.json`. Legacy inline `devices[]`
+entries carry `password`/`enable_password`; these are **Fernet-encrypted** with the same
+`encrypt()` on save and decrypted/legacy-migrated on load
+(`netcanon/storage/schedule_store.py:43-64,73-104`). New-style schedules reference
+`device_profile_id`s and **carry no credentials of their own** (`schedule_store.py:9-13`).
+Same at-rest format and key as §2/§3.
+
+---
+
+## 5. Backup artifacts — RAW device configs, NO at-rest sanitization (the bigger exposure)
+
+This is the larger, *unencrypted* secret surface and the place where netcanon's own
+credential encryption does **not** help.
+
+- **What is written:** `_process_one_device` calls `raw_output = collector.collect(...)` then
+  `storage.save(content=raw_output, ...)` — the device's `running-config` (or vendor
+  equivalent) is written to disk **verbatim** (`netcanon/services/backup_runner.py:233-241`).
+- **Where:** `{configs_dir}/{DeviceType}/{safe_host}/{DeviceType}_{host}_{ts}.{ext}` as
+  **plain text**, UTF-8, atomic temp-rename (`netcanon/storage/file_store.py:1-19,162-186`).
+  The module docstring's own first sentence: "Configurations are saved as **plain text
+  files**" (`file_store.py:1-3`).
+- **What's in them:** these configs routinely contain the *device's own* secrets —
+  hashed/reversible local passwords (`$9$…`, Cisco type-7, `$1$/$5$/$6$`), SNMP community
+  strings, RADIUS/TACACS shared keys, IKE/IPsec PSKs, certificate material. **None of this is
+  encrypted, hashed, or redacted at rest.** It is stored exactly as the device emitted it.
+- **Sidecar:** an optional `{filename}.meta.json` records `{"device_profile_id": "..."}` only
+  — a UUID, **no secrets** (`file_store.py:188-196`).
+- **No size/secret scrubbing on the write path** beyond a 50 MB size ceiling
+  (`file_store.py:100,157-161`).
+
+### 5.1 The sanitizer is ON-DEMAND only — it does NOT touch stored backups
+
+There is a sanitizer (`netcanon/tools/sanitize.py`, exposed at `POST /api/v1/sanitize` and the
+`netcanon sanitize` CLI), but it operates on an **uploaded** config the operator hands it for
+bug-reporting, running parse→redact→render and returning the sanitized text in the HTTP
+response (`netcanon/api/routes/sanitize.py:1-14,43-91`). It is **never** invoked on the
+backup write path (`backup_runner.py` does not import or call it). Therefore:
+
+> **The most voluminous secret material netcanon stores — the fetched device configs — is at
+> rest in cleartext, and nothing in the product encrypts or redacts it at rest.**
+
+This matters for the SOPS verdict: device-credential *encryption* is already solved; the
+realistically larger "secrets on disk" exposure is the `configs/` tree, which is plaintext.
+Any "should we encrypt secrets at rest" conversation that only looks at `devices/*.json` is
+looking at the smaller half.
+
+---
+
+## 6. Non-secret state and supporting stores (for completeness)
+
+| Store / file | Path | Contents | Secret? |
+|---|---|---|---|
+| Job history | `{data_dir}/jobs/{id}.json` | `BackupJob`: id, status, per-device host/status/error/duration, `ConfigRecord` metadata | **No credentials.** `BackupResult`/`BackupJob` carry no password fields (`netcanon/models/backup.py:61-117`); `FileJobStore.save` dumps the model verbatim (`netcanon/storage/job_store.py:37-48`). Host/IP + error strings are network-identifying but not secret. |
+| SSH host-key TOFU store | `{effective_data_dir}/known_hosts` | Device SSH **public** host keys learned on first connect | **Not secret** — public keys, OpenSSH `known_hosts` format. It is *security-relevant* (tamper would weaken MITM detection) but contains no confidential material. Written only in `tofu` mode (`netcanon/collectors/hostkey.py:41-90`), default `auto_add` writes nothing (`config.py:108`). |
+| Egress allow-list | n/a (code-only) | Loopback/link-local block policy | **Config, not secret.** A boolean `block_private_egress` toggle + pure-function IP checks (`netcanon/services/egress.py`, `config.py:107`). No stored state. |
+| Definitions | `{definitions_dir}/**/*.yaml` | Vendor probe/command templates | Not secret (shipped library). |
+| `.env` | repo root | `NETCANON_*` settings incl. optionally `NETCANON_FERNET_KEY` | Potentially key-bearing; gitignored (`.gitignore:69-73`). The Fernet key is the only secret that can appear here. |
+| Desktop prefs | `%APPDATA%\Netcanon\preferences.json` | paths, port, toggles | Not secret (`netcanon_desktop/preferences.py:3,69`). |
+
+**Data-dir layout** (`config.py:33-37,116-128`): `effective_data_dir` = explicit `data_dir`
+if set (desktop prefs / `NETCANON_DATA_DIR`), else `configs_dir.parent`. Under it:
+`devices/` (encrypted creds), `schedules/` (encrypted creds), `jobs/` (no creds),
+`known_hosts` (public keys), `.fernet_key` (Tier-3 key, plaintext), and typically `configs/`
+(plaintext device configs). On the **desktop** the root is `%APPDATA%\Netcanon\`
+(`netcanon_desktop/settings.py:40-52,83-85`; README table `netcanon_desktop/README.md:120`),
+where Tier 2 (DPAPI keyring) is the default key tier and `.fernet_key` normally does **not**
+exist.
+
+---
+
+## 7. The master table: every secret, where, format, who reads it, exposure if data-dir is read
+
+| Secret type | Where stored (path) | At-rest format | Who decrypts/reads it at runtime | Exposed if data-dir is read? |
+|---|---|---|---|---|
+| Device SSH `password` | `{data_dir}/devices/{id}.json` (field `password`) | **Fernet ciphertext** (`gAAAAA…` base64url) inside plaintext JSON | `FileDeviceProfileStore.load_all` → `decrypt` → `DeviceProfile.password` (plaintext str in memory); reused by `backups._resolve_credentials` → `netmiko/paramiko` (`backups.py:128-136`, `netmiko_collector.py:88`, `paramiko_collector.py:184`) | **Only if the Fernet key is also obtained.** Tier 3: **yes** — key is `.fernet_key` in the same dir. Tier 1/2: **no** — key is out-of-band (env/OS keyring). |
+| Device `enable_password` | `{data_dir}/devices/{id}.json` (field `enable_password`) | **Fernet ciphertext** | Same as above; passed as netmiko `secret` (`netmiko_collector.py:91-94`) | Same as above. |
+| Legacy schedule inline creds | `{data_dir}/schedules/{id}.json` (`devices[].password`/`enable_password`) | **Fernet ciphertext** | `FileScheduleStore.load_all` → `decrypt` (`schedule_store.py:88-104`) | Same as above (same key). New-style schedules store none. |
+| **Fernet master key** | `$NETCANON_DATA_DIR/.fernet_key` (**Tier 3 only**) | **Plaintext** 44-char base64 (chmod 0o600 POSIX; no-op Windows) | `_resolve_key`/`_get_fernet` (`credentials.py:192-224`) — caches a process-global Fernet | **YES, fully** — and it decrypts every credential above. Tier 1 (env) / Tier 2 (keyring): key not in data-dir. |
+| **Device-side config secrets** (`$9$`, type-7, SNMP/RADIUS/IKE keys) | `{configs_dir}/{Type}/{host}/*.{ext}` | **Plaintext** (raw device output, verbatim) | Read on demand by config view/migrate/sanitize routes; never decrypted (never encrypted) | **YES, fully.** No at-rest encryption or redaction; sanitizer is on-demand-only (`sanitize.py`), not on the write path (`backup_runner.py:233-241`). |
+| SSH host **public** keys (TOFU) | `{effective_data_dir}/known_hosts` (tofu mode) | Plaintext OpenSSH `known_hosts` | `apply_paramiko_policy` / `save_host_keys` (`hostkey.py:46-90`) | **Yes, but not secret** — public keys. Read-exposure is benign; tamper-exposure weakens MITM detection. |
+| Job history | `{data_dir}/jobs/{id}.json` | Plaintext JSON | `FileJobStore` (`job_store.py`) | Host/IP + error strings exposed; **no credentials** (`models/backup.py:61-117`). |
+| Sidecar metadata | `{configs_dir}/.../{file}.meta.json` | Plaintext JSON | `FileConfigStore.list_configs` (`file_store.py:222-233`) | Profile UUID only — not secret. |
+
+---
+
+## 8. Prose: what is genuinely sensitive-at-rest (candidate SOPS targets) vs not
+
+**Genuinely sensitive at rest (the candidate "encrypt this" set):**
+
+1. **Device login credentials** (`devices/*.json`, legacy `schedules/*.json`). These ARE
+   already Fernet-encrypted at rest (test-guarded). The only at-rest weakness is **Tier 3**,
+   where the decrypting key (`.fernet_key`) sits in the same data-dir as the ciphertext — so
+   a data-dir read defeats the encryption. Tier 1 (env) and Tier 2 (OS keyring) have **no**
+   such co-location.
+2. **The fetched device configs** (`configs/**`). These are **plaintext** and contain real
+   device secrets (hashed/reversible passwords, SNMP/RADIUS/IKE keys). This is the **largest
+   cleartext secret surface in the product** and is the one place the existing credential
+   encryption doesn't reach. If "secrets on disk" is the threat, this is the target that most
+   matters — and notably it is bulk, high-volume, frequently-written content that an
+   encrypt-at-rest scheme would have to wrap on every backup.
+
+**Not meaningfully sensitive at rest (do NOT spend SOPS on these):**
+
+- The **Fernet key under Tier 1/2** — it's already off the data volume; nothing to add.
+- **`known_hosts`** — public keys; the property that matters is integrity, not confidentiality.
+- **`jobs/`**, sidecars, prefs, definitions, egress config — no confidential payload.
+
+**Implication for the SOPS verdict (handed to D1/D2/V1, not decided here):** netcanon's secret
+problem decomposes into (a) a *small, already-encrypted* credential set whose only gap is
+key-co-location in the zero-config Tier-3 mode, and (b) a *large, fully-plaintext* config-artifact
+set the product deliberately stores raw. SOPS is a **file-level encrypt-at-rest-in-a-repo** tool;
+its natural fit is small declarative secret files that live in version control, decrypted at
+render/deploy time by an out-of-band key (the Kontroll model). Neither netcanon secret class
+is that shape: credentials are runtime-mutable per-profile JSON the operator never commits
+(already covered by Fernet + the env-var tier for key separation), and the config artifacts are
+bulk runtime output. The recurring question the design phase must answer honestly is **"where
+does the SOPS key live in each run mode, and does it co-locate with the ciphertext?"** — because
+in the Tier-3/Docker zero-config case it would face the *exact same* co-location problem
+`.fernet_key` already has, and in the desktop case the OS keyring (DPAPI) already provides the
+out-of-band key SOPS would otherwise need an age/gpg key to replicate.
+
+---
+
+## 9. Pointers for peer reports
+
+- **R2 (Kontroll SOPS)**: contrast Kontroll's *committed* `*.sops.yml` + out-of-band age key
+  (control-VM) against netcanon's *gitignored, runtime-mutable* `devices/*.json` + 3-tier
+  key. The "secret file is in git" precondition that makes SOPS valuable in Kontroll does not
+  hold for any netcanon secret.
+- **R3 (runtime/deploy)**: the key-location matrix in §3 is the per-run-mode key story already
+  — Tier 1 env (Docker/server), Tier 2 keyring (desktop/MSI), Tier 3 file (zero-config Docker).
+  Map any SOPS key backend onto these same four modes and check for co-location.
+- **V1 (review)**: fact-check the "Tier-3 key co-locates with ciphertext" claim against
+  `credentials.py:70-79,192-211` + `.gitignore:23-28`, and the "configs stored raw, sanitizer
+  is on-demand-only" claim against `backup_runner.py:233-241` + `sanitize.py`. Both are the
+  spine of any NO-GO / GO-WITH-NARROW-SCOPE argument.

--- a/docs/reviews/2026-06-17-sops-evaluation/11-research-kontroll-sops-precedent.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/11-research-kontroll-sops-precedent.md
@@ -1,0 +1,307 @@
+# 11 — Research: how SOPS works in Kontroll, and what transfers to netcanon
+
+**Run:** 2026-06-17-sops-evaluation · netcanon ultracode blackboard · **Agent:** R2 (research, read-only)
+**Scope:** study the sibling **Kontroll** project's SOPS usage (key backend, key location/provisioning,
+decrypt timing, what it bought / cost) and judge what of that model transfers to netcanon — a single
+local-first app (PySide6 desktop / FastAPI server / Docker / Windows MSI) — vs what is structurally
+Kontroll-specific.
+
+All Kontroll citations are `file:line` from `~/Desktop/kontroll` (read-only). I did **not**
+read or reproduce any secret material — only the encrypted *shape* and the plumbing.
+
+**Bottom line up front:** Kontroll's SOPS works because it is a **multi-node, multi-service, Ansible-deployed
+control plane** with a clean *physical* separation between (a) the **control VM** that holds the age private
+key and renders secrets and (b) the **fleet of containers/devices** that consume the rendered plaintext but
+never hold the key. That separation — *the decryptor is not the ciphertext-host* — is the entire security
+value, and it is **the one property netcanon's run-modes cannot replicate**: in every netcanon run-mode the
+process that would decrypt and the data-dir that holds the ciphertext sit on the same machine, under the same
+user, with the key necessarily reachable by the same process. The render-time-Ansible model, the control-VM
+key custody, and the multi-service `.env` composition are **all Kontroll-specific and do NOT transfer**. What
+*can* be borrowed is narrower: the *discipline* (one-file-per-domain, value-free generated manifests, never
+log the plaintext, `0600` resting place) and the *break-glass / least-privilege key-group* idea — but those
+are postures, not a reason to adopt SOPS itself. Full transferability matrix in §6.
+
+---
+
+## 1. What Kontroll *is* (the context SOPS lives in)
+
+Kontroll is, per its own SECURITY.md, a **single-user homelab control plane running on a dedicated VM on the
+Proxmox cluster, Management VLAN 11** (`SECURITY.md:18-21`). It **holds standing credentials to every managed
+device** — FortiGate/Cisco/OPNsense/RouterOS API tokens + enable creds, Proxmox API tokens, SSH keys for
+docker hosts, Grafana/Semaphore admin passwords, SNMPv3 creds, an ACME DNS token, etc. (`instance/secrets/README.md:10-19`).
+Its trust model explicitly makes "encryption at rest **mandatory**" *because* it is a long-lived networked box
+holding live device control credentials, in contrast to "the migration repo (frozen, local, plaintext
+accepted)" (`SECURITY.md:20-21`). **That contrast is the headline finding for this evaluation: Kontroll's own
+authors classify a "frozen, local, plaintext" repo — which is what netcanon's data-dir is — as a context
+where plaintext is *accepted*.**
+
+Architecturally it is a stack: Semaphore (CI/runner), Grafana, Prometheus, Loki+Vector (logging), Homepage,
+an onboard-GUI, an API, optional Caddy ingress — orchestrated by **Ansible** (`deploy-stack.yml`, 721 lines)
+and deployed as **Docker Compose** services on the VM. This is a fundamentally different shape from a single
+app the operator double-clicks.
+
+---
+
+## 2. (1) Key backend, where the private key physically lives, and how it's provisioned
+
+### 2.1 Backend: SOPS + **age** (not GPG)
+
+The encryption backend is **[age](https://age-encryption.org)** — X25519 recipients written as `age1…`
+public keys — wrapping SOPS's native AES256-GCM data encryption. Confirmed in three independent places:
+
+- The creation-rule recipients are all `age:` key-groups with `age1…` public keys, e.g.
+  `instance/.sops.yaml:26-32` lists three `age1…` recipients for the operational domains.
+- The encrypted files carry `sops: age:` blocks with `-----BEGIN AGE ENCRYPTED FILE-----` per-recipient
+  envelopes and `recipient: age1…` — e.g. `instance/secrets/network.sops.yml:5-32` (the data fields above are
+  `ENC[AES256_GCM,data:…,iv:…,tag:…,type:str]`, the SOPS standard).
+- SECURITY.md names it outright: **"Secrets encrypted at rest (SOPS + age)"** (`SECURITY.md:34`), age key on
+  the control VM (`SECURITY.md:36-37`).
+
+The SOPS version is pinned in the file MAC block: `version: 3.13.1` (`instance/secrets/network.sops.yml:36`).
+
+### 2.2 Three recipients per domain — least-privilege key-groups
+
+`instance/.sops.yaml` is the creation-rule ruleset. Its design (`instance/.sops.yaml:7-20`) is explicitly
+least-privilege per secret domain, with up to **three** age recipients (any one private key decrypts — OR
+semantics within a key-group, `:18`):
+
+1. **Control VM operational key** — `~/.config/sops/age/keys.txt` on the control VM, the day-to-day
+   decryptor, never committed. On **every** domain.
+2. **Offline break-glass recovery key** — private half stored **offline** on a trusted machine, never on the
+   VM / repo / `local/`. Recovery only. On **every** domain.
+3. **Scoped Semaphore runner key** — `~/.config/semaphore/age.key` on the control VM and inside Semaphore's
+   encrypted store so the runner can decrypt at job time. Present **only** on the operational domains
+   (`network`, `proxmox`) — `instance/.sops.yaml:24-35` — so a Semaphore breach cannot decrypt the service
+   secrets (`compute`/`dashboards`/`semaphore`/`acme`/`snmp_observability`/`logging_file_tail`), which use
+   only control + break-glass (`*base_recipients`, `:39-66`).
+
+The path-regex is **basename-anchored** (`(^|/)<domain>\.sops\.ya?ml$`) and the template warns that a path
+prefix would fall through to the catch-all and silently drop the scoped key (`instance.example/.sops.yaml:14-16`).
+
+### 2.3 Physical location of the private key: **the control VM, on disk, mode 0600**
+
+`SECURITY.md:52-54`: *"the age private key lives only at `~/.config/sops/age/keys.txt` (mode 600) on the
+control VM, is never committed."* This is the canonical operational decryptor.
+
+- The **operator workstation** is **not** the resting place of the day-to-day key — the key lives on the
+  control VM, which is itself the long-lived networked box. (The *break-glass* key lives offline on a trusted
+  machine, but that's recovery-only, never the active decryptor.)
+- `.gitignore` blocks the key; `gitleaks` (pre-commit + CI) has a custom rule that always catches an
+  `AGE-SECRET-KEY` (`SECURITY.md:40,108-109,368`).
+
+### 2.4 Provisioning: `kontroll-init.py` mints it locally with `age-keygen`
+
+A brand-new node runs `scripts/kontroll-init.py` (the CLI half of a keygen split):
+
+- `ensure_control_key()` runs `age-keygen -o ~/.config/sops/age/keys.txt` then `chmod 0o600`
+  (`scripts/kontroll-init.py:71-78`; const `AGE_KEY_FILE` at `:41`).
+- `--fresh` scaffolds a private `instance/` overlay from the shipped `instance.example/` skeleton and writes a
+  `.sops.yaml` naming **only the freshly-minted control key** (never inheriting another instance's recipient)
+  — `scripts/kontroll-init.py:20-26,170-194`. The example ruleset (`instance.example/.sops.yaml:3-5`) is a
+  template whose placeholder `age1example…` recipient (`:24`) is replaced by `--fresh`.
+- The init prints the public key + a reminder that *"the private … decrypts every secret"* and to keep a copy
+  in a password manager (`scripts/kontroll-init.py:194-195`). kontroll-init runs **locally as the trusted
+  operator** (no network surface), which is the deliberate exception to Kontroll's otherwise never-persist
+  rule (`SECURITY.md:376-380`).
+- A separate **GUI keygen** surface (`/keygen/{role}`) mints break-glass / Semaphore keys **show-once** — the
+  private half is returned in exactly one response and **never** written to the box/repo/audit/log
+  (`SECURITY.md:334,348-353`). New recipients are added to `.sops.yaml` as *public* recipients via
+  anchor-preserving, idempotent, parse-verified text insertion, with the decrypt-needing `sops updatekeys`
+  re-wrap left as a **deferred operator step, never auto-run** (`SECURITY.md:353-360`).
+
+**Key custody summary:** age private key generated *on the control VM* by `age-keygen`, persisted 0600 at
+`~/.config/sops/age/keys.txt`, gitignored, never leaves the VM; a scoped Semaphore key on the same VM +
+Semaphore store; an offline break-glass key on a separate trusted machine. The custody story is rich because
+there are **multiple distinct principals** (operator, Semaphore runner, recovery) on **multiple machines**.
+
+---
+
+## 3. (2) Decryption is RENDER-TIME (Ansible builds a plaintext `.env` once at deploy)
+
+**Render-time, decisively.** Decryption happens **once per deploy**, inside Ansible, and produces a plaintext
+`docker/.env` that the containers then read. The app/containers **never decrypt SOPS themselves** — they have
+no age key (the deliberate "no-key posture"). Evidence:
+
+### 3.1 The decrypt + render task
+
+The play *"Render docker/.env from SOPS and bring up the stack"* (`deploy-stack.yml:111-115`,
+`connection: local`, runs on the control node) does the decrypt:
+
+- **Platform-core domains** are decrypted by `community.sops.sops` lookups in the play `vars:`, fail-CLOSED
+  (no `errors='ignore'`): `_sem` / `_dash` (`deploy-stack.yml:139-140`).
+- **Device/consumer domains** are decrypted **by name** as the *union* of domains the generated manifest
+  references, fail-SOFT per domain via the `kontroll_sops_domain` filter
+  (`deploy-stack.yml:148-159`). The decrypt is a **lazy** Jinja expression dereferenced **only inside the
+  one `no_log: true` render task** — never `set_fact`'d — so no decrypted value persists outside that boundary
+  (the M3 constraint, `deploy-stack.yml:152-159`).
+- The render task *"Render docker/.env (secrets — never logged)"* writes the file with `mode: "0600"`,
+  operator-owned, gitignored, `no_log: true` (`deploy-stack.yml:246-300`). It emits hardcoded platform-core
+  lines (`SEMAPHORE_*`, `GRAFANA_ADMIN_PASSWORD`, …, `deploy-stack.yml:256-267`) plus a single generic loop
+  composing each device env var from its domain + template via `kontroll_render_token`
+  (`deploy-stack.yml:292-293`).
+- The **snmp** secret is a *third* injection shape: decrypted task-local and rendered into a config FILE
+  (`prometheus/exporters/snmp/snmp.yml`, `0600`, gitignored), not the `.env` (`deploy-stack.yml:367-385`).
+  The `logging_file_tail` SSH private key is rendered into a file the same way (`deploy-stack.yml:401-417`).
+
+### 3.2 The decrypt-by-name mechanism (`kontroll_sops_domain`)
+
+`ansible/filter_plugins/kontroll_sops.py` is a ~25-line filter: given a domain name (= the SOPS file stem)
+and the secrets dir, it shells out to the **`sops` binary** (`subprocess.run(["sops", "--decrypt", path]…)`,
+`:34`), `yaml.safe_load`s stdout, and returns the dict — or `{}` if the file is absent, sops is missing, or
+decrypt fails (fail-soft, never raises, never logs the plaintext) (`kontroll_sops.py:25-43`). It exists so a
+new credentialed device is **zero spine edit**: the domain name IS the file stem, so deploy-stack decrypts the
+*union* of manifest-referenced domains without a hand-maintained `domain→dict` map.
+
+### 3.3 The N-field token composition (`kontroll_render_token`)
+
+`ansible/filter_plugins/kontroll_token.py` composes a `.env` value from a decrypted domain dict + a
+`str.format` template over that domain's **field NAMES** (`:20-38`). A 1-field exporter env (`"{proxmox_api_user}"`)
+and an N-field composed token (`"{user}!{id}={secret}"`) render through the **identical** call — a 1-field map
+is the degenerate template. Fail-soft: if the template is empty or any referenced field is missing/blank, the
+whole token renders `''` (`:25-34`) — the source then auths with an empty header and ships nothing, rather
+than a half-formed token. Never raises (`:27,30,38`).
+
+### 3.4 The manifest is value-free; secrets exist plaintext only in the rendered `.env`
+
+`config/secret-env.manifest.generated.yml` (generated by `scripts/gen-secret-env.py`) holds **ZERO secret
+values** — only env-var NAMES, domain NAMES, and field-NAME templates (`secret-env.manifest.generated.yml:1-19`;
+generator contract `gen-secret-env.py:21-26`). It fail-CLOSES at *generate* time on a malformed descriptor
+(non-UPPER_SNAKE env name, collision with a platform-core var, unsafe template field) — `gen-secret-env.py:52-122`.
+The plaintext secret lives in exactly one place: the gitignored `0600` `docker/.env`, written under `no_log`
+(`.env.example:1-4` confirms the example is value-free and the real values get decrypted in by a deploy step).
+
+**So the model is:** ciphertext at rest in `instance/secrets/*.sops.yml` (committed) → Ansible decrypts the
+union once at deploy under `no_log` → plaintext `docker/.env` (0600, gitignored, never committed) → Docker
+Compose `--env-file` feeds the containers (`deploy-stack.yml:710,715`). **The runtime app never touches SOPS
+or holds the age key.**
+
+---
+
+## 4. (3) What SOPS bought Kontroll, and what it cost
+
+### 4.1 What it bought
+
+| Benefit | Why it's real *for Kontroll* | Cite |
+|---|---|---|
+| **Encrypted secrets safely committed to git** | Kontroll's secret files ARE committed (`*.sops.yml` tracked); the canonical repo + offsite backups can hold them because the age key is not in any of those artifacts. This is the whole "GitOps for a control plane" payoff. | `SECURITY.md:37-38,150-152`; `network.sops.yml` is a committed ciphertext file |
+| **Decryptor ≠ ciphertext-host (the load-bearing property)** | The age key lives on the control VM; the *containers* and *managed devices* that consume the rendered `.env` never hold it. A stolen container image, a compromised exporter, or a read of the git repo yields no plaintext. | no-key posture `SECURITY.md:280-282,301-313`; key only on VM `SECURITY.md:52-54` |
+| **Multi-principal least-privilege** | Three recipients let a Semaphore-runner breach be scoped to 2 of 8 domains, and break-glass survive VM loss — meaningful *because there are genuinely separate principals on separate machines*. | `instance/.sops.yaml:7-66` |
+| **Break-glass against key loss** | Two recipients per domain → losing the VM key is recoverable, not catastrophic. | `SECURITY.md:41-44` |
+| **Backup-artifact safety** | Encrypted secrets are safe to host offsite (`scripts/backup.sh`); the age keys never leave. | `SECURITY.md:140,150-152` |
+
+### 4.2 What it cost
+
+| Cost | Detail | Cite |
+|---|---|---|
+| **Rich key-management ceremony** | A keygen split (CLI `kontroll-init` + GUI `/keygen/{role}` show-once), an offline break-glass custody process, a scoped Semaphore key, `sops updatekeys` re-wrap as a deferred operator step, anchor-preserving `.sops.yaml` edits, parse-verify gates. | `SECURITY.md:334-368`, `kontroll-init.py` |
+| **`age` can't encrypt-without-decrypt** | A standing decrypt key in any always-on service would be a liability, so Kontroll deliberately keeps the API/Semaphore **no-key** and defers cred-encryption to an out-of-band trusted runner. This is an architectural constraint SOPS *imposed*. | `SECURITY.md:280-282` |
+| **A binary dependency** | `sops` + `age` binaries must be present on the control node (a deploy prereq), and the Semaphore runner image is built *"stock + sops/age + baked collections"* (`deploy-stack.yml:446`). The decrypt filter shells out to the `sops` binary (`kontroll_sops.py:34`). | `kontroll_sops.py:16`, `deploy-stack.yml:446` |
+| **A config-injection sink + validation tax** | Turning "which env var gets which value" into generated data created a fail-closed-at-generate-time validation surface (`_SAFE_ENV`, field-name allow-list, platform-core-collision gate) that the secret-injection review made a **blocker** (M2, the run's highest-severity finding). | `gen-secret-env.py:79-122`; `40-adversary.md:169-204` |
+| **A no_log laziness invariant** | The decrypted union must stay a lazy var dereferenced only inside `no_log` tasks; a play-level `set_fact` of a decrypted dict leaks under `-v`/`debug` (M3, a blocker). | `40-adversary.md:102-119` |
+| **Path-coupling / overlay-seam fragility** | The deploy READ path and the GUI onboarding WRITE path must resolve `.sops.yml` through the same seam or a future relocation silently splits them — a fail-soft-hidden ghost (M4). | `30-security-blindjoe.md:51-58`; `40-adversary.md:357` |
+| **Fail-soft hides typos** | A typo'd `secret_domain`/field renders an empty token with no error — the review wanted a value-free "declared-but-absent domains" diagnostic to convert the silent cliff into a hint (D1). | `40-adversary.md:360` |
+
+### 4.3 The adversary's own framing of the threat
+
+Critically, the secret-injection review's threat model is **not a remote attacker** — *"the stack is
+mgmt-VLAN-only, single-operator; [the adversary] is drift and a future contributor"* (`30-security-blindjoe.md:29-32`).
+The legitimate resting place of a plaintext secret at deploy is the `0600` gitignored `docker/.env`
+(`30-security-blindjoe.md:23-26`). So even in Kontroll — a networked box holding live device creds — the SOPS
+machinery's day-to-day adversary is *config drift*, not an attacker reading the disk. The encryption-at-rest
+benefit (§4.1 row 1) is real but is fundamentally about **what's safe to commit/back-up**, not about
+defending a running box whose operator-trusted process can already reach the key.
+
+---
+
+## 5. (4) The Kontroll model, decomposed: what *could* map vs what is structurally Kontroll-specific
+
+The seed asks to itemize Kontroll's model against a single local-first app. Here is the decomposition,
+mechanism by mechanism.
+
+### 5.1 The structural mismatch in one sentence
+
+Kontroll has a **physical custody boundary** — the age key lives on the control VM; the *consumers* (Docker
+containers, managed devices, the offsite backup, the git remote) are **different artifacts that never hold the
+key**. netcanon has **no such boundary in any run-mode**: the process that would decrypt and the data-dir
+holding the ciphertext are the same machine, same OS user, and any key the app can use at startup is a key an
+attacker who already has that data-dir/process can also use. **SOPS's central value (decryptor ≠
+ciphertext-host) evaporates when they co-locate.**
+
+### 5.2 Mechanism-by-mechanism transfer matrix
+
+| Kontroll mechanism | Cite | Transfers to netcanon? | Why / why not |
+|---|---|---|---|
+| **age key on a separate long-lived control VM, never on the consumer** | `SECURITY.md:52-54` | **NO** | netcanon's desktop/server/docker/MSI all run the decryptor on the same box as the data-dir + key. There is no second machine to be the custody boundary. The single most load-bearing property does not exist. |
+| **Render-time Ansible decrypt → one plaintext `.env`** | `deploy-stack.yml:111-300` | **NO** | netcanon has no Ansible deploy step and no orchestrator that runs once on a trusted node distinct from the app. The closest analog (an entrypoint that decrypts on container start) would itself need the key *in the container*, recreating the co-location problem. |
+| **Multi-service `.env` composition (manifest + generic loop + N-field token)** | `gen-secret-env.py`, `kontroll_render_token` | **NO** | This solves "compose creds for *many* containers/exporters from *many* domains with zero spine edit." netcanon is ONE process; there is no fleet of consumers to compose for. The whole modularity machinery is answering a question netcanon doesn't have. |
+| **Multi-principal key-groups (control + break-glass + scoped Semaphore)** | `instance/.sops.yaml:7-66` | **NO (no second principal)** | Least-privilege across principals presupposes ≥2 principals on ≥2 trust levels. netcanon is single-user, single-process; there is no Semaphore-runner equivalent to scope away from, and no separate machine for break-glass to be meaningfully *offline* relative to. |
+| **Committing encrypted secrets to git (the GitOps payoff)** | `network.sops.yml` (tracked) | **NO — and netcanon's posture is the opposite** | netcanon must **never** commit secrets at all (AGENTS.md Hard Rule "Never commit real credentials"); its data-dir (`configs/`, device-profile store) is **gitignored, not committed-encrypted**. Kontroll commits ciphertext *on purpose*; netcanon's design is "secrets never enter the repo," which removes the very problem SOPS-in-git solves. |
+| **The `sops` + `age` binary dependency** | `kontroll_sops.py:34`, `deploy-stack.yml:446` | **NO (and it's a real cost)** | netcanon ships as a pip wheel / Docker image / **Windows MSI**. Bundling a `sops` + `age` binary into the MSI and the Docker image, on every platform, for a benefit that §5.1 already nullified, is pure packaging tax. (A pure-Python `age`/`Fernet` path avoids the binary but doesn't restore the custody boundary.) |
+| **`no_log` discipline on secret-handling tasks** | `deploy-stack.yml:300,385,417` | **PARTIAL (as posture, not via SOPS)** | "Never log the decrypted value" is good hygiene netcanon already practices (the `DeviceProfilePublic` WRITE-ONLY scrub, per MEMORY). It's a logging discipline, not a reason to adopt SOPS. |
+| **One-file-per-domain, value-free generated manifests, `0600` resting place** | `instance/secrets/README.md`, `.env.example:1-4` | **PARTIAL (as discipline)** | These are sound *patterns* portable to any secret store (including netcanon's existing OS-keyring / Fernet options the runtime-deployment agent is surveying). They argue for *care*, not for *SOPS specifically*. |
+| **The "frozen, local, plaintext accepted" classification** | `SECURITY.md:20-21` | **DIRECTLY APPLICABLE — to netcanon** | Kontroll's authors explicitly put a *local, frozen* repo in the "plaintext accepted" bucket and reserved mandatory-encryption for the *networked control plane*. netcanon's data-dir is the former. This is precedent **against** adopting SOPS, written by the same operator. |
+
+### 5.3 The one genuine half-overlap: backup *artifacts*
+
+netcanon's backup artifacts (the fetched device configs in `configs/<host>.<ext>`) *do* routinely contain
+device secrets (hashed/encrypted passwords, SNMP/RADIUS keys) — analogous to Kontroll's device creds. But the
+parallel breaks on custody: Kontroll's encrypted device creds are safe to host *because the age key is on a
+different box*. A netcanon operator's `configs/` dir sits next to whatever key the netcanon process uses; an
+attacker with the data-dir has both. The honest transfer here is "treat `configs/` as sensitive-at-rest"
+(OS-level disk encryption / restrictive perms / the existing sanitiser for *sharing*), not "SOPS-encrypt
+`configs/` with a key the same machine holds."
+
+---
+
+## 6. Synthesis for this run (hand-off to D1/D2/V1 and the main thread)
+
+1. **Key backend / location / provisioning (Q1):** SOPS + **age**; private key on the **control VM** at
+   `~/.config/sops/age/keys.txt` (0600), minted locally by `age-keygen` via `kontroll-init.py`; plus an
+   **offline break-glass** key and a **scoped Semaphore-runner** key. Three-recipient least-privilege
+   key-groups, basename-anchored creation rules.
+
+2. **Decrypt timing (Q2):** **RENDER-TIME.** Ansible's `deploy-stack.yml` decrypts the union of SOPS domains
+   once per deploy (via `community.sops.sops` lookups + the `kontroll_sops_domain` filter), under `no_log`,
+   into a gitignored `0600` `docker/.env`. The app/containers **never decrypt SOPS at runtime** and hold no
+   age key (the deliberate no-key posture).
+
+3. **Bought vs cost (Q3):** Bought = encrypted secrets safe to **commit/back-up** + a real **decryptor ≠
+   ciphertext-host** boundary + multi-principal least-privilege + break-glass. Cost = a binary dependency,
+   rich key-management ceremony, an `age`-can't-encrypt-without-decrypt architectural constraint forcing the
+   no-key posture, a config-injection-sink validation tax, a `no_log`-laziness invariant, and overlay-seam
+   path-coupling fragility — and even then the day-to-day adversary the review modeled is *drift*, not a disk
+   reader.
+
+4. **Transferability verdict (Q4):** **The Kontroll SOPS model is structurally Kontroll-specific and does NOT
+   transfer to netcanon.** The load-bearing property (key on a separate box from the consumers + committing
+   ciphertext to git) has no analog in any netcanon run-mode — desktop/server/docker/MSI all co-locate the
+   decryptor, the key, and the ciphertext on one machine under one user. The render-time Ansible decrypt, the
+   multi-service `.env` composition, the control-VM key custody, and the multi-principal key-groups are all
+   answers to multi-node/multi-service/GitOps questions netcanon does not pose. The same operator's own
+   SECURITY.md classifies a *"frozen, local"* repo as **"plaintext accepted,"** explicitly reserving
+   mandatory encryption for the *networked* control plane — which is precedent *against* porting SOPS here.
+
+   **What transfers is discipline, not the mechanism:** one-file-per-domain organization, value-free generated
+   artifacts, never-log-the-plaintext, `0600`/gitignored resting places, and a break-glass mindset for
+   whatever lighter mechanism netcanon already has (OS keyring / Fernet — see the runtime-deployment agent).
+   These are reasons to be *careful*, not reasons to adopt SOPS.
+
+   **Severity tag for V1:** this report lands on **`THREAT-MISMATCH` + `OVER-ENGINEERING`** for any proposal
+   to port Kontroll's SOPS model wholesale, and **`RUNTIME-BLOCKER`** for the specific claim that SOPS would
+   protect a running netcanon instance (the decryption key co-locates with the ciphertext in every run-mode,
+   so there is no real protection against the local-disk-read / running-process adversary). I flag the one
+   *non*-mismatched sliver — backup-artifact-at-rest sensitivity (§5.3) — to D2 to test against the lighter
+   alternatives, since that's the only place a netcanon "encrypt-at-rest" story has any teeth, and even there
+   OS-level disk encryption likely dominates SOPS.
+
+---
+
+*Verified against source this run: `kontroll/instance/.sops.yaml` (full), `kontroll/instance.example/.sops.yaml`
+(full), `kontroll/instance/secrets/network.sops.yml` (shape only) + `instance/secrets/README.md` (full),
+`kontroll/ansible/filter_plugins/kontroll_sops.py` + `kontroll_token.py` (full),
+`kontroll/scripts/gen-secret-env.py` (full) + `config/secret-env.manifest.generated.yml` (full),
+`kontroll/ansible/playbooks/deploy-stack.yml` L108-300 + L367-417 + L446 + L710-715 (the decrypt + render +
+runner-image + bring-up), `kontroll/docker/.env.example` L1-55, `kontroll/SECURITY.md` L1-70 + the
+grepped C1/C10/keygen sections (L52-54, 280-313, 334-380), `kontroll/scripts/kontroll-init.py` (grepped
+key-provisioning L6-26,41-78,170-195,237-241), and the secret-injection review
+`docs/reviews/2026-06-17-secret-injection/{00,40,99}.md` (full) + `30-security-blindjoe.md` L1-120.*

--- a/docs/reviews/2026-06-17-sops-evaluation/12-research-runtime-deployment.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/12-research-runtime-deployment.md
@@ -1,0 +1,379 @@
+# 12 — Runtime & Deployment: where could a decryption key live per run-mode? (R3)
+
+**Author:** R3 (research) · **Run:** 2026-06-17 SOPS evaluation · **Status:** read-only research
+
+> Mission slice: MAP how netcanon is actually run/deployed in each mode and WHERE a decryption key could
+> live in each — the load-bearing constraint for any at-rest encryption scheme — then survey the Python
+> alternatives, and answer per-mode: **does the decryption key co-locate with the ciphertext on the same
+> disk/host the app runs on?** No recommendation (that's D2). This is the option matrix for the design phase.
+
+---
+
+## 0. TL;DR for the design phase (read this first)
+
+1. **netcanon already ships at-rest credential encryption.** It is *not* a greenfield decision. Device-profile
+   and legacy-schedule credentials are encrypted with **Fernet** (`cryptography`), and the key is resolved by a
+   **mature 3-tier chain** that already implements three of the very alternatives the seed asks me to survey
+   (env-var, OS keyring, file-fallback). See `netcanon/security/credentials.py:1-269`,
+   `netcanon/storage/device_profile_store.py:5-16,61-77`, `SECURITY.md:80-161`. Whatever D1/D2 recommend must be
+   weighed against *this existing system*, not against a hypothetical plaintext baseline.
+
+2. **The key co-locates with the ciphertext in every default zero-config run-mode** (desktop keyring tier,
+   container file-fallback tier, pip/dev file-fallback tier). The *only* tier that decouples key from data-dir
+   is **Tier 1 (`NETCANON_FERNET_KEY` env var)** — and even that is only decoupled if the operator stores the
+   value somewhere off the host (an orchestrator secret store), which is exactly the Kontroll-shaped pattern.
+
+3. **Therefore at-rest encryption here only ever defends an offline-disk / exfil-copy threat** (a stolen laptop
+   data dir, a leaked `data/` volume tarball, an accidentally-committed JSON). It does **not** defend against an
+   attacker who can read the running host/process — because the running app must hold the plaintext key in
+   memory and (in the default tiers) the key sits next to the data. SOPS would inherit exactly the same ceiling.
+
+4. **SOPS adds nothing the env-var tier doesn't already give**, and it adds binary deps (`sops`+`age`/`gpg`) to
+   Docker/MSI and key-management friction to a single-user desktop that will never own an age key. The runtime
+   map below is the evidence for that.
+
+---
+
+## 1. The four run-modes — how each actually launches
+
+| Mode | Entry point | `create_app` call site | Host binding | Who runs it |
+|---|---|---|---|---|
+| **(a) PySide6 desktop** | `python -m netcanon_desktop` → `DesktopApp.run()` | `netcanon_desktop/app.py:58` `create_app(settings)` | `127.0.0.1:8765` (loopback only) | Single local user, their own Windows session |
+| **(b) FastAPI/uvicorn server** | `uvicorn netcanon.main:app` | module-level `app = create_app()` `netcanon/main.py:318` | `0.0.0.0:8000` default (`config.py:100-101`) | Operator on a host/VM |
+| **(c) Docker** | image `ENTRYPOINT ["uvicorn","netcanon.main:app",…]` `Dockerfile:96` | same module-level `create_app()` | `0.0.0.0:8000` in-container | Operator via `docker run` / compose / k8s |
+| **(d) Windows MSI** | `netcanon.exe` (cx_Freeze frozen `netcanon_desktop/__main__.py`) `setup_desktop.py:174-189` | same `create_app(settings)` as desktop | `127.0.0.1:8765` | Single local Windows user |
+
+**Key structural fact:** all four modes funnel through the *same* `create_app()` factory
+(`netcanon/main.py:69`) and the *same* lifespan, which constructs the *same* `FileDeviceProfileStore`
+(`netcanon/main.py:159`). So the credential-encryption code path is **identical across every mode** — the only
+thing that varies per mode is *which Fernet key tier wins* and *where the key physically sits*. That is the
+entire crux of this report.
+
+### Where each mode keeps its data (the ciphertext location)
+
+Data root is resolved through `Settings.effective_data_dir` (`config.py:116-128`): explicit `data_dir` wins,
+else `configs_dir.parent`. The four state stores hang off it in the lifespan:
+`jobs/`, `schedules/`, `devices/` (`netcanon/main.py:147,155,159`). Device credentials live in
+`{data_root}/devices/{id}.json`, Fernet-encrypted (`device_profile_store.py:61-77`).
+
+| Mode | `configs_dir` | `effective_data_dir` (ciphertext lives here) |
+|---|---|---|
+| Desktop dev (source) | `<repo>/configs` (`settings.py:57`) | `<repo>/configs`.parent = `<repo>` |
+| Desktop frozen (MSI) | `%APPDATA%\Netcanon\configs` (`settings.py:51`) | `prefs.data_dir` or `%APPDATA%\Netcanon\configs`.parent = `%APPDATA%\Netcanon` |
+| Server (pip) | `./configs` (default, `config.py:98`) | `./` (cwd) unless `NETCANON_DATA_DIR`/`data_dir` set |
+| Docker | `/app/configs` (`Dockerfile:79`) | `/app/data` (`NETCANON_DATA_DIR=/app/data`, `Dockerfile:80`), bind-mounted `VOLUME` `Dockerfile:94` |
+
+---
+
+## 2. The existing key-resolution chain (the option matrix is already half-built)
+
+`netcanon/security/credentials.py::_resolve_key()` (`credentials.py:156-211`) — **first hit wins**:
+
+| Tier | Source | Code | Key on disk? | Decoupled from data dir? |
+|---|---|---|---|---|
+| **1** | `NETCANON_FERNET_KEY` env var | `credentials.py:163-167` | **No** (in process env) | **Yes — iff** operator stores value off-host |
+| **2** | OS keyring (Win Cred Mgr/DPAPI, macOS Keychain, libsecret) | `credentials.py:169-190` via `keyring` lib | **No** (in OS secret store) | Partially — same host, OS-scoped |
+| **3** | File `$NETCANON_DATA_DIR/.fernet_key` (auto-gen) | `credentials.py:192-211`, `_data_dir()` `:70-79` | **Yes** | **No — sits next to ciphertext** |
+
+Two subtleties the design phase must not miss:
+
+- **`credentials._data_dir()` reads the `NETCANON_DATA_DIR` *env var* directly** (`credentials.py:79`,
+  `os.environ.get("NETCANON_DATA_DIR", "data")`) — it does **NOT** go through `Settings.effective_data_dir`.
+  So the file-fallback key location is governed by the env var (set in Docker `Dockerfile:80`) or defaults to
+  `./data` relative to cwd. In the **desktop** modes nobody sets `NETCANON_DATA_DIR`, so if Tier 2 keyring ever
+  failed, the Tier-3 key would land in `<cwd>/data/.fernet_key`, **not** `%APPDATA%\Netcanon` — a latent
+  inconsistency, though in practice desktop always has a working keyring so Tier 3 never fires there. Flag for
+  D2 as a `POLISH` note; not load-bearing for the SOPS verdict.
+- **The in-memory model always holds plaintext** (`credentials.py` module docstring `:41-46`,
+  `device_profile_store.py:10-12`). Encryption is a storage-layer concern only. This is the same property as
+  pydantic `SecretStr` would give *plus* at-rest protection — see §5.
+
+Operator-facing guidance already exists: `SECURITY.md:80-161` (full three-tier table + rekey procedure),
+`.env.example:32-52`, `README.md:94-121` (Docker key-gen + `-e NETCANON_FERNET_KEY`).
+
+---
+
+## 3. Per-mode key-availability story + the co-location verdict
+
+For each mode I answer the crux plainly: **does the decryption key co-locate with the ciphertext on the same
+disk/host the app runs on?**
+
+### (a) PySide6 desktop
+
+- **Launch:** `DesktopApp.__init__` builds `desktop_settings()` then `create_app(settings)`
+  (`app.py:55-58`); server bound to `127.0.0.1:8765` (`settings.py:32,72-79`). Never exposed on LAN
+  (AGENTS.md "Web only" note, lines 108-109).
+- **Data dir:** `%APPDATA%\Netcanon\` (frozen) or repo root (dev) — §1 table.
+- **Winning key tier:** **Tier 2 — OS keyring** (Windows Credential Manager / DPAPI). `keyring` is a hard runtime
+  dep (`pyproject.toml:74`) and is present in the `[desktop]`/MSI build. On a logged-in Windows session the
+  keyring backend is alive, so Tier 2 always wins; Tier 3 file-fallback never fires.
+- **Would a desktop user ever own an age or gpg key?** **Almost certainly not.** The desktop is explicitly a
+  *single-user local utility* with no telemetry, no auto-update, no shell knob (AGENTS.md:111-128;
+  preferences are a GUI dialog, not env vars). Expecting a network engineer running an MSI to generate, store,
+  and rotate an `age` keypair — or to install `gpg` — is exactly the cargo-culted operational cost the seed
+  warns against (`00-blackboard.md:28-32`). SOPS is a non-starter here.
+- **Co-location verdict:** **YES, key co-locates with ciphertext on the same host.** The DPAPI-protected
+  keyring entry and the `devices/*.json` ciphertext are both on the user's machine, both readable by the
+  user's own account (DPAPI keys are scoped to the user profile). At-rest encryption here defends a **stolen
+  laptop / copied `%APPDATA%` folder** where the attacker does *not* have the user's login session — DPAPI
+  ties the keyring secret to the Windows account, so a raw copy of `%APPDATA%\Netcanon\devices\` off the disk
+  is undecryptable without the account creds. It does **NOT** defend against malware running *as* that user.
+  SOPS would give the *same* ceiling but require the user to manage a key the OS keyring manages for free.
+
+### (b) FastAPI / uvicorn server (pip install / host-run)
+
+- **Launch:** `uvicorn netcanon.main:app` → module-level `create_app()` (`main.py:316-323`). Binds `0.0.0.0:8000`
+  by default (`config.py:100-101`), i.e. **network-exposed** — the one mode where a remote read-the-host threat
+  is plausible.
+- **Data dir:** `configs_dir.parent` = cwd by default, unless operator sets `NETCANON_DATA_DIR` /
+  `NETCANON_CONFIGS_DIR` (`config.py:97-99`, env-prefix `NETCANON_` `config.py:111`).
+- **Winning key tier:** depends on host. A headless Linux server typically has **no SecretService daemon**, so
+  Tier 2 fails (`credentials.py:186-190` swallows it) and either Tier 1 (if operator set the env var) or Tier 3
+  (auto-gen file) wins. SECURITY.md:92 marks Tier 1 as the recommended production tier here.
+- **Co-location verdict:** **DEPENDS on operator choice.**
+  - *Tier 3 (default zero-config):* **YES co-locates** — `.fernet_key` sits in the same dir as `devices/*.json`
+    (`credentials.py:79,192-203`). Encryption protects only an offline copy of the data dir, NOT an attacker
+    who can read the host filesystem (they grab both key and ciphertext in one `tar`).
+  - *Tier 1 with env var sourced from a secret manager:* **NO co-location** — key is injected at process start
+    and never written to the data disk. This is the only configuration that defends against data-dir exfil
+    *and* keeps the key out of the at-rest footprint. **This is precisely what SOPS would also achieve** — and
+    the env-var tier already achieves it with zero new tooling.
+  - **But:** even Tier 1 does **not** defend against an attacker who can read the *running process* (env vars
+    are readable via `/proc/<pid>/environ`, a memory dump, or the app's own logs if misconfigured). No at-rest
+    scheme — SOPS included — closes that gap; that's an authn/authz + host-hardening problem, not an encryption
+    one. SECURITY.md:499-500 already concedes "No API authentication … web operators must add auth via reverse
+    proxy."
+
+### (c) Docker
+
+- **Launch:** `ENTRYPOINT ["uvicorn","netcanon.main:app","--host","0.0.0.0","--port","8000"]` (`Dockerfile:96`).
+  No compose file in the repo (`Glob docker-compose*` → none); README shows raw `docker run` (`README.md:100-104`).
+- **Volumes / data dir:** `VOLUME ["/app/configs","/app/data"]` (`Dockerfile:94`); `NETCANON_DATA_DIR=/app/data`
+  (`Dockerfile:80`). Operator bind-mounts `-v $(pwd)/data:/app/data` (`README.md:102`). `definitions/` is **baked
+  into the image**, not mounted (`Dockerfile:69`; README warns against mounting `README.md:110-114`).
+- **Where would a key be mounted?** Two existing paths:
+  - *Recommended:* `-e NETCANON_FERNET_KEY=<key>` (`README.md:100-104`, `Dockerfile` carries no key). Tier 1 wins;
+    key lives in the container's process env, never on the mounted volume. The README key-gen one-liner and the
+    `.env.example:41-44` already enumerate the orchestrator injection mechanisms (k8s Secret + envFrom, Compose
+    `secrets:`, systemd EnvironmentFile).
+  - *Zero-config fallback:* skip `-e`; Tier 3 auto-generates `/app/data/.fernet_key` (`README.md:118-121`) —
+    which lands **inside the bind-mounted volume next to the ciphertext**.
+- **Co-location verdict:** **DEPENDS, same shape as (b).**
+  - *Tier 1 env-injected:* **NO co-location.** A leaked `data/` volume tarball is undecryptable. This is the
+    Kontroll-equivalent posture, reachable today.
+  - *Tier 3 default:* **YES co-locates** — `.fernet_key` and `devices/*.json` are both in `/app/data`; the
+    volume is a single exfil unit. Encryption is then near-useless against anyone who gets the volume.
+  - **SOPS in Docker would mean** baking `sops` + an `age`/`gpg` binary into the runtime image (it's currently a
+    pure-Python slim image, `Dockerfile:48-63`, no extra binaries beyond `curl` for healthcheck), plus mounting
+    an age private key into the container — which itself re-creates the co-location problem (the age key would
+    sit on the same host/volume as the ciphertext unless *it* is env-injected, at which point you've reinvented
+    Tier 1). Net: SOPS adds image weight and a key-mount problem to solve a problem `-e NETCANON_FERNET_KEY`
+    already solves binary-free.
+
+### (d) Windows MSI
+
+- **Build:** `python setup_desktop.py bdist_msi` via cx_Freeze (`setup_desktop.py:1-8`, CI workflow
+  `desktop-msi-publish.yml`). Bundles Python + deps + `definitions/` next to `netcanon.exe`
+  (`setup_desktop.py:97-110`); installs to `C:\Program Files\Netcanon\` (`setup_desktop.py:130`). Entry point is
+  the frozen desktop app (`setup_desktop.py:174-189`) — so **runtime behaviour ≡ mode (a)**.
+- **Can the MSI even carry a key tool?** The `packages`/`include_files` lists (`setup_desktop.py:76-110`) bundle
+  only Python libs + definitions + license notices. There is **no mechanism to ship a per-install secret** — and
+  shipping one would be catastrophic (every install would share it). cx_Freeze could in principle bundle a
+  `sops`/`age` *binary* via `include_files`, but it could not bundle a *key* (keys must be per-user, generated at
+  runtime). And the MSI is **unsigned** today (`desktop-msi-publish.yml:20-22`) — adding a bundled crypto binary
+  expands the SmartScreen/AV-flag surface for zero benefit.
+- **Winning key tier:** **Tier 2 — OS keyring (Windows Credential Manager / DPAPI)**, same as (a). The MSI build
+  pulls `keyring` transitively (it's a base dep, `pyproject.toml:74`, and `[desktop-build]` extends `[desktop]`
+  which extends the base, `pyproject.toml:103-106`).
+- **Co-location verdict:** **YES, key co-locates with ciphertext on the same host** — identical to (a). DPAPI
+  keyring secret + `%APPDATA%\Netcanon\devices\*.json` ciphertext both on the user's machine. Defends a copied
+  `%APPDATA%` folder lacking the Windows account; does not defend malware-as-user. SOPS/age key management has
+  no realistic home in an MSI-delivered single-user app.
+
+### Co-location summary table
+
+| Mode | Default winning tier | Key on the data disk by default? | Decoupled posture reachable? | SOPS realistic? |
+|---|---|---|---|---|
+| (a) Desktop | Tier 2 keyring (DPAPI) | No (OS secret store, host-scoped) | n/a (already host-scoped) | No — user won't own an age key |
+| (b) Server | Tier 1 or Tier 3 | Tier 3 **YES**; Tier 1 No | **Yes** via Tier 1 env-var | Possible but redundant w/ Tier 1 |
+| (c) Docker | Tier 1 (recommended) or Tier 3 | Tier 3 **YES**; Tier 1 No | **Yes** via `-e` + orchestrator | Possible but adds binaries; redundant |
+| (d) MSI | Tier 2 keyring (DPAPI) | No (OS secret store, host-scoped) | n/a | No — no per-install key home |
+
+**Plain answer to the crux, per mode:** In **every default zero-config configuration**, the key is reachable on
+the same host the app runs on (keyring on desktop/MSI; `.fernet_key` file on server/Docker Tier 3). At-rest
+encryption therefore protects an **offline-disk / exfil-copy** threat only. The *single* exception is the
+**env-var tier on server/Docker when the value is sourced from an off-host secret store** — and that exception
+already exists in netcanon without SOPS.
+
+---
+
+## 4. Threat each scheme actually covers (framing for D2)
+
+| Threat scenario | Defended by at-rest encryption? | Defended by SOPS specifically (beyond Tier 1)? |
+|---|---|---|
+| Stolen laptop / copied `%APPDATA%` or `data/` folder, attacker lacks the host's keyring/env | **Yes** (any of the tiers) | No extra benefit over keyring/Tier-1 |
+| Leaked `data/` volume tarball from Docker (Tier 3 default) | **No** — key is in the tarball | Would require off-host age key — i.e. equals Tier 1 |
+| Leaked `data/` volume, Tier 1 env-injected | **Yes** | Same as Tier 1 |
+| Accidental `git commit` of `devices/*.json` | **Yes** (JSON is ciphertext) — but `.gitignore` already excludes `configs/`,`data/`,`devices/` | No extra benefit |
+| Attacker can read the **running host/process** (RCE, memory dump, `/proc/<pid>/environ`) | **No** (plaintext key is in memory) | **No** — out of scope for any at-rest scheme |
+| Network attacker hitting the exposed API | **No** — this is authn, not encryption (SECURITY.md:499-500) | No |
+
+The honest conclusion this map supports: **the only threat at-rest encryption uniquely closes here is
+offline-disk/exfil-copy, and netcanon already closes it.** SOPS would re-close the same threat with more moving
+parts. (D2 owns the final head-to-head; this is the runtime evidence feeding it.)
+
+---
+
+## 5. Alternatives survey, mapped to the run-modes
+
+The seed asks me to survey six options. **Three are already implemented** in netcanon (annotated ✅). I map each
+to the modes and name the threat it covers and where its key would live.
+
+### 5.1 OS keyring (`keyring` lib) — ✅ ALREADY USED (Tier 2)
+
+- **What it is:** `keyring.get/set_password` against Windows Credential Manager (DPAPI), macOS Keychain, Linux
+  SecretService/libsecret. Code: `credentials.py:82-114,169-190`. Hard dep `pyproject.toml:74`.
+- **Key location:** OS-managed secret store, scoped to the user account; **not on the data disk**.
+- **Threat covered:** offline copy of the data dir by an attacker lacking the user's OS account (DPAPI binds the
+  secret to the Windows profile). Does not cover malware-as-user.
+- **Fits modes:** **(a) desktop, (d) MSI** — perfect fit, zero operator action. **(b)/(c)** headless: no
+  SecretService daemon → backend unavailable → falls through (the code already handles this gracefully,
+  `credentials.py:186-190`). Containers can't realistically use it.
+
+### 5.2 `age` / `pyrage` app-level encryption (the SOPS substrate)
+
+- **What it is:** modern file encryption; `age` recipients are X25519 keypairs or SSH keys. `pyrage` is the Rust
+  `age` lib's Python binding. SOPS uses `age` as one of its key backends (per R2's brief, Kontroll uses SOPS+age).
+- **Key location:** an `age` *identity* (private key) file — which **must live somewhere the app can read at
+  decrypt time**. On desktop/MSI that's the user's disk (co-locates with ciphertext → no gain over keyring). On
+  server/Docker it's a mounted key file (co-locates unless env-injected → equals Tier 1).
+- **Threat covered:** same offline-disk threat as Fernet. No additional threat over the existing scheme.
+- **Fits modes:** technically all, **practically none better than what exists**. Adds a *new* dep (`pyrage` or a
+  bundled `age` binary) to a tree that has zero such binaries today (`Dockerfile` is pure-Python-slim). For
+  desktop/MSI it asks a single user to manage an age identity the OS keyring already manages.
+- **Verdict feed:** this is the SOPS substrate; its key-location story is *identical* to Fernet's, so SOPS
+  inherits the same co-location ceiling. `OVER-ENGINEERING` candidate for D2.
+
+### 5.3 `cryptography` Fernet — ✅ ALREADY THE IMPLEMENTATION
+
+- **What it is:** the at-rest scheme netcanon ships (`credentials.py:227-264`). AES-128-CBC + HMAC, symmetric.
+- **Key from where?** the 3-tier chain (§2). "Key from where?" is *the entire question*, and netcanon answers it
+  with env-var → keyring → file. This is already the strongest realistic answer for a local-first app.
+- **Threat / modes:** see §3 — covers offline-disk exfil in all modes; decouples from the data dir only via
+  Tier 1.
+- **Verdict feed:** baseline. Any proposal must beat this, and SOPS doesn't (it's Fernet-with-extra-steps for
+  the same threat).
+
+### 5.4 pydantic `SecretStr` — in-memory ONLY, explicitly NOT at-rest
+
+- **What it is:** a pydantic type that masks a secret in `repr()`/logs/`.model_dump()` and requires
+  `.get_secret_value()` to read. **Purely an in-memory accidental-leak guard** (stops a secret printing into a
+  log line or a JSON dump).
+- **Key location:** n/a — there is no key; it does not encrypt anything on disk.
+- **Threat covered:** accidental logging / serialization leaks of a live secret. **Does not touch the at-rest
+  threat at all.** netcanon's existing analogue is the WRITE-ONLY `DeviceProfilePublic` scrub
+  (seed `00-blackboard.md:44-45`) which already prevents creds leaking through API reads.
+- **Fits modes:** all modes, but **orthogonal** to SOPS — it would complement, never replace, at-rest
+  encryption. Worth noting to D2 only so the threat taxonomy stays clean: SecretStr ≠ at-rest, and the seed
+  itself flags this.
+
+### 5.5 Operator-supplied passphrase at startup (KDF → key, nothing persisted)
+
+- **What it is:** prompt the operator for a passphrase at process start, run it through a KDF (PBKDF2/scrypt/
+  Argon2 — `cryptography` provides these) to derive the Fernet key, hold it in memory only.
+- **Key location:** **nowhere on disk** — derived fresh each boot from a human secret. This is the strongest
+  off-host posture short of an external HSM.
+- **Threat covered:** offline-disk exfil **and** keeps the key off the data disk entirely (better than Tier 3,
+  comparable to Tier 1 without needing a secret store).
+- **Fits modes:**
+  - **(b) server / (c) Docker:** workable for *attended* starts, but **breaks unattended restart** — the
+    scheduler (`main.py:163-204`) and container auto-restart need the app to boot without a human. A passphrase
+    prompt is hostile to `docker run -d` / systemd / k8s. Could be supplied via stdin/env, but then it's just
+    Tier 1 with a KDF.
+  - **(a) desktop / (d) MSI:** plausible as a "master password" UX, but a regression vs the *zero-friction*
+    DPAPI keyring users have today (they'd now type a password every launch). Most desktop password managers
+    that do this also offer "remember on this device" — which re-introduces co-location.
+- **Verdict feed:** strongest *threat* story, weakest *ergonomics* for netcanon's unattended/zero-friction
+  modes. A `VIABLE`-but-narrow option for the server mode if an operator explicitly wants no key on disk and
+  accepts attended restarts. Strictly better than SOPS on dependency cost (pure `cryptography`, no binaries).
+
+### 5.6 OS-level encrypted volume (BitLocker / LUKS / FileVault)
+
+- **What it is:** full-disk / volume encryption *underneath* the app. Zero application code. The whole data dir
+  (configs, data, devices, the `.fernet_key` itself) is protected by the OS at the block layer.
+- **Key location:** managed by the OS (TPM-sealed for BitLocker, LUKS keyslot, FileVault keychain) — never the
+  app's concern.
+- **Threat covered:** **offline-disk / stolen-hardware** — exactly netcanon's real threat — for *everything* on
+  the volume, including configs/backups and the Fernet key, with **zero app complexity**. Does NOT defend a
+  running host (volume is unlocked while mounted) — same ceiling as every other option.
+- **Fits modes:**
+  - **(a) desktop / (d) MSI:** BitLocker is on-by-default on modern Windows 11 (the platform per the env block).
+    A stolen laptop is already covered at the block layer *for free*. This substantially undercuts the marginal
+    value of app-level encryption on desktop.
+  - **(b) server / (c) Docker:** LUKS on the host volume / encrypted EBS / encrypted PV covers the bind-mounted
+    `data/` and the configs. Standard ops hygiene; orthogonal to the app.
+- **Verdict feed:** the **lowest-complexity option that covers netcanon's actual threat**, and on Windows
+  desktop it's often *already on*. Strong "do-nothing-in-the-app / push it to ops" candidate for D2's matrix.
+  Its weakness vs app-level encryption: it doesn't protect an *accidental git commit* of a `devices/*.json`
+  (the file is plaintext-on-an-encrypted-volume → plaintext once copied off) — but netcanon already mitigates
+  that via Fernet *and* `.gitignore`.
+
+### Alternatives × modes matrix
+
+| Option | Key lives where | Threat covered | (a) Desktop | (b) Server | (c) Docker | (d) MSI | New deps? |
+|---|---|---|---|---|---|---|---|
+| OS keyring ✅ | OS secret store (host) | offline copy w/o OS account | **Best fit** | weak (no daemon) | n/a | **Best fit** | none (have it) |
+| age/pyrage / **SOPS** | key file or env (host unless injected) | offline-disk (= Fernet) | poor (user owns key) | OK if env-injected | OK if env-injected | poor | **+binary/+pyrage** |
+| Fernet ✅ | 3-tier (env/keyring/file) | offline-disk | shipped | shipped | shipped | shipped | none (have it) |
+| SecretStr | nowhere (in-mem mask) | accidental log/serialize leak | orthogonal | orthogonal | orthogonal | orthogonal | none |
+| Startup passphrase (KDF) | nowhere (memory) | offline-disk + off-disk key | friction | attended only | breaks `-d` | friction | none (`cryptography`) |
+| Encrypted volume (BitLocker/LUKS) | OS/TPM | offline-disk / stolen HW (whole dir) | **often already on** | ops-layer | ops-layer | **often already on** | none (OS) |
+
+---
+
+## 6. What this means for the SOPS question (handoff to D1/D2 — no recommendation here)
+
+- **The runtime map shows the decryption key co-locates with the ciphertext in every default mode**, so any
+  at-rest scheme — Fernet *or* SOPS — protects only the offline-disk/exfil threat. `RUNTIME-BLOCKER` for the
+  premise that SOPS adds protection against a host-read attacker.
+- **netcanon already ships the env-var-injected posture that is SOPS's only real advantage**
+  (`NETCANON_FERNET_KEY`, README.md:94-121, SECURITY.md:103-121). SOPS would be a *delivery mechanism* for that
+  same env value — and the orchestrator-secret integrations the `.env.example:41-44` already names (k8s Secret,
+  Compose `secrets:`, systemd EnvironmentFile) cover that delivery without SOPS.
+- **SOPS imposes per-mode costs the runtime map makes concrete:** binary deps in the pure-Python Docker image
+  (`Dockerfile:48-63`), an age-key-mount problem that re-creates co-location, and a key-management burden on a
+  single-user desktop/MSI that will never own an age key (AGENTS.md:111-128). These are `OVER-ENGINEERING`
+  signals for D2 to weigh.
+- **Lighter alternatives that cover the same threat already exist or are nearly free:** the OS keyring (in use),
+  encrypted volumes (often already on for the Windows desktop platform), and — if an operator wants zero key on
+  disk for the server mode — a startup-passphrase KDF using the `cryptography` dep already present.
+
+**Net (for the design phase, not a verdict):** the realistic key-availability story per mode strongly favors
+"keep the existing 3-tier Fernet scheme; if anything, document/encourage Tier 1 + encrypted volumes" over
+adopting SOPS. D1 should cost the SOPS integration against *this* baseline; D2 should run the head-to-head
+threat matrix above and likely land NO-GO or GO-WITH-NARROW-SCOPE.
+
+---
+
+## 7. Citations index
+
+- `netcanon/security/credentials.py:1-269` — Fernet scheme + 3-tier `_resolve_key` (env `:163-167`, keyring
+  `:169-190`, file `:192-211`), `_data_dir()` reads `NETCANON_DATA_DIR` env directly `:70-79`.
+- `netcanon/security/migration.py:18-35` — legacy plaintext → encrypted migration helper.
+- `netcanon/storage/device_profile_store.py:5-16,61-77,86-125` — encrypt-on-save / decrypt-on-load, ciphertext
+  at `{data_root}/devices/{id}.json`.
+- `netcanon/storage/schedule_store.py:9-13,46-54,76-100` — legacy inline-device-list creds encrypted too.
+- `netcanon/main.py:69,98-160,318` — `create_app` factory, lifespan store wiring off `effective_data_dir`,
+  module-level production `app`.
+- `netcanon/config.py:97-128` — `Settings`, `NETCANON_` env prefix, `effective_data_dir` derivation.
+- `netcanon_desktop/app.py:36,55-58` — desktop launches `create_app(desktop_settings())`.
+- `netcanon_desktop/settings.py:32,48-80,83-99` — loopback `:8765`, frozen vs dev paths, `%APPDATA%\Netcanon`.
+- `Dockerfile:48-96` — pure-Python slim runtime, `NETCANON_DATA_DIR=/app/data`, `VOLUME`, uvicorn entrypoint.
+- `setup_desktop.py:1-8,76-110,130,174-189` — cx_Freeze MSI bundle contents + frozen entry point.
+- `.github/workflows/desktop-msi-publish.yml:20-22,57-135` — unsigned MSI build, no key shipped.
+- `pyproject.toml:52-106` — `cryptography`+`keyring` base deps; `[desktop]`/`[desktop-build]` extras.
+- `SECURITY.md:80-161,499-503` — three-tier table, rekey, key-loss/no-auth threat rows.
+- `README.md:94-121` — Docker key-gen + `-e NETCANON_FERNET_KEY` + volume mounts.
+- `.env.example:32-52` — operator key guidance + orchestrator injection mechanisms.
+- `tests/unit/test_data_dir_resolution.py:34-103` — `effective_data_dir` resolution pins.
+- `AGENTS.md:108-128` — desktop is loopback-only, single-user, no telemetry/auto-update (no age-key home).

--- a/docs/reviews/2026-06-17-sops-evaluation/20-design-sops-integration.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/20-design-sops-integration.md
@@ -1,0 +1,449 @@
+# 20 — Design: IF netcanon adopts SOPS, what does the concrete integration look like?
+
+**Author:** D1 (design) · **Run:** 2026-06-17 SOPS evaluation · **Status:** read-only design sketch, builds on R1/R2/R3.
+
+> **Framing this report must state up front (so the synthesis isn't misread):** my brief is *"assume netcanon
+> DOES adopt SOPS, design the concrete integration."* I do that. But the design honesty rule in the seed
+> (`00-blackboard.md:28-32`) and R1/R2/R3's findings force me to flag, at every step, where the integration is
+> either **redundant with the existing 3-tier Fernet scheme** or **structurally blocked** (the SOPS decryption
+> key co-locates with the ciphertext in every netcanon run-mode — R1 §7, R2 §5.1, R3 §3). So this is a *buildable*
+> design with the ugly parts called out, NOT an argument that it should be built. The GO/NO-GO call belongs to
+> D2 + the synthesis; my job is to make the cost and shape concrete enough that the verdict is well-informed.
+> **My own bottom line, stated honestly:** the only integration variant that buys anything real is the narrow
+> one in §1.C (SOPS as an *operator-side, opt-in delivery mechanism for `NETCANON_FERNET_KEY` on the server/
+> Docker mode only*) — and even that is dominated by the env-var tier netcanon already ships. Everything wider
+> than that is `OVER-ENGINEERING`/`RUNTIME-BLOCKER`. I design all variants so the synthesis can pick.
+
+---
+
+## 0. Anchors I am building on (do not re-derive)
+
+From the three research reports, treated as fixed:
+
+- **R1 census (`10-…md`):** two secret classes — (a) device login creds in `devices/*.json` + legacy
+  `schedules/*.json`, **already Fernet-encrypted at rest** (`device_profile_store.py:64-67`,
+  test-guarded `tests/unit/test_device_profile_store.py:124-133`); (b) the fetched device configs in
+  `configs/**`, **plaintext, the largest cleartext secret surface**, never encrypted/redacted on the write
+  path (`backup_runner.py:233-241`, `file_store.py:1-3`). The Fernet key resolves through a 3-tier chain
+  (env → keyring → file) and in Tier 3 **co-locates** with the ciphertext (`credentials.py:192-211`).
+- **R2 Kontroll (`11-…md`):** SOPS+age works in Kontroll because the age key lives on a **separate control VM**
+  from the consumers and the ciphertext is **committed to git**; decryption is **render-time** (Ansible →
+  one `0600` `.env`), the app never holds the key. **None of {separate-machine custody, commit-ciphertext-to-git,
+  render-time Ansible} transfers** to a single local-first app.
+- **R3 runtime (`12-…md`):** four run-modes (desktop/server/docker/MSI) all funnel through the **same
+  `create_app()`** (`main.py:69`). The key co-locates with the ciphertext in **every default zero-config mode**;
+  the *only* decoupled posture is **Tier 1 env-var sourced off-host** — which already exists. SOPS adds binary
+  deps to a pure-Python Docker image + an unsignable MSI for no new property.
+
+I do **not** contradict any of these. Where SOPS is infeasible in a mode (per R3 §3), I say so and scope around it.
+
+---
+
+## 1. (Q1) WHAT gets SOPS-encrypted — the target set
+
+R1 §8 gives three candidate buckets. I evaluate each as a SOPS target and design the *least-bad* mapping.
+There are three coherent variants; I name them A/B/C and recommend C (narrowest).
+
+### 1.A — Device-profile credentials at rest (REPLACE Fernet with SOPS)
+
+**Shape:** stop Fernet-encrypting the two password fields inside each `devices/{id}.json`; instead keep one
+SOPS-encrypted file per profile (or one aggregate file) whose `password`/`enable_password` values are
+`ENC[AES256_GCM,…]`, decrypted via the `sops` library/binary on load.
+
+```yaml
+# data/devices/3f2a….sops.json  (SOPS-encrypted, encrypted_regex catches only cred fields)
+{
+  "id": "3f2a…", "name": "core-sw-1", "type_key": "Cisco", "host": "10.0.0.1",
+  "username": "netadmin",
+  "password": "ENC[AES256_GCM,data:…,iv:…,tag:…,type:str]",
+  "enable_password": "ENC[AES256_GCM,data:…,iv:…,tag:…,type:str]",
+  "sops": { "age": [ … ], "lastmodified": "…", "mac": "ENC[…]", "version": "3.x" }
+}
+```
+
+```yaml
+# .sops.yaml  (creation rule — basename-anchored, like Kontroll instance/.sops.yaml:26-32)
+creation_rules:
+  - path_regex: (^|/)devices/.*\.sops\.json$
+    encrypted_regex: '^(password|enable_password)$'   # leave id/host/username plaintext
+    age: 'age1operator…'                              # ← the load-bearing problem (see §2)
+```
+
+**VERDICT: `OVER-ENGINEERING` + `RUNTIME-BLOCKER`.** This is a pure **rip-and-replace of a working,
+test-guarded scheme** (`credentials.py`, `migration.py`, `device_profile_store.py:64-67`) with one that has the
+**identical at-rest threat ceiling** (R3 §4) and a strictly worse key story: Fernet's Tier 2 (OS keyring/DPAPI)
+gives desktop/MSI an out-of-band key *for free* (R3 §3a/§3d); a SOPS age identity on desktop must live on the
+same disk as the ciphertext → **co-located, no gain, and now the user owns an age key** (AGENTS.md:111-128
+single-user-utility ethos). This variant should be **rejected outright** by the synthesis. I include it only to
+make the rip-and-replace cost explicit: it touches `credentials.py`, both storage loaders, `migration.py`, and
+every credential test, for zero new security property.
+
+### 1.B — The backup artifacts (`configs/**`) at rest (NEW encryption surface)
+
+**Shape:** SOPS-encrypt each fetched config as it is written in `backup_runner.py:233-241` /
+`file_store.py:162-186`; decrypt on the view/migrate/sanitize read paths.
+
+**VERDICT: `THREAT-MISMATCH` + wrong tool + real functional regression.** Three independent problems:
+
+1. **SOPS is a structured-document tool** (YAML/JSON/ENV/INI/dotenv key-value). A Cisco `running-config` or a
+   Junos `set`-form blob is **unstructured text**, so SOPS would fall back to whole-file binary mode
+   (`sops -e --input-type binary`) — which gives you exactly what Fernet/`age -e` gives you with far less
+   ceremony. There is no per-field selectivity to exploit (the value SOPS uniquely adds).
+2. **Bulk volume.** R1 §8 calls this "bulk, high-volume, frequently-written content"; backups run on a schedule
+   and can be 50 MB each (`file_store.py:100`). Wrapping every backup in a `sops`-binary subprocess per file is
+   a throughput + CPU cost for the offline-disk-exfil threat only (R3 §4 — and the key co-locates anyway).
+3. **Functional regression.** The configs tree is *meant to be readable* — operators `View`/`Open in editor`
+   (`POST /api/v1/configs/{filename}/open`, AGENTS.md:85-89), diff, and `git`-track their backups externally.
+   Encrypting them at rest breaks every out-of-band tool the operator already uses on that directory. The
+   **correct** at-rest answer for `configs/` is R3 §5.6: **OS-level volume encryption** (BitLocker is on by
+   default on the Win 11 desktop platform; LUKS/encrypted-EBS for server/Docker) — zero app code, covers the
+   whole tree including the Fernet key, same ceiling. SOPS here is the wrong layer.
+
+If the synthesis wants *any* at-rest story for `configs/`, route it to OS volume encryption + the existing
+on-demand sanitizer for *sharing* — **not** SOPS.
+
+### 1.C — A deploy/config secret file (NARROW, opt-in, server/Docker only) ✅ recommended-if-anything
+
+**Shape:** netcanon stores **nothing new**. Instead, document + (optionally) ship a thin helper so an operator
+who *already* uses SOPS in their estate can keep `NETCANON_FERNET_KEY` in a committed `*.sops.yaml` and have it
+decrypted **at process launch, outside the app**, into the env var Tier 1 already consumes
+(`credentials.py:163-167`). This is the **only** mapping that matches SOPS's actual shape (a small declarative
+secret file, committed, decrypted out-of-band by an off-host key — R2 §4.1) **and** netcanon's actual gap (the
+Tier-3 co-location, fixable by sourcing Tier 1 from off-host).
+
+```yaml
+# secrets.sops.yaml  — operator-owned, lives in THEIR ops repo, NOT netcanon's
+NETCANON_FERNET_KEY: ENC[AES256_GCM,data:…,iv:…,tag:…,type:str]
+sops:
+  age: [ { recipient: age1operator…, enc: "-----BEGIN AGE ENCRYPTED FILE-----…" } ]
+```
+
+```bash
+# launch wrapper (operator-side, NOT in the netcanon image): decrypt → export → exec
+export NETCANON_FERNET_KEY="$(sops --decrypt --extract '["NETCANON_FERNET_KEY"]' secrets.sops.yaml)"
+exec uvicorn netcanon.main:app --host 0.0.0.0 --port 8000
+```
+
+**VERDICT: `VIABLE` but `OVER-ENGINEERING` vs the baseline.** This works, requires **no netcanon code change at
+all** (Tier 1 already reads the env var), keeps `sops`/`age` entirely **out of** netcanon's image/MSI (it runs in
+the operator's deploy tooling, exactly like Kontroll runs it in Ansible — R2 §3), and the age key lives in the
+operator's existing custody (their secret store / CI), never in netcanon's data-dir. **But** R3 §3b/§3c shows the
+same `.env.example:41-44` already enumerates k8s Secret, Compose `secrets:`, systemd `EnvironmentFile` as
+off-host delivery for that same env var — SOPS is just *one more* delivery option among those, valuable **only to
+an operator whose estate is already SOPS-shaped**. So the honest "integration" is: **a 6-line README recipe, zero
+code, zero packaging.** That is the entire defensible scope.
+
+### Target-set summary
+
+| Candidate | Maps to SOPS's shape? | New security property over status quo? | Verdict |
+|---|---|---|---|
+| **A** device creds (replace Fernet) | partial (small JSON) | **none** — same ceiling, worse desktop key story | **REJECT** (`OVER-ENGINEERING`) |
+| **B** `configs/**` artifacts | **no** (unstructured, bulk → binary mode) | none + breaks View/diff/git | **REJECT** (`THREAT-MISMATCH`) — use OS volume encryption |
+| **C** `NETCANON_FERNET_KEY` in a SOPS file, decrypted at launch | **yes** (the only true fit) | only on server/Docker, only if estate already SOPS | **NARROW GO** — docs-only, no code, no packaging |
+
+**Only encrypt what is genuinely sensitive-at-rest (the seed's rule):** creds are already encrypted; configs are
+better served by OS encryption; the one thing worth keeping off the data-dir is the *key*, and variant C does
+exactly that without re-encrypting anything netcanon stores.
+
+---
+
+## 2. (Q2) WHERE the private key lives per run-mode — the hard part
+
+This is the question R3 §3 surfaced as load-bearing. I answer it concretely per mode for the only buildable
+variant (C), and note where it forces a compromise or has **no clean home**. (For A/B the answer is the same
+co-location verdict, only worse, since the app itself would need the key.)
+
+| Mode | Where the age private key would live | Co-located with ciphertext? | Clean home? |
+|---|---|---|---|
+| **(a) Desktop (PySide6)** | Would have to sit on the user's disk (`%APPDATA%` or `~/.config/sops/age/keys.txt`) so the app can read it at launch | **YES** — same machine/user as `devices/*.json` | **NO CLEAN HOME.** DPAPI keyring already gives an out-of-band key for free (R3 §3a). A user-owned age key is strictly worse + new burden. **Scope SOPS OUT of desktop entirely.** |
+| **(b) Server (pip/uvicorn)** | In the **operator's deploy tooling / secret store**, used by the launch wrapper to decrypt → export `NETCANON_FERNET_KEY`, **never written to the data-dir** | **NO** (if wrapper runs on a trusted admin host / CI and only the *decrypted env var* reaches the server process) | **YES-ish** — but identical to "operator sets `NETCANON_FERNET_KEY` from their secret manager," which exists. |
+| **(c) Docker** | **Must NOT be baked into the image** (every pull would share it — catastrophic, cf. R3 §3d on the MSI). Either (i) decrypt **outside** the container in the orchestrator and inject `-e NETCANON_FERNET_KEY` (recommended; key never enters container), or (ii) mount the age key into the container + run `sops` in an entrypoint — which **re-creates co-location** (R3 §3c: the age key now sits on the same host/volume as the ciphertext). | (i) **NO**; (ii) **YES** | (i) **YES** but ≡ Tier 1; (ii) **NO** — reinvents the Tier-3 problem with extra binaries. |
+| **(d) MSI** | **No home exists.** R3 §3d: the MSI can bundle a *binary* via `include_files` (`setup_desktop.py:97-110`) but **cannot bundle a per-user key**; shipping one shared key is catastrophic; generating one at runtime puts it on the same disk as the ciphertext (≡ desktop co-location) and asks a network engineer to manage an age keypair. The MSI is also **unsigned today** (`desktop-msi-publish.yml:20-22`) so adding a crypto binary expands the SmartScreen/AV surface. | **YES** (if a key is generated) | **NO CLEAN HOME.** Same as desktop — **scope SOPS OUT.** |
+
+**The honest per-mode answer:** SOPS has a *defensible* key home in **exactly one place — the operator's
+off-host deploy tooling in server/Docker mode (variant C, path i)** — and that home is **not inside netcanon at
+all**; it is the operator's existing secret custody, the same place Tier 1's env var already comes from. In
+desktop and MSI there is **no clean key home** (DPAPI dominates; no per-install secret mechanism exists). In
+Docker the "in-container" path reinvents co-location. So the design **must explicitly scope SOPS to server/Docker
+operator-tooling and leave desktop/MSI on the existing keyring tier** — anything else is `RUNTIME-BLOCKER`.
+
+---
+
+## 3. (Q3) The decrypt flow — at-load vs at-use; where plaintext lives, for how long
+
+Two candidate flows; the choice only matters for variants A/B (where the app decrypts). For variant C the app
+never sees SOPS — it just reads `NETCANON_FERNET_KEY` from the env exactly as today, so §3 is moot for the
+recommended scope. I document both so the synthesis can see why A/B are also worse here.
+
+### 3.1 At-load (decrypt the whole store on startup → plaintext in memory)
+
+This mirrors netcanon's **current** Fernet behaviour: `FileDeviceProfileStore.load_all()`
+(`device_profile_store.py:86-125`) decrypts every credential field into the in-memory `DeviceProfile` registry
+once at lifespan startup; the in-memory model holds **plaintext for the whole process lifetime** (the module
+docstring is explicit: `credentials.py:41-46`, `device_profile_store.py:10-12`).
+
+- **Plaintext residence:** process memory, for the life of the process (re-resolved each restart).
+- **SOPS-at-load sketch (variant A):** in `load_all()`, replace the `migrate_credential_fields(...)` decrypt with
+  a `sops --decrypt` (or `pysops`/`pyrage`) call per file → parse → hydrate. **Cost vs today:** N subprocess
+  spawns at startup (one `sops` exec per profile) instead of N in-process Fernet decrypts — slower, and adds the
+  binary dep. **Same plaintext-in-memory residence as today.** No improvement, measurable regression.
+
+### 3.2 At-use (decrypt one credential when a backup runs)
+
+Decrypt lazily only when `backups._resolve_credentials` needs the password for an actual SSH connect
+(`backups.py:128-136` re-wraps into `SecretStr`; netmiko reads it at `netmiko_collector.py:88-94`).
+
+- **Plaintext residence:** ideally only for the duration of the SSH session, then dropped. This is the
+  *theoretically* better hygiene posture (shorter plaintext window) and mirrors Kontroll's lazy-deref-under-`no_log`
+  discipline (R2 §3.1).
+- **Reality check:** netcanon's current design materialises plaintext at load, not at use, and the backup worker
+  thread already holds the plaintext profile (`device_profile_store.py:36-44` lock comment). Moving to at-use
+  would be a **larger refactor than the SOPS adoption itself** (the registry currently *is* the plaintext store),
+  and Python `str` immutability means you cannot reliably zero the plaintext anyway (it lingers until GC). So the
+  shorter-window benefit is **mostly illusory in CPython** — `RUNTIME-BLOCKER`-adjacent.
+
+**Recommendation for the flow question:** if (against my recommendation) A is ever built, use **at-load** to
+match the existing architecture and avoid the registry refactor — but recognise it buys nothing over the Fernet
+at-load it replaces. For variant C, **there is no in-app decrypt flow** — `sops` runs once in the launch wrapper,
+emits the key to the env, the app's existing Tier-1 path takes over, and plaintext-key residence is identical to
+today (process env + the in-memory Fernet instance, `credentials.py:214-224`).
+
+---
+
+## 4. (Q4) Key rotation + multi-recipient (operator + CI)
+
+This section only has teeth for variant C (the others have no off-host key to rotate meaningfully). I borrow the
+**discipline** from Kontroll (R2 §2.2) but flag that netcanon has **no second principal** to justify the full
+key-group machinery (R2 §5.2: "Least-privilege across principals presupposes ≥2 principals").
+
+### 4.1 Multi-recipient `.sops.yaml` (operator + CI)
+
+```yaml
+# operator's ops-repo .sops.yaml  (NOT netcanon's repo)
+creation_rules:
+  - path_regex: (^|/)secrets\.sops\.ya?ml$
+    age: >-
+      age1operator…,    # day-to-day operator decrypt (laptop / admin host)
+      age1ci…,          # CI runner that deploys netcanon (decrypts at deploy)
+      age1breakglass…   # offline recovery key (never on the deploy host)
+```
+
+- **Operator key:** the human who runs deploys; lives in their secret store, mirrors Kontroll's control-VM key
+  (`SECURITY.md:52-54` in Kontroll).
+- **CI key:** scoped to the deploy pipeline so CI can `sops --decrypt` → inject `NETCANON_FERNET_KEY`. This is the
+  one place a *second principal* genuinely appears (operator vs CI) — but note it's the **operator's CI**, not
+  netcanon's product, so this is operator-ops design, not netcanon-product design.
+- **Break-glass:** offline recovery key per Kontroll R2 §2.2 — only meaningful if you accept that losing the
+  `NETCANON_FERNET_KEY` means re-entering all device profiles (which netcanon *already* accepts as a tolerated
+  risk — `SECURITY.md:502`, R1 §3). So break-glass is arguably **over-built for netcanon's stated risk posture**.
+
+### 4.2 Rotation
+
+- **`NETCANON_FERNET_KEY` rotation (the real one):** netcanon **already documents** a rekey procedure
+  (`SECURITY.md:80-161`, R3 §2) — generate a new Fernet key, the stores re-encrypt on next save. SOPS is
+  orthogonal: rotating the *Fernet* value inside the SOPS file is `sops --set` then redeploy; rotating the *age
+  recipients* is `sops updatekeys` after editing `.sops.yaml` (Kontroll defers this as a manual operator step —
+  R2 §2.4, `SECURITY.md:353-360`). **Two rotation surfaces instead of one** is a net complexity add.
+- **Flag:** rotation here is a feature of the operator's SOPS workflow, not of netcanon. netcanon's own rotation
+  story (rekey + re-save) is unchanged and already exists.
+
+---
+
+## 5. (Q5) Dev/test story — fixtures/tests must run with NO real key
+
+This is mandatory regardless of variant: CI and contributors must never need a real age key, and AGENTS.md
+Hard Rules forbid committing real secrets (AGENTS.md:249, 290-294).
+
+### 5.1 The Kontroll precedent to copy
+
+Kontroll's `instance.example/.sops.yaml` ships a **placeholder** recipient (`age1example…`,
+R2 §2.4 / `instance.example/.sops.yaml:24`) that `--fresh` replaces. The transferable pattern is a **committed
+test age identity** — a throwaway keypair whose *private* half is committed *on purpose* (it protects nothing
+real), exactly the "DUMMY-domain" approach the seed references.
+
+### 5.2 Concrete test fixture
+
+```
+tests/fixtures/sops/
+  age-test-key.txt          # PUBLICLY-COMMITTED throwaway age identity (AGE-SECRET-KEY-1TEST…)
+  .sops.yaml                # creation rule → the test recipient only
+  example.secrets.sops.yaml # NETCANON_FERNET_KEY encrypted to the test key
+```
+
+```python
+# tests/conftest.py  (or a sops marker fixture)
+@pytest.fixture
+def sops_test_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOPS_AGE_KEY_FILE", str(FIXTURES / "sops" / "age-test-key.txt"))
+    # decrypt with the throwaway key, assert the round-trip; NEVER a real key
+    ...
+```
+
+- **Critical:** the committed test private key must be **unmistakably fake** (mirror AGENTS.md:290-294's
+  synthetic-hash rule), e.g. a comment header `# THROWAWAY TEST KEY — protects nothing — do NOT reuse`. The
+  `gitleaks` custom rule Kontroll uses to *catch* `AGE-SECRET-KEY` (R2 §2.3) would **fire on this file** — so
+  netcanon would need a `gitleaks` allowlist entry for exactly this path, which is itself a small ongoing tax.
+- **The deeper flag:** netcanon today needs **zero** key material in its test tree — Fernet tests
+  (`tests/unit/test_credentials.py:107-149`) generate an ephemeral key in-process via `reset_fernet()`
+  (`credentials.py:266-269`) and `Fernet.generate_key()`. Adopting SOPS **introduces** a committed-key fixture +
+  a `gitleaks` allowlist carve-out where none was needed. That is a new attack-surface-shaped maintenance item
+  (a committed private key, even fake, that a future careless edit could swap for a real one) — `POLISH`-tagged
+  cost but worth naming.
+
+---
+
+## 6. (Q6) Packaging cost — shipping `sops` + `age` into Docker and (critically) the MSI
+
+This is where the integration gets ugliest, and it only arises for variants where **netcanon itself** decrypts
+(A/B, or variant C path-ii where `sops` runs in the container). Variant C path-i (decrypt in operator tooling)
+ships **nothing** — which is the strongest argument for that scope.
+
+### 6.1 Docker
+
+- **Current image is pure-Python slim** with **only `curl`** added at runtime (`Dockerfile:48-56`); the builder
+  stage has `build-essential`/`libffi-dev`/`libssl-dev` but the **runtime stage carries none of them**
+  (`Dockerfile:48-63`). There are deliberately **no extra binaries** in the runtime layer.
+- **To run `sops` in-container** you must either (a) `apt-get install` nothing-from-Debian (sops is not in
+  bookworm's default repos) → download the `sops` + `age` release binaries (~20-40 MB combined) and `COPY` them
+  into the runtime stage, **or** (b) add a pure-Python path: `pyrage` (Rust `age` binding via maturin wheel) +
+  a SOPS-format reader. Either way the pure-Python-slim property R3 §3c calls out is **lost**, the image grows,
+  and the SBOM/attestation surface (AGENTS.md:186 packaging row → SECURITY.md Dependency Supply Chain table)
+  gains a new entry that must be documented in the same commit.
+- **Multi-arch:** the publish workflow builds for amd64 (and likely arm64); the `sops`/`age` binary `COPY` must
+  be arch-aware (`TARGETARCH` build-arg + per-arch download) — a real Dockerfile complication.
+
+### 6.2 Windows MSI — the hard wall
+
+- The MSI is a **cx_Freeze bundle** of Python libs + `definitions/` + license notices
+  (`setup_desktop.py:76-110`); its `packages`/`include_files` lists are Python-import-driven. Adding `sops.exe`
+  + `age.exe` means: download Windows release binaries, add them to `include_files`
+  (`setup_desktop.py:97-110`), redistribute them under **their** licenses (sops = MPL-2.0, age = BSD-3) → a new
+  `THIRD-PARTY-NOTICES.txt` obligation (the file already tracks PySide6/paramiko/pystray — `setup_desktop.py:103-109`).
+- **The MSI is unsigned** (`desktop-msi-publish.yml:20-22`, R3 §3d). Bundling two unsigned native crypto
+  executables **materially expands the SmartScreen / AV false-positive surface** — exactly the kind of friction
+  AGENTS.md:120-122 cites as the reason auto-update was deliberately omitted.
+- **And it buys nothing** (R3 §3d): the MSI's winning key tier is DPAPI keyring; there is **no per-install age
+  key home** in an MSI. So the MSI would ship two crypto binaries to support a key-management flow that **has no
+  valid key location in that mode**. This is the single clearest `RUNTIME-BLOCKER` in the whole packaging story:
+  **the MSI cannot host SOPS meaningfully, so it should not carry the binaries at all.**
+
+### 6.3 Packaging verdict
+
+| Distribution | Binary cost | Buys what? | Recommendation |
+|---|---|---|---|
+| Docker (path-i: decrypt outside) | **none in image** | off-host key delivery ≡ Tier 1 | OK — docs only |
+| Docker (path-ii: decrypt in entrypoint) | +`sops`+`age` (~20-40 MB, arch-aware), loses pure-Python-slim | re-creates co-location | **REJECT** |
+| MSI | +`sops.exe`+`age.exe`, new license notices, bigger AV surface, **unsigned** | **nothing — no key home** | **REJECT** |
+
+**Friction estimate:** Docker path-i = ~6 lines of README. Docker path-ii / MSI = a multi-arch binary-vendoring
+exercise + license-notice updates + SECURITY.md supply-chain row + a bigger unsigned-MSI AV surface, for a key
+flow that **doesn't have a home in the MSI mode**. The packaging math alone argues the scope must be **operator-
+tooling only (C path-i)**, never bundled.
+
+---
+
+## 7. (Q7) Migration of any existing plaintext store
+
+There are two distinct "existing store" migration questions, and netcanon already has machinery for the one that
+matters.
+
+### 7.1 The Fernet legacy-plaintext migration ALREADY EXISTS (do not rebuild)
+
+`migrate_credential_fields` + `decrypt_field` (`migration.py:18-35`, `credentials.py:246-263`) already do
+transparent one-shot migration: any credential field that fails Fernet decryption is treated as legacy plaintext,
+returned as-is, and the file is immediately re-saved encrypted (`device_profile_store.py:104-118`,
+`schedule_store.py:90-104`). This is the migration that already protects real operators upgrading from a
+pre-encryption version. **Any SOPS adoption must NOT regress this** — it is test-and-doc-guarded
+(`SECURITY.md:155-161`).
+
+### 7.2 Migrating Fernet→SOPS (only relevant to the rejected variant A)
+
+If variant A were built, you would need a **second** one-shot migration: on load, detect a Fernet token
+(`gAAAAA…`) vs a SOPS-`ENC[…]` value, decrypt with Fernet, re-encrypt with SOPS, re-save. Sketch:
+
+```python
+def _migrate_fernet_to_sops(value: str) -> tuple[str, bool]:
+    if value.startswith("ENC[AES256_GCM"):       # already SOPS
+        return sops_decrypt_field(value), False
+    plaintext, _ = decrypt_field(value)          # Fernet or legacy plaintext (existing path)
+    return plaintext, True                        # caller re-encrypts via SOPS + re-saves
+```
+
+**Flag:** this is a *third* token format the loader must disambiguate (legacy-plaintext, Fernet, SOPS) — more
+code, more edge cases, for variant A which §1.A already rejects. The migration cost is therefore an argument
+**against** A, not a feature of it.
+
+### 7.3 Variant C needs NO store migration
+
+Because variant C re-encrypts nothing netcanon stores (it only changes how the *operator* delivers
+`NETCANON_FERNET_KEY`), **there is zero data migration** — the existing Fernet-at-rest stores and their legacy
+migration are untouched. This is another reason C is the only sane scope: it is **purely additive operator
+documentation**.
+
+---
+
+## 8. The buildable-now scope (if the synthesis says GO)
+
+Distilling §1-§7 into the *only* thing I'd actually build, and the things I'd explicitly refuse:
+
+**BUILD (if anything):**
+
+1. A **README/SECURITY.md recipe** (no code) under the existing key-management docs (`SECURITY.md:80-161`,
+   `.env.example:32-52`) showing the variant-C launch-wrapper pattern (§1.C): "if your estate already uses SOPS,
+   here's how to source `NETCANON_FERNET_KEY` from a `*.sops.yaml` at launch — server/Docker only." This slots
+   in next to the k8s/Compose/systemd delivery options already documented (R3 §3b/§3c) as one more.
+2. **Explicitly document the non-fit** for desktop/MSI (DPAPI dominates; no key home) so a future contributor
+   doesn't speculatively add it — mirroring AGENTS.md:111-128's "Deliberately omitted (preventive)" pattern.
+
+**REFUSE:**
+
+- Replacing Fernet with SOPS for `devices/*.json` (§1.A — `OVER-ENGINEERING`/`RUNTIME-BLOCKER`).
+- SOPS-encrypting `configs/**` (§1.B — `THREAT-MISMATCH`; use OS volume encryption instead).
+- Bundling `sops`/`age` into the Docker image or the MSI (§6 — packaging tax, no key home in MSI).
+- Adding a committed test age key + `gitleaks` allowlist (§5 — new key-shaped surface where none existed).
+
+---
+
+## 9. Where it gets ugly (consolidated flag list for V1 + synthesis)
+
+| # | Ugly spot | Why | Tag |
+|---|---|---|---|
+| U1 | Desktop/MSI have **no clean key home** for an age identity; DPAPI already provides one for free | §2, R3 §3a/§3d | `RUNTIME-BLOCKER` |
+| U2 | In-container `sops` (Docker path-ii) **re-creates** the Tier-3 co-location it was meant to fix | §2, R3 §3c | `RUNTIME-BLOCKER` |
+| U3 | MSI would ship two unsigned crypto binaries to support a key flow with **no valid key location in that mode** | §6.2 | `RUNTIME-BLOCKER` + `OVER-ENGINEERING` |
+| U4 | Variant A is a rip-and-replace of a working, test-guarded scheme for the **same threat ceiling** | §1.A, R3 §4 | `OVER-ENGINEERING` |
+| U5 | Variant B uses SOPS as a whole-file binary blob on bulk text + **breaks View/diff/git** on `configs/` | §1.B | `THREAT-MISMATCH` |
+| U6 | SOPS introduces a **committed (fake) age key + gitleaks carve-out** where netcanon needs zero key material in tests today | §5.2 | `POLISH` (but a real new surface) |
+| U7 | Two rotation surfaces (Fernet value + age recipients) replace one (existing rekey) | §4.2 | `OVER-ENGINEERING` |
+| U8 | A third loader token format (plaintext/Fernet/SOPS) to disambiguate, if A is built | §7.2 | `OVER-ENGINEERING` |
+| U9 | Variant C's "integration" reduces to a README recipe that is **one of several already-documented** off-host delivery options for the env var | §1.C, R3 §3b | `OVER-ENGINEERING` (redundant) |
+
+---
+
+## 10. Synthesis hand-off (D1 → V1 / 99-synthesis)
+
+- **The only buildable-and-defensible SOPS scope is variant C, server/Docker, docs-only, decrypt-in-operator-
+  tooling.** It requires **no netcanon code change, no store migration, and no `sops`/`age` in any netcanon
+  artifact** — because the work happens in the operator's deploy pipeline (exactly how Kontroll uses it — R2 §3),
+  and the app's existing Tier-1 env-var path (`credentials.py:163-167`) consumes the result unchanged.
+- **Every wider variant is blocked or redundant:** A replaces a working scheme for the same ceiling (and a worse
+  desktop key story); B is the wrong tool for unstructured bulk artifacts and breaks operator workflows; the
+  Docker-in-container and MSI packaging paths have no valid key home (U1-U3).
+- **Therefore my design honestly supports a `GO-WITH-NARROW-SCOPE` at most, leaning `NO-GO`:** even variant C is
+  dominated by the env-var tier netcanon already ships, so its marginal value is *only* "a recipe for operators
+  whose estate is already SOPS." If D2's threat head-to-head confirms the co-location ceiling (it will — R3 §4),
+  the right call is likely **NO-GO + a one-paragraph SECURITY.md note** that SOPS is an operator-side delivery
+  option for Tier 1, not a netcanon feature.
+- **Concrete artifacts I sketched for whoever builds C:** the `.sops.yaml` creation rule (§1.C), the launch
+  wrapper one-liner (§1.C), the multi-recipient ruleset (§4.1), and the test-key fixture layout (§5.2) — all
+  operator-side, none touching netcanon source.
+
+*Verified against source this run: `netcanon/security/credentials.py` (full, 3-tier `_resolve_key` :156-211,
+`encrypt`/`decrypt`/`decrypt_field` :227-263, `reset_fernet` :266-269); `netcanon/security/migration.py` (full);
+`netcanon/storage/device_profile_store.py` (full, encrypt-on-save :64-67, load+migrate :86-125, lock :31-45);
+`netcanon/storage/schedule_store.py` (full, legacy inline-cred encrypt :49-54 / migrate :90-104); `Dockerfile`
+(full, pure-Python-slim runtime :48-63, only `curl` added, `NETCANON_DATA_DIR=/app/data` :80, VOLUME :94,
+uvicorn entrypoint :96); `setup_desktop.py` :70-190 (cx_Freeze packages/include_files/excludes, executables);
+`pyproject.toml` :52-106 (cryptography :73 + keyring :74 base deps, desktop-build extra :103); `AGENTS.md`
+(Hard Rules :249/:290-294, deliberately-omitted :111-128, packaging doc-sync row :186). Peer reports
+10/11/12 read in full.*

--- a/docs/reviews/2026-06-17-sops-evaluation/21-design-threat-and-alternatives.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/21-design-threat-and-alternatives.md
@@ -1,0 +1,301 @@
+# 21 — Threat Model + Alternatives Bake-Off (SOPS for netcanon)
+
+**Author:** D2 (design) · **Run:** 2026-06-17 SOPS evaluation · **Status:** design report, read-only.
+**Inputs:** R1 census (`10-research-secret-census.md`), R2 Kontroll precedent (`11-research-kontroll-sops-precedent.md`),
+R3 runtime/deploy (`12-research-runtime-deployment.md`). D1's SOPS integration design (`20-design-sops-integration.md`)
+had not landed when this was written; I verified the load-bearing source facts myself (cites below) rather than rely on it.
+
+---
+
+## 0. Bottom line up front (the one thing synthesis needs)
+
+**What threat are we actually buying down?** Exactly one: **T4 — an *offline* copy of the data directory (stolen
+disk image, leaked Docker `data/` volume tarball, copied `%APPDATA%` folder) read on a *different* machine that
+lacks the host's key material.** netcanon **already buys this down today** for device credentials via Fernet, and
+buys it down again — for the whole data dir including the plaintext backup configs and the `.fernet_key` itself —
+via the OS-level encrypted volume that ships on by default on the Windows desktop target (BitLocker on Win 11).
+
+**Is SOPS the most cost-appropriate tool for it?** **No.** SOPS's entire security value is *decryptor ≠
+ciphertext-host* (R2 §5.1). That property is **structurally unavailable in every netcanon run-mode** — the process
+that decrypts, the key, and the ciphertext all sit on one machine under one OS user (R3 §3). So SOPS would re-buy
+the *same* T4 mitigation Fernet already provides, while adding a `sops`+`age`/`gpg` binary to the pure-Python
+Docker image and MSI, and a key-management burden onto a single-user desktop that will never own an `age` key.
+
+**Recommendation: NO-GO on SOPS.** The single best-fit is **"do nothing new in the app code; harden the docs +
+default posture"** — specifically (a) document/encourage Tier-1 (`NETCANON_FERNET_KEY`) + an encrypted volume for
+server/Docker operators, and (b) optionally close the one genuine *residual* gap (the plaintext **backup
+artifacts** in `configs/`, which Fernet does not reach) — but even that gap is best closed by the encrypted-volume
+/ ops layer, **not** by SOPS. Full reasoning + matrices below. Severity tags for V1: **`THREAT-MISMATCH`** +
+**`OVER-ENGINEERING`** on any SOPS adoption; **`RUNTIME-BLOCKER`** on the premise that SOPS protects a running
+netcanon instance.
+
+---
+
+## 1. The threat model (explicit attacker × asset × run-mode)
+
+### 1.1 Assets at risk (from R1's census)
+
+| Asset | At-rest format today | Cite |
+|---|---|---|
+| A1 — Device SSH/enable credentials | **Fernet ciphertext** in `devices/*.json` (+ legacy `schedules/*.json`) | `device_profile_store.py:64-67`, `credentials.py:227-233` |
+| A2 — The Fernet master key | **Plaintext** `.fernet_key` (Tier 3 only); off-disk in Tier 1/2 | `credentials.py:117-153,192-211` |
+| A3 — Backup artifacts (fetched device configs) | **Plaintext, verbatim** in `configs/**` — contain device `$9$`/type-7/`$6$` hashes, SNMP/RADIUS/IKE keys | `backup_runner.py:233-241`, `file_store.py:1-3` |
+| A4 — Job history / sidecars / known_hosts | Plaintext, **no confidential payload** (hosts/IPs + public keys only) | `models/backup.py:61-117`, `hostkey.py:41-90` |
+
+A4 is out of scope for any confidentiality scheme (it holds no secret). The real candidates are **A1 (small,
+already encrypted)** and **A3 (large, plaintext, the product stores it raw on purpose)**.
+
+### 1.2 The candidate threats (the seed's T1–T6, made precise)
+
+| ID | Attacker / scenario | What they get access to | Realistic for netcanon? |
+|---|---|---|---|
+| **T1** | A **non-root local user** on the same host reads the data dir | Filesystem read of `data_dir` *while the host is live*, but **without** the owning user's session/keyring/env | Server/Docker: plausible on a shared box. Desktop: only if OS file ACLs are wrong (they aren't — `%APPDATA%` is per-user). |
+| **T2** | **Backup-artifact exfil** — someone copies `configs/**` off the box | The plaintext device configs (A3) | **The most realistic high-value leak.** A3 is plaintext and bulky; the device secrets inside are the payload. |
+| **T3** | **Accidental `git commit` / `git add -A`** of the data dir or a secrets file | Whatever lands in the repo + is pushed | Low — `.gitignore` already excludes `devices/`,`schedules/`,`jobs/`,`configs/`,`.fernet_key`,`**/.fernet_key` (`.gitignore:18-28`). |
+| **T4** | **Stolen disk image / offline backup** of the host, read on another machine | A cold copy of the whole data dir + `.fernet_key` *if Tier 3*; **no** live keyring/env | **The canonical at-rest threat.** Stolen laptop, leaked volume tarball, offsite backup tape. |
+| **T5** | **Shared / multi-tenant host** — another tenant or admin reads the data | Filesystem read as a *different principal* on the same live host | Server/Docker only; the desktop/MSI is explicitly single-user loopback-only (`AGENTS.md:108-109`). |
+| **T6** | **Secret in a process-memory dump** of the running app | Live RSS of the netcanon process (RCE, core dump, `/proc/<pid>/mem`, hibernation file) | Possible wherever the app runs; **inherent** to any decrypt-at-runtime design. |
+
+Two extra scenarios worth naming because they reframe the verdict:
+
+- **T2′ — exfil of `configs/` specifically** is a *subset of T2* but matters on its own because A3 is the **only**
+  asset Fernet does **not** cover. Any "should we encrypt more at rest" conversation is really about A3.
+- **T-net — a network attacker hitting the exposed `0.0.0.0:8000` API** is an **authn/authz** problem, not an
+  encryption one (`SECURITY.md:499-500` concedes there is no API auth — operators add a reverse proxy). No at-rest
+  scheme touches it; listed only to keep it out of scope cleanly.
+
+### 1.3 The load-bearing fact: key co-location per run-mode (verified, not assumed)
+
+R3 §3 establishes — and I re-confirmed against source — that in **every default zero-config run-mode the
+decryption key is reachable on the same host the app runs on**, and the running app must hold the plaintext key in
+memory regardless:
+
+| Run-mode | Default winning key tier | Key on the data disk? | Key reachable by a live-host attacker who is the owning user? |
+|---|---|---|---|
+| (a) Desktop / (d) MSI | Tier 2 — OS keyring (DPAPI) | No (OS store, **user-scoped**) | Yes (DPAPI unseals for the owning account) |
+| (b) Server | Tier 1 (env) **or** Tier 3 (file) | Tier 3 **YES** (`.fernet_key` beside `devices/`) ; Tier 1 No | Yes (env via `/proc/<pid>/environ`; file via FS read) |
+| (c) Docker | Tier 1 (recommended) **or** Tier 3 | Tier 3 **YES** (in the bind-mounted volume) ; Tier 1 No | Yes |
+
+Source: `credentials.py:70-79` (`_data_dir()` = `NETCANON_DATA_DIR`/`./data`), `:192-211` (Tier-3 writes
+`.fernet_key` into that dir), `:163-167` (Tier-1 env), `:169-190` (Tier-2 keyring). Confirmed first-hand this run.
+
+**The consequence (the spine of the whole verdict):** because the key is co-resident with the ciphertext on a live
+host, **at-rest encryption can only ever defend a threat where the attacker has the *ciphertext on a different /
+offline machine without the key* — i.e. T4 (and the T3 git-leak, since the committed bytes are ciphertext, and
+the keyring/env/`.fernet_key` are gitignored or off-disk).** It can do **nothing** for an attacker who is on the
+live host as the owning user (T1-as-owner, T5-as-same-principal, T6), because that attacker can read the key the
+same way the app does. This is **equally true of Fernet and of SOPS** — SOPS does not change the ceiling.
+
+---
+
+## 2. Threat × SOPS, per run-mode (ruthless: does the key-colocation reality defeat it?)
+
+For each threat I ask the seed's exact question: *given that the SOPS key would sit beside the ciphertext on a
+running host (or in the keyring / env exactly where the Fernet key already sits), is the threat mitigated?*
+
+| Threat | (a)/(d) Desktop/MSI | (b) Server | (c) Docker | Net SOPS verdict |
+|---|---|---|---|---|
+| **T1** local non-root user, no owning session | Partial — but **only if** the SOPS `age` key is itself protected by OS ACL/keyring, which is exactly what DPAPI+Fernet already do. SOPS adds nothing. | **No** — Tier-3-equivalent: the `age` key would sit in `data_dir` (or be env-injected = Tier 1). A non-owning local user with FS read either can't read the key (then Fernet already stopped them) or can (then SOPS doesn't either). | **No** (same as server) | **No gain over Fernet** |
+| **T2 / T2′** backup-artifact exfil (`configs/`) | **No** — A3 is plaintext; SOPS-on-`devices/*.json` never touches `configs/`. SOPS would have to *additionally* wrap every backup write (a bulk, high-volume re-encrypt on every collect) — and then the `age` key co-locates anyway on a live box. | **No** (same) | **No** (same) | **No** — wrong asset, and key co-locates even if extended |
+| **T3** accidental `git commit` | Already mitigated by `.gitignore` (ciphertext + gitignore). SOPS-committed-to-git is the *Kontroll* model netcanon's posture explicitly forbids ("never commit secrets", `AGENTS.md:249`). | same | same | **No gain** — `.gitignore`+Fernet already cover it; SOPS-in-git is anti-pattern here |
+| **T4** stolen disk / offline backup | **Yes** — but Fernet+keyring already gives this (DPAPI-sealed key isn't in the offline copy), and BitLocker gives it for the *whole* volume for free. | **Yes iff** the `age` key is off-host (env-injected) — which is **identical to Fernet Tier 1**. If the `age` key is in `data_dir` (the zero-config shape), **No** — it's in the stolen image. | **Yes iff** env-injected `age` key (= Tier 1); else **No** (key in the volume tarball) | **No gain over Fernet Tier 1 / encrypted volume** |
+| **T5** shared / multi-tenant host | n/a (single-user platform) | **No** — a co-tenant reading the live FS gets whatever the FS ACL allows; if the `age` key is FS-readable they decrypt, if not Fernet already stopped them. Same-principal/admin defeats everything. | **No** (same) | **No** |
+| **T6** process-memory dump | **No** — the decrypted creds + the `age`/Fernet key are in RSS by definition. | **No** | **No** | **No** — out of scope for any at-rest scheme |
+
+**Reading the row that matters (T4):** SOPS *does* mitigate T4 — but **only in the exact configuration where the
+key is off-host**, which is *byte-for-byte the posture netcanon's existing `NETCANON_FERNET_KEY` env tier already
+delivers* (R3 §3(b)/(c)). In the zero-config configuration (Tier-3-equivalent: `age` key written into `data_dir`),
+SOPS faces the **same co-location defeat** the seed warns about — the key is in the stolen image. So SOPS's only
+"win" is a win Fernet already owns, and SOPS's only "loss" mode is the same loss Fernet's Tier 3 has. **SOPS is a
+lateral move on the one threat at-rest encryption can address, with strictly higher operational cost.**
+
+---
+
+## 3. The alternatives bake-off (same threats, same modes)
+
+R3 surveyed six options; three are **already shipped** in netcanon. I score each against T1–T6, then give the
+per-mode fit. The baseline every option must *beat* is the existing Fernet 3-tier scheme — not a plaintext
+strawman.
+
+### 3.1 Option roster
+
+| # | Option | Status in netcanon | Key lives where |
+|---|---|---|---|
+| O1 | **SOPS + age** (Kontroll model) | Not present | `age` identity file on host, OR env-injected (= Tier 1) |
+| O2 | **OS keyring** (`keyring` lib, DPAPI/Keychain/SecretService) | ✅ shipped (Tier 2) | OS secret store, user-scoped, off the data disk |
+| O3 | **App-level age/Fernet, key from OS keychain or operator passphrase** | ✅ Fernet shipped (Tier 1/2/3); passphrase-KDF not | 3-tier (env/keyring/file) today; KDF variant = nowhere-on-disk |
+| O4 | **"Never persist device creds — resolve at backup-time from an operator-entered value"** | **Partially mischaracterised — see §3.3** | n/a (no stored secret) |
+| O5 | **OS-level encrypted volume** (BitLocker / LUKS / FileVault) | Not app-managed (often already on, Win 11) | OS/TPM, block layer, below the app |
+| O6 | **Document-only** (status quo + operator guidance) | The honest baseline | Whatever the operator already runs |
+
+### 3.2 Threat × option matrix (mitigates / partial / no)
+
+Scored for the **realistic default configuration** of each option, with the per-mode caveats in the footnotes.
+"mitigates" = closes the threat in the common case; "partial" = closes it only under a specific config or only
+for one asset class; "no" = does not address it.
+
+| Option | T1 local user | T2/T2′ config exfil | T3 git commit | T4 stolen/offline | T5 multi-tenant | T6 memory dump |
+|---|---|---|---|---|---|---|
+| **O1 SOPS+age** | no¹ | no² | no³ | partial⁴ | no | no |
+| **O2 OS keyring** ✅ | partial⁵ | no² | mitigates⁶ | mitigates⁷ | partial⁵ | no |
+| **O3 Fernet 3-tier** ✅ | partial⁵ | no² | mitigates⁶ | mitigates⁷ | partial⁵ | no |
+| **O3-KDF passphrase** | partial⁵ | no² | mitigates⁶ | **mitigates**⁸ | partial⁵ | no |
+| **O4 never-persist creds** | mitigates⁹ | **no**² | mitigates⁹ | mitigates⁹ | mitigates⁹ | partial¹⁰ |
+| **O5 encrypted volume** | no¹¹ | **mitigates**¹² | partial¹³ | **mitigates**¹² | no¹¹ | no |
+| **O6 document-only** | = whatever O2/O3/O5 the operator runs | — | — | — | — | — |
+
+**Footnotes (the load-bearing caveats):**
+
+1. **O1/T1:** the `age` key sits on the same FS as the ciphertext (or in the keyring = O2, or env = O3-Tier1).
+   A non-owning local user either can read the key (no mitigation) or can't (O2/O3 already stopped them). SOPS
+   adds nothing.
+2. **·/T2:** **no option in this column except O5 touches A3 (the plaintext `configs/` backups)**, because A1's
+   credential encryption is a *different asset*. O1–O4 all leave `configs/**` in cleartext. This is the single
+   most important cell in the matrix: **the biggest realistic leak (T2 backup-artifact exfil) is unaddressed by
+   every secret-management option — only the volume-level O5 covers it.**
+3. **O1/T3:** SOPS *committed to git* is the Kontroll pattern; netcanon's Hard Rule is "never commit secrets"
+   (`AGENTS.md:249`) and `.gitignore` already excludes the data dir. SOPS-in-git would *introduce* a commit path,
+   not close one.
+4. **O1/T4:** mitigates **only** when the `age` key is off-host (env-injected) — which is identical to O3 Tier 1.
+   In the zero-config (key-in-`data_dir`) shape it does **not** mitigate T4 (key is in the stolen image).
+5. **O2/O3/T1,T5:** "partial" = mitigates against a **different** principal who can't unseal the keyring / read
+   the env / read the user-scoped key file, but **not** against the owning user or a root/admin co-tenant.
+   DPAPI binds the secret to the Windows account, so a non-owning local user can't decrypt — genuine partial win.
+6. **·/T3:** the persisted creds are **ciphertext**, and `devices/`,`schedules/`,`.fernet_key` are all gitignored
+   (`.gitignore:18-28`) — double-covered.
+7. **O2/O3/T4:** mitigates because the offline copy lacks the keyring secret (DPAPI, host-bound) or the env value;
+   the `.fernet_key` is in the image **only** in Tier 3 (then it's NOT mitigated — see O3 row reality).
+8. **O3-KDF/T4:** **strongest** at-rest story — the key is never on disk in any tier; derived per-boot from a human
+   passphrase. Defeats the offline copy even versus Tier-3 leakage. Cost: breaks unattended `docker run -d` /
+   scheduler restart (R3 §5.5).
+9. **O4/T1,T3,T4,T5:** if creds are **never persisted**, there is no stored A1 secret to leak in any of those
+   scenarios — strictly dominant *for A1*. **But see §3.3 — this changes the product, and does nothing for A3.**
+10. **O4/T6:** the cred is still in memory *during* the backup run; the window is narrower (only while a job runs)
+    but non-zero.
+11. **O5/T1,T5:** the volume is **unlocked while mounted** on the live host — a local user / co-tenant with FS
+    access reads plaintext. Encrypted volume defends offline, not live.
+12. **O5/T2,T4:** **covers the entire data dir including `configs/` and `.fernet_key`** at the block layer, with
+    zero app code. This is the only option that mitigates T2 (config exfil) for an offline/stolen-disk attacker.
+13. **O5/T3:** partial — a file copied *off* the encrypted volume into a git repo is plaintext again; but
+    `.gitignore` + Fernet already cover the credential file specifically.
+
+### 3.3 Special handling: O4 "never persist creds" vs the #53–#65 work (what already exists)
+
+The seed asks how far the #53–#65 remediation already moved toward "never persist; resolve at backup-time." I
+verified the actual code path:
+
+- `DeviceProfilePublic` is **WRITE-ONLY** — creds are scrubbed from API *reads* (seed `00-blackboard.md:44-45`).
+- Server-side resolution: `backups._resolve_credentials` takes the **already-persisted, already-decrypted**
+  profile password and re-wraps it as `SecretStr` for transport to the collector
+  (`backups.py:114-137`, esp. `:128-136`). Confirmed first-hand this run.
+
+**So the #53–#65 work did NOT make creds ephemeral.** Creds are still **persisted** (Fernet-encrypted in
+`devices/*.json`) so unattended/scheduled backups can run without a human. "Server-side resolution" means *the API
+never echoes creds back to the client*, **not** *the server never stores them*. The move was a **read-path /
+egress** hardening (no cred leakage through the public API), not an at-rest-persistence change.
+
+Going **fully** O4 (never store; prompt the operator per backup) would:
+
+- **Eliminate A1 at rest entirely** — the strongest possible answer for T1/T3/T4/T5 *on the credential asset*.
+- **Break the core product** — netcanon's whole value is **unattended scheduled backups** (the scheduler,
+  `main.py:163-204`; new-style schedules reference `device_profile_id`s precisely so they can run headless,
+  `schedule_store.py:9-13`). A per-run human prompt is incompatible with `docker run -d`, systemd, k8s, and the
+  desktop tray's background scheduling. This is a **product-shape change, not a security tweak.**
+- **Do nothing for A3** — the backup *artifacts* still land in plaintext `configs/`. T2 is untouched.
+
+Verdict on O4: **right idea, wrong product.** It's the cleanest theoretical answer for the credential asset but
+collides head-on with the unattended-backup design that is netcanon's reason to exist. Worth noting in the
+synthesis as the "if we were greenfield and didn't need scheduling" option — not actionable here.
+
+### 3.4 Per-mode fit summary (which option wins where)
+
+| Mode | Best-fit option(s) | Why | SOPS realistic? |
+|---|---|---|---|
+| (a) Desktop / (d) MSI | **O2 keyring (have it) + O5 BitLocker (often already on)** | DPAPI manages the key for free; BitLocker covers the whole `%APPDATA%` offline. Zero operator action. | **No** — a network engineer running an MSI will not generate/rotate an `age` key; no per-install key home (R3 §3(d)). |
+| (b) Server | **O3 Tier-1 env (have it) + O5 LUKS** | Env-injected key = off-host (the only real T4 win); LUKS covers `configs/` + the rest. | Redundant with Tier 1; adds binary deps for no new threat coverage. |
+| (c) Docker | **O3 Tier-1 `-e NETCANON_FERNET_KEY` (have it) + encrypted PV/EBS** | Orchestrator secret → env is the documented path (`README.md:100-104`, `.env.example:41-44`); encrypted volume covers the bind-mount. | **No** — re-introduces `sops`+`age`/`gpg` into a pure-Python slim image (`Dockerfile:48-63`) + an age-key-mount problem that recreates co-location. |
+
+---
+
+## 4. The recommendation
+
+### 4.1 Verdict: **NO-GO on SOPS.** Best-fit = **document-only (O6) + push T2 to the encrypted-volume / ops layer (O5)**
+
+The deliverable the synthesis asked for — *what threat are we buying down, and is SOPS the most cost-appropriate
+tool* — resolves cleanly:
+
+1. **The only threat at-rest encryption can address here is T4 (offline-disk / exfil-copy).** Every live-host
+   threat (T1-as-owner, T5-same-principal, T6) is defeated by key co-location, identically for Fernet and SOPS
+   (R2 §5.1, R3 §3). This is a hard ceiling, not a tuning knob.
+
+2. **netcanon already buys down T4** for the credential asset (Fernet + DPAPI keyring / env Tier 1, test-guarded
+   at `tests/unit/test_device_profile_store.py:124-133`), and the Windows desktop target buys it down for the
+   *entire* data dir for free via BitLocker.
+
+3. **SOPS re-buys the *same* T4 mitigation** that `NETCANON_FERNET_KEY` already provides, while:
+   - adding a `sops`+`age`/`gpg` binary to the pure-Python Docker image and the unsigned MSI (R3 §3(c)/(d)),
+   - imposing an `age`-key-management burden on a single-user desktop that will never own one (R3 §3(a)),
+   - recreating the **exact** co-location defeat in the zero-config mode (the `age` key lands in `data_dir`), and
+   - pushing toward a *commit-secrets-to-git* posture that netcanon's Hard Rules forbid (`AGENTS.md:249`).
+   The same operator's **own Kontroll SECURITY.md** classifies a *"frozen, local"* repo as **"plaintext
+   accepted,"** reserving mandatory encryption for the *networked control plane* (R2 §1, `kontroll/SECURITY.md:20-21`)
+   — precedent *against* porting SOPS here, written by the same hand.
+
+4. **The biggest *real* exposure is T2 — the plaintext backup artifacts in `configs/`** (A3), which no
+   secret-management option (O1–O4) touches, because they encrypt a *different* asset (A1). The cost-appropriate
+   mitigation for T2 is the **encrypted volume (O5)** + the existing on-demand sanitiser for *sharing* — not SOPS.
+
+### 4.2 Concrete buildable-now actions (all docs / posture, **no app code, no new deps**)
+
+These are the right-sized actions the synthesis can green-light. None require SOPS.
+
+1. **Doc the Tier-1 + encrypted-volume posture as the recommended server/Docker default.** Most of this prose
+   already exists (`SECURITY.md:80-161`, `README.md:94-121`, `.env.example:32-52`); the gap is an explicit
+   "for confidential-at-rest, set `NETCANON_FERNET_KEY` from an orchestrator secret **and** run on an encrypted
+   volume — that covers your `configs/` too" paragraph that names T2/T4 in operator language.
+2. **Name the `configs/`-is-plaintext fact in SECURITY.md as a known, deliberate posture** with the encrypted-volume
+   recommendation, so it's an honest documented decision, not a silent gap (matrix-honesty discipline,
+   `AGENTS.md`). R1 §5 establishes the fact; SECURITY.md should state it.
+3. *(Optional, lowest priority)* **`POLISH`:** the Tier-3 `.fernet_key` path uses `NETCANON_DATA_DIR` directly,
+   not `Settings.effective_data_dir` (`credentials.py:79` vs `config.py:116-128`) — a latent desktop inconsistency
+   R3 §2 flagged. Not security-load-bearing (desktop never hits Tier 3); note for a future cleanup, not this run.
+
+### 4.3 What would change the verdict (the honest "GO" preconditions)
+
+For completeness, SOPS would become the right tool **iff** netcanon grew a property it does not have:
+
+- a **second machine** that holds the key but not the ciphertext (a control-plane / render-node split), **or**
+- a requirement to **commit encrypted secrets to a repo** (GitOps), **or**
+- **multiple distinct principals** at different trust levels needing scoped decrypt (Kontroll's Semaphore-runner case).
+
+None of these exist in a local-first single app. Until one does, SOPS is `THREAT-MISMATCH` + `OVER-ENGINEERING`.
+
+---
+
+## 5. Hand-off notes for V1 (review) and the synthesis
+
+- **Fact-check anchors I re-verified this run** (not just inherited from R1/R3): Tier-3 key co-location
+  (`credentials.py:70-79,192-211`); `.gitignore` already excludes the data dir + both `.fernet_key` forms
+  (`.gitignore:18-28`) → T3 is *already* closed, which weakens any "SOPS prevents accidental commits" argument;
+  server-side cred resolution re-wraps **persisted** plaintext, so the #53–#65 work is **not** a "never-persist"
+  move (`backups.py:114-137`).
+- **The one cell V1 should pressure-test:** O5/T2 ("encrypted volume covers `configs/`"). It's the strongest claim
+  in the matrix and the basis for not doing anything app-side about A3. It holds for *offline* T2 (stolen disk),
+  but **not** for a live-host copy or an operator who deliberately `scp`s a config out — that's the on-demand
+  sanitiser's job, and it's bug-reporting-only, not a general redaction. V1 should confirm the synthesis doesn't
+  over-claim O5 as covering *all* of T2.
+- **Steelman of the GO side, for honesty:** the genuine sliver is that **Tier 3** (zero-config Docker) *does* leave
+  the key in the volume, so a leaked tarball is fully decryptable — a real T4 hole. But the fix is "tell operators
+  to set Tier 1 / use an encrypted volume" (already documented, `README.md:118-121` even warns about it), not
+  "adopt SOPS" — because a SOPS `age` key in the same zero-config container lands in the same volume. The hole is
+  *operator config*, not *missing tooling*.
+- **Severity tags:** `THREAT-MISMATCH` + `OVER-ENGINEERING` for SOPS adoption; `RUNTIME-BLOCKER` for "SOPS protects
+  a running instance"; `VIABLE` for the document-only + encrypted-volume recommendation; `POLISH` for the
+  `_data_dir()` vs `effective_data_dir` inconsistency.
+
+---
+
+*Verified against source this run: `netcanon/security/credentials.py:60-219` (3-tier resolve, `_data_dir`,
+Windows-chmod-no-op caveat), `.gitignore:1-98` (data-dir + `.fernet_key` exclusions), `netcanon/api/routes/backups.py:110-154`
+(server-side cred resolution re-wrapping persisted plaintext). All other cites inherited from R1/R2/R3 reports,
+which themselves cite `file:line`.*

--- a/docs/reviews/2026-06-17-sops-evaluation/30-review-adversarial.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/30-review-adversarial.md
@@ -1,0 +1,283 @@
+# 30 — Adversarial GO/NO-GO Review: SOPS for netcanon
+
+**Author:** V1 (review, read-only) · **Run:** 2026-06-17 SOPS evaluation · **Status:** adversarial review.
+**Inputs read in full:** R1 census (`10-…`), R2 Kontroll precedent (`11-…`), R3 runtime/deploy (`12-…`),
+D1 SOPS integration (`20-…`), D2 threat + alternatives (`21-…`). **Re-verified against source this run** (not
+inherited): `credentials.py` (full), `device_profile_store.py` (full), `models/device_profile.py:1-70`,
+`.gitignore:1-98`, `backup_runner.py:225-249`, `api/routes/backups.py:108-138`, `Dockerfile` (grep on
+data-dir/volume/apt). Both load-bearing claims the seed asked me to fact-check are **CONFIRMED true**.
+
+---
+
+## 0. One-line verdict
+
+**NO-GO on adopting SOPS as a netcanon feature.** The recommendation does **not** flip, because the two
+load-bearing claims that drive it both check out against source. The honest right-sized answer is: **do nothing
+new in app code; ship a small docs/posture hardening pass instead** — name the `configs/`-is-plaintext fact in
+SECURITY.md, point operators at Tier-1 (`NETCANON_FERNET_KEY`) + an OS-encrypted volume, and (optionally) add a
+one-paragraph "SOPS is an operator-side delivery option for Tier 1, not a netcanon feature" note so a future
+contributor doesn't speculatively wire it in. **The lighter thing to do instead of SOPS is: (1) a SECURITY.md
+honesty paragraph about `configs/` + encrypted-volume guidance, and (2) keep the existing 3-tier Fernet scheme.**
+
+If the synthesis wants to leave a door open, the *only* non-rejected scope is D1's variant C (a docs-only
+launch-wrapper recipe, server/Docker, zero code, zero packaging) — and even that is dominated by delivery options
+netcanon already documents, so it is at most a `GO-WITH-NARROW-SCOPE` for a README paragraph, never a build.
+
+---
+
+## 1. Fact-check of the two load-bearing claims (I opened the files myself)
+
+The seed (`00-blackboard.md:70`) tasks V1 with verifying the two facts the whole verdict hangs on, because "if
+either claim is wrong, the recommendation flips." I did not trust R1/R3/D2; I re-read the source.
+
+### 1.1 Claim (a) — R1's at-rest-format claim: is the device-credential store plaintext / encoded / encrypted?
+
+**R1's claim (`10-…:52-75`):** device login credentials are **Fernet-encrypted** at rest inside an
+otherwise-plaintext JSON file; `SecretStr` is in-memory masking only and contributes nothing at rest.
+
+**VERDICT: CONFIRMED — genuinely encrypted at rest (not merely encoded/obfuscated), with one subtlety worth
+stating precisely.**
+
+| Sub-claim | Source I read | Finding |
+|---|---|---|
+| Persisted creds are plaintext `str` *in memory* | `models/device_profile.py:34,59-60` | TRUE. `password: str`, `enable_password: str \| None`; docstring line 34 reads literally "plaintext in memory; encrypted on disk". |
+| Only the two password fields are encrypted on write | `device_profile_store.py:64-67` | TRUE. `data = json.loads(model_dump_json())`, then `data["password"] = encrypt(profile.password)` and (conditionally) `data["enable_password"] = encrypt(...)`. Everything else (`id`, `name`, `host`, `port`, `username`, `notes`, `detected_facts`, …) is written as **plaintext JSON**. |
+| `encrypt()` is real Fernet, not base64/obfuscation | `credentials.py:227-233` | TRUE. `_get_fernet().encrypt(plaintext.encode()).decode()` — Fernet is AES-128-CBC + HMAC-SHA256 with a random IV, an authenticated token (`gAAAAA…`). This is **encryption**, not encoding. |
+| Decrypt-on-load + legacy-plaintext migration | `device_profile_store.py:86-125`, `credentials.py:246-263` | TRUE. `migrate_credential_fields` → `decrypt_field`; a value that fails `InvalidToken` is treated as legacy plaintext and re-saved encrypted. |
+| `SecretStr` is in-memory hygiene only | `device_profile.py:59-60` (plain `str`, NOT `SecretStr`); re-wrap at `backups.py:128-136` | TRUE. The persisted model uses plain `str`; the transport model re-wraps into `SecretStr` only on the way to the collector. `SecretStr` never reaches disk and adds **zero** at-rest protection. |
+
+**Why this matters for the verdict:** R1's framing — "device-credential *encryption* is already solved; the real
+unencrypted surface is `configs/`" — is factually correct. If the store had been plaintext (the strawman the seed
+warns against), the SOPS case would be far stronger. It is not. The credential asset is already encrypted with a
+test-guarded scheme (`tests/unit/test_device_profile_store.py:124-133` per R1 — I did not re-open that test but
+the code path is unambiguous). **Claim (a) holds → the verdict does not flip on it.**
+
+One nuance the synthesis should keep crisp: "encrypted at rest" is only as strong as where the key lives — which
+is exactly claim (b).
+
+### 1.2 Claim (b) — R3/D2's key-colocation claim: does the decryption key co-locate with the ciphertext per run-mode?
+
+**R3/D2's claim (`12-…:21-29`, `21-…:67-87`):** in **every default zero-config run-mode** the Fernet key is
+reachable on the same host/disk as the ciphertext, so at-rest encryption only ever defends an *offline/exfil*
+threat — and SOPS would inherit the identical ceiling.
+
+**VERDICT: CONFIRMED, per tier, from source.**
+
+| Tier | Source I read | Key location | Co-locates with ciphertext? |
+|---|---|---|---|
+| **1 — env var** `NETCANON_FERNET_KEY` | `credentials.py:163-167` | Process environment; "never touches disk inside the data directory" (docstring `:17-18`) | **NO** — *iff* the operator sources the value off-host. Decoupled posture, exists today. |
+| **2 — OS keyring** (DPAPI/Keychain/SecretService) | `credentials.py:169-190` (`_read_keyring`/`_write_keyring` `:82-114`) | OS secret store, user-scoped | **NO** to the data disk; but **YES reachable** by the owning account on a live host (DPAPI unseals for that user). Defends an *offline copy* lacking the account, not malware-as-user. |
+| **3 — file fallback** `$NETCANON_DATA_DIR/.fernet_key` | `credentials.py:70-79` (`_data_dir()`), `:117-153` (`_read/_write_key_file`), `:192-211` (Tier-3 resolve) | Plaintext 44-char base64 in the data dir | **YES** — explicitly. `_data_dir()` returns `Path(os.environ.get("NETCANON_DATA_DIR", "data"))`; `_write_key_file` writes `.fernet_key` *into that same dir*. The module's own docstring (`:25-34`) says the key is "persisted in the operator's bind-mounted data volume … plaintext on disk … the same volume the operator already chose to trust." |
+
+**Docker confirmation (the worst case):** `Dockerfile:80` sets `NETCANON_DATA_DIR=/app/data` and `:94`
+`VOLUME ["/app/configs","/app/data"]`. So in the zero-config container path (no `-e NETCANON_FERNET_KEY`), the
+Tier-3 `.fernet_key` lands **inside the bind-mounted `/app/data` volume right next to `devices/*.json`** — a
+single `tar` of the volume contains both ciphertext and key. The runtime image adds only `curl` (`Dockerfile:51-52`,
+grep-confirmed), so it is genuinely pure-Python-slim; bundling `sops`+`age` would be a real new binary surface.
+
+**The chmod-0600 caveat is real and in the source** (`credentials.py:147-152`): on Windows `os.chmod(0o600)` is a
+no-op and the failure is *deliberately swallowed*; confidentiality there rests on the inherited NTFS user-profile
+ACL. This is honestly documented in the docstring (`:130-141`) and does not change the verdict.
+
+**Why this matters:** SOPS's entire security value (R2 §5.1) is *decryptor ≠ ciphertext-host*. Claim (b) proves
+that property is **structurally unavailable** in every netcanon run-mode: the process that decrypts, the key, and
+the ciphertext are one machine / one user. The *only* decoupled posture (Tier-1 env sourced off-host) is exactly
+what netcanon already ships. **Claim (b) holds → the verdict does not flip on it.** The one place SOPS would help
+(off-host key) is byte-for-byte the env-var tier; the one place SOPS would *not* help (zero-config) recreates the
+same co-location with extra binaries. Both research conclusions are sound.
+
+### 1.3 Two ancillary facts I spot-checked because the verdict leans on them
+
+- **T3 "accidental git commit" is already closed.** `.gitignore:18-28` excludes `devices/`, `schedules/`,
+  `jobs/`, `configs/`, **and** `.fernet_key` + `**/.fernet_key`. D2's claim that SOPS-prevents-accidental-commits
+  is a non-benefit here is correct — and SOPS-in-git would *introduce* a commit path (the Kontroll model), which
+  `AGENTS.md:249` ("Never commit real credentials") forbids. CONFIRMED.
+- **The #53–#65 work is NOT "never-persist".** `backups.py:128-136` builds `DeviceCredentials` from
+  `profile.username` / `SecretStr(profile.password)` — i.e. it re-wraps the **already-persisted, already-decrypted**
+  profile password for transport. D2 §3.3's correction (server-side resolution = read-path hardening, not
+  ephemerality) is CONFIRMED. This matters because it rules out O4 ("never persist creds") as a free win — creds
+  must persist for unattended scheduled backups, which is netcanon's reason to exist.
+
+**Net on fact-checking:** both load-bearing claims are true; both ancillary facts are true. There is no factual
+escape hatch that flips the recommendation toward GO. The peer reports are unusually well-grounded (every cite I
+re-checked landed exactly where claimed).
+
+---
+
+## 2. Steelman of BOTH positions (the seed's explicit ask)
+
+I owe the synthesis the strongest honest version of each side, not a strawman of the loser.
+
+### 2.1 Strongest case FOR adopting SOPS
+
+The best pro-SOPS argument is **not** "encrypt the creds better" (they're already encrypted) — it's a combination
+of three genuinely-true sub-points that, stacked, look compelling until you test them against co-location:
+
+1. **The zero-config Tier-3 hole is real and embarrassing.** In the most common headless Docker path, a leaked
+   `/app/data` tarball is *fully decryptable* because `.fernet_key` rides along in the same volume
+   (`credentials.py:192-211` + `Dockerfile:80,94`). That is a true at-rest weakness, and "the key sits next to the
+   ciphertext" is exactly the smell SOPS exists to fix. A reviewer who stopped here would say GO.
+2. **Operator-estate consistency / least-astonishment.** The sibling Kontroll already standardizes on SOPS+age
+   (R2 §2). An operator running both would reasonably want one secret-management idiom across their estate. SOPS
+   is a real, audited, widely-deployed tool; "use the thing the org already uses" is a legitimate ops argument.
+3. **`configs/` is the biggest unencrypted secret surface and nothing covers it.** R1 §5 / D2 A3 establish that the
+   fetched device configs are plaintext and contain `$9$`/type-7/`$6$` hashes, SNMP/RADIUS/IKE keys. A SOPS-shaped
+   "encrypt the sensitive files at rest" reflex points right at it. The honest pro side says: *netcanon stores a
+   lot of secret material in cleartext on purpose, and a file-encryption tool is the obvious lever.*
+
+**The strongest single sentence for GO:** *"There is a true zero-config at-rest hole (Tier-3 key co-location) and a
+true large plaintext surface (`configs/`), the org already runs SOPS, so adopt SOPS to close both with one
+familiar tool."*
+
+### 2.2 Strongest case AGAINST (the steelman the data actually supports)
+
+1. **SOPS's load-bearing property does not exist here, in any run-mode.** *Decryptor ≠ ciphertext-host* (R2 §5.1)
+   requires a second machine or a commit-to-git GitOps split. netcanon has neither — desktop/server/docker/MSI all
+   co-locate process+key+ciphertext (claim (b), confirmed). So SOPS cannot deliver the one thing it is *for*.
+2. **Every "win" SOPS offers, netcanon already has cheaper.** The off-host-key posture = Tier-1 env var
+   (`credentials.py:163-167`), already documented with k8s Secret / Compose `secrets:` / systemd EnvironmentFile
+   delivery (`.env.example`, per R3 §3). SOPS becomes "one more delivery mechanism for an env var we already read."
+3. **The Tier-3 hole is fixed by operator config, not tooling.** A SOPS `age` key in the same zero-config
+   container lands in the same `/app/data` volume — recreating the identical hole (D1 U2, D2 §5 steelman). The fix
+   is "set Tier 1 / use an encrypted volume," which the README *already warns about* (`README.md:118-121` per R3).
+4. **`configs/` is the wrong asset for SOPS specifically** (D1 §1.B): it's unstructured bulk text → SOPS degrades
+   to whole-file binary mode (no per-field selectivity, its only differentiator), it breaks the operator's
+   View/diff/git workflows on a directory meant to be readable (`AGENTS.md:85-89`), and the right layer is OS
+   volume encryption (BitLocker on by default on the Win 11 target). CONFIRMED reasoning.
+5. **Packaging cost is real and one-sided.** Pure-Python-slim Docker image gains `sops`+`age` (~20-40 MB, arch-aware
+   `COPY`); the **unsigned** MSI (D1 §6.2) gains two unsigned native crypto binaries (bigger SmartScreen/AV
+   surface) — to support a key flow that **has no valid key home in the MSI/desktop mode** (DPAPI dominates; no
+   per-install secret mechanism). Pure tax.
+6. **The same operator's own doctrine argues against it.** Kontroll's SECURITY.md (R2 §1, `kontroll/SECURITY.md:20-21`)
+   explicitly classifies a *"frozen, local"* repo as **"plaintext accepted,"** reserving mandatory encryption for
+   the *networked control plane*. netcanon's data-dir is the former. This is precedent against, written by the same
+   hand — the strongest anti-cargo-cult point.
+
+**The strongest single sentence for NO-GO:** *"SOPS's only value is key-on-a-different-box, which no netcanon
+run-mode can offer; the one posture it would give (off-host key) is the env-var tier we already ship, and the one
+hole worth caring about (`configs/` + Tier-3 leak) is closed by an encrypted volume, not by adding two crypto
+binaries to a pure-Python image and an unsigned MSI."*
+
+### 2.3 Adjudication: the against-case wins decisively, and here's the pro-case's fatal flaw
+
+The pro-case (§2.1) is real right up to the moment you ask *where does the SOPS key live*. All three pro-points
+collapse on that question:
+
+- Pro-point 1 (Tier-3 hole): a SOPS age key in the zero-config container lands in the **same volume** → hole not
+  closed. To close it you must put the key off-host = Tier 1 = no SOPS needed.
+- Pro-point 2 (estate consistency): legitimate, but it argues for an **operator-side launch wrapper** (D1 variant
+  C, docs-only), **not** for SOPS *inside the netcanon product*. The operator can already `sops -d → export
+  NETCANON_FERNET_KEY → exec uvicorn` today with zero netcanon changes.
+- Pro-point 3 (`configs/`): the obvious lever is the wrong lever — SOPS on unstructured bulk text is binary-mode
+  encryption that breaks readable-directory workflows; OS volume encryption is strictly better and free on the
+  primary target.
+
+So the pro-case, fully steelmanned, resolves to "write a README paragraph for SOPS-shaped operators" — which is
+exactly the narrowest non-rejected scope, not a product feature. **The against-case is correct.**
+
+---
+
+## 3. Reviewer verdict table (severity-tagged, per claim/option)
+
+| # | Item under review | Reviewer finding | Tag |
+|---|---|---|---|
+| V1 | **Replace Fernet with SOPS for `devices/*.json`** (D1 §1.A / variant A) | Rip-and-replace of a working, test-guarded scheme for the identical at-rest ceiling; worse desktop key story (loses free DPAPI). Same threat, more code, new burden. | `OVER-ENGINEERING` + `RUNTIME-BLOCKER` |
+| V2 | **SOPS-encrypt `configs/**`** (D1 §1.B / variant B) | Unstructured bulk → SOPS binary mode (no differentiator); breaks View/diff/git; key co-locates anyway. Wrong tool, wrong layer. Use OS volume encryption. | `THREAT-MISMATCH` |
+| V3 | **SOPS protects a *running* netcanon instance** (the premise) | False in every run-mode: key, decryptor, ciphertext are one host/user (claim (b), confirmed). At-rest encryption only ever defends offline/exfil. | `RUNTIME-BLOCKER` |
+| V4 | **Bundle `sops`+`age` into Docker image / MSI** (D1 §6) | Pure-Python-slim image gains arch-aware binaries; **unsigned** MSI gains AV-flag surface; MSI has **no key home** at all. Tax for negative value. | `RUNTIME-BLOCKER` + `OVER-ENGINEERING` |
+| V5 | **Variant C: operator-side launch-wrapper recipe, docs-only** (D1 §1.C) | Genuinely works, zero code, zero packaging — but redundant with k8s/Compose/systemd delivery already documented for the same env var. Defensible *only* as one README line for SOPS-shaped estates. | `VIABLE`-but-redundant → at most `POLISH` |
+| V6 | **Existing 3-tier Fernet scheme as the baseline** | Correctly identified as the thing to beat; SOPS does not beat it. Tier-3 zero-config co-location is a real (already-documented) operator-config hole. | baseline / `VIABLE` |
+| V7 | **`configs/` plaintext is an undocumented honesty gap** | R1 §5 + D2 §4.2 correct: the largest cleartext secret surface is unstated in SECURITY.md as a deliberate posture. This is the **real** finding of the whole run. | `POLISH` (docs) — the lighter thing to fix |
+| V8 | **`_data_dir()` reads `NETCANON_DATA_DIR` directly, not `effective_data_dir`** (R3 §2, D2 §4.2.3) | Latent desktop inconsistency; desktop never reaches Tier 3 so not security-load-bearing. Note for a future cleanup. | `POLISH` |
+| V9 | **D2's strongest claim: "encrypted volume (O5) covers `configs/` (T2)"** | Holds for *offline* T2 (stolen disk). Does **NOT** cover a live-host copy or a deliberate `scp`-out (that's the on-demand sanitiser's job, bug-reporting-only). Synthesis must not over-claim O5 as covering *all* of T2. | `POLISH` (pressure-test) |
+
+**No `VIABLE` row supports building SOPS into the product.** The only `VIABLE` items are the existing scheme (V6)
+and a docs paragraph (V5/V7).
+
+---
+
+## 4. Where I push back on the peer reports (adversarial, not rubber-stamp)
+
+The peer reports are strong and converge — which is itself a mild risk (groupthink). I tested for it. Two
+push-backs and one caution:
+
+1. **D1 variant C is over-credited even as "narrow GO."** D1 calls it "NARROW GO — docs-only" (`20-…:142`). I'd
+   downgrade further: the `.env.example` *already* enumerates k8s Secret / Compose `secrets:` / systemd
+   EnvironmentFile as off-host delivery (R3 §3b). A SOPS launch-wrapper is just a fourth example of "decrypt
+   something → export the env var." It does not deserve its own integration section; at most one sentence
+   ("operators whose estate uses SOPS can source `NETCANON_FERNET_KEY` from a `*.sops.yaml` the same way"). Calling
+   it a "GO" of any kind risks the synthesis greenlighting a build. It is a **footnote**, not a scope.
+
+2. **The reports under-emphasize that the real deliverable is the `configs/` honesty gap, not SOPS at all.** R1
+   §5 and D2 §4.2 both surface it, but it's framed as "the thing SOPS *doesn't* fix." Re-frame it as the *positive*
+   outcome of this run: the most valuable thing the team learned is that the largest secret surface
+   (`configs/**`) is deliberately plaintext and **unstated in SECURITY.md**. That's a matrix-honesty gap of the
+   exact kind `AGENTS.md` exists to prevent. Fixing *that* (a SECURITY.md paragraph) is the run's actual ROI.
+
+3. **Caution on D2's O5/T2 cell (V9 above).** "Encrypted volume covers `configs/`" is the linchpin for *not* doing
+   anything app-side about A3 — but it only covers the **offline** threat. A live-host attacker or an operator who
+   `scp`s a config out gets plaintext. The synthesis should state O5's ceiling honestly rather than imply
+   `configs/` is "handled." This does not change the NO-GO (SOPS is still the wrong tool for A3), but it keeps the
+   recommendation honest.
+
+None of these flip the verdict; they tighten it.
+
+---
+
+## 5. The lighter thing to do instead of SOPS (named plainly, as the seed demands)
+
+**Do NOT add SOPS. Instead, ship a docs/posture pass — no app code, no new dependency:**
+
+1. **SECURITY.md honesty paragraph for `configs/`** (the run's real finding): state plainly that fetched device
+   configs are stored verbatim in plaintext, that they contain device-side secrets, and that the recommended
+   at-rest control is an **OS-encrypted volume** (BitLocker on by default on the Win 11 desktop target; LUKS /
+   encrypted EBS/PV for server/Docker), with the on-demand sanitiser reserved for *sharing*. This converts a
+   silent gap into a documented, deliberate posture (matrix-honesty discipline). Cite the exact fact at
+   `backup_runner.py:233-241` + `file_store.py` plaintext docstring.
+2. **Recommend Tier-1 + encrypted volume as the server/Docker default**, naming the threats (offline-disk / volume
+   exfil) in operator language. Most of this prose exists (`SECURITY.md:80-161`, `README.md:94-121`,
+   `.env.example`); the gap is one explicit "for confidential-at-rest, set `NETCANON_FERNET_KEY` from an
+   orchestrator secret AND run on an encrypted volume — that covers `configs/` too" paragraph.
+3. **(Optional) Preventive non-fit note**, mirroring `AGENTS.md:111-128`'s "Deliberately omitted (preventive)"
+   pattern: "SOPS is an operator-side delivery option for Tier 1, not a netcanon feature; desktop/MSI use the OS
+   keyring (DPAPI) and have no per-install key home." This stops the next contributor from re-litigating.
+4. **(Optional `POLISH`, future cleanup, not this run)** align `credentials._data_dir()` with
+   `Settings.effective_data_dir` (V8) so a desktop Tier-3 fallback would land in `%APPDATA%\Netcanon`, not `<cwd>/data`.
+
+Items 1–2 are the meat; 3–4 are nice-to-have. None require SOPS, `age`, `gpg`, a binary in Docker/MSI, a committed
+test key, or a `gitleaks` allowlist carve-out.
+
+---
+
+## 6. Must-answer questions the synthesis must resolve before any build
+
+Even though the verdict is NO-GO, the synthesis should explicitly resolve these so the decision is auditable and
+the door is closed cleanly:
+
+| # | Must-answer question | Why it must be answered before acting |
+|---|---|---|
+| Q1 | **Is the verdict NO-GO (no SOPS, docs-only) or GO-WITH-NARROW-SCOPE (a single README sentence for variant C)?** | These are the only two live options. The synthesis must pick one and say so; "we'll think about SOPS later" is not a resolution — write the preventive non-fit note instead. |
+| Q2 | **Does the synthesis ship the `configs/`-plaintext honesty paragraph in SECURITY.md this run, or defer it?** | This is the run's actual ROI (V7). If deferred, it must be logged so the gap isn't silently dropped — `AGENTS.md` doc-sync discipline applies. |
+| Q3 | **Does the O5/encrypted-volume recommendation over-claim coverage of `configs/`?** | D2's O5/T2 cell only covers *offline* exfil (V9). The SECURITY.md prose must state O5's ceiling (does not defend a live-host read or a deliberate config copy-out) or it lies by omission. |
+| Q4 | **Is the zero-config Tier-3 `.fernet_key`-in-the-volume hole adequately steered against?** | `README.md:118-121` already warns; confirm that warning is loud enough, or strengthen it. This is the one *real* at-rest hole, and the fix is operator config (Tier 1 / encrypted volume), not SOPS. |
+| Q5 | **Does any AGENTS.md doc-sync row fire for a SECURITY.md-only change?** | A SECURITY.md edit touching the secret-handling posture should round-trip its own "Updating This Document" trigger list (AGENTS.md packaging row references this). Confirm no other doc (README install, IDENTITY) needs a same-commit touch. |
+| Q6 | **Confirm no test re-run is warranted.** | A docs-only change touches no code/fixtures, so per AGENTS.md's "judge whether a test re-run is warranted" rule, the answer is "no" — but the synthesis should state it rather than assume. |
+
+---
+
+## 7. Bottom line for the synthesis
+
+- **Both load-bearing claims are TRUE** (verified against source this run): credentials are genuinely
+  Fernet-encrypted at rest (claim a); the decryption key co-locates with the ciphertext in every default
+  zero-config run-mode, and the only decoupled posture is the env-var tier netcanon already ships (claim b).
+- **The recommendation does not flip.** SOPS's defining property (decryptor ≠ ciphertext-host) is structurally
+  unavailable in a local-first single app; it would re-buy the one threat (offline-disk/exfil) the existing scheme
+  already buys, at the cost of binaries in a pure-Python image, an unsigned-MSI AV surface with no key home, and a
+  git-commit-secrets posture the project's Hard Rules forbid.
+- **Verdict: NO-GO on SOPS** (with at most a one-sentence variant-C footnote for SOPS-shaped operator estates).
+- **Lighter thing to do instead:** a SECURITY.md honesty paragraph about plaintext `configs/` + Tier-1 +
+  OS-encrypted-volume guidance, and a preventive "SOPS-is-not-a-netcanon-feature" note. No code, no deps.
+
+*Verified against source this run: `netcanon/security/credentials.py` (full), `netcanon/storage/device_profile_store.py`
+(full), `netcanon/models/device_profile.py:1-70`, `.gitignore:1-98`, `netcanon/services/backup_runner.py:225-249`,
+`netcanon/api/routes/backups.py:108-138`, `Dockerfile` (data-dir/volume/apt grep). Peer reports 10/11/12/20/21 read in full.*

--- a/docs/reviews/2026-06-17-sops-evaluation/99-synthesis.md
+++ b/docs/reviews/2026-06-17-sops-evaluation/99-synthesis.md
@@ -1,0 +1,72 @@
+# 99 — Synthesis: Should netcanon adopt SOPS? (2026-06-17)
+
+**Author:** main thread (orchestrator). **Inputs:** R1 census (`10-`), R2 Kontroll precedent (`11-`),
+R3 runtime/deploy (`12-`), D1 SOPS integration (`20-`), D2 threat+alternatives (`21-`), V1 adversarial
+review (`30-`). This run was **read-only research/design** — no app code was written or proposed for build.
+
+## Verdict: **NO-GO on adopting SOPS as a netcanon feature.**
+
+Unanimous across all six agents; the adversarial reviewer re-opened the source itself and **both load-bearing
+claims held**, so the recommendation does not flip. SOPS is `THREAT-MISMATCH` + `OVER-ENGINEERING` for netcanon
+as it exists today.
+
+## Why (the two facts the whole decision hangs on, verified against source)
+
+1. **netcanon already encrypts device credentials at rest.** `devices/*.json` store the two password fields as
+   real **Fernet** ciphertext (`device_profile_store.py:64-67` → `credentials.py:227-233`; AES-128-CBC + HMAC,
+   not encoding), test-guarded (`tests/unit/test_device_profile_store.py:124-133`). The key resolves 3-tier:
+   **Tier 1** `NETCANON_FERNET_KEY` env (off-host), **Tier 2** OS keyring / Windows DPAPI (off-disk, the desktop
+   default), **Tier 3** file fallback `$NETCANON_DATA_DIR/.fernet_key` (plaintext, zero-config Docker). `SecretStr`
+   is in-memory masking only — it never reaches disk. **The thing SOPS would "add" is already shipped.**
+
+2. **SOPS's one value prop is structurally unavailable here.** SOPS exists to make *the decryptor ≠ the
+   ciphertext host* (key on a control VM / committed-ciphertext GitOps). Every netcanon run-mode —
+   desktop / server / docker / MSI — co-locates the process, the key, and the ciphertext on **one machine, one
+   user** (`credentials.py:70-79,163-211`; `Dockerfile:80,94` puts `.fernet_key` in the same bind-mounted volume
+   as `devices/`). So at-rest encryption can only ever defend the **offline/exfil** threat (stolen disk, leaked
+   volume tarball) — and on *that* threat SOPS merely re-buys what Fernet Tier-1/keyring + an OS-encrypted volume
+   already deliver, while adding `sops`+`age` binaries to a pure-Python-slim image, an unsigned-MSI AV surface
+   **with no key home at all**, and a commit-secrets-to-git posture the project's Hard Rules forbid
+   (`AGENTS.md:249`).
+
+**Precedent against, by the same hand:** Kontroll's own `SECURITY.md:20-21` classifies a *"frozen, local"* repo
+as **"plaintext accepted,"** reserving mandatory encryption for the *networked control plane*. netcanon's
+gitignored single-host data dir is the former; Kontroll's multi-service, control-VM-custody, render-time-`.env`,
+multi-principal SOPS model answers questions netcanon doesn't pose (R2 transferability verdict: does **not**
+transfer).
+
+## The run's real ROI (the finding worth more than the SOPS answer)
+
+The largest **plaintext** secret surface isn't the credentials (those are encrypted) — it's the **backup
+artifacts**: fetched device configs are written verbatim to `configs/**` (`backup_runner.py:233-241`) and
+routinely contain `$9$`/type-7/`$6$` hashes + SNMP/RADIUS/IKE keys. Nothing encrypts or redacts them at rest, the
+on-demand sanitiser is bug-reporting-only (never on the backup-write path), and **SECURITY.md does not state this
+as a deliberate posture.** That silent gap — not SOPS — is the actionable output of this run.
+
+## Resolution of the reviewer's must-answer questions
+
+| Q | Resolution |
+|---|---|
+| **Q1** NO-GO vs narrow-scope? | **NO-GO** on SOPS-in-product. The only non-rejected sliver (an operator-side `sops -d → export NETCANON_FERNET_KEY → exec` launch recipe) is redundant with the k8s/Compose/systemd env delivery already documented → demote to **at most one README sentence**, not a feature. |
+| **Q2** Ship the `configs/` honesty paragraph now? | **Recommend YES as a small follow-up PR** (docs-only) — it's the run's ROI. Proposed, not yet built; awaiting go-ahead (see Buildable-now). |
+| **Q3** Does "encrypted volume covers `configs/`" over-claim? | Yes if stated flatly. O5 (BitLocker/LUKS) covers **offline** T2 only (stolen disk / leaked tarball). It does **not** defend a live-host read or a deliberate `scp`-out. The SECURITY.md prose must state that ceiling. |
+| **Q4** Is the Tier-3 zero-config hole steered against? | `README.md:118-121` already warns; the docs pass should make it explicit that zero-config Docker leaves `.fernet_key` in the data volume → **set Tier-1 or use an encrypted volume.** Fix is operator config, not tooling (a SOPS `age` key would land in the same volume). |
+| **Q5** Doc-sync fan-out for a SECURITY.md edit? | SECURITY.md is the primary surface; cross-check README install section + `.env.example` comments for a one-line pointer. No code/IDENTITY/packaging doc implicated. |
+| **Q6** Test re-run warranted? | **No** — docs-only, touches no code/fixtures. |
+
+## Buildable-now contract (if/when greenlit — all docs/posture, NO app code, NO new deps)
+
+1. **SECURITY.md: name the plaintext-`configs/` posture** as a deliberate, documented decision, with the
+   encrypted-volume recommendation and O5's honest ceiling (offline-only; sanitiser is for *sharing*).
+2. **SECURITY.md / README: recommend Tier-1 + encrypted volume as the server/Docker confidential-at-rest default**,
+   naming the offline-disk / volume-exfil threats in operator language; make the zero-config Tier-3 `.fernet_key`
+   warning explicit.
+3. **(Optional) Preventive non-fit note** (mirrors `AGENTS.md` "Deliberately omitted" pattern): "SOPS is an
+   operator-side delivery option for Tier 1, not a netcanon feature; desktop/MSI use the OS keyring (DPAPI) and
+   have no per-install key home" — stops the next contributor re-litigating.
+4. **(Deferred POLISH, not this work)** align `credentials._data_dir()` with `Settings.effective_data_dir`
+   (`credentials.py:79` vs `config.py:116-128`) so a desktop Tier-3 fallback lands in `%APPDATA%\Netcanon`, not
+   `<cwd>/data`. Not security-load-bearing (desktop never hits Tier 3).
+
+This dossier is the frozen evidence trail (EXPECTED-STALE; a future audit must not flag it as drift). The
+SECURITY.md follow-up, if taken, is its own behaviour-preserving docs PR under the standing actuation rules.


### PR DESCRIPTION
## What

Outcome of the ultracode blackboard run on **"should netcanon adopt SOPS?"** — verdict **NO-GO** — plus the SECURITY.md honesty fix the run surfaced, and the frozen evaluation dossier.

### Verdict: NO-GO on SOPS (no practical use case for a local-first single app)
Two facts, re-verified against source by the adversarial reviewer:
1. **Device credentials are already Fernet-encrypted at rest** (`netcanon/security/credentials.py`, 3-tier key: env / OS-keyring / file), test-guarded. SOPS would add a parallel mechanism for the half that's already solved.
2. **SOPS's only value — key on a *different host* than the ciphertext — is structurally unavailable**: desktop/server/Docker/MSI all co-locate process+key+ciphertext on one machine. SOPS would re-buy the one threat (offline/exfil) that Fernet Tier-1 + an OS-encrypted volume already cover, while adding `sops`+`age` to a pure-Python image, an unsigned-MSI AV surface with no key home, and a commit-secrets-to-git posture the Hard Rules forbid. (Kontroll's own SECURITY.md classes a "frozen, local" repo as "plaintext accepted" — precedent against, by the same hand.)

### The honesty fix (the run's real ROI)
The largest *plaintext* secret surface is the fetched **backup artifacts** in `configs/` (device `$9$`/type-7/`$6$` hashes, SNMP/RADIUS/IKE keys) — written verbatim, and never stated in SECURITY.md as a deliberate posture. This PR:
- Adds a **"Backup artifacts are stored in plaintext"** subsection under *Credential Storage*: states the posture, recommends an **OS-encrypted volume** (with its honest *offline-only* ceiling), and records why SOPS isn't adopted.
- Adds a **Known-Limitations row** for the plaintext-`configs/` accepted risk.

### Evidence trail
Commits the full dossier (`00-blackboard` → `99-synthesis`, 6 read-only agents) under `docs/reviews/2026-06-17-sops-evaluation/` (EXPECTED-STALE frozen record).

## Notes
- Docs-only; no code/deps changed; no test re-run warranted. `ruff` clean.
- Scrubbed two `C:\…`-style path literals from the dossier before commit (PII-guard hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)