### PR TITLE
fix(cisco_iosxe_cli): infer access mode from bare switchport access vlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ timestamp if your timezone matters for an audit.
   annotation fix in `icons.py`, etc.) and the CI `ruff check` scope is
   widened to all four trees so they stay clean. No runtime behaviour change.
 
+### Fixed
+
+* **Cisco access-VLAN membership no longer dropped when `switchport mode
+  access` is implicit.**  IOS treats an interface carrying `switchport
+  access vlan N` as an access port even without the explicit `switchport
+  mode access` line; the `cisco_iosxe_cli` parser now infers
+  `switchport_mode="access"` in that case, so VLAN membership survives
+  translation to VLAN-centric targets (e.g. Junos `ethernet-switching vlan
+  members`).  Conservative: an explicit mode is never overridden, ports
+  that also carry trunk config are left untouched, and sub-interfaces
+  (names with a `.`) are excluded since real IOS rejects `switchport`
+  there.  CODEC_BUG count unchanged (5).
+
 ## [0.3.1] - 2026-06-17
 
 ### Added

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -1013,6 +1013,30 @@ def _build_canonical_interface(raw: dict[str, Any]) -> CanonicalInterface:
             description=g.get("description", ""),
         ))
 
+    # IOS treats an interface carrying `switchport access vlan N` as an
+    # access port even when the explicit `switchport mode access` line is
+    # absent (extremely common in real configs -- operators set the access
+    # VLAN and rely on the default).  Without inferring the mode here the
+    # canonical interface carries access_vlan but switchport_mode=None, and
+    # target renderers that gate L2 membership on switchport_mode=="access"
+    # (e.g. juniper_junos) silently drop the VLAN membership.  Only fill the
+    # gap: never override an explicit mode; leave ports that also carry
+    # trunk config untouched (their mode is genuinely ambiguous without the
+    # explicit line); and skip sub-interfaces (names with a "."), since real
+    # IOS rejects `switchport` on a sub-interface -- an access_vlan there
+    # came from a cross-vendor source's logical unit (e.g. Junos
+    # `ge-0/0/1.100`), not an L2 access port, and inferring access mode
+    # would desync round-trip membership against that source.
+    switchport_mode = raw.get("switchport_mode")
+    if (
+        switchport_mode is None
+        and raw.get("access_vlan") is not None
+        and not raw.get("trunk_allowed")
+        and raw.get("trunk_native") is None
+        and "." not in raw.get("name", "")
+    ):
+        switchport_mode = "access"
+
     return CanonicalInterface(
         name=raw["name"],
         description=raw.get("description", ""),
@@ -1027,7 +1051,7 @@ def _build_canonical_interface(raw: dict[str, Any]) -> CanonicalInterface:
             )
             for a in raw.get("ipv6", [])
         ],
-        switchport_mode=raw.get("switchport_mode"),
+        switchport_mode=switchport_mode,
         access_vlan=raw.get("access_vlan"),
         trunk_allowed_vlans=raw.get("trunk_allowed", []),
         trunk_native_vlan=raw.get("trunk_native"),

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -855,6 +855,103 @@ class TestPipelineWithCLICodec:
 
 
 # ---------------------------------------------------------------------------
+# access-vlan implies access mode
+# ---------------------------------------------------------------------------
+
+
+class TestAccessVlanImpliesAccessMode:
+    """Real IOS treats an interface carrying ``switchport access vlan N``
+    as an access port even when the explicit ``switchport mode access``
+    line is absent (very common in real configs).  The parser must infer
+    ``switchport_mode="access"`` so VLAN-centric / L2 targets (e.g. Junos
+    ``ethernet-switching``) do not silently drop the membership.
+    """
+
+    def test_bare_access_vlan_infers_access_mode(self):
+        raw = (
+            "hostname r1\n!\n"
+            "vlan 10\n name DATA\n!\n"
+            "interface GigabitEthernet1/0/1\n"
+            " switchport access vlan 10\n"
+            "!\n"
+        )
+        intent = CiscoIOSXECLICodec().parse(raw)
+        iface = next(
+            i for i in intent.interfaces if i.name.endswith("1/0/1")
+        )
+        assert iface.switchport_mode == "access"
+        assert iface.access_vlan == 10
+
+    def test_inference_round_trips_membership_to_junos(self):
+        from netcanon.migration.codecs.registry import get_codec
+        from netcanon.services.migration_pipeline import (
+            run_plan_with_rename,
+        )
+        raw = (
+            "hostname r1\n!\n"
+            "vlan 10\n name DATA\n!\n"
+            "interface GigabitEthernet1/0/1\n"
+            " switchport access vlan 10\n"
+            "!\n"
+        )
+        job = run_plan_with_rename(
+            CiscoIOSXECLICodec(), get_codec("juniper_junos"), raw,
+            port_rename_map={},
+        )
+        assert "ethernet-switching vlan members DATA" in (
+            job.rendered or ""
+        )
+
+    def test_explicit_trunk_mode_is_not_overridden(self):
+        raw = (
+            "hostname r1\n!\n"
+            "interface GigabitEthernet1/0/1\n"
+            " switchport mode trunk\n"
+            " switchport access vlan 10\n"
+            "!\n"
+        )
+        iface = CiscoIOSXECLICodec().parse(raw).interfaces[0]
+        assert iface.switchport_mode == "trunk"
+
+    def test_access_vlan_with_trunk_config_not_inferred(self):
+        # Ambiguous: both access vlan and a trunk-allowed list, no
+        # explicit mode.  The conservative inference leaves the mode
+        # unset rather than guessing a classification.
+        raw = (
+            "hostname r1\n!\n"
+            "interface GigabitEthernet1/0/1\n"
+            " switchport access vlan 10\n"
+            " switchport trunk allowed vlan 20\n"
+            "!\n"
+        )
+        iface = CiscoIOSXECLICodec().parse(raw).interfaces[0]
+        assert iface.switchport_mode is None
+
+    def test_subinterface_access_vlan_not_inferred(self):
+        # Real IOS rejects `switchport` on a sub-interface; an access_vlan
+        # on a dotted name came from a cross-vendor logical unit, not an L2
+        # access port, so the mode stays unset (keeps cross-mesh round-trip
+        # membership symmetric with the source codec).
+        raw = (
+            "hostname r1\n!\n"
+            "interface GigabitEthernet0/0.100\n"
+            " switchport access vlan 100\n"
+            "!\n"
+        )
+        iface = CiscoIOSXECLICodec().parse(raw).interfaces[0]
+        assert iface.switchport_mode is None
+
+    def test_l3_only_interface_stays_unset(self):
+        raw = (
+            "hostname r1\n!\n"
+            "interface GigabitEthernet1/0/1\n"
+            " ip address 10.0.0.1 255.255.255.0\n"
+            "!\n"
+        )
+        iface = CiscoIOSXECLICodec().parse(raw).interfaces[0]
+        assert iface.switchport_mode is None
+
+# ---------------------------------------------------------------------------
 # Bug 4 — ip default-gateway
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

The `cisco_iosxe_cli` parser now infers `switchport_mode="access"` when an interface carries `switchport access vlan N` but no explicit `switchport mode access` line — matching real IOS behaviour.

## Why

`switchport access vlan N` without the explicit mode line is extremely common in real configs. The parser stored `access_vlan=N` but left `switchport_mode=None`, so renderers that gate L2 membership on `switchport_mode == "access"` (e.g. `juniper_junos` `ethernet-switching vlan members`) **silently dropped VLAN membership** on translation.

Before → after (Cisco → Junos, source has `switchport access vlan 10` only):

```
# before:  set interfaces ge-1/0/1                              (membership lost)
# after:   set interfaces ge-1/0/1 unit 0 family ethernet-switching interface-mode access
#          set interfaces ge-1/0/1 unit 0 family ethernet-switching vlan members DATA
```

## Conservative guards

- Never overrides an explicit mode (access/trunk).
- Skips ports that also carry trunk config (genuinely ambiguous without the mode line).
- Skips sub-interfaces (names with a `.`): real IOS rejects `switchport` on a sub-interface, so an `access_vlan` on a dotted name (e.g. a Junos `ge-0/0/1.100` logical unit rendered verbatim in the cross-mesh harness) is not an L2 access port — inferring there would desync round-trip membership against the source codec. This guard keeps the cross-mesh `CODEC_BUG` count flat at **5**.

The `cisco_iosxe` (OpenConfig) codec parses no switchport/access-vlan, so no symmetric change is needed there.

## Verification

- New `TestAccessVlanImpliesAccessMode` (6 cases: positive inference, Junos round-trip renders `vlan members`, explicit trunk not overridden, trunk-config guard, sub-interface guard, L3-only stays unset).
- Full `tests/unit` + `tests/integration` green; ruff clean; changelog guard passes.
- Cross-mesh + phase4 regenerated locally: `CODEC_BUG` unchanged at **5**, no fixture dispositions shifted (artifacts not committed — the only diff was timestamp churn + a pre-existing cosmetic traceback line number).

Surfaced during the demo/README front-page fix ([#119](https://github.com/netcanon/netcanon/pull/119)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
