### PR TITLE
chore(release): cut v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-06-19
+
 ### Added
 
 * **Contribution hygiene (audit finding LIC-01).**  Added a Developer


### PR DESCRIPTION
Cuts **v0.3.3**, bundling all post-`v0.3.2` work — the 2026-06 blind-audit remediation (8 PRs, #123–#129). Moves the accumulated `[Unreleased]` entries under `## [0.3.3] - 2026-06-19` and keeps an empty `[Unreleased]` anchor.

### What's in 0.3.3
- **ENG-01** — switch→L3-target migrations now surface dropped L2 switchport membership (block finding) instead of a green banner.
- **ENG-03** — Cisco IOS-XE DHCP pool lease-time round-trips losslessly (`lease d h m` + `infinite`).
- **OBS-01** — `NETCANON_LOG_LEVEL` now takes effect on the server/Docker path.
- **DATA-02** — sanitiser strips Tier-3 `raw_sections` fail-closed.
- **SEC-01** — opt-in `NETCANON_API_KEY` bearer gate on `/api/v1` + new `netcanon serve` that refuses an unauthenticated non-loopback bind. **⚠ Behavior change:** the default Docker entrypoint now refuses `0.0.0.0` without `NETCANON_API_KEY` or `NETCANON_ALLOW_INSECURE_BIND=1` — documented in the changelog entry and README/SECURITY.md.
- **DOC-01 / CI-02 / CI-04 + LIC-01** — documentation honesty fixes + contribution hygiene (DCO, `TRADEMARKS.md`, fixture-copyright note).
- **SUP-01** — Docker base image digest-pinned.
- **MKT-01** — README now leads with a migrate-page screenshot.

### Release mechanics
- No version file — `setuptools_scm` derives the version from the annotated git tag.
- Changelog/version guard (`tests/unit/test_changelog.py`) is green for the new `## [0.3.3]` header.
- After this merges, the **annotated tag `v0.3.3` push triggers publish** (PyPI + Docker + MSI) — done only on explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)