### PR TITLE
feat(security): opt-in API key + fail-closed non-loopback bind (SEC-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,9 @@ jobs:
 
       - name: Boot image and check /health + dashboard renders
         run: |
-          docker run -d --name smoke -p 8000:8000 netcanon-smoke:pr
+          # SEC-01: the smoke container binds 0.0.0.0 with no API key;
+          # opt out of the fail-closed bind guard for this throwaway run.
+          docker run -d --name smoke -e NETCANON_ALLOW_INSECURE_BIND=1 -p 8000:8000 netcanon-smoke:pr
           # Poll /health for up to 60 seconds.  HEALTHCHECK in the
           # Dockerfile has start-period 10s, so ~12s is the typical
           # ready time; budget extra for slow CI runners.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Added
+
+* **Opt-in API authentication + fail-closed bind (audit finding
+  SEC-01).**  Set `NETCANON_API_KEY=<token>` to require an
+  `Authorization: Bearer <token>` header on every `/api/v1` route;
+  unset (the default) keeps the zero-config loopback / desktop
+  experience unauthenticated.  A new `netcanon serve` command (now the
+  Docker `ENTRYPOINT`) refuses to start on a non-loopback bind (e.g.
+  `0.0.0.0`) unless a key is set or `NETCANON_ALLOW_INSECURE_BIND=1` is
+  passed, so accidental unauthenticated public exposure is a conscious
+  choice rather than the default.  **Breaking:** an existing
+  `docker run` (binds `0.0.0.0`) now needs one of those env vars — see
+  the README quickstart and SECURITY.md.
+
 ### Fixed
 
 * **The sanitiser now strips Tier-3 `raw_sections` (audit finding

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,10 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # Operator-overridable bind-mount targets.
 VOLUME ["/app/configs", "/app/data"]
 
-ENTRYPOINT ["uvicorn", "netcanon.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# SEC-01: `netcanon serve` reads host/port/auth from NETCANON_* env
+# (default 0.0.0.0:8000) and refuses an unauthenticated non-loopback
+# bind unless NETCANON_API_KEY or NETCANON_ALLOW_INSECURE_BIND is set.
+ENTRYPOINT ["netcanon", "serve"]
 
 # OCI labels for image discovery + supply-chain provenance.  Repository
 # label is what GHCR keys against for "View source" links on the package

--- a/README.md
+++ b/README.md
@@ -111,10 +111,16 @@ For the full audit narrative + the variance-class taxonomy, see
 # leak = decryptable stored credentials.
 NETCANON_FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
 
+# Required for a network-exposed (0.0.0.0) deployment: an API key gates
+# /api/v1.  Without it (or NETCANON_ALLOW_INSECURE_BIND=1) the container
+# refuses to start on a non-loopback bind (SEC-01 fail-closed).
+NETCANON_API_KEY=$(python -c "import secrets; print(secrets.token_urlsafe(32))")
+
 docker run --rm -p 8000:8000 \
     -v $(pwd)/configs:/app/configs \
     -v $(pwd)/data:/app/data \
     -e NETCANON_FERNET_KEY="$NETCANON_FERNET_KEY" \
+    -e NETCANON_API_KEY="$NETCANON_API_KEY" \
     ghcr.io/netcanon/netcanon:latest
 # -> http://127.0.0.1:8000        (UI)
 # -> http://127.0.0.1:8000/docs   (Swagger)
@@ -134,6 +140,15 @@ generates a key on first run inside `data/.fernet_key` so the
 container works zero-config; for the production deployment path see
 [`SECURITY.md`](SECURITY.md) "Credential Storage".
 
+`NETCANON_API_KEY` turns on a built-in bearer-token gate: when set,
+every `/api/v1` request must carry `Authorization: Bearer
+$NETCANON_API_KEY`.  `/health` and the HTML UI shell stay open, but the
+UI's data calls hit `/api/v1`, so an exposed UI should sit behind your
+reverse proxy's auth.  Because the image binds `0.0.0.0`, `netcanon
+serve` refuses to start without a key (or `NETCANON_ALLOW_INSECURE_BIND=1`),
+so an unauthenticated public bind is a deliberate choice — see
+[`SECURITY.md`](SECURITY.md) "Threat Model".
+
 The published image is signed via Sigstore (`cosign verify
 ghcr.io/netcanon/netcanon ...`) with an SBOM attestation.
 
@@ -141,7 +156,7 @@ ghcr.io/netcanon/netcanon ...`) with an SBOM attestation.
 Hub if your tooling defaults to `docker.io`:
 
 ```bash
-docker run --rm -p 8000:8000 netcanon/netcanon:latest
+docker run --rm -p 8000:8000 -e NETCANON_ALLOW_INSECURE_BIND=1 netcanon/netcanon:latest
 ```
 
 The Docker Hub mirror has the same image bytes but no cosign

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,13 @@ Netcanon ships in two deployment shapes:
    controls (nginx + auth_request, Caddy + basic-auth, Cloudflare
    Access, etc.) and restrict ingress at the network layer.
 
+   As an in-app backstop, set `NETCANON_API_KEY=<token>` to require an
+   `Authorization: Bearer <token>` header on every `/api/v1` route.
+   `netcanon serve` (the Docker entry point) refuses to start on a
+   non-loopback bind unless a key is set or
+   `NETCANON_ALLOW_INSECURE_BIND=1` is passed, so accidental
+   unauthenticated exposure is a conscious opt-out, not the default.
+
    For this shape you can also set `NETCANON_BLOCK_PRIVATE_EGRESS=true`
    (default `false`): the backup entry points then refuse any target
    that resolves to a loopback or link-local address — including the
@@ -527,7 +534,7 @@ regulated environments.
 
 | Item | Risk | Accepted? | Rationale |
 |------|------|-----------|-----------|
-| No API authentication | Any local process can call the API | Yes (desktop) / Operator responsibility (web/Docker) | Desktop assumes single-user local machine; web operators must add auth via reverse proxy |
+| No API authentication by default | Any reachable peer can call the API when exposed | Opt-in: set `NETCANON_API_KEY` to gate `/api/v1`; `netcanon serve` refuses a non-loopback bind without a key or `NETCANON_ALLOW_INSECURE_BIND=1` | Desktop binds loopback; web operators should set a key and/or front with a reverse proxy |
 | Credentials over localhost HTTP | Plaintext in transit on loopback | Yes | Loopback is not a network interface; TLS on localhost adds no practical security |
 | OS keyring unavailable (container / headless Linux) | Resolved via env-var tier (recommended) or file-fallback tier (auto-bootstrap) | No (resolved) | Three-tier key resolution — `NETCANON_FERNET_KEY` for production; `$NETCANON_DATA_DIR/.fernet_key` auto-bootstrap for zero-config containers.  See "Credential Storage" above |
 | Key loss (keyring entry deleted / env var unset on restart / `.fernet_key` deleted) | Encrypted profiles become unreadable | Accepted | User must re-enter credentials; profiles are low-volume.  Operators using tier 1 / tier 3 should back the key up alongside their other infrastructure secrets |

--- a/netcanon/api/auth.py
+++ b/netcanon/api/auth.py
@@ -1,0 +1,95 @@
+"""Optional API authentication + bind-safety guard (audit finding SEC-01).
+
+Netcanon ships with **no** authentication by default: the desktop shell
+binds ``127.0.0.1`` and web/Docker operators are told to front the app
+with a reverse proxy.  That posture is documented in ``SECURITY.md``, but
+the insecure ``0.0.0.0`` default makes accidental public exposure one
+``docker run -p`` away.  This module adds two opt-in, fail-closed controls:
+
+1. :func:`require_api_key` — when ``Settings.api_key`` (env
+   ``NETCANON_API_KEY``) is set, every ``/api/v1`` route requires a
+   matching ``Authorization: Bearer <key>`` header.  Empty key (the
+   default) makes the dependency a no-op, so the zero-config loopback /
+   desktop experience is unchanged.  Credentials stay write-only over the
+   API (``DeviceProfilePublic``); this is an orthogonal front door, not a
+   replacement for the reverse proxy.
+
+2. :func:`bind_refusal_reason` — used by ``netcanon serve`` to refuse to
+   start when binding a non-loopback interface with no API key and no
+   explicit ``NETCANON_ALLOW_INSECURE_BIND`` opt-out, so the insecure path
+   is a conscious choice rather than the default.
+"""
+
+from __future__ import annotations
+
+import hmac
+import ipaddress
+
+from fastapi import HTTPException, Request, status
+
+_LOOPBACK_NAMES = {"localhost"}
+
+
+def require_api_key(request: Request) -> None:
+    """FastAPI dependency: enforce the optional static bearer token.
+
+    No-op when no key is configured.  Uses a constant-time compare so the
+    response timing does not leak the key's length or prefix.
+    """
+    # Fail open when no settings/key is configured: auth is opt-in, and
+    # minimal app fixtures (e.g. the sanitize-only test app) may not attach
+    # ``state.settings`` at all — that means "no key", not a 500.
+    settings = getattr(request.app.state, "settings", None)
+    expected = (getattr(settings, "api_key", "") or "").strip()
+    if not expected:
+        return  # auth disabled — zero-config local UX preserved
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer" or not hmac.compare_digest(
+        token.strip(), expected
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid API key.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def is_loopback_host(host: str) -> bool:
+    """True if *host* binds only the loopback interface.
+
+    ``localhost`` and any loopback IP (``127.0.0.0/8``, ``::1``) are
+    loopback; ``0.0.0.0`` / ``::`` (all interfaces) and real hostnames are
+    not (a non-``localhost`` hostname can't be proven loopback, so it is
+    treated as exposed — the safe default).
+    """
+    h = host.strip().lower()
+    if h in _LOOPBACK_NAMES:
+        return True
+    try:
+        return ipaddress.ip_address(h).is_loopback
+    except ValueError:
+        return False
+
+
+def bind_refusal_reason(
+    host: str, api_key: str, allow_insecure_bind: bool
+) -> str | None:
+    """Return a refusal message if binding *host* is unsafe, else ``None``.
+
+    Unsafe = a non-loopback bind with no API key and no explicit opt-out.
+    """
+    if is_loopback_host(host):
+        return None
+    if (api_key or "").strip():
+        return None
+    if allow_insecure_bind:
+        return None
+    return (
+        f"Refusing to start: binding {host!r} exposes the API on a "
+        "non-loopback interface with no authentication. Set "
+        "NETCANON_API_KEY=<token> to require a bearer token on /api/v1, or "
+        "set NETCANON_ALLOW_INSECURE_BIND=1 to acknowledge an "
+        "unauthenticated bind (e.g. behind a reverse proxy that terminates "
+        "auth). See SECURITY.md."
+    )

--- a/netcanon/cli.py
+++ b/netcanon/cli.py
@@ -99,6 +99,17 @@ def main(argv: list[str] | None = None) -> int:
         help="List all available demo scenarios and exit",
     )
 
+    subparsers.add_parser(
+        "serve",
+        help="Run the Netcanon web server (host/port/auth from NETCANON_* env)",
+        description=(
+            "Start the FastAPI app via uvicorn, binding Settings.host:port "
+            "(NETCANON_HOST / NETCANON_PORT, default 0.0.0.0:8000).  Refuses "
+            "to start on a non-loopback bind unless NETCANON_API_KEY is set "
+            "or NETCANON_ALLOW_INSECURE_BIND=1 (SEC-01 fail-closed)."
+        ),
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "sanitize":
@@ -110,6 +121,8 @@ def main(argv: list[str] | None = None) -> int:
 
         demo_argv = ["--list"] if args.list else ["--pair", args.pair]
         return _demo_main(demo_argv)
+    if args.command == "serve":
+        return _cmd_serve(args)
     return 1
 
 
@@ -167,6 +180,37 @@ def _cmd_sanitize(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
+    return 0
+
+
+def _cmd_serve(args: argparse.Namespace) -> int:
+    """``netcanon serve`` — boot the web server with a fail-closed bind guard.
+
+    Refuses to start on a non-loopback bind with no API key and no
+    explicit opt-out (SEC-01), so accidental public exposure is a
+    conscious choice rather than the zero-config default.
+    """
+    from .api.auth import bind_refusal_reason
+    from .config import Settings
+
+    settings = Settings()
+    reason = bind_refusal_reason(
+        settings.host, settings.api_key, settings.allow_insecure_bind
+    )
+    if reason:
+        print(f"error: {reason}", file=sys.stderr)
+        return 2
+
+    # Lazy import — keeps `netcanon --help` / sanitize fast and avoids
+    # building the app on the refusal path.
+    import uvicorn
+
+    uvicorn.run(
+        "netcanon.main:app",
+        host=settings.host,
+        port=settings.port,
+        log_level=settings.log_level,
+    )
     return 0
 
 

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -108,6 +108,15 @@ class Settings(BaseSettings):
     max_memory_jobs: int = Field(default=1000, ge=0)
     block_private_egress: bool = False
     ssh_host_key_checking: Literal["auto_add", "tofu", "reject"] = "auto_add"
+    # ── SEC-01 — opt-in API auth + bind safety ──
+    # When set, every /api/v1 route requires `Authorization: Bearer
+    # <api_key>`.  Empty (default) disables auth — the zero-config
+    # loopback / desktop posture is unchanged.
+    api_key: str = ""
+    # `netcanon serve` refuses to bind a non-loopback host with no
+    # api_key unless this opt-out is set (acknowledging that a reverse
+    # proxy terminates auth).  See netcanon/api/auth.py.
+    allow_insecure_bind: bool = False
 
     model_config = SettingsConfigDict(
         env_prefix="NETCANON_",

--- a/netcanon/main.py
+++ b/netcanon/main.py
@@ -28,10 +28,11 @@ from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 
 # Side-effect import — registers all built-in migration adapters.
 from . import migration as _migration_pkg  # noqa: F401
+from .api.auth import require_api_key
 from .api.routes import backups as backups_router
 from .api.routes import configs as configs_router
 from .api.routes import definitions as defs_router
@@ -297,13 +298,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Routers
     # ------------------------------------------------------------------
     app.include_router(health_router.router)  # /health (no prefix; conventional probe path)
-    app.include_router(defs_router.router, prefix="/api/v1")
-    app.include_router(configs_router.router, prefix="/api/v1")
-    app.include_router(backups_router.router, prefix="/api/v1")
-    app.include_router(schedules_router.router, prefix="/api/v1")
-    app.include_router(device_profiles_router.router, prefix="/api/v1")
-    app.include_router(migration_router.router, prefix="/api/v1")
-    app.include_router(sanitize_router.router, prefix="/api/v1")
+    # SEC-01: opt-in bearer-token gate on the whole /api/v1 surface.
+    # No-op when NETCANON_API_KEY is unset (zero-config local UX).
+    _api_v1_auth = [Depends(require_api_key)]
+    app.include_router(defs_router.router, prefix="/api/v1", dependencies=_api_v1_auth)
+    app.include_router(configs_router.router, prefix="/api/v1", dependencies=_api_v1_auth)
+    app.include_router(backups_router.router, prefix="/api/v1", dependencies=_api_v1_auth)
+    app.include_router(schedules_router.router, prefix="/api/v1", dependencies=_api_v1_auth)
+    app.include_router(device_profiles_router.router, prefix="/api/v1", dependencies=_api_v1_auth)
+    app.include_router(migration_router.router, prefix="/api/v1", dependencies=_api_v1_auth)
+    app.include_router(sanitize_router.router, prefix="/api/v1", dependencies=_api_v1_auth)
     app.include_router(docs_router.router)  # custom Swagger UI at /docs (no prefix)
     app.include_router(ui_router.router)  # UI routes at root (/, /jobs, …)
 

--- a/tests/integration/test_sec01_api_auth.py
+++ b/tests/integration/test_sec01_api_auth.py
@@ -1,0 +1,44 @@
+"""SEC-01 integration: the API-key gate is actually wired onto /api/v1.
+
+The unit tests prove ``require_api_key`` works in isolation; this proves
+the dependency is mounted on the real router set (a forgotten
+``dependencies=`` on any include_router would slip past the unit test).
+``/health`` and the browser UI stay open; only ``/api/v1`` is gated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_api_v1_open_when_no_key(client):
+    # Default fixture has no api_key → /api/v1 is unauthenticated.
+    assert client.get("/api/v1/definitions").status_code == 200
+
+
+def test_api_v1_gated_when_api_key_set(client):
+    client.app.state.settings.api_key = "s3cret"
+
+    # Unauthenticated request to a real /api/v1 route → 401.
+    unauth = client.get("/api/v1/definitions")
+    assert unauth.status_code == 401
+    assert unauth.headers.get("www-authenticate") == "Bearer"
+
+    # Correct bearer token → not blocked by auth.
+    ok = client.get(
+        "/api/v1/definitions", headers={"Authorization": "Bearer s3cret"}
+    )
+    assert ok.status_code == 200
+
+    # Wrong token → 401.
+    assert (
+        client.get(
+            "/api/v1/definitions", headers={"Authorization": "Bearer nope"}
+        ).status_code
+        == 401
+    )
+
+    # /health is a conventional probe path and stays open even with a key.
+    assert client.get("/health").status_code == 200

--- a/tests/unit/test_sec01_auth_bind.py
+++ b/tests/unit/test_sec01_auth_bind.py
@@ -1,0 +1,128 @@
+"""SEC-01: opt-in API-key gate + fail-closed non-loopback bind.
+
+Two opt-in, fail-closed controls (audit finding SEC-01):
+
+* ``require_api_key`` — when ``NETCANON_API_KEY`` is set, ``/api/v1``
+  requires a matching ``Authorization: Bearer`` header; unset = no-op.
+* ``bind_refusal_reason`` — ``netcanon serve`` refuses a non-loopback
+  bind with no key and no explicit ``NETCANON_ALLOW_INSECURE_BIND`` opt-out.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from netcanon.api.auth import (
+    bind_refusal_reason,
+    is_loopback_host,
+    require_api_key,
+)
+from netcanon.cli import main as cli_main
+from netcanon.config import Settings
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# require_api_key dependency (tested in isolation on a minimal app)
+# ---------------------------------------------------------------------------
+
+
+def _client(api_key: str) -> TestClient:
+    app = FastAPI()
+
+    class _Settings:
+        pass
+
+    s = _Settings()
+    s.api_key = api_key
+    app.state.settings = s
+
+    @app.get("/x", dependencies=[Depends(require_api_key)])
+    def _x():
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_no_key_configured_allows_unauthenticated():
+    assert _client("").get("/x").status_code == 200
+
+
+def test_key_configured_rejects_missing_header():
+    r = _client("s3cret").get("/x")
+    assert r.status_code == 401
+    assert r.headers["www-authenticate"] == "Bearer"
+
+
+def test_key_configured_accepts_valid_bearer():
+    r = _client("s3cret").get("/x", headers={"Authorization": "Bearer s3cret"})
+    assert r.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["Bearer wrong", "s3cret", "Basic s3cret", "Bearer "],
+)
+def test_key_configured_rejects_bad_credentials(header):
+    assert _client("s3cret").get("/x", headers={"Authorization": header}).status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# bind-safety guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.0.0.5", "localhost", "::1"])
+def test_loopback_hosts_recognised(host):
+    assert is_loopback_host(host)
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "10.0.0.5", "example.com"])
+def test_non_loopback_hosts_recognised(host):
+    assert not is_loopback_host(host)
+
+
+def test_loopback_bind_never_refused():
+    assert bind_refusal_reason("127.0.0.1", "", False) is None
+
+
+def test_nonloopback_bind_no_key_refuses():
+    reason = bind_refusal_reason("0.0.0.0", "", False)
+    assert reason is not None and "NETCANON_API_KEY" in reason
+
+
+def test_nonloopback_bind_with_key_allowed():
+    assert bind_refusal_reason("0.0.0.0", "s3cret", False) is None
+
+
+def test_nonloopback_bind_with_optout_allowed():
+    assert bind_refusal_reason("0.0.0.0", "", True) is None
+
+
+# ---------------------------------------------------------------------------
+# Settings env wiring + `netcanon serve` refusal
+# ---------------------------------------------------------------------------
+
+
+def test_settings_reads_api_key_env(monkeypatch):
+    monkeypatch.setenv("NETCANON_API_KEY", "k")
+    assert Settings().api_key == "k"
+
+
+def test_settings_reads_allow_insecure_bind_env(monkeypatch):
+    monkeypatch.setenv("NETCANON_ALLOW_INSECURE_BIND", "1")
+    assert Settings().allow_insecure_bind is True
+
+
+def test_serve_refuses_insecure_bind(monkeypatch, capsys):
+    # 0.0.0.0 + no key + no opt-out → refuse to start (exit 2), without
+    # importing uvicorn or building the app.
+    monkeypatch.setenv("NETCANON_HOST", "0.0.0.0")
+    monkeypatch.delenv("NETCANON_API_KEY", raising=False)
+    monkeypatch.delenv("NETCANON_ALLOW_INSECURE_BIND", raising=False)
+    rc = cli_main(["serve"])
+    assert rc == 2
+    assert "Refusing to start" in capsys.readouterr().err


### PR DESCRIPTION
## What

Closes audit finding **SEC-01** (the #1 ship-blocker; verified DESIGN_DECISION — the no-auth posture is documented, so this hardens the *insecure default*, the one actionable piece).

Two opt-in, **fail-closed** controls so accidental public exposure is a conscious choice, not the zero-config default:

### 1. Optional API-key gate (`require_api_key`)
- Set `NETCANON_API_KEY=<token>` → every `/api/v1` route requires `Authorization: Bearer <token>` (constant-time compare).
- Unset (default) → **no-op**, preserving the zero-config loopback/desktop UX. Fails open when no settings are attached (minimal app fixtures).
- `/health` and the HTML UI shell stay open; credentials remain write-only (`DeviceProfilePublic` untouched).

### 2. Fail-closed bind (`netcanon serve`)
- New `netcanon serve` command — **now the Docker `ENTRYPOINT`** — refuses to start on a non-loopback bind (e.g. `0.0.0.0`) with no key, unless `NETCANON_ALLOW_INSECURE_BIND=1`.
- The check lives at the real bind point, **not in `create_app`**, so it never affects `TestClient`/`create_app` (the whole test suite) or the desktop (binds `127.0.0.1`).

## ⚠️ Breaking change

An existing `docker run` (binds `0.0.0.0`) now requires `NETCANON_API_KEY` **or** `NETCANON_ALLOW_INSECURE_BIND=1`. The CI Docker smoke test sets the opt-out; README + SECURITY.md document the API key as the recommended posture.

## Verification

- ✅ `ruff` clean (incl. isort)
- ✅ Unit: dependency in isolation (401/200/bad-creds), `is_loopback_host` / `bind_refusal_reason`, `netcanon serve` refusal (exit 2, no server start), `Settings` env wiring
- ✅ Integration: gate is **wired onto the real `/api/v1` routers** (401 unauthenticated, 200 with bearer, `/health` open) — and no-key is a no-op across the existing suite
- ✅ Full `tests/unit` + `tests/integration` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)