### PR TITLE
fix(definitions): AOS-CX show-version probe also matches the CX Switch Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ timestamp if your timezone matters for an audit.
   other three backup defs from #110 (`CiscoNXOS`, `CiscoIOSXR`, `ArubaCX`)
   remain provisional — no free emulator to validate against.
 
+* **AOS-CX backup `show version` probe now also matches the CX Switch Simulator**
+  (`definitions/aruba/aos-cx/10.x.yaml`).  The probe captured the OS version only
+  from the two-letter hardware platform prefix (`FL.`/`GL.`); the free AOS-CX
+  *Switch Simulator* reports `Virtual.10.x`, which the old regex silently missed
+  (the job goes green while `detected_os_version` stays empty).  Widened the
+  prefix to `(?:[A-Z]{2}|Virtual)\.` so the version probe fires on both hardware
+  and the simulator (hardware contract unchanged).  Surfaced by the virtual-NOS
+  viability research (`docs/reviews/2026-06-17-virtual-nos-viability/`); the
+  `ArubaCX` def itself stays provisional until run against a real device.
+
 ## [0.3.0] - 2026-06-16
 
 The user-facing counterpart to v0.2.0's internal refactor: a web-UI

--- a/definitions/aruba/aos-cx/10.x.yaml
+++ b/definitions/aruba/aos-cx/10.x.yaml
@@ -48,7 +48,8 @@ probe:
   # non-fatal.
   command: "show version"
   patterns:
-    detected_os_version: 'Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)'
+    # FL./GL. on hardware; the CX Switch Simulator prints 'Virtual.' — accept both.
+    detected_os_version: 'Version\s*:\s*(?:[A-Z]{2}|Virtual)\.(\d+\.\d+)'
 
 notes: >
   ⚠ NOT YET VALIDATED on a live device — the backup-collection wiring

--- a/tests/unit/definitions/test_aruba_aoscx_definition.py
+++ b/tests/unit/definitions/test_aruba_aoscx_definition.py
@@ -132,6 +132,14 @@ class TestProbeRegexes:
         facts = parse_probe_output(_SHOW_VERSION_AOSCX, _load_definition().probe)
         assert facts.get("detected_os_version") == "10.10"
 
+    def test_extracts_version_from_simulator_virtual_prefix(self):
+        """The CX Switch Simulator prints ``Version : Virtual.10.13.1110``; the
+        widened prefix branch captures ``10.13`` (hardware FL./GL. still matches).
+        Sim banner per documented sim output, not yet live-run."""
+        sim = "Version      : Virtual.10.13.1110\n"
+        facts = parse_probe_output(sim, _load_definition().probe)
+        assert facts.get("detected_os_version") == "10.13"
+
     def test_probe_timestamp_attached(self):
         facts = parse_probe_output(_SHOW_VERSION_AOSCX, _load_definition().probe)
         assert PROBE_TIMESTAMP_KEY in facts


### PR DESCRIPTION
## What

The AOS-CX `show version` probe regex (`definitions/aruba/aos-cx/10.x.yaml`) only matched the **two-letter hardware platform prefix** (`FL.`/`GL.`). The free **AOS-CX Switch Simulator** — the image we'd use to live-validate the `ArubaCX` backup def — reports `Version : Virtual.10.x`, which the old `[A-Z]{2}\.` regex silently misses: the backup job goes green while `detected_os_version` stays empty.

Widened the prefix to `(?:[A-Z]{2}|Virtual)\.` so the probe fires on **both** real hardware and the simulator. The hardware contract is unchanged (`FL.`/`GL.` still match exactly as before).

## Why now

Surfaced by the virtual-NOS viability research ([`docs/reviews/2026-06-17-virtual-nos-viability/`](docs/reviews/2026-06-17-virtual-nos-viability/)) into whether NX-OS/IOS-XR/AOS-CX can be virtualized to validate the three remaining provisional backup defs. The parity-skeptic flagged this as a blocker: validating the version probe against the one device class (the sim) on which it provably can't fire would be theater. This fix removes that gap so a future sim-based validation is meaningful.

## Tests

- New `test_extracts_version_from_simulator_virtual_prefix` asserts `Version : Virtual.10.13.1110` → `10.13`.
- Existing `test_extracts_version_from_platform_prefixed_line` (hardware `FL.10.10.1000` → `10.10`) still passes — hardware behavior unchanged.

The `ArubaCX` def itself **stays provisional** (`⚠ NOT YET VALIDATED`) until it's run against a real device; this only fixes the probe regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)