### PR TITLE
chore(release): cut v0.4.0 + loud fail-closed-bind callout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
-## [0.3.3] - 2026-06-19
+## [0.4.0] - 2026-06-19
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ For the full audit narrative + the variance-class taxonomy, see
 
 ### Docker (recommended)
 
+> [!IMPORTANT]
+> **As of 0.4.0 the container fails closed on a public bind.** The
+> default entrypoint (`netcanon serve`) binds `0.0.0.0`, so it now
+> **refuses to start** unless you either set an API key
+> (`-e NETCANON_API_KEY=...`, which gates `/api/v1`) **or** explicitly
+> opt out with `-e NETCANON_ALLOW_INSECURE_BIND=1`. This is deliberate
+> — it stops an accidental `docker run -p` from exposing an
+> unauthenticated API to your network. Just kicking the tyres? Add
+> `-e NETCANON_ALLOW_INSECURE_BIND=1`; for anything reachable by other
+> hosts, set `NETCANON_API_KEY` (the full command below does). A pure
+> loopback bind (`-e NETCANON_HOST=127.0.0.1`) needs neither.
+
 ```bash
 # Optional but recommended for production: setting the key explicitly keeps
 # it in your secret store, separate from the data volume.  Skip this line


### PR DESCRIPTION
Cuts **v0.4.0** (bumped up from the originally-planned 0.3.3) for all post-`v0.3.2` work — the 2026-06 blind-audit remediation (8 PRs, #123–#129).

### Why a minor bump (0.4.0), not a patch
**SEC-01 changes default Docker behavior.** The container entrypoint (`netcanon serve`) binds `0.0.0.0` and now **refuses to start** without `NETCANON_API_KEY` or `NETCANON_ALLOW_INSECURE_BIND=1`. A `:latest` operator who previously ran `docker run -p 8000:8000 …` with no env would see the container refuse to start (fail-closed, by design). A patch version understates that; a minor bump signals it.

### Loud setup-docs callout
Added a `> [!IMPORTANT]` block at the **top of the README "Docker (recommended)" section** — the first thing a new operator reads before the run command — spelling out the three paths:
- set `NETCANON_API_KEY` (gates `/api/v1`),
- opt out with `NETCANON_ALLOW_INSECURE_BIND=1` (for tyre-kicking / reverse-proxy fronted),
- or bind loopback only (`NETCANON_HOST=127.0.0.1`).

### Contents of 0.4.0
ENG-01, ENG-03, OBS-01, DATA-02, SEC-01, DOC-01/CI-02/CI-04+LIC-01, SUP-01, MKT-01 — see the `## [0.4.0]` CHANGELOG section.

### Release mechanics
- No version file — `setuptools_scm` derives the version from the annotated git tag.
- Changelog/version guard (`tests/unit/test_changelog.py`) green for the `## [0.4.0]` header (unique + descending vs 0.3.2 + dated).
- After merge, the annotated tag `v0.4.0` push triggers publish (PyPI + Docker + MSI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)