### PR TITLE
fix(logging): make NETCANON_LOG_LEVEL effective on the server/Docker path (OBS-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **`NETCANON_LOG_LEVEL` now takes effect on the server/Docker path
+  (audit finding OBS-01).**  `main.py` called `configure_logging(
+  level="INFO")` with a hardcoded level at import time, so the stdlib
+  root logger ignored `Settings.log_level` — `NETCANON_LOG_LEVEL=debug`
+  silently dropped all `logger.debug(...)` output under the bare
+  `uvicorn netcanon.main:app` entry point (uvicorn configures only its
+  own `uvicorn.*` loggers, never the root).  The level now resolves from
+  `Settings().log_level`.  Also corrected the `logging_config` /
+  `config.py` docstrings that wrongly described the call as a uvicorn-CLI
+  no-op.
+
 * **Cisco IOS-XE DHCP pool lease-time now round-trips losslessly
   (audit finding ENG-03).**  `cisco_iosxe_cli` render emitted
   `lease 0 <total_hours>`, truncating days into hours and dropping

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -39,9 +39,11 @@ class Settings(BaseSettings):
             the per-user data root independently of ``configs_dir``.
         host: Bind address for the Uvicorn server.
         port: TCP port for the Uvicorn server.
-        log_level: Logging verbosity passed to Uvicorn and the standard-library
-            ``logging`` module.  One of ``debug``, ``info``, ``warning``,
-            ``error``, ``critical``.
+        log_level: Logging verbosity.  Sets the stdlib root logger level via
+            ``configure_logging`` (so application logs honour it on every
+            entry point, incl. the bare-uvicorn Docker path) and is passed
+            to Uvicorn on the desktop server path.  One of ``debug``,
+            ``info``, ``warning``, ``error``, ``critical``.
         open_in_editor: Enable the ``POST /api/v1/configs/{filename}/open``
             endpoint that opens a config file in the OS default text editor
             via ``os.startfile()``.  Disabled by default because it only

--- a/netcanon/logging_config.py
+++ b/netcanon/logging_config.py
@@ -18,9 +18,12 @@ Usage (desktop)::
     from pathlib import Path
     configure_logging(level="INFO", log_file=Path("/path/to/netcanon.log"))
 
-When running under the ``uvicorn`` CLI the CLI configures logging itself via
-``dictConfig``; in that case the root logger will already have handlers and
-this function is a no-op — the uvicorn log format is used as-is.
+Under the ``uvicorn`` CLI, uvicorn configures only its own ``uvicorn.*``
+loggers (its default ``LOGGING_CONFIG`` has no ``root`` entry), so the root
+logger is left to this function — it is NOT a no-op there and does set the
+application's root level.  It short-circuits only when *real* (non-pytest)
+root handlers already exist (a prior call, or a host that installed its own
+root config).
 
 Log format::
 

--- a/netcanon/main.py
+++ b/netcanon/main.py
@@ -46,13 +46,15 @@ from .config import Settings
 from .definitions.loader import DefinitionLoader
 
 # Configure application-level logging once, at module import time.  The
-# ``configure_logging`` helper (netcanon/logging_config.py) is idempotent
-# and a no-op under uvicorn's own log config / under pytest's harness, so
-# calling it here gives ``logger.info(...)`` output everywhere except
-# environments that have already installed a root-logger config.  This
-# replaces the prior state where our app-level INFO logs (most visibly
-# the migration pipeline's "Migration plan X: src -> tgt = status" line)
-# were silently dropped by the default WARNING threshold.
+# level comes from ``Settings().log_level`` (env ``NETCANON_LOG_LEVEL``,
+# default ``info``) so the operator's verbosity reaches the stdlib root
+# logger on every entry point — including the bare ``uvicorn
+# netcanon.main:app`` Docker path, where uvicorn configures only its own
+# ``uvicorn.*`` loggers and leaves the root logger to us (so this call is
+# NOT a no-op there).  ``configure_logging`` is idempotent and skips only
+# when real (non-pytest) root handlers already exist.  Previously the
+# level was hardcoded ``INFO`` and NETCANON_LOG_LEVEL was silently ignored
+# for application logs (audit finding OBS-01).
 from .logging_config import configure_logging
 from .storage.device_profile_store import FileDeviceProfileStore
 from .storage.file_store import FileConfigStore
@@ -60,7 +62,7 @@ from .storage.job_registry import BackupJobRegistry
 from .storage.job_store import FileJobStore
 from .storage.schedule_store import FileScheduleStore
 
-configure_logging(level="INFO")
+configure_logging(level=Settings().log_level)
 
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_obs01_log_level.py
+++ b/tests/unit/test_obs01_log_level.py
@@ -1,0 +1,73 @@
+"""OBS-01 regression: NETCANON_LOG_LEVEL must reach the stdlib root logger.
+
+``netcanon/main.py`` previously called ``configure_logging(level="INFO")``
+with a hardcoded level at import time, so ``Settings.log_level`` (env
+``NETCANON_LOG_LEVEL``) never reached the stdlib root logger on the
+server/Docker path — every ``logger.debug(...)`` site was silently dropped
+under the bare ``uvicorn netcanon.main:app`` entry point.  ``main`` now
+resolves ``Settings().log_level``.
+
+These tests exercise the fix's mechanism directly (env -> Settings ->
+configure_logging -> root level) rather than reloading ``netcanon.main``,
+which instantiates the app + scheduler at module level.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from netcanon.config import Settings
+from netcanon.logging_config import configure_logging
+
+pytestmark = pytest.mark.unit
+
+
+def _run_with_clean_root(fn):
+    """Run *fn* with the root logger's non-pytest handlers stripped so
+    ``configure_logging``'s idempotency guard lets it (re)configure, then
+    restore the original handlers + level."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    root.handlers[:] = [
+        h for h in saved_handlers if type(h).__module__.startswith("_pytest")
+    ]
+    try:
+        return fn(root)
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_settings_log_level_reads_env(monkeypatch):
+    monkeypatch.setenv("NETCANON_LOG_LEVEL", "debug")
+    assert Settings().log_level == "debug"
+
+
+def test_settings_log_level_defaults_to_info(monkeypatch):
+    monkeypatch.delenv("NETCANON_LOG_LEVEL", raising=False)
+    assert Settings().log_level == "info"
+
+
+def test_resolved_env_level_reaches_root_logger(monkeypatch):
+    # Mirrors exactly what netcanon.main does at import time:
+    #   configure_logging(level=Settings().log_level)
+    monkeypatch.setenv("NETCANON_LOG_LEVEL", "debug")
+
+    def check(root):
+        configure_logging(level=Settings().log_level)
+        assert root.level == logging.DEBUG
+
+    _run_with_clean_root(check)
+
+
+def test_default_resolves_to_info_root_level(monkeypatch):
+    monkeypatch.delenv("NETCANON_LOG_LEVEL", raising=False)
+
+    def check(root):
+        configure_logging(level=Settings().log_level)
+        assert root.level == logging.INFO
+
+    _run_with_clean_root(check)


### PR DESCRIPTION
## What

Closes audit finding **OBS-01** (verified CONFIRMED; severity recalibrated HIGH→MEDIUM).

`main.py` called `configure_logging(level="INFO")` with a **hardcoded** level at module import time, so `Settings.log_level` (env `NETCANON_LOG_LEVEL`) never reached the stdlib root logger on the bare `uvicorn netcanon.main:app` Docker entry point. uvicorn's default `LOGGING_CONFIG` has **no `root` entry** — it configures only its own `uvicorn.*` loggers and leaves the root logger to us — so `NETCANON_LOG_LEVEL=debug` silently dropped every application `logger.debug(...)` call (68 sites across collectors, the migration pipeline, credentials, codecs).

## Fix

Resolve the level from `Settings().log_level` (env + `.env`, default `info`) at import time:

```diff
-configure_logging(level="INFO")
+configure_logging(level=Settings().log_level)
```

Default behaviour is unchanged (`info`). Also corrected two docstrings (`logging_config` module + `config.py` `log_level`) that wrongly described the call as a no-op under the uvicorn CLI.

## Scope

Scoped to the **server/Docker path** (the reported bug). The desktop shell hardcodes `log_level="info"` in its own settings builder; making that env-configurable is a separate prefs-model change, deliberately out of scope here.

## Verification

- ✅ `ruff` clean
- ✅ New `test_obs01_log_level.py`: env→`Settings.log_level`→`configure_logging`→root level (debug + default-info), mirroring main's exact import-time call
- ✅ Full `tests/unit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)