### PR TITLE
chore(release): cut v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-18
+
 ### Changed
 
 * **Cross-vendor interface-name translation now runs by default.**  A


### PR DESCRIPTION
## Release v0.3.2

Moves the `[Unreleased]` entries into `## [0.3.2] - 2026-06-18`. CHANGELOG-only — the version is derived from the git tag via `setuptools_scm`, so tagging `v0.3.2` after merge publishes PyPI + Docker + MSI.

### Bundled since v0.3.1

- **Default cross-vendor interface-name translation** — a plain `POST /api/v1/migration/plan` translation (and the browser UI's standard flow) now renders native target interface names (`GigabitEthernet1/0/1` → `ge-1/0/1`, Aruba `1/1`, ...) instead of leaving source names verbatim; demo/README/walkthrough synced to honest output ([#119](https://github.com/netcanon/netcanon/pull/119)).
- **Cisco access-VLAN mode inference** — `switchport access vlan N` without an explicit `switchport mode access` line now infers access mode, so VLAN membership survives translation to VLAN-centric targets; conservative guards (explicit mode, trunk config, sub-interfaces) keep cross-mesh `CODEC_BUG` flat at 5 ([#120](https://github.com/netcanon/netcanon/pull/120)).
- **Lint gate widened** to `tools/` + `netcanon_desktop/` ([#117](https://github.com/netcanon/netcanon/pull/117)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
