### PR TITLE
fix(sanitize): strip Tier-3 raw_sections fail-closed (DATA-02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **The sanitiser now strips Tier-3 `raw_sections` (audit finding
+  DATA-02).**  `sanitize_intent` cleared `dropped_tier3_sections` but
+  left `raw_sections` (verbatim carry-through vendor text) untouched.
+  No production parser populates it today, but the IOS-XE renderer
+  emits any entries verbatim, so a future parser filling it could
+  round-trip unredacted secrets.  It is now stripped fail-closed
+  alongside `dropped_tier3_sections`, with a coverage-guard test.
+
 * **`NETCANON_LOG_LEVEL` now takes effect on the server/Docker path
   (audit finding OBS-01).**  `main.py` called `configure_logging(
   level="INFO")` with a hardcoded level at import time, so the stdlib

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -486,6 +486,21 @@ def sanitize_intent(
         ))
         sanitized.dropped_tier3_sections = []
 
+    # ---- Tier-3 raw_sections carry-through — strip entirely ----
+    # Defense-in-depth (audit finding DATA-02): no production parser
+    # populates raw_sections today, but the IOS-XE renderer emits any
+    # entries verbatim, so a future parser that fills it must not be
+    # able to round-trip unredacted vendor text through the sanitiser.
+    if sanitized.raw_sections:
+        n = len(sanitized.raw_sections)
+        subs.append(Substitution(
+            category="tier3-stripped",
+            field="raw_sections",
+            original=f"{n} entries",
+            redacted="(stripped)",
+        ))
+        sanitized.raw_sections = {}
+
     return sanitized, subs
 
 

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -976,3 +976,24 @@ class TestPiiTailRenderedOutputClean:
         rendered = get_codec("aruba_aoss").render(sanitized)
         assert "9.9.9.9" not in rendered            # SVI leak closed
         assert "admin@corp.example" not in rendered   # contact leak closed
+
+
+def test_raw_sections_stripped_by_sanitiser():
+    """DATA-02: Tier-3 ``raw_sections`` (verbatim vendor text) is cleared.
+
+    No production parser populates ``raw_sections`` today, but the IOS-XE
+    renderer emits any entries verbatim, so the sanitiser must fail closed
+    and strip it (mirrors the ``dropped_tier3_sections`` strip) — otherwise
+    a future parser that fills it could round-trip unredacted secrets.
+    """
+    intent = CanonicalIntent(
+        hostname="r1",
+        raw_sections={
+            "router bgp 65000": "neighbor 203.0.113.7 password SENTINEL-raw",
+        },
+    )
+    sanitized, subs = sanitize_intent(intent)
+    assert sanitized.raw_sections == {}
+    assert any(s.field == "raw_sections" for s in subs)
+    # The verbatim secret must not survive anywhere in the output.
+    assert "SENTINEL-raw" not in sanitized.model_dump_json()


### PR DESCRIPTION
## What

Closes audit finding **DATA-02** (verified PARTIALLY_CONFIRMED; defense-in-depth).

`sanitize_intent` stripped `dropped_tier3_sections` but left **`raw_sections`** (the other Tier-3 verbatim carry-through field) untouched. No production parser populates `raw_sections` today — only test fixtures — so this is **not an active leak**. But the IOS-XE renderer emits any `raw_sections` entries **verbatim**, so a future parser that starts populating it could silently round-trip unredacted vendor text (passwords, public IPs) straight through the sanitiser.

## Fix

Strip `raw_sections` fail-closed in `sanitize_intent`, mirroring the existing `dropped_tier3_sections` strip (records a `tier3-stripped` substitution, clears the dict). Adds a coverage-guard regression test asserting a populated `raw_sections` is cleared and its sentinel secret never survives into the sanitised output.

## Verification

- ✅ `ruff` clean
- ✅ `tests/unit/tools/test_sanitize.py` (incl. new guard) + `tests/integration -k sanitize` green
- ✅ Pure defense-in-depth; no behaviour change for any current code path (field is dormant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)