### PR TITLE
fix(sanitize): strip Junos apply-group bodies + redact more free-text PII (self-audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Security
+
+* **Sanitiser strips Junos apply-group bodies + redacts more free-text
+  PII (v0.4.0 self-audit).**  A `$6$` hash, SNMP community, or username
+  placed INSIDE a Junos `apply-group` was carried verbatim in
+  `group_content` and re-emitted by the renderer, bypassing every
+  field-typed redaction in the bug-report sanitiser (the flattened
+  top-level copies were redacted, but the group-sourced `set groups
+  <G> ...` lines were not).  `group_content` + `apply_groups` are now
+  stripped fail-closed alongside `raw_sections`/`dropped_tier3_sections`.
+  Also redacted the modelled free-text fields the walk previously
+  skipped -- VLAN name/description, static-route / routing-instance /
+  VRRP description, and DHCP domain-name (operator/org PII); VLAN-name
+  redaction is cross-reference-stable so `vlan members <name>` stays
+  consistent.  Found by the post-release adversarial self-audit; the
+  earlier DATA-02 fix had covered only `raw_sections`.
+
 ## [0.4.0] - 2026-06-19
 
 ### Added

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -269,6 +269,14 @@ def sanitize_intent(
                     redacted=new_auth,
                 ))
                 group.authentication = new_auth
+            if group.description:
+                subs.append(Substitution(
+                    category="vrrp-description",
+                    field=f"interfaces[{i}].vrrp_groups[{k}].description",
+                    original=group.description,
+                    redacted="description redacted",
+                ))
+                group.description = "description redacted"
 
     # ---- VLAN SVI IPv4 addresses ----
     # R-16 / CF-04: SVI L3 addressing lives on ``CanonicalVlan.
@@ -282,6 +290,29 @@ def sanitize_intent(
     # so a copy that mirrors an interface address resolves to the SAME
     # docs-range substitute (cross-reference stable).
     for i, vlan in enumerate(sanitized.vlans):
+        # R-16 / CF-04 follow-up (v0.4.0 self-audit): VLAN name +
+        # description are operator free text (``CEO-OFFICE``,
+        # ``Jane-Desk x4012``).  Name is redacted via a stable table so
+        # every ``vlan members <name>`` cross-reference stays consistent;
+        # description → opaque placeholder.
+        if vlan.name:
+            new_name = table.redact_vlan_name(vlan.name)
+            subs.append(Substitution(
+                category="vlan-name",
+                field=f"vlans[{i}].name",
+                original=vlan.name,
+                redacted=new_name,
+            ))
+            vlan.name = new_name
+        if vlan.description:
+            subs.append(Substitution(
+                category="vlan-description",
+                field=f"vlans[{i}].description",
+                original=vlan.description,
+                redacted="description redacted",
+            ))
+            vlan.description = "description redacted"
+
         for j, addr in enumerate(vlan.ipv4_addresses):
             new_ip = table.redact_ipv4(addr.ip)
             if new_ip != addr.ip:
@@ -462,7 +493,21 @@ def sanitize_intent(
                 ))
                 pool.gateway = new_gw
 
-    # ---- static-route gateways ----
+        # v0.4.0 self-audit: the DHCP domain-name is an internal DNS
+        # suffix (``corp.acme.example``) — operator/org-identifying PII.
+        # Reuse the domain table so it matches the top-level domain
+        # redaction style (and stays stable if the same suffix recurs).
+        if pool.domain_name:
+            new_domain = table.redact_domain(pool.domain_name)
+            subs.append(Substitution(
+                category="domain",
+                field=f"dhcp_servers[{i}].domain_name",
+                original=pool.domain_name,
+                redacted=new_domain,
+            ))
+            pool.domain_name = new_domain
+
+    # ---- static-route gateways + descriptions ----
     for i, route in enumerate(sanitized.static_routes):
         if route.gateway:
             new_gw = table.redact_ip_string(route.gateway)
@@ -474,6 +519,14 @@ def sanitize_intent(
                     redacted=new_gw,
                 ))
                 route.gateway = new_gw
+        if route.description:
+            subs.append(Substitution(
+                category="static-route-description",
+                field=f"static_routes[{i}].description",
+                original=route.description,
+                redacted="description redacted",
+            ))
+            route.description = "description redacted"
 
     # ---- Tier-3 carry-through — strip entirely ----
     if sanitized.dropped_tier3_sections:
@@ -500,6 +553,44 @@ def sanitize_intent(
             redacted="(stripped)",
         ))
         sanitized.raw_sections = {}
+
+    # ---- routing-instance descriptions ----
+    for i, ri in enumerate(sanitized.routing_instances):
+        if ri.description:
+            subs.append(Substitution(
+                category="routing-instance-description",
+                field=f"routing_instances[{i}].description",
+                original=ri.description,
+                redacted="description redacted",
+            ))
+            ri.description = "description redacted"
+
+    # ---- Junos apply-groups verbatim carry-through — strip entirely ----
+    # v0.4.0 self-audit (HIGH): ``group_content`` holds the verbatim
+    # token tails of every applied ``set groups <G> ...`` line, and the
+    # Junos renderer re-emits them byte-for-byte — so a password hash,
+    # SNMP community, or username placed INSIDE an apply-group bypasses
+    # every field-typed redaction above and round-trips unredacted.  The
+    # flattened canonical surfaces (local_users, snmp.community, ...) are
+    # already redacted, so dropping the verbatim group bodies loses no
+    # *modelled* intent; strip fail-closed like raw_sections rather than
+    # re-parsing arbitrary group bodies (same defense-in-depth posture).
+    if sanitized.group_content:
+        subs.append(Substitution(
+            category="apply-groups-stripped",
+            field="group_content",
+            original=f"{len(sanitized.group_content)} group(s)",
+            redacted="(stripped)",
+        ))
+        sanitized.group_content = {}
+    if sanitized.apply_groups:
+        subs.append(Substitution(
+            category="apply-groups-stripped",
+            field="apply_groups",
+            original=f"{len(sanitized.apply_groups)} reference(s)",
+            redacted="(stripped)",
+        ))
+        sanitized.apply_groups = []
 
     return sanitized, subs
 
@@ -536,6 +627,7 @@ class _SubstitutionTable:
         # user definition AND the AAA reference.
         self._local_user_names: dict[str, str] = {}
         self._snmpv3_user_names: dict[str, str] = {}
+        self._vlan_names: dict[str, str] = {}
 
     def redact_hostname(self, name: str) -> str:
         if name not in self._hostnames:
@@ -620,6 +712,20 @@ class _SubstitutionTable:
         scheme, sep, _secret = value.partition(":")
         placeholder = self.redact_secret("VRRP-AUTH")
         return f"{scheme}{sep}{placeholder}" if sep else placeholder
+
+    def redact_vlan_name(self, name: str) -> str:
+        """Cross-reference-stable VLAN-name redaction.
+
+        VLAN membership is modelled by numeric ID (``access_vlan`` /
+        ``trunk_allowed_vlans`` are ints), so the human VLAN *name* is a
+        display label the renderer resolves from this VLAN object —
+        redacting it here flows consistently to every ``set vlans
+        <name> ...`` / ``vlan members <name>`` reference.  A VLAN name
+        like ``CEO-OFFICE`` or ``Jane-Desk`` is operator PII.
+        """
+        if name not in self._vlan_names:
+            self._vlan_names[name] = f"vlan-{len(self._vlan_names) + 1}"
+        return self._vlan_names[name]
 
     def redact_local_user_name(self, name: str) -> str:
         """Cross-reference-stable local-user-name redaction.

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -34,6 +34,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalIPv4Address,
     CanonicalLocalUser,
     CanonicalRADIUSServer,
+    CanonicalRoutingInstance,
     CanonicalSNMP,
     CanonicalSNMPv3User,
     CanonicalStaticRoute,
@@ -997,3 +998,98 @@ def test_raw_sections_stripped_by_sanitiser():
     assert any(s.field == "raw_sections" for s in subs)
     # The verbatim secret must not survive anywhere in the output.
     assert "SENTINEL-raw" not in sanitized.model_dump_json()
+
+
+# ---------------------------------------------------------------------------
+# v0.4.0 self-audit — verbatim apply-group carry-through + free-text PII
+# ---------------------------------------------------------------------------
+
+
+class TestJunosApplyGroupsStripped:
+    """v0.4.0 self-audit (HIGH): secrets inside a Junos ``apply-group``
+    are carried verbatim in ``group_content`` and re-emitted by the
+    renderer, bypassing every field-typed redaction.  They must be
+    stripped fail-closed (like ``raw_sections``)."""
+
+    def test_group_content_and_apply_groups_emptied(self):
+        intent = CanonicalIntent(
+            hostname="r1",
+            group_content={
+                "GLOBAL": [
+                    ["system", "login", "user", "backdoor",
+                     "authentication", "encrypted-password",
+                     "$6$RealSalt$RealHashSENTINEL"],
+                    ["snmp", "community", "SuperSecretSENTINEL",
+                     "authorization", "read-only"],
+                ]
+            },
+            apply_groups=["GLOBAL"],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        assert sanitized.group_content == {}
+        assert sanitized.apply_groups == []
+        assert {s.field for s in subs} >= {"group_content", "apply_groups"}
+        assert "SENTINEL" not in sanitized.model_dump_json()
+
+    def test_end_to_end_junos_apply_group_secret_not_rendered(self):
+        raw = (
+            "set system host-name real-edge-rtr\n"
+            "set groups GLOBAL system login user backdoor authentication "
+            'encrypted-password "$6$RealSaltHere$RealHashSecretXYZ"\n'
+            "set groups GLOBAL snmp community SuperSecretCommunity "
+            "authorization read-only\n"
+            "set apply-groups GLOBAL\n"
+        )
+        out = sanitize_text(raw, "juniper_junos").sanitized_text
+        assert "$6$RealSaltHere$RealHashSecretXYZ" not in out
+        assert "SuperSecretCommunity" not in out
+        assert "backdoor" not in out
+
+
+class TestFreeTextPiiRedaction:
+    """v0.4.0 self-audit: free-text fields besides interface.description
+    (VLAN name/description, static-route / routing-instance / VRRP
+    description, DHCP domain-name) are operator/org PII and must not
+    survive sanitisation."""
+
+    def test_modelled_free_text_fields_redacted(self):
+        intent = CanonicalIntent(
+            vlans=[CanonicalVlan(
+                id=10, name="CEO-OFFICE", description="Jane Doe x4012")],
+            static_routes=[CanonicalStaticRoute(
+                destination="0.0.0.0/0", gateway="10.0.0.1",
+                description="to-DC-NYC-rack42")],
+            routing_instances=[CanonicalRoutingInstance(
+                name="MGMT", description="customer ACME tenant")],
+            dhcp_servers=[CanonicalDHCPPool(
+                network="10.0.0.0/24",
+                domain_name="internal.acmecorp.example")],
+            interfaces=[CanonicalInterface(
+                name="ge-0/0/0", default_name="ge-0/0/0",
+                vrrp_groups=[CanonicalVRRPGroup(
+                    group_id=1, description="HQ gateway - John")])],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        blob = sanitized.model_dump_json()
+        for leaked in (
+            "CEO-OFFICE", "Jane Doe x4012", "to-DC-NYC-rack42",
+            "customer ACME tenant", "internal.acmecorp.example",
+            "HQ gateway - John",
+        ):
+            assert leaked not in blob, f"PII survived: {leaked!r}"
+
+    def test_vlan_name_redaction_is_cross_reference_stable(self):
+        """Same VLAN name → same placeholder, so ``vlan members <name>``
+        cross-references stay consistent in the rendered output."""
+        intent = CanonicalIntent(
+            vlans=[
+                CanonicalVlan(id=10, name="SECRET-VLAN"),
+                CanonicalVlan(id=20, name="SECRET-VLAN"),
+                CanonicalVlan(id=30, name="OTHER"),
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        names = [v.name for v in sanitized.vlans]
+        assert "SECRET-VLAN" not in names and "OTHER" not in names
+        assert names[0] == names[1]      # same source name → same redaction
+        assert names[0] != names[2]      # distinct names stay distinct


### PR DESCRIPTION
A **post-release adversarial self-audit** of v0.4.0 (6 hostile auditors → independent skeptics refuting each finding) surfaced two real leaks in the bug-report **redaction tool** that the earlier DATA-02 fix did not cover. Both reproduced 2/2.

## 🔴 HIGH — Junos apply-group bodies bypass the sanitiser
A `$6$` password hash, SNMP community, or username placed **inside a Junos `apply-group`** is stored verbatim in `CanonicalIntent.group_content` and re-emitted byte-for-byte by the Junos renderer. The *flattened* top-level copies (`local_users[].hashed_password`, `snmp.community`) **are** redacted — but the renderer suppresses those for group-sourced data and emits the unredacted `set groups <G> …` lines instead, so secrets round-tripped through `sanitize_text` / the `/sanitize` page.

Repro (before): `sanitize_text(<config with secrets in 'set groups GLOBAL …'>, 'juniper_junos')` → the real hash, community, and username all survive verbatim.

**Fix:** `group_content` + `apply_groups` are stripped fail-closed alongside `raw_sections` / `dropped_tier3_sections` (same defense-in-depth posture). The modelled intent already survives in redacted form via the flattened fields, so nothing modelled is lost.

## 🟡 MEDIUM — more free-text PII now redacted
`sanitize_intent` redacted `interface.description` but skipped sibling free-text the walk reached: **VLAN name/description, static-route / routing-instance / VRRP description, DHCP domain-name** (operator/org PII — names, rack/site IDs, tenant names, internal DNS suffixes). Now redacted. VLAN-name redaction is **cross-reference-stable** (membership is by numeric ID; the name is a display label the renderer resolves from the VLAN object), so `vlan members <name>` stays consistent in the sanitised output.

## Tests
- End-to-end Junos apply-group leak repro (the secret must not appear in `sanitized_text`).
- Free-text PII coverage across all 6 fields + VLAN-name cross-reference stability.
- Existing sanitize unit suite (61 tests) + sanitize integration tests green; no codec behavior changed.

Part of holding-for-v0.4.1: this lands on `main` now; the patch tag waits until the broader adversarial re-run reports so one release bundles everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)