### PR TITLE
docs(definitions): graduate VyOS backup def to live-validated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ tests/fixtures/real/_phase4_runs/*.json
 # private GitHub repo or non-git cloud for long-term retention.
 _pr-archive-pre-public.json
 _pr-archive-pre-public.md
+
+# Dogfood/scratch-VM lab — mirrors Kontroll's gitignored `local/` paradigm.
+# Holds pulled SSH keys, any decrypted secrets, the scratch-VM ledger, and the
+# PVE build/watch/destroy scripts. NEVER commit — contains credentials.
+/local/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Changed
+
+* **VyOS backup definition graduated from provisional to live-validated**
+  (`definitions/vyos/vyos/1.x.yaml`).  The backup-collection wiring (netmiko
+  `vyos` driver, `show configuration commands`, prompt patterns, `show
+  version` probe) shipped in #110 flagged "NOT YET VALIDATED" — verified in
+  code only.  It has now been run end-to-end against a real VyOS rolling
+  instance: a backup job completed and pulled the set-form running config, so
+  the honesty marker is dropped (def notes + `/definitions` Notes column +
+  CAPABILITIES.md), and the def's test now asserts the marker is absent.  The
+  other three backup defs from #110 (`CiscoNXOS`, `CiscoIOSXR`, `ArubaCX`)
+  remain provisional — no free emulator to validate against.
+
 ## [0.3.0] - 2026-06-16
 
 The user-facing counterpart to v0.2.0's internal refactor: a web-UI

--- a/definitions/vyos/vyos/1.x.yaml
+++ b/definitions/vyos/vyos/1.x.yaml
@@ -54,12 +54,10 @@ probe:
     detected_serial: '^Hardware S/N:\s+(\S+)'
 
 notes: >
-  ⚠ NOT YET VALIDATED on a live device — the backup-collection wiring
-  (netmiko driver, config command, prompt patterns, probe regexes) is
-  verified in code and against sample `show version` output only, never
-  run against real hardware.  Treat as provisional and confirm on a real
-  router before relying on it.  VyOS 1.3 (equuleus) / 1.4 (sagitta).
-  Pairs with the vyos migration codec.  Backup uses
-  `show configuration commands` (set-form) over netmiko's `vyos` driver in
-  operational mode; the codec converts set-form to its curly-brace tree on
-  parse.  No enable mode on VyOS.
+  Backup-collection LIVE-VALIDATED 2026-06-17: a real VyOS rolling instance
+  was backed up end-to-end (netmiko `vyos` driver → `show configuration
+  commands` → set-form running-config captured; `show version` probe
+  matched).  VyOS 1.3 (equuleus) / 1.4 (sagitta) and rolling.  Pairs with the
+  vyos migration codec.  Backup uses `show configuration commands` (set-form)
+  over netmiko's `vyos` driver in operational mode; the codec converts
+  set-form to its curly-brace tree on parse.  No enable mode on VyOS.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -42,11 +42,12 @@ Backup-side device-definition YAMLs ship for every codec family above
 (plus per-OS-version overlays).  Cisco and Aruba each span two NOSes with
 separate definitions — `Cisco` (IOS-XE) + `CiscoNXOS` + `CiscoIOSXR`, and
 `Aruba` (AOS-S) + `ArubaCX` (AOS-CX) — keyed distinctly because `type_key`
-must be unique.  **`CiscoNXOS`, `CiscoIOSXR`, `ArubaCX`, and `VyOS` are
+must be unique.  **`CiscoNXOS`, `CiscoIOSXR`, and `ArubaCX` are
 provisional**: their backup wiring is verified in code and against sample
 `show version` output, but has not yet been run against a live device —
 the `/definitions` Notes column flags each with a "NOT YET VALIDATED"
-warning.  See
+warning.  (`VyOS` was provisional too until it was live-validated against a
+real VyOS rolling instance — backup run end-to-end — and graduated.)  See
 [`../definitions/README.md`](../definitions/README.md) for the
 authoring guide and the live `/definitions` page in the running app
 for the per-vendor inventory.  RESULTS.md is the source of truth for

--- a/tests/unit/definitions/test_vyos_definition.py
+++ b/tests/unit/definitions/test_vyos_definition.py
@@ -63,10 +63,12 @@ class TestSchemaCompliance:
         fixtures (tests/fixtures/real/vyos/*.conf)."""
         assert _load_definition().file_extension == "conf"
 
-    def test_notes_flag_not_validated_on_live_hardware(self):
-        """Honesty marker surfaced in the /definitions Notes column —
-        the backup actuation has never run against real hardware."""
-        assert "NOT YET VALIDATED" in _load_definition().notes
+    def test_notes_no_longer_flags_not_validated(self):
+        """VyOS graduated: the backup was live-validated against a real VyOS
+        rolling instance (2026-06-17), so the provisional marker is dropped."""
+        notes = _load_definition().notes
+        assert "NOT YET VALIDATED" not in notes
+        assert "LIVE-VALIDATED" in notes
 
     def test_loaded_via_definition_loader(self):
         defs = DefinitionLoader(_REPO_ROOT / "definitions").load_all()


### PR DESCRIPTION
## What

The `VyOS` backup device definition shipped in #110 flagged
`⚠ NOT YET VALIDATED` — its backup-collection wiring (netmiko `vyos` driver,
`show configuration commands`, prompt patterns, `show version` probe) was
verified in code and against sample output only, never run against real
hardware. It has now been **live-validated**, so the honesty marker is dropped.

## Validation (how)

Stood up a throwaway lab and ran the real product against a real device:

- **App under test:** the published `netcanon/netcanon:0.3.0` Docker image.
- **Device:** a real **VyOS 2026.06.17-0055-rolling** instance (official VyOS
  nightly ISO, sha256-pinned + minisign-verified against VyOS's published key).
- **Result:** created a device profile (`type_key=VyOS`), POSTed a backup → job
  **completed**, device result **success** in ~5.4s. netmiko `vyos` →
  `show configuration commands` pulled a genuine 1403-byte set-form running
  config; the `show version` probe matched the version line.

So the wiring works end-to-end on real VyOS.

## Changes

- `definitions/vyos/vyos/1.x.yaml` — notes now state `LIVE-VALIDATED 2026-06-17`
  (marker removed).
- `tests/unit/definitions/test_vyos_definition.py` — flip the assertion: the
  marker must be **absent** and `LIVE-VALIDATED` present.
- `docs/CAPABILITIES.md` — drop `VyOS` from the provisional list.
- `CHANGELOG.md` — `[Unreleased]` entry.
- `.gitignore` — ignore the dogfood lab's `local/` working dir (creds/ledger/
  scripts; never committed).

The other three backup defs from #110 (`CiscoNXOS`, `CiscoIOSXR`, `ArubaCX`)
**remain provisional** — no free emulator to validate against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)