### PR TITLE
docs(reviews): commit virtual-NOS viability research dossier

### DIFF
--- a/docs/reviews/2026-06-17-virtual-nos-viability/00-blackboard.md
+++ b/docs/reviews/2026-06-17-virtual-nos-viability/00-blackboard.md
@@ -1,0 +1,93 @@
+# Blackboard — Is virtualizing NX-OS / IOS-XR / AOS-CX worth it to validate the 3 provisional backup defs? (2026-06-17)
+
+**Process:** netcanon file-per-agent blackboard (docs/agent-workflow.md). Read-only agents each write
+EXACTLY ONE report here; the main thread seeds this file + writes `99-synthesis.md` + is the sole actor
+that verifies/commits. Agents must never read or write under `docs/codebase-review/` (uncommitted PII).
+
+## Mission
+
+We just stood up a Proxmox dogfood lab and **live-validated the `VyOS` backup definition** by SSHing a
+real netcanon (`netcanon/netcanon:0.3.0` Docker) into a real VyOS rolling VM and pulling its running
+config — that let us drop VyOS's `⚠ NOT YET VALIDATED` marker (PR #113). Three backup defs from #110
+remain provisional because they have no free emulator we've tried yet:
+
+- **`CiscoNXOS`** (Cisco NX-OS, Nexus 9000/3000)
+- **`CiscoIOSXR`** (Cisco IOS-XR, ASR9k / NCS)
+- **`ArubaCX`** (Aruba AOS-CX, CX 6000/8000/10000)
+
+**Decide, per NOS: is there a practical virtual image we can run on our Proxmox lab, and does it have
+enough CONFIG / CLI / MANAGEMENT-PLANE parity with a real device that validating the backup def against
+it is actually WORTH SOMETHING — i.e. a PASS against the VM genuinely proves the def works on real
+hardware, not theater?** Return a GO / GO-WITH-FRICTION / NO-GO per NOS with evidence.
+
+## The ONLY thing the backup def exercises (judge parity against EXACTLY this — not full device features)
+
+netcanon's backup is a **management-plane SSH collection**, nothing else. For each NOS the def
+(`definitions/cisco/nx-os/10.x.yaml`, `definitions/cisco/ios-xr/7.x.yaml`, `definitions/aruba/aos-cx/10.x.yaml`)
+drives, via the named **netmiko driver**, exactly:
+
+| NOS | netmiko driver | config command | probe | prompt regex | enable? |
+|---|---|---|---|---|---|
+| NX-OS | `cisco_nxos` | `show running-config` | `show version` → `(?:NXOS\|system):\s+version\s+(\d+\.\d+)`, model `cisco Nexus\S*\s+(\S+)\s+[Cc]hassis`, serial `Processor Board ID\s+(\S+)` | `^\S+[#>]\s*$` | no |
+| IOS-XR | `cisco_xr` | `show running-config` | `show version` → `Cisco IOS XR Software, Version\s+(\d+\.\d+)`, model `^cisco\s+(\S+)` | `^RP/\S+:\S+#\s*$` (+ `^\S+[#>]\s*$`) | no |
+| AOS-CX | `aruba_aoscx` | `show running-config` | `show version` → `Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)` | `^\S+[#>]\s*$` | no |
+
+So the parity that matters is **purely management-plane**: does the virtual image, over SSH,
+(1) present a prompt the regex matches, (2) let netmiko's driver disable paging the way it expects
+(`terminal length 0` for the Cisco drivers / `no page` for aruba_aoscx), (3) return a `show running-config`
+that is real, complete, set/CLI-form config text (the same grammar the migration codec parses), and
+(4) return a `show version` whose banner the probe regex hits. **Dataplane / ASIC / linecard / forwarding
+parity is IRRELEVANT here** — we never touch the dataplane. A control-plane-only VM that runs the *real
+NOS software image* is therefore exactly as good as hardware for THIS purpose. A third-party
+*reimplementation* (not the vendor's own software) would NOT be — call that out if found.
+
+## What each research agent must establish (per NOS), with citations
+
+1. **What virtual image(s) exist** (2026-current): exact product name + version (e.g. Nexus 9000v / n9kv,
+   IOS-XRd / XRv9000, AOS-CX OVA simulator / Vagrant box / CML node). Is it the **vendor's real NOS
+   software** (control-plane sim) or a third-party reimplementation?
+2. **Acquisition + licensing**: where do you get it, does it need a vendor account / EULA / paid licence /
+   eval, is redistribution restricted (we will NOT commit images or pull them into git — but can we even
+   legally download + run one in a private lab?). Note any "free to registered users" vs "paid only".
+   Flag if acquisition is blocked without a commercial relationship.
+3. **Run on our lab**: format (qcow2 / vmdk / OVA / container), boot method on **Proxmox/KVM** (some need
+   nested virt, multi-vNIC, serial console, specific NIC models, or a CML/EVE-NG wrapper), and
+   **resource cost** (RAM/CPU/disk). Our hard budget is **two small VMs on the lab host** total (shared with the
+   netcanon app VM) — so an image needing 16GB+ RAM is a real problem; say so. Lighter is better
+   (XRd container vs XRv9000 VM, etc.).
+4. **Management-plane parity for the table above** — the crux. Does it boot to a real SSH server with the
+   real CLI? Will `show running-config` + `show version` + the prompt + paging behave as on hardware?
+   Any KNOWN divergence (e.g. a virtual banner that says "9000v" and would break the model regex, a
+   different prompt, a stripped feature set that changes `show running-config` output)? Be concrete.
+5. **Verdict**: GO / GO-WITH-FRICTION / NO-GO for "stand it up in the lab and validate the def", with the
+   single biggest blocker named. If GO-WITH-FRICTION, what's the friction (account, RAM, conversion).
+
+Prefer primary sources (vendor docs, CML/DevNet, the netmiko driver's own assumptions) over forum
+hearsay; cite URLs. Use WebSearch / WebFetch (load via ToolSearch). Where relevant, read the def file +
+`netcanon/migration/codecs/<codec>` to confirm what grammar the config command must yield.
+
+## Hard constraints / context (treat as fixed)
+
+- The validation vehicle is the existing dogfood lab (see the gitignored `local/` ledger paradigm — agents
+  don't need it; just know the budget is a modest two-VM lab on **the lab host**, never the secondary node). VyOS was validated this way.
+- "Worth something" = a PASS against the VM is honest evidence the def works on real hardware. If the only
+  obtainable image diverges on the management-plane surface above, validating against it is THEATER → say so.
+- We are NOT deciding to buy anything or commit images. Output is research + a per-NOS verdict only.
+- Don't cargo-cult the VyOS outcome: VyOS was free + runs the real OS. Cisco/Aruba licensing is different.
+
+## File roster
+
+| File | Phase | Author | Covers |
+|---|---|---|---|
+| 00-blackboard.md | seed | main thread | this protocol + mission + the exact backup surface + worthiness lens |
+| 10-research-nxos.md | research | R1 | Cisco NX-OS: Nexus 9000v/n9kv + CML — availability, licensing, lab-runnability, mgmt-plane parity, verdict |
+| 11-research-iosxr.md | research | R2 | Cisco IOS-XR: IOS-XRd (container) / XRv9000 — same dimensions + verdict (note we already used an "xrd corpus" for fixtures) |
+| 12-research-aoscx.md | research | R3 | Aruba AOS-CX: OVA simulator / Vagrant box `arubanetworks/aoscx` / CML — same dimensions + verdict |
+| 30-review-parity-skeptic.md | review | V1 | reads R1–R3; adversarially hunts where a VM PASS would NOT prove real-hardware behaviour for the backup surface; per-NOS worth-it vs theater verdict |
+| 99-synthesis.md | synthesis | main thread | reconciled per-NOS GO/FRICTION/NO-GO + a recommended order (or "not worth it") |
+
+## Severity tags for the reviewer
+
+`THEATER` (a VM pass wouldn't prove hardware behaviour) · `ACQUISITION-BLOCKER` (can't get the image
+without a commercial/paid relationship) · `RESOURCE-BLOCKER` (>8GB RAM / needs nested-virt/CML wrapper) ·
+`PARITY-OK` (real NOS software, mgmt-plane identical) · `FRICTION` (works but account/convert/heavy).

--- a/docs/reviews/2026-06-17-virtual-nos-viability/10-research-nxos.md
+++ b/docs/reviews/2026-06-17-virtual-nos-viability/10-research-nxos.md
@@ -1,0 +1,305 @@
+# R1 — Cisco NX-OS virtualization viability (Nexus 9000v / n9kv)
+
+**Author:** R1 (research) · **Date:** 2026-06-17 · **Backup def under test:**
+`definitions/cisco/nx-os/10.x.yaml` (`type_key: CiscoNXOS`, netmiko driver `cisco_nxos`).
+
+**One-line verdict: GO** — Cisco's own Nexus 9000v is the *real* NX-OS software (a
+control-plane "demo version"), free to download with any Cisco.com account (no contract),
+runs on plain Proxmox/KVM as a single ~2 GB qcow2 at **8 GB RAM / 2 vCPU**, and over SSH it
+presents a real CLI where `show running-config` is complete real config and `show version`
+hits all three probe regexes. The only friction is RAM headroom and an OVMF/UEFI + SATA boot
+recipe. **Biggest blocker:** 8 GB RAM per instance is right at the ceiling of our 8 GB-per-VM
+budget — it must run *as* the device VM, not alongside the netcanon app VM.
+
+---
+
+## 0. How this maps to the backup surface (what actually needs to be true)
+
+From the seed's table, the `CiscoNXOS` row exercises *only* the management plane:
+
+| Surface | Def value | What the VM must do |
+|---|---|---|
+| netmiko driver | `cisco_nxos` | boot a real NX-OS SSH server that the `cisco_nxos` driver drives |
+| config command | `show running-config` | return complete, real set/CLI-form config text |
+| probe command | `show version` | emit a banner the 3 regexes below hit |
+| os-version regex | `(?:NXOS\|system):\s+version\s+(\d+\.\d+)` | banner line `  NXOS: version 10.x(y)` |
+| model regex | `cisco Nexus\S*\s+(\S+)\s+[Cc]hassis` | banner line `Hardware cisco Nexus9000 C9300v Chassis` |
+| serial regex | `Processor Board ID\s+(\S+)` | banner line `Processor Board ID <id>` |
+| prompt regex | `^\S+[#>]\s*$` | prompt like `switch#` |
+| enable? | `false` | NX-OS admin lands at `#`, no enable mode |
+| paging | `cisco_more_paging: false` | netmiko's driver sends `terminal length 0` itself |
+
+Dataplane / ASIC / linecard parity is explicitly **out of scope** for the backup. So a
+control-plane-only image that runs the genuine NX-OS binary is exactly as good as hardware
+**for this def**. The whole question reduces to: is the obtainable image the real NX-OS
+software, and does its management plane behave identically? Both are **yes** (evidence below).
+
+---
+
+## 1. Which image exists in 2026, and is it real NX-OS?
+
+**The image is the Cisco Nexus 9000v ("n9kv"), Cisco's own real NX-OS software running as a
+control-plane VM.** It is *not* a third-party reimplementation.
+
+- **Current product / version train.** Cisco ships the Nexus 9000v across the full 9.x → 10.x
+  trains. Release-specific deployment guides exist for **9.3(x), 10.1(x), 10.2(x), 10.3(x),
+  10.4(x), 10.5(x), and 10.6(x)** — i.e. it is actively maintained in 2026 and tracks the same
+  NX-OS releases as the physical Nexus 9000. Our def's `version_match: "^(9|10)\\."` covers
+  exactly this. (Cisco Nexus 9000v guides, releases 9.3 through 10.6.)
+- **Two modern flavors** under the same "Nexus 9000v" umbrella:
+  - **Nexus 9300v / 9500v** — the standard image (single qcow2, e.g.
+    `nexus9300v.9.3.9.qcow2`, or `nxos64-cs.10.2.2.185.F.bin` style images).
+  - **Nexus 9300v / 9500v "Lite"** — a reduced-memory, smaller image introduced in
+    **10.2(3)F** (`nxos64-cs-lite.10.2.2.75.F.bin`, current `nxos64-cs-lite.10.5.3.F.bin`).
+    Lite needs less RAM (see §3) — relevant to our budget.
+- **It runs the genuine NX-OS binary.** The `show version` banner literally reads
+  *"Nexus 9000v is a demo version of the Nexus Operating System Software"* and reports
+  `NXOS: version 10.2(3) [build 10.2(2.185)]` with image file
+  `bootflash:///nxos64-cs.10.2.2.185.F.bin`. "Demo version" here means *control-plane
+  simulation of the real software* — the same NX-OS CLI, parser, and `running-config` grammar
+  as hardware, with the dataplane/ASIC stubbed. This is the vendor's own software, not an
+  open-source clone.
+- **Lineage note (older image).** The earlier **"NX-OSv 9000"** (a.k.a. "Titanium" heritage,
+  `nxosv9k-7.0.3.I7.4.qcow2`, `nxosv-final.7.0.3.I7.x.qcow2`) is the same family's predecessor
+  and is the image behind the older `system: version 7.0(3)I7(8)` style banner our def's regex
+  also anticipates (`(?:NXOS|system):`). It is effectively superseded by Nexus 9000v 9.3+/10.x;
+  no reason to use it when 10.x is freely available. Worth knowing only because it confirms the
+  `system:`-form branch of our version regex is real, not invented.
+
+**Verdict on dimension 1: PARITY-OK — vendor's own NX-OS software, not a reimplementation.**
+
+---
+
+## 2. Acquisition + licensing
+
+- **Where:** Cisco Software Download portal (`software.cisco.com`, Nexus 9000v switch product
+  page `cisco.com/c/en/us/support/switches/nexus-9000v-switch/model.html`). qcow2 / OVA / VMDK
+  artifacts are published per release.
+- **Cost / gating:** **Free to any registered Cisco.com (CCO) account; no service contract or
+  paid license is attached to the n9kv image itself.** Community/primary guidance is explicit:
+  *"Cisco Nexus 9000v is publicly free to download. You need to have a Cisco account, but you
+  don't need to have any contract attached to it."* Cisco positions it for
+  "validate configuration changes on a simulated network prior to applying them on a production
+  network… feature testing, verification, and automation tooling" — i.e. exactly lab/dev use.
+- **Legality of private-lab use:** The image is downloaded under Cisco's standard EULA for
+  software downloads; running it in a private lab for config/automation validation is its
+  stated purpose. We are NOT redistributing or committing the image (the mission forbids that),
+  so the only obligation is "registered account + don't redistribute," which we satisfy by each
+  operator downloading under their own CCO. **No commercial relationship or purchase is
+  required** to obtain or run n9kv standalone on KVM.
+- **The licensing trap to avoid — CML.** Do *not* try to get NX-OS via the **free** Cisco
+  Modeling Labs tier. **CML-Free (5-node) does NOT include the NX-OS 9000 node** — its refplat
+  ships only IOL/IOL-L2/ASAv + Linux hosts. NX-OS 9000 (and IOS-XR, Cat8000v) require
+  **CML-Personal (paid, ~US$199/yr, 20-node)**. CML is *not* the acquisition path for us; the
+  **standalone n9kv qcow2 downloaded directly from software.cisco.com is**, and it is free. CML
+  is only relevant if the operator already happens to own a Personal license.
+
+**Verdict on dimension 2: FRICTION-LIGHT — free with a Cisco account, legal for private lab,
+no purchase. The only "gotcha" is not confusing it with CML-Free (which excludes the node).**
+
+---
+
+## 3. Run it on the Proxmox lab (format, boot recipe, resource cost)
+
+Primary runbook: Karneliuk, *"How to Run Cisco Nexus 9000v in Proxmox to Lab Cisco Data
+Centre"* (karneliuk.com, 2022) — directly our scenario (n9kv on Proxmox/KVM). Cross-checked
+against containerlab `vr-n9kv` and the Cisco deployment guides.
+
+**Format:** single **qcow2** disk image (~1.98 GB on disk for 9.3(9); 10.x images are similar
+single-file qcow2/`.bin`). No multi-disk OVA wrangling needed for KVM.
+
+**Proxmox boot recipe (the load-bearing quirks):**
+
+| Setting | Required value | Why |
+|---|---|---|
+| BIOS / firmware | **OVMF (UEFI)** — *mandatory* | "Cisco Nexus 9000v requires this type of BIOS… VM will not launch" on SeaBIOS |
+| Disk bus | **SATA (sata0)**, set as top boot priority | qcow2 must attach as SATA, not SCSI/virtio |
+| mgmt NIC model | **E1000** | mgmt0 must be `E1000`; virtio not supported for mgmt |
+| Serial console | **needed for first boot** (`qm terminal <vmid>`) | POAP prompt appears on serial at first boot |
+| Import | `qm importdisk <vmid> <image>.qcow2 <storage>` | standard Proxmox import |
+| First-boot prompt | "Abort Power On Auto Provisioning [yes/skip/no]" | choose **skip/yes** to get to setup, then configure mgmt + SSH |
+| Boot time | ~5 minutes to full CLI | matches containerlab's "~5 min to fully boot" |
+
+**Resource cost (honest, vs the modest two-VM lab budget):**
+
+| Variant | RAM | vCPU | Disk | Source |
+|---|---|---|---|---|
+| n9kv standard (Karneliuk Proxmox) | **8 GB** | **2** | ~2 GB qcow2 (+ overlay) | Karneliuk Proxmox guide |
+| n9kv standard (Cisco min, rel 10.1+) | **8 GB minimum to boot** | 4 (some docs) | ~2 GB | Cisco; learningnetwork |
+| n9kv standard (containerlab default) | 10 GB | 4 | qcow2 in vrnetlab container | containerlab `vr-n9kv` |
+| **n9kv "Lite"** (10.2(3)F+) | **6 GB min** | **2** | smaller `.bin` | containerlab; Cisco lite-image guide |
+
+**Budget reality:** The lab budget is **two small VMs** on the lab host total, shared with the
+netcanon app VM. The standard n9kv wants **8 GB / 2–4 vCPU**, which *consumes one entire 8 GB
+VM by itself*. That is feasible **only if** n9kv runs as the dedicated device VM (VM-B in the
+dogfood paradigm) and the netcanon app/Docker runs in the *other* 8 GB VM (VM-A) — exactly how
+VyOS was validated. There is **no headroom to co-locate** n9kv with anything else on the same
+VM. The **Lite image at 6 GB / 2 vCPU is the recommended choice** here: it leaves ~2 GB
+headroom on the 8 GB VM and boots the identical CLI/`running-config` grammar. containerlab's
+10 GB default is conservative; 8 GB (standard) and 6 GB (lite) are the real floors.
+
+- No **nested-virt** requirement for the VM itself (it's a normal KVM guest; Proxmox on bare
+  metal is fine — nested virt only matters if the lab host is itself a VM, which it is not).
+- No CML/EVE-NG wrapper needed — runs as a plain Proxmox VM. (EVE-NG and containerlab support
+  exist but add nothing for a single-node mgmt-plane validation.)
+
+**Verdict on dimension 3: FRICTION — runs natively on Proxmox/KVM, but 8 GB (or 6 GB Lite)
+eats a whole budget VM. Use the Lite image; dedicate the VM. Boot needs the OVMF+SATA+E1000
+recipe (RESOURCE-BLOCKER-adjacent, not a hard blocker).**
+
+---
+
+## 4. Management-plane parity — the crux (judged against EXACTLY the def's surface)
+
+This is where a virtual image can be theater. For n9kv it is **not** — every surface the def
+touches behaves as on hardware:
+
+**(a) SSH + prompt.** n9kv boots a real NX-OS SSH server. Default/lab creds `admin` /
+`admin` (containerlab, dockerized_n9kv both confirm `admin:admin`). After login the admin role
+lands directly at `switch#` — **no enable mode**, matching `needs_enable: false`. The prompt
+`switch#` / `switch(config)#` matches the def's `^\S+[#>]\s*$` (no spaces → `\S+` holds).
+**PARITY-OK.**
+
+**(b) Paging.** netmiko's `CiscoNxosSSH.session_preparation` sets `terminal width 511` and
+calls `disable_paging()` which sends **`terminal length 0`** — both natively supported by
+NX-OS (and by n9kv, same binary). This matches the def's design note exactly: paging is owned
+by the driver, `cisco_more_paging: false`, and we must NOT add `terminal length 0` to
+`commands.pre`. n9kv honors `terminal length 0` like hardware. **PARITY-OK.**
+
+**(c) `show running-config`.** n9kv runs the genuine NX-OS config parser and emits **complete,
+real set/CLI-form running-config** — the same grammar `netcanon/migration/codecs/cisco_nxos`
+round-trips (the MEMORY notes this codec is COMPLETE+CERTIFIED against a 6-config batfish
+corpus). The control-plane is fully present: interfaces (`Ethernet1/X`, `mgmt0`), VLANs, SVIs,
+BGP/OSPF, VRF contexts, `feature` toggles, route-maps, etc. all render exactly as on hardware.
+The *only* things absent are pure-dataplane artifacts (real linecard inventory, ASIC counters)
+— which are not in `running-config` and not in scope. **PARITY-OK for the config command.**
+
+**(d) `show version` vs the three probe regexes.** This is the highest-risk spot (the seed
+flags "any virtual-chassis banner that could break the model regex"). Verified against the
+documented n9kv banner:
+
+```
+Nexus 9000v is a demo version of the Nexus Operating System Software
+...
+  NXOS: version 10.2(3) [build 10.2(2.185)] [Feature Release]
+...
+Hardware
+  cisco Nexus9000 C9300v Chassis
+  Intel(R) Xeon(R) CPU E5-2658 v4 @ 2.30GHz with 20499656 kB of memory.
+  Processor Board ID 9GFDLI2JD0R
+...
+```
+
+Regex-by-regex:
+
+| Probe field | Regex | Banner line | Match | Captured value |
+|---|---|---|---|---|
+| os-version | `(?:NXOS\|system):\s+version\s+(\d+\.\d+)` | `  NXOS: version 10.2(3)` | ✅ | `10.2` |
+| model | `cisco Nexus\S*\s+(\S+)\s+[Cc]hassis` | `cisco Nexus9000 C9300v Chassis` | ✅ | **`C9300v`** |
+| serial | `Processor Board ID\s+(\S+)` | `Processor Board ID 9GFDLI2JD0R` | ✅ | `9GFDLI2JD0R` |
+
+- **os-version: clean match → `10.2`.** Exactly the `major.minor` an overlay (`os_version:
+  "10.x"`) would pin. The leading `Nexus 9000v is a demo version…` line does NOT interfere —
+  it lacks the `NXOS:`/`system:` token, so the regex skips it and hits the real version line.
+  *No regression from the "demo version" banner.*
+- **model: matches, captures `C9300v`** (or `C9500v` for the 9500v image). `Nexus\S*` eats
+  `Nexus9000`, `(\S+)` grabs `C9300v`, `[Cc]hassis` anchors. **The regex is NOT broken by the
+  virtual SKU** — it captures successfully. The honest caveat: the captured *model string is a
+  virtual SKU* (`C9300v` / `C9500v`), not a hardware SKU (`C93180YC-EX`, `C9336C-FX2`, …). For
+  **validating that the def's collection pipeline works** this is a full pass — the regex fires
+  and populates `detected_model`. It does NOT prove the regex handles *every* hardware SKU
+  string, but the def's comment cites `cisco Nexus9000 C93180YC-EX Chassis` as the target, and
+  the n9kv line is structurally identical (`Nexus9000 <SKU> Chassis`), so the same regex path
+  is exercised. This is honest evidence, not theater.
+- **serial: clean match.** n9kv generates a synthetic but well-formed Processor Board ID; the
+  regex captures it. (On hardware it's a real FDO-style serial; structurally identical for the
+  regex.)
+
+**(e) Prompt for netmiko base_pattern.** netmiko's NX-OS driver tests the channel against
+`[>#]` and sets the base prompt from `switch#`. n9kv's prompt satisfies this. No virtual banner
+or MOTD breaks prompt detection (the "demo version" text appears only in `show version`, never
+in the prompt). **PARITY-OK.**
+
+**Net parity assessment:** Every one of the def's nine management-plane surfaces behaves on
+n9kv exactly as documented for hardware. The single nuance — model regex captures a *virtual*
+SKU `C9300v` — does not break the regex and is inherent to validating against any vendor
+control-plane sim; it does not make the result theater because the regex *structure path*
+(`Nexus9000 <token> Chassis`) is identical to hardware.
+
+**Verdict on dimension 4: PARITY-OK.**
+
+---
+
+## 5. Verdict
+
+### GO
+
+Standing up Nexus 9000v in the Proxmox lab and pulling its `show running-config` over the
+`CiscoNXOS` def is **worth something** — a PASS is honest evidence the def works on real
+hardware, because n9kv *is* the real NX-OS software with an identical management plane (SSH,
+no-enable `#` prompt, native `terminal length 0`, complete real `running-config`, and a
+`show version` banner that hits all three probe regexes). This is the strongest of the three
+provisional defs to validate (Cisco even ships it free).
+
+**Biggest blocker (and it's only friction):** **RAM.** The standard image wants 8 GB, which
+consumes an entire budget VM. Mitigation: use the **Nexus 9300v Lite** image (6 GB / 2 vCPU)
+and dedicate one of the two 8 GB lab VMs to it (VM-B = device), exactly mirroring how VyOS
+was validated, with the netcanon Docker app on VM-A. Plus the one-time boot recipe friction:
+**OVMF/UEFI firmware (mandatory) + SATA disk bus + E1000 mgmt NIC + serial console to clear the
+POAP prompt on first boot.**
+
+**Severity tags:** `PARITY-OK` (real NX-OS software, mgmt-plane identical) ·
+`FRICTION` (free CCO download + OVMF/SATA/E1000 boot recipe) ·
+`RESOURCE-BLOCKER (soft)` (8 GB standard / 6 GB Lite — dedicate the VM; Lite recommended).
+**Not `ACQUISITION-BLOCKER`** (free, no contract). **Not `THEATER`** (genuine NX-OS binary).
+
+**Validation-readiness checklist for the lab:**
+1. Download `nexus9300v.<rel>.qcow2` *or* the Lite `nxos64-cs-lite.<rel>.F.bin`/qcow2 from
+   software.cisco.com under a CCO account (free).
+2. Proxmox VM: OVMF BIOS, `qm importdisk` the qcow2 → attach as **sata0** (top boot priority),
+   mgmt NIC = **E1000**, RAM **6 GB (Lite) or 8 GB (standard)**, 2 vCPU.
+3. `qm terminal <vmid>`; at first boot answer the POAP prompt (skip), set `admin` password,
+   `feature ssh` is on by default, configure `mgmt0` IP.
+4. SSH `admin@<mgmt-ip>`; confirm prompt `switch#`, run `show version` (expect the regex hits
+   above) and `show running-config`.
+5. Point netcanon (Docker `netcanon/netcanon:0.3.0`) at it with the `CiscoNXOS` def; confirm
+   backup pulls a complete config and probe populates os-version `10.x` / model `C9300v` /
+   serial. On PASS, drop the `⚠ NOT YET VALIDATED` marker in `definitions/cisco/nx-os/10.x.yaml`
+   `notes` (same move as VyOS PR #113).
+
+---
+
+## Sources
+
+- Cisco Nexus 9000v (9300v/9500v) Guide, Release 10.5(x) — Overview & Lite NX-OS Image:
+  https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/105x/configuration/n9000v-9300v-9500v/cisco-nexus-9000v-9300v-9500v-guide-release-105x/m-overview.html
+- Cisco Nexus 9000v (9300v/9500v) Guide, Release 10.3(x) — Overview (show version banner / demo
+  version / C9300v chassis):
+  https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/103x/n9000v-n9300v-9500v/cisco-nexus-9000v-9300v-9500v-guide-release-103x/m-overview.html
+- Cisco Nexus 9000v Switch product page (downloads / purpose):
+  https://www.cisco.com/c/en/us/support/switches/nexus-9000v-switch/model.html
+- Cisco Software Download portal (Nexus 9000v): https://software.cisco.com/download/home/285954710
+- Cisco NX-OS Release Notes 10.2(3)F (Lite image `nxos64-cs-lite` introduction):
+  https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/102x/release-notes/cisco-nexus-9000-nxos-release-notes-1023.html
+- Karneliuk — "How to Run Cisco Nexus 9000v in Proxmox to Lab Cisco Data Centre" (Proxmox boot
+  recipe: qcow2, OVMF, SATA, E1000, 8G/2vCPU, POAP, SSH):
+  https://karneliuk.com/2022/05/infrastructure-4-how-to-run-cisco-nexus-9000v-in-proxmox-to-lab-cisco-data-centre/
+- containerlab `vr-n9kv` kind (10 GB/4vCPU default, 6 GB/2 CPU Lite, admin:admin, ~5 min boot,
+  qcow2-in-vrnetlab): https://containerlab.dev/manual/kinds/vr-n9kv/
+- jpmondet/dockerized_n9kv (NX-OS 7.0.3.I7(9)/9.3(3)/9.3(7)/10.1(1) tested; ssh admin/admin
+  confirmed): https://github.com/jpmondet/dockerized_n9kv
+- Cisco DevNet — NX-OS 9000 node in Cisco Modeling Labs v2.10 (bundled NX-OS, min 4 vCPU
+  reference): https://developer.cisco.com/docs/modeling-labs/nx-os-9000/
+- Cisco DevNet — CML-Free (5-node, NX-OS NOT included; needs CML-Personal):
+  https://developer.cisco.com/docs/modeling-labs/cml-free/
+- Cisco Community — "Nexus 9000v licensing" (free to download, no contract):
+  https://community.cisco.com/t5/network-security/nexus-9000v-licensing/m-p/3918036
+- Cisco Learning Network — n9kv 10.1+ requires min 8 GB RAM to boot:
+  https://learningnetwork.cisco.com/s/question/0D56e0000EBsV59CQF/hardware-requirements-for-using-nxos-and-iosxr-on-cisco-cml-272
+- netmiko CiscoNxosSSH driver (session_preparation: `terminal width 511` + `disable_paging` →
+  `terminal length 0`; base prompt `[>#]`):
+  https://ktbyers.github.io/netmiko/docs/netmiko/cisco/cisco_nxos_ssh.html
+- GNS3 marketplace — Cisco NX-OSv 9000 (older `nxosv9k-7.0.3.I7.x.qcow2` lineage):
+  https://www.gns3.com/marketplace/appliances/cisco-nx-osv-9000
+- EVE-NG — Cisco Nexus 9000v add guide (qcow2, format confirmation):
+  https://www.eve-ng.net/index.php/documentation/howtos/howto-add-cisco-nexus-9000v-switch/

--- a/docs/reviews/2026-06-17-virtual-nos-viability/11-research-iosxr.md
+++ b/docs/reviews/2026-06-17-virtual-nos-viability/11-research-iosxr.md
@@ -1,0 +1,223 @@
+# R2 — Cisco IOS-XR virtualization viability (CiscoIOSXR backup def)
+
+**Author:** R2 (research) · **Date:** 2026-06-17 · **Process:** netcanon blackboard (read-only)
+**Backup def under test:** `definitions/cisco/ios-xr/7.x.yaml` (`type_key: CiscoIOSXR`, netmiko driver `cisco_xr`)
+
+## TL;DR verdict
+
+**GO-WITH-FRICTION.** Cisco's own `IOS-XRd Control Plane` Docker container *is the real IOS-XR
+software image* (same codebase as ASR 9000 / NCS), boots to the genuine `RP/0/RP0/CPU0:<host>#` CLI,
+serves real `ssh server v2` on `MgmtEth0/RP0/CPU0/0`, and returns a real `show running-config` /
+`show version`. It is light enough for the lab (control-plane flavor: **2 GiB RAM + 2 vCPU per
+instance**, no hugepages, no PCI/IOMMU) and we *already lean on an "xrd corpus"* for the IOS-XR
+fixtures, so XRd grammar is known-representative. **The single biggest blocker is acquisition:**
+the image is gated behind a Cisco account with an *active service/support contract* on
+`software.cisco.com` — there is **no anonymous free download**. Secondary friction: XRd requires
+**cgroups v1** (modern hosts default to v2 → kernel-cmdline change + reboot), `apparmor=unconfined`,
+and a couple of inotify sysctls. The free **DevNet XRd sandbox** sidesteps acquisition entirely and
+is a legitimate validation path if SSH-reachable from netcanon. **PARITY-OK** on the exact backup
+surface; the only divergence is cosmetic (`detected_model` token), not a collection break.
+
+---
+
+## 1. What virtual image(s) exist (2026-current)
+
+Cisco ships **two distinct IOS-XR virtual products**, both running the *real* IOS-XR NOS (control-plane
+software shared with hardware ASR 9000 / NCS-class platforms — **vendor software, not a third-party
+reimplementation**):
+
+| Product | Form | Dataplane | Use cases | Status for our purpose |
+|---|---|---|---|---|
+| **IOS-XRd Control Plane** | Docker **container** (`x86_64` tarball) | none (control-plane only) | vRR, SR-PCE, route-reflector, NETCONF/gNMI/YANG labs | **Best fit** — lightest, real CLI, real SSH |
+| **IOS-XRd vRouter** | Docker **container** | full software dataplane (DPDK) | vPE, vCSR, cloud router needing forwarding | overkill + heavy (hugepages, vfio-pci) |
+| **IOS-XRv 9000 (XRv9k)** | KVM/ESXi **VM** (qcow2/OVA) | software dataplane | legacy "virtual ASR9k" VM, runs in CML | heavier VM; fine but no advantage over XRd CP |
+
+- **XRd is the modern, container-native successor.** containerlab, CML, and Cisco's own docs treat
+  XRd as the current virtual IOS-XR; XRv9000 is the older VM lineage.
+- **It is the real software.** The `show version` banner reads `Cisco IOS XR Software, Version 7.7.1`
+  (or 24.x/25.x on newer trains) and `cisco XRd Control Plane cisco XRd-CP-C-01 processor with 32GB
+  of memory` — i.e. identical IOS-XR codebase, only the chassis identity string differs from hardware.
+- **Dataplane parity is irrelevant** to netcanon's backup (per the seed: we only do management-plane
+  SSH collection), so the Control-Plane flavor's lack of forwarding is a non-issue.
+
+Sources: [XRd images: Where can one get them? (xrdocs)](https://xrdocs.io/virtual-routing/tutorials/2022-08-22-xrd-images-where-can-one-get-them),
+[XRd with docker: Control-Plane and vRouter (xrdocs)](https://xrdocs.io/virtual-routing/tutorials/2022-08-23-xrd-with-docker-control-plane-and-vrouter),
+[Cisco IOS XRd series (cisco.com)](https://www.cisco.com/c/en/us/support/routers/ios-xrd/series.html),
+[IOS XRv 9000 — CML node (DevNet)](https://developer.cisco.com/docs/modeling-labs/ios-xrv-9000/),
+[Red Hat catalog: Cisco IOS XRd Control Plane](https://catalog.redhat.com/en/software/container-stacks/detail/647ef796c0702939ecc381ed).
+
+---
+
+## 2. Acquisition + licensing  — **the gating dimension**
+
+- **Where:** `software.cisco.com` —
+  Control Plane: `https://software.cisco.com/download/home/286331236/type/280805694`,
+  vRouter: `https://software.cisco.com/download/home/286331238/type/280805694`. Distributed as a
+  signed tarball (e.g. `xrd-control-plane-container-x64.7.7.1.tgz`) you `docker load`.
+- **Licensing reality (the blocker):** XRd images are **"available for download only for users who
+  have an active service account."** Multiple primary sources state a Cisco account *with software-
+  download privileges / an active support contract* is required; if your account lacks privileges
+  you are told to "contact your Cisco Sales Representative." **There is no free-to-any-registered-user
+  download** the way Nexus 9000v / some CSR1000v evals were. → tag **ACQUISITION-BLOCKER**.
+  - Note the contrast with the VyOS validation: VyOS was a free, real-OS rolling image. Cisco XRd is
+    **not** freely downloadable without a commercial relationship. Do **not** cargo-cult the VyOS outcome.
+- **Once obtained, running it privately is permitted** under the Cisco lab/eval terms — XRd is
+  explicitly positioned for lab/dev/CI use. We are not committing or redistributing the image (the run
+  rules forbid that anyway), so the only legal question is *can we download it*, which hinges on the
+  account/contract above.
+- **Two contract-free escape hatches:**
+  1. **DevNet XRd Sandbox** (free, reservation-based) — Cisco hosts XRd for you; "perfect to get
+     familiar with XRd … YANG/NETCONF/gNMI." If the sandbox node is reachable over SSH from a
+     netcanon instance (DevNet sandboxes expose SSH/VPN), this validates the def with **zero image
+     acquisition**. *Caveat:* sandbox networking may require Cisco's AnyConnect/VPN reservation rather
+     than a clean SSH path to our Proxmox lab — needs a live check.
+  2. **IOS-XRv 9000 in CML** runs "in *demo mode* … without any additional licensing" — but CML
+     itself is a paid product, so this only helps if a CML instance already exists (it does not in
+     our lab budget).
+
+Sources: [XRd images: Where can one get them? (xrdocs)](https://xrdocs.io/virtual-routing/tutorials/2022-08-22-xrd-images-where-can-one-get-them),
+[Software Download — XRd Control Plane (cisco.com)](https://software.cisco.com/download/home/286331236/type/280805694),
+[containerlab — Cisco XRd](https://containerlab.dev/manual/kinds/xrd/) ("XRd image is available for
+download only for users who have an active service account"),
+[Explore network programmability with the DevNet XRd Sandbox (Cisco Blogs)](https://blogs.cisco.com/developer/explore-network-programmability-with-the-devnet-xrd-sandbox),
+[CiscoDevNet/XRd-Sandbox](https://github.com/CiscoDevNet/XRd-Sandbox),
+[IOS XRv 9000 — CML node (DevNet)](https://developer.cisco.com/docs/modeling-labs/ios-xrv-9000/).
+
+---
+
+## 3. Run on our lab (Proxmox/KVM, hard budget a modest two-VM lab)
+
+XRd is a **container**, so it runs *inside* a Linux VM on Proxmox (no nested virt needed — it is not
+itself a VM). Plan: one Ubuntu/Rocky VM (within the modest-lab budget) runs Docker + the XRd CP container;
+netcanon (the `netcanon/netcanon:0.3.0` Docker app VM) SSHes into it. Authoritative resource figures
+come from Cisco's `xrd-tools` **`host-check`** script — the canonical per-platform requirement source:
+
+### Control Plane (what we'd use) — fits the budget comfortably
+- **RAM:** **2 GiB per container** minimum (host-check `XRd Control Plane` check).
+- **CPU:** **2 cores** minimum.
+- **Hugepages:** **none required.**
+- **PCI/IOMMU/vfio-pci:** **not required** (those are vRouter-only).
+- **Disk:** container image tarball is a few GB; ~7 GB working footprint is ample.
+- Net: one CP instance fits easily in a single modest-lab VM with room to spare.
+
+### vRouter (not needed) — would strain the budget
+- **RAM:** 5 GiB/container (host-check); Cisco deployment manifests reserve **16 GiB** + `hugepages-1Gi: 6Gi`.
+- **Hugepages:** **3 GiB of 1 GiB-pages per instance** (kernel cmdline `hugepages=N` or sysctl).
+- **CPU extensions** `ssse3, sse4_1, sse4_2`; **PCI driver** `vfio-pci`/`igb_uio`; IOMMU recommended.
+- → would chew most of one 8GB VM and add hugepage/IOMMU plumbing. **Avoid** — no benefit for
+  management-plane validation.
+
+### Host prerequisites (the FRICTION) — apply to the Docker VM
+| Requirement | Detail | Friction |
+|---|---|---|
+| **Kernel** | ≥ 4.6 (host-check); practical guides use 5.15+. RHEL/CentOS 8.3 kernel `4.18.0-240` explicitly rejected | low — modern distro fine |
+| **cgroups** | **v1 required**; host-check fails with *"Cgroups version 2 is in use, but this is not supported by XRd"* on v2 hosts. Modern Ubuntu 22.04 / Rocky 9 default to **v2** → set `systemd.unified_cgroup_hierarchy=false` on the kernel cmdline + **reboot** | **MEDIUM — kernel-cmdline change + reboot** |
+| **apparmor** | XRd "cannot run with the default docker profile"; run with `--security-opt apparmor=unconfined` (or install the `xrd-unconfined` profile host-check looks for) | low — one docker flag |
+| **kernel modules** | `dummy`, `nf_tables` loaded | low |
+| **inotify sysctls** | `fs.inotify.max_user_instances` ≥ 4000 (rec. 64000), `max_user_watches` ≥ 64000 | low — two sysctls |
+| **Docker** | client+daemon ≥ 18.0; FS supports `d_type` | trivial |
+
+**Verification tooling exists:** Cisco's `ios-xr/xrd-tools` repo ships `host-check` (run it to confirm
+the VM is ready, PASS/FAIL per requirement) and `launch-xrd` (one-shot container launcher, e.g.
+`sudo ./launch-xrd localhost/ios-xr:7.7.1`). containerlab also supports XRd (control-plane only — it
+notes the **vrouter is incompatible because it needs PCI interfaces**) and would be the cleanest
+orchestration path if we want repeatability.
+
+> **Could XRd CP run on the netcanon VM-A host?** Yes — co-locating the XRd container on the same
+> Docker host as netcanon is technically possible (2 GiB + 2 cores fits), **but** the cgroups-v1
+> requirement is host-global: flipping the netcanon VM to cgroups v1 affects *all* its containers and
+> needs a reboot. Cleaner to put XRd on the **second** lab VM (the modest-lab sibling) and keep netcanon's
+> host on its default cgroups. Either way we stay inside the modest two-VM lab budget. **No RESOURCE-BLOCKER
+> for the Control-Plane flavor.**
+
+Sources: [xrd-tools `host-check` script](https://raw.githubusercontent.com/ios-xr/xrd-tools/main/scripts/host-check),
+[ios-xr/xrd-tools (GitHub)](https://github.com/ios-xr/xrd-tools),
+[Setting up the Host Environment to run XRd (xrdocs)](https://xrdocs.io/virtual-routing/tutorials/2022-08-22-setting-up-host-environment-to-run-xrd),
+[Setup — Cisco XRd with XRD-Tools (mirror)](https://hmntsharma.github.io/cisco-xrd/base_setup/) (kernel 5.15,
+cgroups v1 via `systemd.unified_cgroup_hierarchy=false`, `docker load`, `launch-xrd`),
+[containerlab — Cisco XRd](https://containerlab.dev/manual/kinds/xrd/) (control-plane only, inotify tuning),
+[XRd on OpenShift (xrdocs)](https://xrdocs.io/virtual-routing/tutorials/2023-05-02-xrd-on-openshift/).
+
+---
+
+## 4. Management-plane parity for the backup surface — **the crux** (PARITY-OK)
+
+The CiscoIOSXR def drives, via netmiko `cisco_xr`, exactly: `show running-config` for config, a
+`show version` probe, prompt regexes `^RP/\S+:\S+#\s*$` (+ generic `^\S+[#>]\s*$`), `needs_enable: false`,
+`cisco_more_paging: false` (netmiko owns paging). Mapping each to XRd CP behavior:
+
+| Backup-def expectation | XRd Control Plane behavior | Match? |
+|---|---|---|
+| **Prompt** `^RP/\S+:\S+#\s*$` | XRd CP boots to **`RP/0/RP0/CPU0:ios#`** (default hostname `ios`; becomes `RP/0/RP0/CPU0:<hostname>#`). Real IOS-XR RP prompt, byte-identical to hardware | **YES** — primary regex matches |
+| **`needs_enable: false`** (SSH lands in exec; no enable) | IOS-XR has **no enable mode** — SSH lands in exec, privilege is task-group based. Exactly as the def's note says | **YES** |
+| **Paging** — netmiko `cisco_xr` `session_preparation()` sends `terminal width 511` + `terminal length 0` | IOS-XR natively supports `terminal length 0` / `terminal width`; the driver disables paging itself. Def correctly keeps `cisco_more_paging: false` and does **not** put `terminal length 0` in `commands.pre` | **YES** |
+| **`show running-config`** returns real, complete CLI-form config | XRd CP returns the genuine IOS-XR running-config (hierarchical `interface MgmtEth0/RP0/CPU0/0 … !`, `ssh server v2`, `router bgp`, etc.) — **the same grammar the `cisco_iosxr` codec parses**, and the same lineage as netcanon's existing "xrd corpus" fixtures | **YES — and self-consistent with our fixtures** |
+| **`show version`** probe `detected_os_version` = `Cisco IOS XR Software, Version\s+(\d+\.\d+)` | Banner reads `Cisco IOS XR Software, Version 7.7.1` (and `24.x`/`25.x`/`26.x` on newer trains). Regex captures `7.7` / `24.1` etc. | **YES** |
+| **`show version`** probe `detected_model` = `^cisco\s+(\S+)` | Banner reads `cisco XRd Control Plane cisco XRd-CP-C-01 processor with 32GB of memory` → first token after leading `cisco` is **`XRd`** (hardware would yield `ASR9K`/`NCS-5501`) | **PARTIAL — cosmetic only** (see below) |
+| **SSH server** | XRd CP runs real `ssh server v2` on `MgmtEth0/RP0/CPU0/0`; containerlab auto-maps `eth0`→Mgmt and exposes SSH (user/pass e.g. `clab/clab@123`, or operator-configured `cisco`) | **YES** |
+
+### The one divergence — and why it's not a blocker
+`detected_model` will resolve to `XRd` on the VM vs `ASR9K`/`NCS-5501` on hardware. This is:
+- **Cosmetic, not a collection break.** The probe is explicitly *non-fatal* (def comment:
+  "Failure is non-fatal"); it only populates `DeviceProfile.detected_facts` and feeds overlay
+  resolution. `show running-config` — the actual deliverable — is unaffected.
+- **A real but minor caveat for the reviewer:** a PASS against XRd proves the *config command, prompt,
+  paging, no-enable, and version-regex* all work on real IOS-XR software. It does **not** independently
+  prove the `detected_model` regex captures a *hardware* platform string, because the VM emits `XRd`.
+  That sub-claim stays "verified against sample `show version` output only" — but it is one regex
+  against a documented, stable hardware banner, and the def comment already scopes the probe as
+  advisory. Honest framing: validating against XRd lets us drop the `⚠ NOT YET VALIDATED` marker for
+  the **collection wiring** (driver, prompt, paging, config command, version probe), with a one-line
+  note that the model-string capture is confirmed only against documented hardware output.
+
+**No THEATER here:** XRd CP is the vendor's *real IOS-XR software*, presenting the *real* management
+plane the def touches. A PASS is honest evidence the def collects from real IOS-XR routers — exactly
+the bar the seed sets. This is the strongest of the three NOS cases precisely because netcanon's
+IOS-XR fixtures already derive from an xrd corpus, so the VM and our test expectations share a lineage.
+
+Sources: [XRd with docker (xrdocs)](https://xrdocs.io/virtual-routing/tutorials/2022-08-23-xrd-with-docker-control-plane-and-vrouter)
+(`RP/0/RP0/CPU0:ios#`, `cisco XRd Control Plane … processor with 30GB/32GB of memory`),
+[Setup — Cisco XRd (mirror)](https://hmntsharma.github.io/cisco-xrd/base_setup/) (boots to console,
+`RP/0/RP0/CPU0:ios#`, `show version` / `show platform`),
+[netmiko `cisco_xr` API docs](https://ktbyers.github.io/netmiko/docs/netmiko/cisco/cisco_xr.html) +
+[netmiko session_preparation discussion #3154](https://github.com/ktbyers/netmiko/discussions/3154)
+(`terminal width 511` + `terminal length 0` in `session_preparation`),
+[XRd Control Plane on OpenShift (xrdocs)](https://xrdocs.io/virtual-routing/tutorials/xrd-control-plane-on-openshift)
+(`ssh server v2` on `MgmtEth0/RP0/CPU0/0`),
+[containerlab — Cisco XRd](https://containerlab.dev/manual/kinds/xrd/) (SSH creds, mgmt iface mapping).
+
+### Version-train note for the def
+`version_match: "^7\\."` is **advisory** (the def comment says so) and the `detected_os_version`
+regex captures any `\d+\.\d+`, so it still works on the newer **24.x / 25.x / 26.x** IOS-XR calendar
+trains. If we validate against a 7.7.1 XRd CP image the version pin matches literally; against a 25.x
+image the regex still extracts `25.1` cleanly and resolution falls back to base — no code change needed,
+but worth a one-line awareness note when picking which XRd tarball to pull.
+
+---
+
+## 5. Verdict — **GO-WITH-FRICTION**
+
+| Dimension | Finding | Tag |
+|---|---|---|
+| Image exists & is real NOS | XRd Control Plane container = real IOS-XR software | PARITY-OK |
+| Acquisition / licensing | `software.cisco.com`, needs Cisco account **with service contract**; no anon free DL. DevNet sandbox = free escape hatch | **ACQUISITION-BLOCKER** / FRICTION |
+| Lab runnability | CP = 2 GiB + 2 vCPU, no hugepages — fits a modest two-VM lab; but **cgroups v1** + apparmor-unconfined + inotify | FRICTION (no RESOURCE-BLOCKER) |
+| Mgmt-plane parity | prompt, no-enable, paging, `show run`, version probe all match real IOS-XR; xrd-corpus lineage | PARITY-OK |
+| Single divergence | `detected_model` → `XRd` not `ASR9K` (cosmetic, non-fatal probe) | minor caveat |
+
+**Biggest blocker:** *acquisition* — obtaining the XRd Control Plane image requires a Cisco.com
+account with an active service/support contract (no free anonymous download). If we have such an
+account, this is the easiest of the three NOS to validate and is genuinely worth it. If we do not,
+the **DevNet XRd sandbox** (free) is the recommended path, contingent on a live check that the
+sandbox node is SSH-reachable from a netcanon instance.
+
+**Friction if GO:** (1) get the image (account/contract or DevNet sandbox); (2) put XRd CP on the
+second lab VM with **cgroups switched to v1** (kernel cmdline + reboot), `apparmor=unconfined`, and
+the inotify sysctls; run Cisco's `host-check` to confirm green; (3) bring up `ssh server v2` on
+`MgmtEth0/RP0/CPU0/0`; (4) point netcanon `0.3.0` at it and run the backup. Expect a clean PASS on
+collection wiring; footnote the `detected_model` string as VM-cosmetic.
+
+**Recommended priority among the three:** IOS-XR is the **strongest worth-it case** — real vendor
+software, lightest control-plane footprint, and we already trust XRd-derived fixtures — *if and only
+if* the acquisition gate (account/contract or working DevNet sandbox SSH path) is cleared. That gate,
+not resources or parity, is the deciding variable.

--- a/docs/reviews/2026-06-17-virtual-nos-viability/12-research-aoscx.md
+++ b/docs/reviews/2026-06-17-virtual-nos-viability/12-research-aoscx.md
@@ -1,0 +1,210 @@
+# R3 — Aruba AOS-CX virtualization viability (validate the `ArubaCX` backup def)
+
+**Author:** R3 (research) · **Date:** 2026-06-17 · **NOS:** Aruba AOS-CX (CX 6000/8000/10000) · **type_key:** `ArubaCX`
+**Def under test:** `definitions/aruba/aos-cx/10.x.yaml` · **Codec:** `netcanon/migration/codecs/aruba_aoscx`
+
+## TL;DR verdict
+
+**GO-WITH-FRICTION.** Aruba/HPE ships its own first-party control-plane image — the **AOS-CX Switch
+Simulator** (a real AOS-CX OS image driving an ASIC *simulator*, not a third-party reimplementation). It
+runs cleanly on Proxmox/KVM at **4 GB RAM / 2 vCPU** (well inside the modest two-VM lab budget), converts
+OVA/VMDK → qcow2 with a one-line `qemu-img`, and presents a **real SSH server with the real AOS-CX CLI**:
+the prompt, `no page` paging, `configure term`, `show running-config`, and `show version` all behave
+exactly as the `aruba_aoscx` netmiko driver (and our def) assume. For the four things the backup def
+actually exercises — prompt regex, paging, `show running-config` grammar, SSH — the simulator is a
+**faithful management-plane twin of hardware.**
+
+The friction is two-fold and both are real but surmountable:
+
+1. **ACQUISITION** — the image is **free but gated behind an HPE/Aruba account** on the HPE Networking
+   Support Portal (registration + EULA). Not anonymous like VyOS, but not paid either.
+2. **One probe divergence (`THEATER`-adjacent but minor)** — the simulator's `show version` reports
+   **`Version : Virtual.10.13.1110`**, i.e. the platform prefix is the literal word **`Virtual`**, NOT
+   the **two-letter hardware code** (`FL`/`GL`/`TL`/…) that the def's probe regex
+   `Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)` requires. So the **probe's version-capture would NOT fire on the
+   simulator** even though it fires on hardware. The probe is documented `non-fatal`, so backup itself
+   still succeeds — but a "PASS" on the simulator would NOT prove the regex matches real hardware. This is
+   the single most important nuance for the parity-skeptic. Verdict stays GO-WITH-FRICTION because the
+   *hardware* regex is independently confirmed correct (see §4) and the def's high-value surface
+   (`show running-config` collection) is fully validated by the simulator.
+
+**Biggest blocker:** HPE/Aruba account-gated download (FRICTION, not a wall) + the `Virtual.` vs
+`[A-Z]{2}.` probe-regex mismatch that makes the version-probe specifically un-validatable on the sim.
+
+---
+
+## 1. What virtual image exists — and is it the real AOS-CX software?
+
+| Attribute | Finding | Source |
+|---|---|---|
+| Product name | **Aruba / HPE Networking AOS-CX Switch Simulator** (a.k.a. "CX Simulator", `Aruba_AOS-CX_Switch_Simulator`) | GNS3 marketplace; Airheads |
+| What it is | "The virtual machine version of the Aruba CX switch series. At its core an **ASIC simulator** performs switching and routing functions with **the AOS-CX operating system managing and controlling** the device's operation." → **first-party real NOS, control-plane-identical**; only the dataplane is simulated. | GNS3 / Airheads |
+| Vendor-real vs reimplementation | **Vendor-real.** It is the same AOS-CX build family shipped on hardware — disk images are named `arubaoscx-disk-image-genericx86-p4-<timestamp>.vmdk` (a `genericx86-p4` *platform build* of the real OS). **Not** a third-party reimplementation. | GNS3 appliance file (`aruba-arubaoscx.gns3a`) |
+| Latest version (2026-current) | **10.15.0005** (`...-20241115202521.vmdk`) is the newest in the GNS3 registry; netlab reports testing against **10.15**. Older trains down to 10.01 are also published. The def targets the **10.x** train, so any of these is in-scope. | GNS3 registry; netlab |
+| Ports | 10 interfaces total (1 management `1/1/1` + 9 data), virtio-net-pci. Enough for the management-plane test (we only need mgmt). | GNS3 appliance; containerlab |
+
+**Image/version matrix (GNS3 registry, real OS builds):**
+
+| AOS-CX version | VMDK filename |
+|---|---|
+| 10.15.0005 | `arubaoscx-disk-image-genericx86-p4-20241115202521.vmdk` |
+| 10.14.1000 | `arubaoscx-disk-image-genericx86-p4-20240731173624.vmdk` |
+| 10.13.1000 | `arubaoscx-disk-image-genericx86-p4-20240129204649.vmdk` |
+| 10.12.1000 | `arubaoscx-disk-image-genericx86-p4-20230810165021.vmdk` |
+| 10.11.0001 | `arubaoscx-disk-image-genericx86-p4-20221130174651.vmdk` |
+| 10.10.1000 | `arubaoscx-disk-image-genericx86-p4-20220815162137.vmdk` |
+| … (down to 10.01.0001) | … |
+
+**Conclusion:** This is exactly the "control-plane sim running the vendor's real NOS" the seed says is
+"as good as hardware for THIS purpose." `PARITY-OK` on the software-realness axis. The `genericx86-p4`
+build is the real OS; the simulated piece (ASIC/forwarding) is the part the backup def never touches.
+
+---
+
+## 2. Acquisition + licensing
+
+| Question | Answer |
+|---|---|
+| Where do you get it | **HPE Networking / Aruba Support Portal** ("Software & Documents" → search `Aruba_AOS-CX_Switch_Simulator`). Distributed as a `.zip` containing an OVA. | Airheads "Downloading the Aruba AOS-CX Switch Simulator"; GNS3 init page |
+| Account required | **Yes — a free HPE/Aruba account (registration + accept EULA).** Not a paid product; "free to registered users." This is the VyOS-vs-Cisco difference the seed warns about: VyOS was anonymous; AOS-CX needs a (no-cost) login. | Airheads; GNS3 |
+| Paid / eval / licence file | **No paid licence and no licence-server / feature licence file** required to run the simulator. It boots and runs the full CLI for free. (Contrast: Cisco n9kv/XRv often need Smart Licensing tokens.) | GNS3 marketplace; Airheads |
+| Redistribution | **Restricted** — the image is downloaded under HPE's EULA; we must **not** commit it to git or redistribute (consistent with our "never commit images" rule). Each lab operator downloads under their own account. | HPE EULA (download-gated) |
+| Blocked without commercial relationship? | **No.** A free HPE account is sufficient; no reseller/partner/support-contract relationship is needed to obtain the simulator. | Airheads |
+
+**Severity:** `FRICTION` (account + EULA), **not** `ACQUISITION-BLOCKER`. We can legally download and run
+it in a private lab with a free login.
+
+---
+
+## 3. Run it on our Proxmox/KVM lab
+
+| Dimension | Finding | Source |
+|---|---|---|
+| Format | OVA (zip) → contains a **VMDK** (`arubaoscx-disk-image-genericx86-p4-*.vmdk`). | GNS3 registry |
+| OVA/VMDK → qcow2 | One line: `qemu-img convert -f vmdk -O qcow2 arubaoscx-disk-image-genericx86-p4-20221130174651.vmdk arubacx-10.11.qcow2`. Well-trodden — this is exactly how vrnetlab/containerlab and netlab package it. | containerlab `vr-aoscx`; vrnetlab |
+| Boot on KVM/libvirt | Three documented paths, all on plain KVM/QEMU: (a) **import the qcow2 directly into a Proxmox VM** (q35/virtio, no nested virt needed — it is an x86 OS, not nested hypervisor); (b) **netlab** `netlab libvirt package arubacx <ova>` builds a Vagrant/libvirt box; (c) **containerlab `vr-aoscx`** wraps the qcow2 in vrnetlab (QEMU-in-docker). For our lab the simplest is the direct Proxmox-qcow2 import. | netlab; containerlab; vrnetlab |
+| RAM | **4096 MB** (GNS3 appliance `ram: 4096`; vrnetlab launches QEMU with `-m 4096`). | GNS3 appliance; vrnetlab |
+| vCPU | **2** (GNS3 `cpus: 2`). | GNS3 appliance |
+| Disk | Single VMDK/qcow2, a few GB. | GNS3 registry |
+| NIC model | `virtio-net-pci`, 8 data adapters (+ mgmt) in GNS3; mgmt is `1/1/1`. | GNS3 appliance; containerlab |
+| Console | Telnet/serial console exposed by QEMU; SSH on the mgmt interface once configured. Boot to login ~2 min (containerlab); first-boot/key-gen a bit longer. | GNS3; containerlab |
+| KVM accel | KVM required (`kvm: required` in GNS3 appliance) — the lab host provides this natively; **no nested-virt** needed for the guest itself. | GNS3 appliance |
+| vNICs / serial for our test | We only need the **management vNIC + SSH**. Trivial. | — |
+
+**Resource verdict vs the modest two-VM lab budget:** **4 GB / 2 vCPU is comfortably inside one of the two
+8 GB VMs**, leaving headroom for the OS and the netcanon app VM. No 16 GB problem. (The "16 GB / 4 vCPU"
+figure seen in the *Codespaces* arubavsx labs is a recommendation for **multi-node topologies in a
+codespace**, not the per-instance requirement — a single sim node is 4 GB.)
+
+**Severity:** `FRICTION` only (OVA→qcow2 conversion + portal download); **no** `RESOURCE-BLOCKER`.
+
+---
+
+## 4. Management-plane parity — the crux
+
+The def exercises exactly: (1) prompt regex, (2) paging via the `aruba_aoscx` driver, (3) `show
+running-config` grammar, (4) `show version` probe regex. Point-by-point against the simulator:
+
+### 4.1 Prompt regex — **PARITY-OK**
+- Def trailing prompt: `^\S+[#>]\s*$` (e.g. `switch#` / `switch>`).
+- netmiko `aruba_aoscx` (`ArubaCxSSH`, inherits `CiscoSSHConnection`) tests the channel with pattern
+  `r"[>#]"` and the simulator lands at the manager `#` prompt (`agg-1#` in the arubavsx example).
+- The simulator's prompt is produced by the **real AOS-CX CLI** → identical to hardware. ✔
+- Source: netmiko `aruba.aruba_aoscx` API docs; arubavsx README (`agg-1#`).
+
+### 4.2 Paging (`no page`) — **PARITY-OK**
+- Def: `cisco_more_paging: false`, relies on the driver. netmiko's `ArubaCxSSH.session_preparation()`
+  calls `disable_paging(command="no page")` and sets `ansi_escape_codes = True`.
+- `no page` is a **real AOS-CX command** present in the simulator's CLI (same OS). The driver's paging
+  disable works identically on sim and hardware. ✔
+- Source: netmiko `aruba.aruba_aoscx` API docs (`disable_paging(command="no page")`).
+
+### 4.3 `show running-config` grammar — **PARITY-OK (high-value surface)**
+- Def `config: "show running-config"`.
+- The simulator runs the **same AOS-CX OS** that generates running-config on hardware; the
+  CLI grammar the `aruba_aoscx` migration codec parses (VLAN/interface/`no routing` L2 opt-in,
+  active-gateway, BGP/OSPF, VRF) is produced **byte-for-byte by the same code path** as hardware. The
+  netlab build even copy-pastes AOS-CX config during box creation — confirming the sim takes/returns
+  real config. This is **exactly the parity that matters** for the backup, and it's solid. ✔
+- Caveat for the skeptic: the simulator omits **hardware-only stanzas** that have no meaning without an
+  ASIC/linecard (e.g. transceiver/PoE/some QoS-hardware knobs). The backup just *collects whatever the
+  device emits*, so this is not a parse failure — but a sim running-config will be **narrower** than a
+  fully-featured hardware config. A PASS proves the collector + codec handle real AOS-CX grammar; it does
+  **not** exercise hardware-only stanzas the sim can't produce. (Tag this `FRICTION`, not `THEATER` — the
+  grammar is identical, only the surface coverage is a subset.)
+- Source: GNS3/Airheads ("ASIC simulator … OS managing the device"); netlab build guide.
+
+### 4.4 `show version` probe regex — **THE DIVERGENCE (FRICTION / partial-THEATER)**
+This is the load-bearing finding and the one place the simulator is **not** a faithful twin.
+
+- Def probe regex: `detected_os_version: 'Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)'` — requires **exactly two
+  uppercase letters then a dot** (the hardware platform code).
+- **Hardware** `show version` Version line (confirmed): `Version : FL.10.10.0001` (6300/6400),
+  `Version : GL.10.07.xxxx` (8320). The `[A-Z]{2}\.` regex **matches** these (`FL.`, `GL.`, `TL.`, `XL.`,
+  `RL.`, `PL.`, …). ✔ on hardware.
+- **Simulator** `show version` Version line (confirmed from TWO independent first-party-derived sources —
+  the Shajeervu/arubavsx and cheddarking/arubavsx containerlab labs):
+  ```
+  Version      : Virtual.10.13.1110
+  Build Date   : ...
+  Build ID     : ArubaOS-CX:Virtual.10.13.1110:40649b64b204:202506162315
+  ```
+  The platform prefix is the **literal word `Virtual`**, not a two-letter code.
+- **Regex behaviour on the sim:** `[A-Z]{2}\.` would try to match `Vi` followed by `.` — but `Vi` is
+  followed by `rtual`, not a dot → **NO MATCH**. The probe would fail to extract `detected_os_version` on
+  the simulator (it would on hardware). Because the probe is documented **non-fatal**, the *backup itself
+  still succeeds* (prompt + paging + `show running-config` all work), so the def is still validated on its
+  high-value path. But the **version-probe specifically cannot be validated against the sim** — a sim PASS
+  proves nothing about the regex, and the regex is only confirmed correct on *hardware* via the
+  independent FL./GL. evidence above.
+
+**Net parity:** 3 of the 4 surfaces (prompt, paging, running-config) are **PARITY-OK** on the simulator.
+The 4th (version probe) **diverges** because the sim's platform code is `Virtual`, not `[A-Z]{2}`. The
+divergence is *known, bounded, and explained by independent hardware evidence* — so it's `FRICTION` with
+a thin slice of `THEATER` (the probe line specifically), not a wholesale theater verdict.
+
+> **Actionable note for the main thread (NOT an edit by me):** if the team wants the version-probe to be
+> validatable on the simulator too, the regex could be widened from `[A-Z]{2}\.` to something like
+> `(?:[A-Z]{2}|Virtual)\.(\d+\.\d+)` or `[A-Za-z]+\.(\d+\.\d+)`. That would make the sim a full twin for
+> all 4 surfaces. As-is, dropping the `⚠ NOT YET VALIDATED` marker on the strength of a sim run is
+> *defensible for the collection path but overstated for the probe* — call that out in synthesis.
+
+---
+
+## 5. Verdict
+
+**GO-WITH-FRICTION.**
+
+| Axis | Result |
+|---|---|
+| Real vendor NOS? | **Yes** — first-party AOS-CX OS (`genericx86-p4` build), ASIC-only simulated. `PARITY-OK`. |
+| Acquirable in a private lab? | **Yes**, free, but **HPE/Aruba account + EULA** gate. `FRICTION`. |
+| Runs on our Proxmox/KVM budget? | **Yes** — 4 GB / 2 vCPU, OVA→qcow2 one-liner, no nested virt. `FRICTION` (conversion) only. |
+| Mgmt-plane parity for the backup surface | prompt ✔, `no page` paging ✔, `show running-config` ✔ (subset of hardware stanzas); **`show version` probe ✗** (sim prefix `Virtual.` ≠ `[A-Z]{2}.`). |
+| Worth something / not theater? | **Mostly yes.** A sim PASS genuinely proves the collector + codec + prompt + paging work on real AOS-CX grammar. The **version-probe alone is un-validatable on the sim** and stays hardware-confirmed only. |
+
+**Single biggest blocker:** the HPE/Aruba account-gated download (free, but not anonymous) — and the
+secondary, more interesting gotcha that the simulator's `show version` carries a **`Virtual.` platform
+prefix** instead of the two-letter hardware code, so the def's probe regex (as written) **will not fire on
+the simulator** and that specific line cannot be validated this way.
+
+**Severity tags:** `PARITY-OK` (software realness, prompt, paging, running-config) · `FRICTION` (account +
+OVA→qcow2 conversion + sim config is a subset of hardware stanzas) · partial `THEATER` scoped to the
+`show version` probe line (`Virtual.` vs `[A-Z]{2}.`).
+
+---
+
+## Sources
+- GNS3 marketplace — ArubaOS-CX Simulation Software: https://www.gns3.com/marketplace/appliances/arubaos-cx-simulation-software
+- GNS3 server appliance def (RAM/vCPU/NIC/image matrix): https://github.com/GNS3/gns3-server/blob/master/gns3server/appliances/aruba-arubaoscx.gns3a
+- netlab — Building an ArubaOS-CX Libvirt Box (OVA filename, netlab package, tested 10.15, admin creds): https://netlab.tools/labs/arubacx/
+- containerlab — Aruba AOS-CX kind (`admin:admin`, mgmt `1/1/1`, ~2 min boot, vrnetlab): https://containerlab.dev/manual/kinds/vr-aoscx/
+- containerlab — vrnetlab integration (qemu-img vmdk→qcow2 one-liner, `-m 4096`): https://containerlab.dev/manual/vrnetlab/
+- Shajeervu/arubavsx (sim `show version` → `Version : Virtual.10.13.1110`, `admin:admin`): https://github.com/Shajeervu/arubavsx
+- cheddarking/arubavsx (independent confirmation of `Virtual.10.13.1110` Build ID `ArubaOS-CX:Virtual...`): https://github.com/cheddarking/arubavsx
+- netmiko `aruba.aruba_aoscx` API (ArubaCxSSH: `disable_paging("no page")`, prompt `[>#]`, `ansi_escape_codes=True`, `configure term`): https://ktbyers.github.io/netmiko/docs/netmiko/aruba/aruba_aoscx.html
+- aruba/aoscx-ansible-collection (min firmware 10.04, SSH + REST): https://github.com/aruba/aoscx-ansible-collection
+- Airheads — Downloading the Aruba AOS-CX Switch Simulator (portal, registration, free): https://airheads.hpe.com/discussion/downloading-the-aruba-aos-cx-switch-simulator
+- HPE blog — Explore CX Switches with the AOS-CX Switch Simulator: https://blogs.arubanetworks.com/solutions/explore-aruba-cx-switches-with-the-aos-cx-switch-simulator/
+- Hardware Version-line format (FL.10.x on 6300/6400, GL.10.x on 8320) via AOS-CX release-notes / show-version docs: https://arubanetworking.hpe.com/techdocs/AOS-CX/10.11/HTML/fundamentals_6300-6400/Content/SysHW_cmds/sho-ver-10.htm
+- Repo def under test: `definitions/aruba/aos-cx/10.x.yaml` (probe regex `Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)`, `aruba_aoscx`, `no page`, no enable)

--- a/docs/reviews/2026-06-17-virtual-nos-viability/30-review-parity-skeptic.md
+++ b/docs/reviews/2026-06-17-virtual-nos-viability/30-review-parity-skeptic.md
@@ -1,0 +1,326 @@
+# V1 — Parity-skeptic review: would a backup PASS against the virtual image PROVE hardware behaviour, or is it THEATER?
+
+**Author:** V1 (review, adversarial) · **Date:** 2026-06-17 · **Process:** netcanon blackboard (read-only)
+**Reads:** `00-blackboard.md`, `10-research-nxos.md` (R1), `11-research-iosxr.md` (R2), `12-research-aoscx.md` (R3)
+**Def files independently re-read:** `definitions/cisco/nx-os/10.x.yaml`, `definitions/cisco/ios-xr/7.x.yaml`,
+`definitions/aruba/aos-cx/10.x.yaml`. Primary `show version` strings + netmiko driver behaviour
+re-verified against vendor docs / netmiko API / the cited repos (citations inline).
+
+---
+
+## 0. The skeptic's bar
+
+A backup PASS is "worth something" only if **every one of the def's management-plane surfaces that the
+PASS *claims* to exercise actually behaves on the VM the way it does on hardware.** Where a surface
+diverges, the honest move is to scope the claim down, not to silently drop the `⚠ NOT YET VALIDATED`
+marker. The four surfaces per the seed are: (1) prompt regex, (2) netmiko paging-disable, (3) `show
+running-config` completeness + real grammar, (4) `show version` probe regex. I treat the `show version`
+probe as the highest-risk surface exactly because a control-plane sim is most likely to lie about its
+*own platform identity* while telling the truth about everything else.
+
+**Methodology guardrail I applied:** I re-read all three def files myself rather than trusting the peer
+quotes, and re-fetched the two load-bearing `show version` strings (AOS-CX `Virtual.`, XRd `cisco XRd`)
+and the three netmiko `session_preparation` bodies from primary sources. Two peer claims changed nuance
+under scrutiny (see AOS-CX §3 and the shared `ansi_escape_codes` finding §4); the rest held.
+
+**Bottom-line per-NOS verdict (detail below):**
+
+| NOS | Worth-it? | Dominant tag | One-line reason |
+|---|---|---|---|
+| **NX-OS (Nexus 9000v)** | **YES** | `PARITY-OK` | All 3 probe regexes fire on the real banner; only the *captured model token* is a virtual SKU, and the regex *path* is byte-identical to hardware. |
+| **IOS-XR (XRd CP)** | **YES, scoped** | `PARITY-OK` + `ACQUISITION-BLOCKER` | Collection surface is genuine IOS-XR; `detected_model` captures `XRd` (cosmetic). Real blocker is *getting the image* (contract-gated; sandbox needs VPN). |
+| **AOS-CX (CX Simulator)** | **PARTIAL — collection yes, probe NO** | `THEATER` (scoped to the probe) | The def's *only* probe regex `[A-Z]{2}\.` **cannot fire** on the sim's `Virtual.10.13.1110` banner. A sim PASS proves the collector, not the probe. |
+
+`buildable_now_confirmed` → **NX-OS first** (no acquisition gate, parity clean), **AOS-CX second**
+(free-ish, but the probe must be fixed or the marker-drop scoped). IOS-XR only when the image/account is
+already in hand.
+
+---
+
+## 1. NX-OS — steelman the case against it, then where it survives
+
+### 1.1 The strongest attack: "the model regex captures a fake SKU → detected_model is a lie"
+The def's `detected_model: 'cisco Nexus\S*\s+(\S+)\s+[Cc]hassis'` will, on Nexus 9000v, capture
+**`C9300v`** (or `C9500v`), not a hardware SKU like `C93180YC-EX`. I confirmed the banner verbatim from
+Cisco's own 9000v overview docs (search-verified across the 9.3 → 10.6 guide family): the hardware line
+is literally `cisco Nexus9000 C9300v Chassis` and `Processor Board ID 9TG6I6JMWV4`, under the header
+*"Nexus 9000v is a demo version of the Nexus Operating System Software."*
+
+**Why this attack FAILS (PARITY-OK, not THEATER):** the parity that matters for a regex test is whether
+the **regex path** is exercised, not whether the captured *value* equals a hardware string. The 9000v
+emits the identical token structure `cisco Nexus9000 <SKU> Chassis`; the def's own comment cites
+`cisco Nexus9000 C93180YC-EX Chassis` as the target — structurally the same line. `Nexus\S*` eats
+`Nexus9000`, `(\S+)` grabs the SKU token (`C9300v` *or* `C93180YC-EX` — both single non-space tokens),
+`[Cc]hassis` anchors. The capture group fires on both. A PASS therefore honestly proves the regex
+*matches and captures* on real NX-OS `show version` output. The only thing it does **not** prove is that
+the regex handles *every exotic hardware SKU spelling*; but that is a regex-coverage question, not a
+VM-vs-hardware question, and the structural class is identical. **Not theater.**
+
+### 1.2 Second attack: "the 'demo version' banner line could be mis-captured by the version regex"
+`detected_os_version: '(?:NXOS|system):\s+version\s+(\d+\.\d+)'`. The leading `Nexus 9000v is a demo
+version of the Nexus Operating System Software` line contains the word *version* but **lacks the
+`NXOS:`/`system:` anchor token**, so the regex skips it and hits the real `  NXOS: version 10.2(3)` line,
+capturing `10.2`. I verified the real banner shows `NXOS: version 10.2(3)` / `9.3(3)` / `10.1(1)` forms.
+**Attack fails — PARITY-OK.** R1's claim holds exactly.
+
+### 1.3 Third attack: "paging / prompt / no-enable might differ on the sim"
+- **Paging:** I re-read netmiko `CiscoNxosSSH.session_preparation`: it sets `ansi_escape_codes = True`,
+  `set_terminal_width("terminal width 511")`, then `disable_paging()` (NX-OS default → `terminal length
+  0`), then `set_base_prompt()`. All four are real NX-OS commands the genuine binary on 9000v honours.
+  The def correctly keeps `cisco_more_paging: false` and adds nothing to `commands.pre`. **PARITY-OK.**
+- **Prompt / no-enable:** admin role lands at `switch#` (no enable), matching `needs_enable: false` and
+  `^\S+[#>]\s*$`. containerlab/dockerized_n9kv confirm `admin:admin` and the `#` landing. **PARITY-OK.**
+
+### 1.4 `show running-config` completeness — the subtle one
+A 9000v running-config omits **pure-dataplane** artifacts (real linecard inventory, transceiver/optics,
+ASIC counters) — but none of those live in `show running-config` anyway, and the `cisco_nxos` codec is
+already COMPLETE+CERTIFIED against a 6-config batfish corpus (per MEMORY). The control-plane grammar
+(`feature` toggles, `interface Ethernet1/X`, SVIs, `vrf context`, BGP/OSPF, route-maps) is generated by
+the same parser as hardware. **One honest caveat:** a *single default-config* 9000v will emit a *narrow*
+running-config; to make the PASS meaningful, the operator should push a representative config first (a
+few VLANs, an SVI, a `vrf context`, a BGP stanza) so the collector pulls real grammar, not an empty box.
+That is a test-design note, not a parity gap. **PARITY-OK with a "configure it first" must-do.**
+
+### 1.5 NX-OS verdict — **WORTH IT (YES). Tag: PARITY-OK + RESOURCE-FRICTION.**
+The only real friction is RAM (8 GB standard / 6 GB Lite eats a whole budget VM) and the OVMF+SATA+E1000
+boot recipe — neither is a parity problem. This is the cleanest of the three: free CCO download, no
+contract (do **not** route through CML-Free, which excludes the node). A PASS is honest hardware
+evidence.
+
+---
+
+## 2. IOS-XR — steelman, then scope
+
+### 2.1 Attack: "`detected_model` will say `XRd`, which is not a hardware platform → the probe is a lie"
+Confirmed verbatim from XRd docs: `show version` reads `Cisco IOS XR Software, Version 7.7.1 LNT` and
+`cisco XRd Control Plane cisco XRd-CP-C-01 processor with 32GB of memory`. The def's
+`detected_model: '^cisco\s+(\S+)'` (multiline-anchored) captures **`XRd`** — hardware would yield
+`ASR9K` / `NCS-5501`.
+
+**Severity — this is a *real* but *bounded* divergence, NOT wholesale theater.** Unlike AOS-CX (below),
+the IOS-XR model regex **still fires and captures a value** — it just captures the VM's honest platform
+identity (`XRd`) rather than a hardware one. So a PASS proves the `^cisco\s+(\S+)` regex *matches real
+IOS-XR `show version` output and extracts the first post-`cisco` token*. What it does **not** prove is
+that token equals a hardware platform string. Because `detected_model` is a documented *non-fatal,
+advisory* probe (feeds overlay resolution only; the def comment scopes it so), this is a cosmetic caveat
+to footnote, not a blocker. **Tag: minor caveat, scope the marker-drop to "collection wiring + version
+probe verified; model-token confirmed against documented hardware banner only."**
+
+### 2.2 Attack: "the version regex breaks on the `LNT` suffix or on 24.x/25.x trains"
+`detected_os_version: 'Cisco IOS XR Software, Version\s+(\d+\.\d+)'` on `...Version 7.7.1 LNT` →
+`(\d+\.\d+)` greedily-but-correctly captures `7.7` and stops; the trailing `.1 LNT` is ignored. On a
+25.x image it captures `25.1`. I verified XRd ships current 7.11.x / 24.x / 25.1.1 trains (Cisco XRd
+release-notes family). The def's `version_match: "^7\\."` is advisory; the probe regex is train-agnostic.
+**Attack fails — PARITY-OK.**
+
+### 2.3 Attack: "prompt / paging / no-enable differ"
+Prompt `RP/0/RP0/CPU0:ios#` matches the primary regex `^RP/\S+:\S+#\s*$` (verified default hostname
+`ios`). IOS-XR has no enable mode (task-group privilege) → `needs_enable: false` correct. netmiko
+`cisco_xr` `session_preparation` sends `terminal width 511` + `terminal length 0` itself; def keeps
+`cisco_more_paging: false`, `pre: []`. All **PARITY-OK** and self-consistent with netcanon's existing
+xrd-derived fixture corpus (so VM and test expectations share a lineage — a point *in favour* of
+worth-it).
+
+### 2.4 The actual deciding variable: ACQUISITION (this is where IOS-XR is weakest)
+- The XRd Control-Plane tarball on `software.cisco.com` is **"available for download only for users who
+  have an active service account"** (containerlab + xrdocs both state this). There is **no
+  free-to-any-registered-user** path like Nexus 9000v. → `ACQUISITION-BLOCKER` unless the operator
+  already has a contract-backed CCO. **Do not cargo-cult the VyOS outcome** (VyOS was anonymous + free).
+- **R2's escape hatch (DevNet XRd sandbox) is NOT turnkey.** I verified the DevNet reservation flow: the
+  sandbox is reservation-based and reached via **Cisco AnyConnect VPN into private IP space** — VPN
+  credentials are emailed per reservation; SSH only works *through that tunnel*. For our lab this means
+  netcanon (Docker on VM-A) would have to source-route to the sandbox's private IP *over an AnyConnect
+  tunnel established on the VM-A host* — doable but materially more plumbing than "SSH to a Proxmox VM,"
+  and the reservation is time-boxed. This is `FRICTION`, edging `ACQUISITION-BLOCKER`, not the clean path
+  R2's prose implies. Flag it as a live-check item, not an assumed fallback.
+
+### 2.5 IOS-XR verdict — **WORTH IT *IF* the image is already obtainable; else gated. Tag: PARITY-OK (collection) + ACQUISITION-BLOCKER.**
+The management-plane parity is genuine (this *is* real IOS-XR software, lightest footprint at 2 GiB/2
+vCPU). The PASS would be honest evidence for prompt/paging/no-enable/config-command/version-probe, with
+a one-line model-token footnote. But the deciding variable is acquisition, not parity — and the
+contract-free fallback (DevNet sandbox) carries VPN friction that must be live-checked before counting on
+it. **Lower priority than NX-OS purely because of the gate, not the parity.**
+
+---
+
+## 3. AOS-CX — the one place a PASS would be THEATER (scoped to the probe)
+
+### 3.1 The crux, re-verified independently
+The AOS-CX def has **exactly one** probe pattern — `detected_os_version: 'Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)'`
+— and **no model probe at all** (I re-read the file: the comment explicitly says model lives in
+`show system`, not `show version`, so it is deliberately omitted). So for AOS-CX the *entire* `show
+version` probe surface rides on that single `[A-Z]{2}\.` regex.
+
+I re-confirmed from **two independent first-party-derived repos** (Shajeervu/arubavsx and
+cheddarking/arubavsx) that the AOS-CX **Switch Simulator** emits:
+```
+Version      : Virtual.10.13.1110
+Build ID     : ArubaOS-CX:Virtual.10.13.1110:40649b64b204:202506162315
+```
+The platform prefix is the **literal word `Virtual`**, not a two-letter hardware code. I also noted the
+HPE **AOS-CX Switch Simulator OVA Release Notes** are themselves published as `10.13.1000` / `10.15.1000`
+builds — i.e. `Virtual.` is *structural to the simulator build train*, not a per-VM accident a different
+download would avoid.
+
+**Trace the regex against the sim banner:** `[A-Z]{2}\.` needs two uppercase letters *immediately
+followed by a dot*. The sim line is `Version      : Virtual.10.13.1110`. The first two letters are `Vi`
+— but `Vi` is followed by `rtual`, **not** a `.`. The regex finds no `[A-Z]{2}\.` anywhere on the line
+(`Vi`, `rt`-lowercase, etc. all fail). → **NO MATCH. `detected_os_version` is never captured on the
+simulator.** On *hardware* the line is `Version : FL.10.10.0001` / `GL.10.07.xxxx` and the regex fires
+(`FL.`, `GL.` are `[A-Z]{2}\.`). I confirmed the hardware FL./GL. format from the AOS-CX show-version
+techdoc.
+
+### 3.2 Why this is THEATER (scoped), and the steelman that *doesn't* rescue it
+The probe is documented **non-fatal**, so the *backup job still succeeds* on the sim — prompt, paging,
+and `show running-config` all work. The tempting steelman is: "the high-value surface (config
+collection) passes, so dropping the marker is fine." **I reject that as applied to the probe regex
+specifically.** The `⚠ NOT YET VALIDATED` marker covers *the probe regexes* by name (the def's `notes`
+literally lists "probe regex" as one of the things verified "in code and against sample `show version`
+output only"). If we drop the marker after a sim run, we would be asserting the probe regex is validated
+against a live device — when in fact **the live device we ran against is the one device class on which
+the regex provably cannot fire.** That is the definition of theater for *that line*: the green result
+tells us nothing about whether the regex works, and worse, a naive reading of "it passed" hides that the
+version fact silently came back empty.
+
+So the verdict is **bifurcated**, and the bifurcation must be preserved in any marker-drop:
+- `show running-config` collection + prompt + paging + no-enable → **PARITY-OK** on the sim (genuine
+  AOS-CX OS, same grammar the `aruba_aoscx` codec round-trips; ~37 supported surfaces per MEMORY).
+- `detected_os_version` probe regex → **THEATER on the sim** (cannot fire; remains hardware-confirmed
+  only via the independent FL./GL. evidence).
+
+### 3.3 The fix that converts theater → parity (must-fix, for the main thread — I do not edit)
+Widen the probe regex so it fires on *both* hardware and the sim, e.g.
+`Version\s*:\s*[A-Za-z]+\.(\d+\.\d+)` or the more conservative `(?:[A-Z]{2}|Virtual)\.(\d+\.\d+)`. With
+that change, a sim run would capture `10.13` and the probe becomes genuinely validatable on the
+simulator — making the sim a full 4-of-4 twin. **Caveat on the broad form:** `[A-Za-z]+\.` would also
+match any unexpected prefix; the targeted `(?:[A-Z]{2}|Virtual)\.` is the safer widening because it
+keeps the hardware contract tight while admitting the one known sim token. Either is a one-line YAML
+edit. Until that lands, dropping the marker on the strength of a sim run is **defensible only for the
+collection path and overstated for the probe** — the synthesis must say so explicitly.
+
+### 3.4 Second AOS-CX attack I checked: does `ansi_escape_codes=True` corrupt the captured config?
+netmiko's `ArubaCxSSH.session_preparation` sets `ansi_escape_codes = True` (verified) — because real
+AOS-CX emits ANSI control sequences. The sim runs the same OS, so it emits the same sequences and the
+driver strips them the same way. This is a *reason the parity holds*, not a gap — but it is worth a
+one-line confirmation during the actual run that `show running-config` comes back clean (no stray escape
+bytes), because a sim with a slightly different terminal type could in principle differ. Low risk;
+verify-on-run. **FRICTION-low, not a blocker.**
+
+### 3.5 Third AOS-CX attack: provisioning friction (login user creation)
+The netlab build guide notes "it seems impossible to create a user called `vagrant` on AOS-CX" and uses a
+`netlab/netlab` account instead; containerlab uses `admin/admin`. This is a real lab-bring-up wrinkle:
+the netmiko collector needs a working SSH credential, and AOS-CX has constraints on username creation.
+Not a parity issue, but a `FRICTION` item for the runbook (use `admin/admin` on the sim or a
+manager-role account; confirm SSH login before pointing netcanon at it).
+
+### 3.6 `show running-config` completeness on the sim
+Same caveat as NX-OS but sharper: the sim omits hardware-only stanzas (transceiver/PoE/some
+hardware-QoS) that have no meaning without an ASIC. The collector just grabs whatever the device emits,
+so this is not a parse failure — but a sim running-config is a **subset** of a fully-featured hardware
+config. To make the PASS meaningful, push a representative L2/L3 config first (VLANs, `no routing` L2
+opt-in, an SVI, active-gateway, a BGP/OSPF stanza) so the codec-relevant grammar is actually exercised.
+**FRICTION (test-design), not theater** for the config surface.
+
+### 3.7 AOS-CX verdict — **WORTH IT for collection; NOT worth it for the probe until the regex is widened. Tag: PARITY-OK (collection) + THEATER (probe) + FRICTION (account/qcow2/login).**
+Free HPE/Aruba account (not anonymous, not paid), 4 GB/2 vCPU (comfortably in budget), OVA→qcow2
+one-liner. The blocker is **not** resources or acquisition — it is the `Virtual.` probe mismatch. A sim
+PASS is honest for ~37 supported config surfaces but **cannot** validate the lone `show version` probe.
+
+---
+
+## 4. Cross-cutting finding none of the three peers fully closed
+
+**All three netmiko drivers set `ansi_escape_codes = True` and all three rely on the driver (not the
+def) to disable paging.** I verified the three `session_preparation` bodies:
+- `cisco_nxos`: `ansi_escape_codes=True`; `terminal width 511`; `disable_paging()` (→ `terminal length 0`).
+- `aruba_aoscx`: `ansi_escape_codes=True`; `disable_paging(command="no page")`.
+- `cisco_xr`: `terminal width 511` + `terminal length 0` in `session_preparation`.
+
+Implication for all three validations: the def is *correct* to keep `cisco_more_paging: false` and
+`commands.pre: []` — adding `terminal length 0` ourselves would double-issue and (per MEMORY's standing
+rule + AGENTS.md) is forbidden. The single thing to **confirm on each live run** is that the captured
+`show running-config` is byte-clean (no residual ANSI/`--More--` fragments), since all three OSes are
+ANSI-emitters and the sims run the same code. This is a *verify-on-run* checklist item, not a parity
+verdict — but it is the one place a green job could still hide a dirty capture, so it belongs in every
+runbook.
+
+---
+
+## 5. Per-NOS verdicts + must-fixes (what to confirm/work around to make each validation honest)
+
+### NX-OS — **GO (worth it).** `PARITY-OK`
+**Must-do before claiming the PASS validates hardware behaviour:**
+1. Push a representative config (VLANs + SVI + `vrf context` + BGP) before backup, so `show
+   running-config` exercises real grammar, not an empty default box.
+2. When dropping the marker, note `detected_model` captured the **virtual SKU** `C9300v` (regex path
+   identical to hardware `Nexus9000 <SKU> Chassis`; capture confirmed, hardware-SKU spellings not
+   exhaustively exercised).
+3. Confirm captured config is ANSI-clean (cross-cutting §4).
+4. Resource: dedicate one 8 GB VM (use 6 GB Lite image); OVMF+SATA+E1000+serial-POAP boot recipe.
+
+### IOS-XR — **GO-WITH-FRICTION (worth it only once the image is in hand).** `PARITY-OK` + `ACQUISITION-BLOCKER`
+**Must-do:**
+1. Resolve acquisition FIRST: either a contract-backed CCO download, or live-check that the **DevNet XRd
+   sandbox is SSH-reachable from netcanon over AnyConnect VPN** (it is NOT a plain SSH path — VPN tunnel
+   on the VM host + time-boxed reservation). Do not assume the sandbox is turnkey.
+2. Scope the marker-drop: "collection wiring + version probe verified on real IOS-XR software;
+   `detected_model` captured `XRd` (VM platform identity), hardware platform-token confirmed against
+   documented banner only."
+3. Host prep: cgroups v1 (kernel cmdline + reboot), `apparmor=unconfined`, inotify sysctls; run Cisco
+   `host-check` green. CP flavour only (2 GiB/2 vCPU) — never vRouter.
+4. Confirm ANSI-clean capture (§4).
+
+### AOS-CX — **GO-WITH-FRICTION for collection; NO-GO for the probe until the regex is widened.** `PARITY-OK` (collection) + `THEATER` (probe)
+**Must-fix (the load-bearing one):**
+1. **Widen the probe regex** `Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)` → `(?:[A-Z]{2}|Virtual)\.(\d+\.\d+)`
+   (preferred) or `[A-Za-z]+\.(\d+\.\d+)` so it fires on the sim's `Virtual.10.13.1110`. **Without this,
+   a sim PASS does NOT validate the probe regex** — the marker-drop must explicitly exclude the probe
+   line, or the regex must be widened first. This is the difference between honest evidence and theater.
+**Must-do:**
+2. Push a representative config first (VLANs, `no routing` L2 opt-in, SVI, active-gateway, BGP/OSPF) so
+   the codec grammar is exercised (sim config is otherwise a subset).
+3. Confirm SSH login works (AOS-CX username-creation constraints; use `admin/admin` on the sim).
+4. Confirm ANSI-clean capture (§4).
+5. Resource: 4 GB/2 vCPU, OVA→qcow2 one-liner — comfortably in budget.
+
+---
+
+## 6. `buildable_now_confirmed` — what is genuinely worth standing up next
+
+1. **NX-OS (Nexus 9000v / 9300v Lite)** — *first*. No acquisition gate (free CCO), parity clean across
+   all three probe regexes, only RAM friction. Highest signal-per-effort.
+2. **AOS-CX (CX Switch Simulator)** — *second, but only after widening the probe regex* (must-fix #1
+   above) so the validation isn't theater on the one probe it has. Free-ish account, light resources.
+3. **IOS-XR (XRd CP)** — *only if the image is already obtainable* (contract CCO or a confirmed
+   VPN-reachable DevNet sandbox). Parity is genuine; the gate is acquisition, not behaviour.
+
+**Net:** none of the three is wholesale theater, but **AOS-CX's sole `show version` probe is theater on
+the simulator as the regex stands** — that is the single most important must-fix in this run. NX-OS is
+the safe first move.
+
+---
+
+## Sources (re-verified by V1)
+- NX-OS 9000v `show version` banner (`cisco Nexus9000 C9300v Chassis`, `Processor Board ID`, `NXOS:
+  version 10.2(3)`, "demo version") — Cisco Nexus 9000v overview guides, releases 9.3(x)–10.6(x):
+  https://www.cisco.com/c/en/us/td/docs/dcn/nx-os/nexus9000/103x/n9000v-n9300v-9500v/cisco-nexus-9000v-9300v-9500v-guide-release-103x/m-overview.html
+- XRd CP `show version` (`Cisco IOS XR Software, Version 7.7.1 LNT`, `cisco XRd Control Plane cisco
+  XRd-CP-C-01 processor with 32GB`) — XRdocs "XRd with docker":
+  https://xrdocs.io/virtual-routing/tutorials/2022-08-23-xrd-with-docker-control-plane-and-vrouter
+- AOS-CX simulator `Version : Virtual.10.13.1110` / `Build ID : ArubaOS-CX:Virtual...` — two independent
+  repos: https://github.com/Shajeervu/arubavsx and https://github.com/cheddarking/arubavsx
+- AOS-CX hardware `Version : FL.10.x` / `GL.10.x` two-letter format — AOS-CX show-version techdoc:
+  https://arubanetworking.hpe.com/techdocs/AOS-CX/10.11/HTML/fundamentals_6300-6400/Content/SysHW_cmds/sho-ver-10.htm
+- AOS-CX Switch Simulator OVA Release Notes (10.13.1000 build train — `Virtual.` is structural):
+  https://arubanetworking.hpe.com/techdocs/AOS-CX/10.13/OVA/RN/rn_ova_10.13.1000.pdf
+- netmiko `aruba_aoscx` (`disable_paging("no page")`, `ansi_escape_codes=True`, prompt `[>#]`):
+  https://ktbyers.github.io/netmiko/docs/netmiko/aruba/aruba_aoscx.html
+- netmiko `cisco_nxos` (`ansi_escape_codes=True`, `terminal width 511`, `disable_paging()`,
+  `_test_channel_read(pattern=r"[>#]")`):
+  https://ktbyers.github.io/netmiko/docs/netmiko/cisco/cisco_nxos_ssh.html
+- DevNet XRd sandbox = reservation + AnyConnect VPN into private IP space (NOT a plain SSH path):
+  https://developer.cisco.com/docs/sandbox/first-reservation-guide/
+- netlab AOS-CX box guide (tested 10.15; `netlab/netlab` user — `vagrant` user can't be created):
+  https://netlab.tools/labs/arubacx/
+- Def files re-read: `definitions/cisco/nx-os/10.x.yaml:54-58`, `definitions/cisco/ios-xr/7.x.yaml:51-54`,
+  `definitions/aruba/aos-cx/10.x.yaml:51` (single probe, `[A-Z]{2}\.`, no model probe).

--- a/docs/reviews/2026-06-17-virtual-nos-viability/99-synthesis.md
+++ b/docs/reviews/2026-06-17-virtual-nos-viability/99-synthesis.md
@@ -1,0 +1,56 @@
+# 99 — Synthesis: is virtualizing NX-OS / IOS-XR / AOS-CX worth it to validate the 3 provisional backup defs? (2026-06-17)
+
+**Author:** main thread. **Inputs:** R1 NX-OS (`10-`), R2 IOS-XR (`11-`), R3 AOS-CX (`12-`),
+V1 parity-skeptic (`30-`). This was a **read-only research run** — no code changed.
+
+## Verdict: all three are virtualizable with REAL vendor software → not theater, **with two caveats**. Recommended order: **NX-OS → AOS-CX (after a 1-line regex fix) → IOS-XR (only if a contract-backed Cisco account exists).**
+
+The headline question — "do the available virtual images have enough parity that the work is worth
+something?" — resolves **YES for all three on the collection surface** (prompt, paging, `show
+running-config`), because every candidate is the vendor's **own NOS binary** (control-plane sim), not a
+third-party reimplementation. The dataplane is stubbed, but netcanon's backup never touches it. Two real
+catches sit on the `show version` **probe**, and one is a genuine theater finding.
+
+## Per-NOS
+
+| NOS | Image (real SW) | Acquire | Lab fit | Mgmt-plane parity | Verdict |
+|---|---|---|---|---|---|
+| **NX-OS** | Nexus 9000v / **9300v "Lite"** (real NX-OS) | **Free** CCO download, **no contract** | 6–8 GB RAM (Lite=6) → dedicated VM-B; OVMF/UEFI+SATA+E1000+serial/POAP boot | **Full 9/9** — prompt, no-enable, `terminal length 0`, real running-config, **all 3 probe regexes fire** (model captures virtual SKU `C9300v` via the *same* hardware regex path) | **GO — do first** |
+| **AOS-CX** | CX **Switch Simulator** (real AOS-CX) | Free, **HPE/Aruba account + EULA** | 4 GB/2 vCPU, OVA→qcow2 one-liner, plain KVM | Collection 3/4 OK; **`show version` probe BREAKS**: sim prints `Version : Virtual.10.13.1110`, def regex `[A-Z]{2}\.` needs two caps+dot → no match (hardware `FL.`/`GL.` matches) | **GO-WITH-FIX** (widen regex first) |
+| **IOS-XR** | **IOS-XRd Control-Plane** container (real XR; lineage of our xrd corpus) | **Cisco account + ACTIVE SERVICE CONTRACT** (no anonymous DL); DevNet sandbox needs AnyConnect VPN | Light: 2 GB/2 vCPU, no hugepages (CP flavor); needs host **cgroups v1** (`systemd.unified_cgroup_hierarchy=false`) | Full — real `RP/0/RP0/CPU0:ios#` prompt, no-enable, native paging, real running-config; probe fires (model captures `XRd`) | **GO-WITH-FRICTION** — gated on acquisition |
+
+## The two catches that make this "worth something" vs theater
+
+1. **AOS-CX probe regex is theater on the sim (blocker, MF-1).** `definitions/aruba/aos-cx/10.x.yaml:51`
+   `Version\s*:\s*[A-Z]{2}\.(\d+\.\d+)` matches hardware (`FL.10.x` / `GL.10.x`, both confirmed) but
+   provably **cannot** fire on the simulator's `Virtual.10.13.1110`. A sim backup would go green while
+   `detected_os_version` stays silently empty — validating the probe against the one device class on which
+   it can't fire. **Fix before any AOS-CX run:** widen to `(?:[A-Z]{2}|Virtual)\.(\d+\.\d+)` (keeps the
+   hardware contract tight). This is a genuine, cheap def improvement the research surfaced — worth doing
+   regardless, since anyone running the free sim hits it.
+2. **Marker-drop honesty for the Cisco model token (minor, MF-3).** NX-OS `detected_model` captures the
+   virtual SKU `C9300v` (not a hardware SKU); IOS-XR captures `XRd` (not `ASR9K`/`NCS-5501`). Both regexes
+   *do* fire — so it's evidence, not theater — but a marker-drop should be scoped: "collection wiring +
+   version probe verified on real NOS software; the hardware *model* token is confirmed against documented
+   `show version` banners only." (Same honesty discipline as the VyOS graduation.)
+
+Plus MF-4 (minor): for each run, push a representative config (VLAN/SVI/VRF/BGP; AOS-CX also `no routing`
+L2 opt-in + active-gateway) before backup so the codec grammar is actually exercised, and confirm the
+capture is byte-clean (no residual ANSI / `--More--`). Don't validate against a bare default box.
+
+## Recommended order (each = a VyOS-shaped run: device on VM-B, netcanon Docker on VM-A, ≤2 VMs)
+
+1. **NX-OS first.** Only one with a free, no-contract image AND all probe regexes firing. A PASS is honest
+   hardware evidence → drop the marker (scoped per MF-3). Cost: the OVMF/SATA/E1000/serial-POAP boot recipe
+   + 6 GB Lite image on the dedicated VM.
+2. **AOS-CX second — but land the MF-1 regex widening first** (tiny PR, also a real correctness fix), then
+   the sim validates collection + prompt + paging + (post-fix) the version probe. Free account-gated DL.
+3. **IOS-XR only if you have a contract-backed Cisco.com account** (or are willing to drive the DevNet XRd
+   sandbox over AnyConnect — not a clean SSH path). Parity itself is excellent and the image is light;
+   acquisition is the sole gate.
+
+**Bottom line:** the work is worth doing — these are real NOS binaries, so a PASS means what we want it to
+mean. NX-OS is the clear next target. AOS-CX needs a one-line probe-regex fix first (and that fix is worth
+making either way). IOS-XR is parity-ready but acquisition-gated on a Cisco support contract.
+
+This dossier is the frozen evidence trail (EXPECTED-STALE; a future audit must not flag it as drift).


### PR DESCRIPTION
## What

Commits the blackboard research dossier (`docs/reviews/2026-06-17-virtual-nos-viability/`) that answered: *is virtualizing NX-OS / IOS-XR / AOS-CX worth it to validate the three remaining provisional backup defs, or theater?*

Six files: the seed (`00-blackboard.md`), one report per NOS (`10`/`11`/`12`), the adversarial parity-skeptic review (`30`), and the synthesis (`99`).

## Verdicts

All three candidate images are the **vendor's own NOS binary** (control-plane sims, not reimplementations), so management-plane parity — all the backup def touches — is genuine.

- **NX-OS = GO** — free Nexus 9300v "Lite" (CCO account, no contract); all three `show version` probe regexes fire. Do next.
- **AOS-CX = GO** — CX Switch Simulator; needed the probe-regex widening already shipped in [#114](https://github.com/netcanon/netcanon/pull/114).
- **IOS-XR = parked** — IOS-XRd parity is excellent + light, but acquisition needs a Cisco account with an active service contract.

## Why commit it

The [#114](https://github.com/netcanon/netcanon/pull/114) CHANGELOG entry already cites this dossier path, so `main` currently has a dangling reference — committing resolves it. Consistent with the prior `docs/reviews/` dossiers (UX review, SOPS eval).

Internal homelab hostnames + budget specifics are scrubbed; only the vendor research + per-NOS verdicts are public. The three defs themselves remain provisional until run against real devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)