### PR TITLE
fix(cisco_iosxe_cli): render full DHCP lease d/h/m triple (ENG-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Cisco IOS-XE DHCP pool lease-time now round-trips losslessly
+  (audit finding ENG-03).**  `cisco_iosxe_cli` render emitted
+  `lease 0 <total_hours>`, truncating days into hours and dropping
+  minutes (e.g. `lease 2 6 30` rendered as `lease 0 54`, silently
+  losing 30 minutes), and never emitted `lease infinite`.  Render now
+  emits the full `lease <days> <hours> <minutes>` triple (and the
+  `infinite` marker), matching the parser grammar and the arista_eos
+  render.  Cross-mesh `CODEC_BUG` unchanged at 5.
+
 * **Switch -> firewall/router migrations now surface dropped L2
   switchport membership instead of a green banner (audit finding
   ENG-01).**  The L3-only target codecs (`fortigate_cli`, `opnsense`,

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -574,8 +574,22 @@ def render_intent(tree: Any) -> str:
         if pool.domain_name:
             out.append(f" domain-name {pool.domain_name}")
         if pool.lease_time and pool.lease_time != 86400:
-            hours = pool.lease_time // 3600
-            out.append(f" lease 0 {hours}")
+            if pool.lease_time == 0xFFFFFFFF:
+                # DHCP infinite-lease marker (max uint32 seconds).
+                out.append(" lease infinite")
+            else:
+                # Emit the full day/hour/minute triple so multi-day
+                # and sub-hour leases round-trip losslessly (matches
+                # the parser's `lease <days> <hours> <minutes>` grammar
+                # and arista_eos render).  The old `lease 0 <hours>`
+                # form truncated days into hours and dropped minutes
+                # (audit finding ENG-03).
+                days = pool.lease_time // 86400
+                rem = pool.lease_time - days * 86400
+                hours = rem // 3600
+                rem -= hours * 3600
+                minutes = rem // 60
+                out.append(f" lease {days} {hours} {minutes}")
         out.append("!")
 
     # --- RADIUS servers ---

--- a/tests/unit/migration/test_eng03_cisco_dhcp_lease.py
+++ b/tests/unit/migration/test_eng03_cisco_dhcp_lease.py
@@ -1,0 +1,70 @@
+"""ENG-03 regression: cisco_iosxe_cli DHCP lease-time round-trips losslessly.
+
+The old render emitted ``lease 0 <total_hours>`` — it truncated days
+into hours and dropped minutes entirely (e.g. ``lease 2 6 30`` = 196200s
+rendered as ``lease 0 54`` = 194400s, losing 30 min and collapsing the
+day field), and never emitted the ``lease infinite`` marker.  The parser
+already read the full ``lease <days> <hours> <minutes>`` + ``infinite``
+grammar, so the render was the lossy side.  Render now emits the matching
+day/hour/minute triple (audit finding ENG-03).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.cisco_iosxe_cli.codec import CiscoIOSXECLICodec
+
+pytestmark = pytest.mark.unit
+
+_BASE = """hostname r1
+!
+ip dhcp pool LAN
+ network 10.0.0.0 255.255.255.0
+ default-router 10.0.0.1
+ {lease}
+!
+"""
+
+
+def _roundtrip(lease_line: str):
+    codec = CiscoIOSXECLICodec()
+    intent = codec.parse(_BASE.format(lease=lease_line))
+    rendered = codec.render(intent)
+    reparsed = codec.parse(rendered)
+    return intent, rendered, reparsed
+
+
+def test_multi_day_lease_with_minutes_roundtrips_without_truncation():
+    # 2 days 6 hours 30 minutes = 196200s.  The old render collapsed this
+    # to `lease 0 54` (194400s), silently losing 30 minutes.
+    intent, rendered, reparsed = _roundtrip("lease 2 6 30")
+    assert intent.dhcp_servers[0].lease_time == 196200
+    assert " lease 2 6 30" in rendered
+    assert "lease 0 " not in rendered  # the old truncated form is gone
+    assert reparsed.dhcp_servers[0].lease_time == 196200
+
+
+def test_sub_hour_lease_preserves_minutes():
+    # 30 minutes = 1800s.  The old render emitted `lease 0 0`, dropping it.
+    intent, rendered, reparsed = _roundtrip("lease 0 0 30")
+    assert intent.dhcp_servers[0].lease_time == 1800
+    assert " lease 0 0 30" in rendered
+    assert reparsed.dhcp_servers[0].lease_time == 1800
+
+
+def test_infinite_lease_roundtrips():
+    intent, rendered, reparsed = _roundtrip("lease infinite")
+    assert intent.dhcp_servers[0].lease_time == 0xFFFFFFFF
+    assert " lease infinite" in rendered
+    assert reparsed.dhcp_servers[0].lease_time == 0xFFFFFFFF
+
+
+def test_whole_hour_multi_day_lease_roundtrips():
+    # 7 days exactly = 604800s.  Even the old render happened to be
+    # value-lossless here (`lease 0 168`), but it lost the human-readable
+    # day field; the triple now preserves the operator's `lease 7 0 0`.
+    intent, rendered, reparsed = _roundtrip("lease 7 0 0")
+    assert intent.dhcp_servers[0].lease_time == 604800
+    assert " lease 7 0 0" in rendered
+    assert reparsed.dhcp_servers[0].lease_time == 604800

--- a/tests/unit/migration/test_synthetic_cisco_iosxe_cli_kitchen_sink.py
+++ b/tests/unit/migration/test_synthetic_cisco_iosxe_cli_kitchen_sink.py
@@ -316,11 +316,10 @@ class TestCanonicalCoverage:
 
     def test_dhcp_pool_lease_one_day(self, parsed_intent) -> None:
         # Second pool uses ``lease 1 0 0`` (one day) — exercises the
-        # multi-token Cisco lease form.  ``lease infinite`` is a real
-        # IOS-XE form but its render path collapses to ``lease 0
-        # <hours>`` which is lossy on round-trip; that bug is out of
-        # scope here, so we keep the kitchen-sink to forms the
-        # codec round-trips cleanly.
+        # multi-token Cisco lease form.  The full day/hour/minute
+        # triple and ``lease infinite`` now round-trip losslessly
+        # (ENG-03 render fix); their dedicated round-trip coverage
+        # lives in test_eng03_cisco_dhcp_lease.py.
         voice = parsed_intent.dhcp_servers[1]
         assert voice.lease_time == 86400
 


### PR DESCRIPTION
## What

Closes audit finding **ENG-03** (verified CONFIRMED).

The `cisco_iosxe_cli` DHCP pool render emitted `lease 0 <total_hours>`, which **truncated days into hours and dropped minutes**, and never emitted `lease infinite`:

| Source | Old render | Re-parsed | Lost |
|---|---|---|---|
| `lease 2 6 30` (196200s) | `lease 0 54` | 194400s | 30 min |
| `lease 0 0 30` (1800s) | `lease 0 0` | 0s | the whole lease |
| `lease infinite` | `lease 0 ...` | — | the infinite marker |

The parser already read the full `lease <days> <hours> <minutes>` + `infinite` grammar (`parse.py:1388-1403`), so render was the lossy side.

## Fix

Render now emits the matching day/hour/minute triple (and `infinite`), a direct port of the lossless `arista_eos/render.py` block. Multi-day and sub-hour leases round-trip exactly.

## Verification

- ✅ `ruff` clean
- ✅ New `test_eng03_cisco_dhcp_lease.py`: multi-day+minutes, sub-hour, infinite, whole-hour round-trips
- ✅ Full `tests/unit/migration` + `tests/integration` green
- ✅ Cross-mesh regen: **`CODEC_BUG` unchanged at 5**, `ALIGNED` unchanged at 1569
- ✅ Refreshed the kitchen-sink comment that previously described this as an out-of-scope bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)