### PR TITLE
fix(migration): translate interface names by default + honest demo/README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ timestamp if your timezone matters for an audit.
 
 ### Changed
 
+* **Cross-vendor interface-name translation now runs by default.**  A
+  plain `POST /api/v1/migration/plan` translation (and the browser UI's
+  standard translate flow) engages the auto port-name heuristic even
+  when no target profile or rename map is supplied, so physical
+  switchports, LAGs, SVIs, and loopbacks render with native
+  target-vendor names (Cisco `GigabitEthernet1/0/1` -> Junos `ge-1/0/1`,
+  Aruba `1/1`, ...) instead of being left verbatim.  Explicit rename
+  maps and target profiles still win; the low-level `run_plan` primitive
+  is unchanged (still verbatim for callers that compose their own
+  transforms).  The bundled `netcanon demo` now exercises this path and
+  prints the interface-name translations it applied.
+
 * **Lint gate now covers `tools/` and `netcanon_desktop/`**
   (`.github/workflows/ci.yml`).  The v0.2.0 ruff baseline linted only
   `netcanon/` + `tests/`; the dev tools and the desktop shell are now

--- a/README.md
+++ b/README.md
@@ -31,14 +31,17 @@ docker run --rm --entrypoint netcanon ghcr.io/netcanon/netcanon:latest demo --pa
 Paste this:
 
 ```
-hostname leaf-01
+hostname access-sw-01
 !
 vlan 10
  name DATA
 !
-interface GigabitEthernet0/0/0
- description Uplink to spine
+interface GigabitEthernet1/0/1
+ description Server-A
+ switchport mode access
  switchport access vlan 10
+!
+snmp-server community public RO
 !
 ip route 0.0.0.0 0.0.0.0 192.168.1.1
 ```
@@ -46,11 +49,19 @@ ip route 0.0.0.0 0.0.0.0 192.168.1.1
 Get this:
 
 ```
-set system host-name leaf-01
-set interfaces GigabitEthernet0/0/0 description "Uplink to spine"
+set system host-name access-sw-01
+set interfaces ge-1/0/1 description "Server-A"
+set interfaces ge-1/0/1 unit 0 family ethernet-switching interface-mode access
+set interfaces ge-1/0/1 unit 0 family ethernet-switching vlan members DATA
 set vlans DATA vlan-id 10
 set routing-options static route 0.0.0.0/0 next-hop 192.168.1.1
+set snmp community public authorization read-only
 ```
+
+Notice ``GigabitEthernet1/0/1`` became ``ge-1/0/1`` and the access-VLAN
+membership rendered into Junos `ethernet-switching` form — Netcanon
+translates interface names and L2 membership across vendor conventions,
+not just the surrounding scalar config.
 
 Same canonical pipeline drives the HTTP API and the browser UI.  Run
 `netcanon demo --list` (or `python tools/demo.py --list` from a source

--- a/docs/walkthroughs/cisco_iosxe_to_junos.md
+++ b/docs/walkthroughs/cisco_iosxe_to_junos.md
@@ -22,7 +22,11 @@ isn't sustainable.
 - `ip name-server` → `set system name-server`
 - `ntp server` → `set system ntp server`
 - `ip route` → `set routing-options static route ... next-hop`
+- `snmp-server community ... RO/RW` → `set snmp community ... authorization`
 - LAGs (`Port-channel<N>`) → `ae<N>` aggregated-ethernet
+- **Interface names**, translated across vendor conventions
+  (`GigabitEthernet1/0/1` → `ge-1/0/1`) when a target profile is
+  selected or the rename pane is engaged (see the checklist below)
 
 **Deferred (Tier-3, see [`../CAPABILITIES.md`](../CAPABILITIES.md)):**
 
@@ -39,35 +43,76 @@ isn't sustainable.
 python tools/demo.py --pair cisco__junos
 ```
 
-Sample output (run the demo for the full version; the snippets below
-are excerpted):
+Actual demo output:
 
 ```
 INPUT (cisco_iosxe_cli)
 ========================================================================
-hostname leaf-01
+hostname access-sw-01
 !
 vlan 10
  name DATA
 !
-interface GigabitEthernet0/0/0
- description Uplink to spine
+vlan 20
+ name VOICE
+!
+interface GigabitEthernet1/0/1
+ description Server-A
+ switchport mode access
  switchport access vlan 10
+ no shutdown
+!
+interface GigabitEthernet1/0/2
+ description Desk-Phone
+ switchport mode access
+ switchport access vlan 20
+ no shutdown
+!
+interface GigabitEthernet1/0/24
+ description Uplink-to-core
+ switchport mode trunk
+ switchport trunk allowed vlan 10,20
+!
+snmp-server community public RO
+ip name-server 192.168.1.10
+ip name-server 192.168.1.11
+ntp server 192.168.1.20
 !
 ip route 0.0.0.0 0.0.0.0 192.168.1.1
 
 OUTPUT (juniper_junos)
 ========================================================================
-set system host-name leaf-01
+set system host-name access-sw-01
 set system name-server 192.168.1.10
+set system name-server 192.168.1.11
 set system ntp server 192.168.1.20
-set interfaces GigabitEthernet0/0/0 description "Uplink to spine"
-set interfaces GigabitEthernet0/0/1 description "Server-A"
-set interfaces GigabitEthernet0/0/2 description "Phone"
+set interfaces ge-1/0/1 description "Server-A"
+set interfaces ge-1/0/1 unit 0 family ethernet-switching interface-mode access
+set interfaces ge-1/0/1 unit 0 family ethernet-switching vlan members DATA
+set interfaces ge-1/0/2 description "Desk-Phone"
+set interfaces ge-1/0/2 unit 0 family ethernet-switching interface-mode access
+set interfaces ge-1/0/2 unit 0 family ethernet-switching vlan members VOICE
+set interfaces ge-1/0/24 description "Uplink-to-core"
+set interfaces ge-1/0/24 unit 0 family ethernet-switching interface-mode trunk
+set interfaces ge-1/0/24 unit 0 family ethernet-switching vlan members DATA
+set interfaces ge-1/0/24 unit 0 family ethernet-switching vlan members VOICE
 set vlans DATA vlan-id 10
 set vlans VOICE vlan-id 20
 set routing-options static route 0.0.0.0/0 next-hop 192.168.1.1
+set snmp community public authorization read-only
+
+========================================================================
+Interface-name translations applied
+========================================================================
+  GigabitEthernet1/0/1 -> ge-1/0/1
+  GigabitEthernet1/0/2 -> ge-1/0/2
+  GigabitEthernet1/0/24 -> ge-1/0/24
 ```
+
+The demo runs the rename-aware pipeline (the same path the browser UI
+takes once you select a target profile), so Cisco interface names are
+translated to native Junos form (`GigabitEthernet1/0/1` → `ge-1/0/1`)
+rather than left verbatim.
 
 ## Tier-3 boundary
 
@@ -89,13 +134,17 @@ adjacent tools (Capirca / Aerleon for firewall ACL translation).
 Before applying the rendered Junos config to a real QFX/EX device,
 verify:
 
-- [ ] **Interface naming**: Cisco `GigabitEthernet0/0/0` becomes the
-      same string in Junos because Netcanon preserves names by
-      default.  If you want `ge-0/0/0` mapping, use the migrate-page
-      rename modal (web UI) or pass `rename_overrides` in the
-      `POST /api/v1/migration/run` payload — the rename mesh handles
-      Cisco↔Junos↔Arista name translation across all renamable
-      categories.
+- [ ] **Interface naming**: netcanon auto-translates names across
+      vendor conventions (Cisco `GigabitEthernet1/0/1` → Junos
+      `ge-1/0/1`).  Every `POST /api/v1/migration/plan` translation and
+      the browser UI's standard translate flow do this **by default** —
+      no target profile or rename map required.  (The low-level
+      `run_plan` primitive still preserves names verbatim for callers
+      that compose their own transforms.)  Verify the auto-mapping
+      matches your slot/module layout before applying — the heuristic
+      preserves the structural coordinates (`1/0/1`) but can't know
+      your physical hardware; use the rename modal / a `port_rename_map`
+      to override any port that needs a different target name.
 - [ ] **VLAN-Vlan SVI mapping**: IOS-XE's `interface Vlan<id>` SVIs
       translate to Junos's `interface irb.<id>` form.  Verify the
       irb numbering matches your VLAN IDs.

--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -107,7 +107,6 @@ from ...models.migration import (
 )
 from ...services.migration_detect import DetectCandidate, detect_codec
 from ...services.migration_pipeline import (
-    run_plan,
     run_plan_with_overrides,
 )
 from ...storage.base import BaseConfigStore
@@ -190,10 +189,13 @@ def plan_migration(
     Stages executed: class-guard → parse → (transforms) → validate →
     render.  Per-pane override transforms (port / VLAN / local_user /
     SNMP community / SNMPv3 user) are dispatched via
-    :func:`run_plan_with_overrides` whenever the request body carries
-    ANY override map or a ``target_profile`` selection; legacy callers
-    that supply none of those continue through :func:`run_plan`
-    unchanged.  Free-form caller-supplied transform lists are not
+    :func:`run_plan_with_overrides`.  When the body carries any
+    override map or a ``target_profile``, every supplied category is
+    threaded; when it carries none the endpoint STILL engages the auto
+    port-name heuristic (``port_rename_map={}``) so a plain translation
+    renders native target-vendor interface names
+    (``GigabitEthernet1/0/1`` -> ``ge-1/0/1``) instead of leaving
+    source names verbatim.  Free-form caller-supplied transform lists are not
     accepted on this endpoint — per-pane categories cover the shipped
     rewrite surface.
 
@@ -212,11 +214,11 @@ def plan_migration(
     source = resolve_adapter_or_422(body.source, side="source")
     target = resolve_adapter_or_422(body.target, side="target")
     raw_text = resolve_input_text(body, storage)
-    # Route to the rename-aware pipeline when the caller supplied
-    # ANY per-category override map OR a target profile selection
-    # (target-profile alone means "run auto-heuristic + return
-    # diagnostics the UI can render").  Legacy callers that supply
-    # none of these get ``run_plan`` unchanged.
+    # Route to the FULL multi-category pipeline when the caller
+    # supplied ANY per-category override map OR a target profile
+    # selection (target-profile alone means "run auto-heuristic +
+    # return diagnostics the UI can render").  Callers that supply
+    # none of these STILL get auto port-name translation (else branch).
     if request_has_overrides_or_profile(body):
         # Dispatch directly to run_plan_with_overrides so EVERY
         # category map threads through — run_plan_with_rename is
@@ -237,7 +239,16 @@ def plan_migration(
             force=body.force,
         )
     else:
-        job = run_plan(source, target, raw_text, force=body.force)
+        # No override map and no target profile, but STILL engage the
+        # auto port-name heuristic so a plain translation renders
+        # native target-vendor interface names (GigabitEthernet1/0/1
+        # -> ge-1/0/1) rather than leaving source-vendor names
+        # verbatim.  port_rename_map={} = auto-only; the other per-pane
+        # categories stay disengaged (None) so a bare request only
+        # rewrites port names.
+        job = run_plan_with_overrides(
+            source, target, raw_text, port_rename_map={}, force=body.force,
+        )
     logger.info(
         "Migration plan %s: %s -> %s = %s",
         job.id[:8],

--- a/netcanon/tools/demo.py
+++ b/netcanon/tools/demo.py
@@ -22,9 +22,12 @@ Each scenario uses a small embedded synthetic config (~10-25 lines) so the
 demo is fully self-contained: no devices, no fixtures on disk, no FastAPI
 server.
 
-Internally this calls the same migration pipeline (`run_plan`) the API uses,
-through the same codec registry — so if the demo translates correctly, the
-production path does too.
+Internally this runs the rename-aware migration pipeline
+(``run_plan_with_rename``) — the same path the HTTP API's
+``POST /api/v1/migration/plan`` takes when a target profile is selected.
+So the cross-vendor interface-name translation you see here
+(``GigabitEthernet1/0/1`` -> ``ge-1/0/1``) is exactly what the API and
+browser UI produce, through the same codec registry.
 """
 
 from __future__ import annotations
@@ -34,7 +37,7 @@ import sys
 from dataclasses import dataclass
 
 from ..migration.codecs.registry import get_codec
-from ..services.migration_pipeline import run_plan
+from ..services.migration_pipeline import run_plan_with_rename
 
 # ---------------------------------------------------------------------------
 # Scenarios
@@ -51,7 +54,7 @@ class Scenario:
 
 
 _CISCO_IOSXE = """\
-hostname leaf-01
+hostname access-sw-01
 !
 vlan 10
  name DATA
@@ -59,21 +62,24 @@ vlan 10
 vlan 20
  name VOICE
 !
-interface GigabitEthernet0/0/0
- description Uplink to spine
- switchport access vlan 10
- no shutdown
-!
-interface GigabitEthernet0/0/1
+interface GigabitEthernet1/0/1
  description Server-A
+ switchport mode access
  switchport access vlan 10
  no shutdown
 !
-interface GigabitEthernet0/0/2
- description Phone
+interface GigabitEthernet1/0/2
+ description Desk-Phone
+ switchport mode access
  switchport access vlan 20
  no shutdown
 !
+interface GigabitEthernet1/0/24
+ description Uplink-to-core
+ switchport mode trunk
+ switchport trunk allowed vlan 10,20
+!
+snmp-server community public RO
 ip name-server 192.168.1.10
 ip name-server 192.168.1.11
 ntp server 192.168.1.20
@@ -174,10 +180,11 @@ SCENARIOS: dict[str, Scenario] = {
         source_codec="cisco_iosxe_cli",
         target_codec="juniper_junos",
         description=(
-            "Translate VLAN definitions, switchport-mode interfaces with "
-            "VLAN membership, DNS / NTP servers, and a default static route "
-            "from Cisco's per-interface model into Junos' VLAN-centric "
-            "set-form syntax."
+            "Translate a Catalyst access switch into Junos set-form: "
+            "hostname, VLAN definitions, switchport access + trunk ports "
+            "with their VLAN membership, an SNMP community, DNS / NTP "
+            "servers, and a default static route - including cross-vendor "
+            "interface-name translation (GigabitEthernet1/0/1 -> ge-1/0/1)."
         ),
         source_text=_CISCO_IOSXE,
     ),
@@ -262,7 +269,7 @@ def _run_scenario(scenario: Scenario) -> int:
 
     source = get_codec(scenario.source_codec)
     target = get_codec(scenario.target_codec)
-    job = run_plan(source, target, scenario.source_text)
+    job = run_plan_with_rename(source, target, scenario.source_text, port_rename_map={})
 
     if str(job.status).endswith("failed"):
         _print_section("FAILED")
@@ -274,6 +281,25 @@ def _run_scenario(scenario: Scenario) -> int:
         (job.rendered or "").rstrip(),
     )
     print()
+
+    # Show the cross-vendor interface-name translation explicitly — it
+    # is the load-bearing step that turns source-vendor port names into
+    # valid target-vendor syntax (GigabitEthernet1/0/1 -> ge-1/0/1).
+    renames = dict(job.port_renames or {})
+    if renames:
+        _print_section("Interface-name translations applied")
+        for src_name, tgt_name in renames.items():
+            print(f"  {src_name} -> {tgt_name}")
+        print()
+
+    # Advisories: port names the target codec has no clean equivalent
+    # for (left verbatim), plus any other per-pane warnings — honest
+    # about what the auto-heuristic could not resolve.
+    if job.warnings:
+        _print_section("Advisories")
+        for entry in job.warnings:
+            print(f"  - {entry}")
+        print()
 
     # Honest reporting of what didn't translate
     dropped = list(job.dropped_tier3_sections or [])

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -763,10 +763,16 @@ interface GigabitEthernet1/0/1
         # user overrides applied, but source_vlans still populates.
         assert "source_vlans" in body
 
-    def test_plan_without_any_override_still_works(self, client):
-        """Legacy behaviour: no override maps, no target profile →
-        plain run_plan path.  Source-shape fields stay empty because
-        the capture only fires in the overrides engine."""
+    def test_plan_without_any_override_still_translates_port_names(
+        self, client,
+    ):
+        """No override maps and no target profile STILL translates
+        port names: the endpoint engages the auto port-name heuristic
+        so a plain cross-vendor translation renders native target
+        interface names (GigabitEthernet1/0/1 -> aruba 1/1) instead of
+        leaving them verbatim.  VLAN / local-user categories stay
+        disengaged (their maps were None), and the source-shape
+        capture fires."""
         resp = client.post(
             "/api/v1/migration/plan",
             json={
@@ -777,10 +783,13 @@ interface GigabitEthernet1/0/1
         )
         assert resp.status_code == 200
         body = resp.json()
-        # No overrides → empty renames.
-        assert body["port_renames"] == {}
+        # Auto port-name translation engaged even with no overrides.
+        assert body["port_renames"].get("GigabitEthernet1/0/1") == "1/1"
+        # Categories the caller didn't engage stay empty.
         assert body["vlan_renames"] == {}
         assert body["local_user_renames"] == {}
+        # Capture now fires (source-shape fields populate for the modal).
+        assert body["source_vlans"] == [10]
 
 
 class TestSourceShapeCapture:

--- a/tests/integration/test_migration_target_profiles_api.py
+++ b/tests/integration/test_migration_target_profiles_api.py
@@ -85,12 +85,13 @@ end
 
 
 class TestPlanWithRenameMap:
-    def test_plan_without_rename_map_is_legacy_shape(
+    def test_plan_without_rename_map_still_translates_port_names(
         self, client: TestClient,
     ):
-        """Legacy callers that don't send port_rename_map or
-        target_profile get the original run_plan behaviour — no
-        port_renames in response."""
+        """A plain translation (no port_rename_map, no target_profile)
+        now engages the auto port-name heuristic, so physical ports,
+        LAGs, and loopbacks are rewritten to native target names
+        instead of left verbatim."""
         resp = client.post(
             "/api/v1/migration/plan",
             json={
@@ -101,10 +102,9 @@ class TestPlanWithRenameMap:
         )
         assert resp.status_code == 200
         body = resp.json()
-        # port_renames and warnings exist in the model but are empty
-        # for legacy callers.
-        assert body["port_renames"] == {}
-        assert body["warnings"] == []
+        renames = body["port_renames"]
+        assert renames["GigabitEthernet1/0/1"] == "1/1"
+        assert renames["Port-channel1"] == "Trk1"
 
     def test_plan_with_target_profile_runs_auto_rename(
         self, client: TestClient,

--- a/tests/unit/tools/test_demo.py
+++ b/tests/unit/tools/test_demo.py
@@ -32,11 +32,14 @@ class TestDemoModule:
             assert f"--pair {key}" in out
 
     def test_default_pair_translates_to_junos(self, capsys):
-        # No args → default cisco__junos scenario; Cisco hostname becomes
-        # Junos set-form.  Proves the pipeline actually ran end-to-end.
+        # No args → default cisco__junos scenario.  Proves the
+        # rename-aware pipeline ran end-to-end: the Cisco hostname becomes
+        # Junos set-form AND the Cisco port name is translated to native
+        # Junos form (ge-1/0/1), not left verbatim.
         assert demo_main([]) == 0
         out = capsys.readouterr().out
-        assert "set system host-name leaf-01" in out
+        assert "set system host-name access-sw-01" in out
+        assert "set interfaces ge-1/0/1" in out
 
     @pytest.mark.parametrize("pair", sorted(SCENARIOS))
     def test_every_scenario_runs_clean(self, pair, capsys):


### PR DESCRIPTION
## What

Cross-vendor interface-name translation now runs **by default**, and the front-page demo / README / walkthrough show real, valid translated output instead of source-vendor names left verbatim.

## Root cause

The bundled `netcanon demo` called the bare `run_plan` entry point, which **deliberately skips** the `translate_port_names` transform — and the `/plan` route only engaged that transform when a target profile or rename map was present. So a plain translation rendered source interface names verbatim (e.g. `set interfaces GigabitEthernet0/0/0` — invalid Junos) and dropped VLAN membership, and the demo/README/walkthrough all inherited that pre-translation output. The translation engine (`classify_port_name` → `format_port_identity`) was correct all along; it just wasn't on the default path.

## Changes

- **`/plan` route** (`netcanon/api/routes/migration.py`): the no-profile / no-override branch now calls `run_plan_with_overrides(port_rename_map={})`, so a plain `POST /api/v1/migration/plan` (and the browser UI's standard translate flow) auto-translates interface names:
  - `GigabitEthernet1/0/1` → Junos `ge-1/0/1`, Aruba `1/1`
  - `Port-channel1` → Aruba `Trk1`; `Loopback0` → Aruba `loopback1`
  - Same-vendor stays a **no-op** (`port_renames={}`, names preserved). Explicit rename maps + target profiles still win. The low-level `run_plan` primitive is **unchanged** (still verbatim for callers composing their own transforms).
- **`netcanon/tools/demo.py`**: runs via `run_plan_with_rename` with a realistic Catalyst access-switch input (real ports + `switchport mode access` + trunk uplink + SNMP, no "spine" framing), and prints the interface-name translations it applied; fixed the false "same pipeline the API uses" docstring.
- **README + walkthrough**: synced to the real translated output (valid Junos `ge-` names + `ethernet-switching` VLAN membership + SNMP community).
- Flipped two integration tests that pinned the old verbatim contract (`test_plan_without_any_override_*`, `test_plan_without_rename_map_*`); added a CHANGELOG `[Unreleased]` entry.

## Verification

- `ruff check` clean on all touched files.
- Full `tests/integration` + `tests/unit/migration` + `tests/unit/api` pass locally; changelog guard passes; demo suite passes.
- e2e basic flow uses same-vendor pairs (auto-rename no-op, `Gi0/0/0` preserved), verified safe; e2e remains the final CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
