### PR TITLE
fix(migration): surface dropped L2 switchport loss on L3-only targets (ENG-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Fixed
+
+* **Switch -> firewall/router migrations now surface dropped L2
+  switchport membership instead of a green banner (audit finding
+  ENG-01).**  The L3-only target codecs (`fortigate_cli`, `opnsense`,
+  `cisco_iosxr`, `mikrotik_routeros`, `vyos`) have no Cisco-style
+  access/trunk port model, so a source switch's per-port VLAN
+  membership (`switchport-mode`, `access-vlan`, `trunk-allowed-vlans`,
+  `trunk-native-vlan`, `voice-vlan`) is dropped on render.  Those
+  paths were previously undeclared, so `CapabilityMatrix.classify()`
+  defaulted them to `supported` and the validation report said
+  `severity: ok` while the membership was silently lost (reproduced
+  live in the 2026-06 blind audit).  Each L3-only target now declares
+  the switchport surface `unsupported`, so the loss is reported as a
+  block-severity migration finding.  Cross-mesh `CODEC_BUG` unchanged
+  at 5 (the drift demotes to `EXPECTED_UNSUPPORTED`).
+
 ## [0.3.2] - 2026-06-18
 
 ### Changed

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -209,6 +209,31 @@ class CiscoIOSXRCodec(CodecBase):
             ),
         ],
         unsupported=[
+            # ── L2 switchport surface (ENG-01) — this codec has no
+            #    Cisco-style access/trunk port model, so the per-port VLAN
+            #    membership the walker yields is dropped on render.  Declared
+            #    unsupported so a switch→{firewall,router} migration surfaces
+            #    the L2 loss instead of reporting `severity: ok`. ──
+            UnsupportedPath(
+                path="/interfaces/interface/switchport-mode",
+                reason="IOS-XR is SP-routing with no L2 switchport model (L2VPN is Tier-3); the mode is dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/access-vlan",
+                reason="IOS-XR has no per-port access-VLAN; VLANs are dot1q sub-interfaces — dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-allowed-vlans",
+                reason="IOS-XR has no switchport trunk allowed-list; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-native-vlan",
+                reason="IOS-XR has no switchport native VLAN; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/voice-vlan",
+                reason="IOS-XR has no voice-VLAN; dropped on render.",
+            ),
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -236,6 +236,31 @@ class FortiGateCLICodec(CodecBase):
             ),
         ],
         unsupported=[
+            # ── L2 switchport surface (ENG-01) — this codec has no
+            #    Cisco-style access/trunk port model, so the per-port VLAN
+            #    membership the walker yields is dropped on render.  Declared
+            #    unsupported so a switch→{firewall,router} migration surfaces
+            #    the L2 loss instead of reporting `severity: ok`. ──
+            UnsupportedPath(
+                path="/interfaces/interface/switchport-mode",
+                reason="FortiOS has no switchport access/trunk mode — every port is L3; the mode is dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/access-vlan",
+                reason="FortiOS has no per-port access-VLAN; the port→VLAN binding is dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-allowed-vlans",
+                reason="FortiOS trunks via stacked VLAN child-interfaces, not an allowed-list; dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-native-vlan",
+                reason="FortiOS has no native-VLAN on a routed port; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/voice-vlan",
+                reason="FortiOS has no per-port voice-VLAN; dropped on render.",
+            ),
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -200,6 +200,31 @@ class MikroTikRouterOSCodec(CodecBase):
             ),
         ],
         unsupported=[
+            # ── L2 switchport surface (ENG-01) — this codec has no
+            #    Cisco-style access/trunk port model, so the per-port VLAN
+            #    membership the walker yields is dropped on render.  Declared
+            #    unsupported so a switch→{firewall,router} migration surfaces
+            #    the L2 loss instead of reporting `severity: ok`. ──
+            UnsupportedPath(
+                path="/interfaces/interface/switchport-mode",
+                reason="RouterOS models L2 via bridge VLAN filtering, not switchport modes; the mode is dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/access-vlan",
+                reason="RouterOS has no per-port access-VLAN (bridge VLAN table instead); dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-allowed-vlans",
+                reason="RouterOS tags VLANs in the bridge VLAN table; the allowed-list is dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-native-vlan",
+                reason="RouterOS PVID lives on the bridge port, not modelled here; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/voice-vlan",
+                reason="RouterOS has no voice-VLAN; dropped on render.",
+            ),
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -205,6 +205,31 @@ class OPNsenseCodec(CodecBase):
             ),
         ],
         unsupported=[
+            # ── L2 switchport surface (ENG-01) — this codec has no
+            #    Cisco-style access/trunk port model, so the per-port VLAN
+            #    membership the walker yields is dropped on render.  Declared
+            #    unsupported so a switch→{firewall,router} migration surfaces
+            #    the L2 loss instead of reporting `severity: ok`. ──
+            UnsupportedPath(
+                path="/interfaces/interface/switchport-mode",
+                reason="OPNsense (BSD) has no Cisco-style access/trunk port mode; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/access-vlan",
+                reason="OPNsense models VLANs as <vlans> child-interfaces, not a per-port access-VLAN; dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-allowed-vlans",
+                reason="OPNsense uses the allowed-list only as a parent-binding hint; not preserved on the port.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-native-vlan",
+                reason="OPNsense has no native-VLAN concept; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/voice-vlan",
+                reason="OPNsense has no voice-VLAN; dropped on render.",
+            ),
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9).  NB: domain +

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -271,6 +271,31 @@ class VyOSCodec(CodecBase):
             ),
         ],
         unsupported=[
+            # ── L2 switchport surface (ENG-01) — this codec has no
+            #    Cisco-style access/trunk port model, so the per-port VLAN
+            #    membership the walker yields is dropped on render.  Declared
+            #    unsupported so a switch→{firewall,router} migration surfaces
+            #    the L2 loss instead of reporting `severity: ok`. ──
+            UnsupportedPath(
+                path="/interfaces/interface/switchport-mode",
+                reason="VyOS has no switchport access/trunk mode (L2 via bridge/vif); the mode is dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/access-vlan",
+                reason="VyOS models VLANs as vif <vid> sub-interfaces, not a per-port access-VLAN; dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-allowed-vlans",
+                reason="VyOS has no switchport trunk allowed-list (tagged VLANs are vif sub-ifaces); dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-native-vlan",
+                reason="VyOS has no switchport native VLAN; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/voice-vlan",
+                reason="VyOS has no voice-VLAN; dropped on render.",
+            ),
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──

--- a/tests/unit/migration/test_aruba_aoss.py
+++ b/tests/unit/migration/test_aruba_aoss.py
@@ -564,11 +564,33 @@ class TestProbe:
 
 class TestCrossAdapter:
     def test_aruba_to_opnsense(self):
-        """Aruba AOS-S parsed and rendered as OPNsense config.xml."""
+        """Aruba AOS-S (a switch) rendered as OPNsense config.xml.
+
+        OPNsense is an L3 firewall with no Cisco-style switchport model,
+        so the Aruba source's per-port VLAN membership is dropped on
+        render.  Since ENG-01 the OPNsense matrix declares that
+        switchport surface ``unsupported``, so this run honestly
+        terminates as ``partial`` with a block-severity validation
+        report rather than silently ``completed``.  The L3 surfaces
+        (hostname, addresses) still render — that's the partial output.
+        """
         from netcanon.migration.codecs.opnsense import OPNsenseCodec
         raw = FIXTURES.joinpath("show_run_simple.txt").read_text()
         job = run_plan(ArubaAOSSCodec(), OPNsenseCodec(), raw)
-        assert job.status is MigrationJobStatus.completed
+        assert job.status is MigrationJobStatus.partial
+        assert job.validation is not None
+        assert job.validation.severity == "block"
+        # The dropped L2 switchport membership is surfaced (ENG-01),
+        # not silently classified supported.
+        assert any(
+            p.path
+            in {
+                "/interfaces/interface/switchport-mode",
+                "/interfaces/interface/access-vlan",
+                "/interfaces/interface/trunk-allowed-vlans",
+            }
+            for p in job.validation.unsupported_paths
+        )
         assert job.rendered is not None
         assert "<hostname>sw-edge-01</hostname>" in job.rendered
 

--- a/tests/unit/migration/test_eng01_switchport_loss_visible.py
+++ b/tests/unit/migration/test_eng01_switchport_loss_visible.py
@@ -1,0 +1,96 @@
+"""ENG-01 regression: L2 switchport-membership loss must be VISIBLE.
+
+A switch → firewall/router migration that drops per-port VLAN membership
+must surface that loss as an ``unsupported`` path in the validation
+report — not silently classify ``severity: ok``.
+
+Before this fix the L3-only target codecs (FortiGate, OPNsense, IOS-XR,
+RouterOS, VyOS) declared *none* of the switchport xpaths, so
+``CapabilityMatrix.classify`` defaulted them to ``supported`` and a
+dropped trunk/access membership shipped with a green banner — reproduced
+live in the 2026-06 blind audit (finding ENG-01).  Each of those targets
+now declares the switchport surface ``unsupported`` (it has no Cisco-style
+access/trunk port model), so the walker-yielded loss is reported.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.cisco_iosxe_cli.codec import CiscoIOSXECLICodec
+from netcanon.migration.codecs.cisco_iosxr.codec import CiscoIOSXRCodec
+from netcanon.migration.codecs.fortigate_cli.codec import FortiGateCLICodec
+from netcanon.migration.codecs.mikrotik_routeros.codec import MikroTikRouterOSCodec
+from netcanon.migration.codecs.opnsense.codec import OPNsenseCodec
+from netcanon.migration.codecs.vyos.codec import VyOSCodec
+from netcanon.services.migration_validate import validate_against
+
+pytestmark = pytest.mark.unit
+
+# A Cisco access switch: one access port (VLAN 10) + one trunk port
+# (VLANs 10,20).  Explicit ``switchport mode`` lines so the parse is
+# unambiguous.
+_SWITCH_CONFIG = """hostname access-sw-01
+!
+vlan 10
+ name DATA
+!
+vlan 20
+ name VOICE
+!
+interface GigabitEthernet1/0/1
+ description Server-A
+ switchport mode access
+ switchport access vlan 10
+!
+interface GigabitEthernet1/0/2
+ description Uplink
+ switchport mode trunk
+ switchport trunk allowed vlan 10,20
+!
+"""
+
+# The per-port L2 surface the switch config carries (and the walker
+# therefore yields) — every one must land in ``unsupported`` on an
+# L3-only target, not be silently blessed as supported.
+_DROPPED_SWITCHPORT_XPATHS = {
+    "/interfaces/interface/switchport-mode",
+    "/interfaces/interface/access-vlan",
+    "/interfaces/interface/trunk-allowed-vlans",
+}
+
+# Targets with no Cisco-style L2 switchport model — they drop the
+# membership on render, so the matrix must declare it unsupported.
+_L3_ONLY_TARGETS = [
+    FortiGateCLICodec,
+    OPNsenseCodec,
+    CiscoIOSXRCodec,
+    MikroTikRouterOSCodec,
+    VyOSCodec,
+]
+
+
+@pytest.mark.parametrize(
+    "target_cls", _L3_ONLY_TARGETS, ids=lambda c: c.__name__
+)
+def test_switchport_loss_surfaces_as_unsupported(target_cls):
+    source = CiscoIOSXECLICodec()
+    tree = source.parse(_SWITCH_CONFIG)
+    # Sanity: the source genuinely parsed the L2 membership the audit
+    # showed being silently dropped.
+    g1 = next(i for i in tree.interfaces if i.name == "GigabitEthernet1/0/1")
+    g2 = next(i for i in tree.interfaces if i.name == "GigabitEthernet1/0/2")
+    assert g1.switchport_mode == "access" and g1.access_vlan == 10
+    assert g2.switchport_mode == "trunk" and g2.trunk_allowed_vlans == [10, 20]
+
+    report = validate_against(tree, target_cls(), source=source)
+    unsupported = {u.path for u in report.unsupported_paths}
+
+    missing = _DROPPED_SWITCHPORT_XPATHS - unsupported
+    assert not missing, (
+        f"{target_cls.__name__}: switchport loss NOT surfaced — these dropped "
+        f"L2 paths classified as supported instead of unsupported: {sorted(missing)}"
+    )
+    # Any unsupported path forces a block-severity, incompatible report.
+    assert report.severity == "block"
+    assert report.compatible is False


### PR DESCRIPTION
## What

Closes audit finding **ENG-01** (verified CONFIRMED, severity HIGH, reproduced live in the 2026-06 blind audit).

A **switch → firewall/router** migration silently dropped per-port L2 VLAN membership behind a green `severity: ok` validation banner. The L3-only target codecs declared **none** of the switchport xpaths, so `CapabilityMatrix.classify()` defaulted them to `supported` even though their render drops the surface entirely — directly contradicting the product's headline "detects silent translation errors" claim on a common migration (e.g. Cisco access switch → FortiGate).

## Fix

Declare the L2 switchport surface `unsupported` on the five L3-only targets that have no Cisco-style access/trunk port model:

| Codec | Surface declared `unsupported` |
|---|---|
| `fortigate_cli`, `opnsense`, `cisco_iosxr`, `mikrotik_routeros`, `vyos` | `switchport-mode`, `access-vlan`, `trunk-allowed-vlans`, `trunk-native-vlan`, `voice-vlan` |

The walker already yields these xpaths (review #9); they were just undeclared on the targets that drop them. This matches the documented intent in `docs/vendor-references/cisco_iosxe_cli_to_fortigate_cli/switchport.md` ("Disposition for the entire switching surface: **unsupported**").

## Why this is honest, not over-declaration

The registry capability-honesty parity test (`test_roundtrip_emitted_xpath_not_unsupported`) **fails** if a codec declares `unsupported` any xpath it actually round-trips. It passes here — confirming none of the five preserve the switchport surface (including OPNsense's `trunk-allowed-vlans`, which it consumes only as a VLAN-parent-binding hint, not a preserved field).

## Verification

- ✅ `ruff` clean
- ✅ Full `tests/unit` + `tests/integration` green
- ✅ Registry capability-honesty parity test green
- ✅ New parametrized regression test asserts the loss surfaces as `unsupported` / block-severity for all five targets
- ✅ Updated `test_aruba_to_opnsense` (which codified the old silent-blessing behaviour) to assert the honest `partial` / block outcome
- ✅ Cross-mesh regen: **`CODEC_BUG` unchanged at 5** (the drift demotes to `EXPECTED_UNSUPPORTED`, never promotes to a bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)