### PR TITLE
fix: self-audit honesty/robustness follow-ups (matrix, render, config, docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,45 @@ timestamp if your timezone matters for an audit.
   consistent.  Found by the post-release adversarial self-audit; the
   earlier DATA-02 fix had covered only `raw_sections`.
 
+### Fixed
+
+* **`cisco_iosxe` (NETCONF stub) now declares the switchport surface
+  unsupported (v0.4.0 self-audit, ENG-01 completion).**  The
+  OpenConfig/NETCONF stub renders only name/enabled/type per interface
+  and drops every per-port VLAN-membership attribute, but left the 5
+  switchport xpaths undeclared -- so `classify` defaulted them to
+  `supported` and a switch->iosxe migration reported `severity: ok`
+  while the membership was silently discarded.  It now declares them
+  unsupported like its 5 sibling L3-style targets.  Cross-mesh
+  `CODEC_BUG` unchanged at 5.
+
+* **Sub-minute DHCP lease no longer renders the invalid, unstable
+  `lease 0 0 0` (v0.4.0 self-audit).**  A lease of 0 < t < 60 s floored
+  all of days/hours/minutes to 0 in `cisco_iosxe_cli` (and `arista_eos`)
+  render, emitting a wire-invalid `lease 0 0 0` that reparsed to 0 and
+  then drifted to the 86400 default on the next render -- contradicting
+  the ENG-03 lossless claim.  Sub-minute leases now floor to 1 minute
+  (IOS-XE/EOS finest granularity), so the output is valid and stable
+  across re-renders.
+
+* **An invalid `NETCANON_LOG_LEVEL` no longer crashes startup
+  (v0.4.0 self-audit).**  `configure_logging` runs at import time,
+  outside the graceful-startup handler, so a mistyped level
+  (`verbose`, a stray-whitespace `"DEBUG "`, an empty value) raised an
+  unhandled `ValueError` and took down every entry path (bare uvicorn,
+  `netcanon serve`, desktop) with a raw traceback.  `Settings.log_level`
+  is now a validated `Literal` with a normalising validator that lowers
+  case/strips whitespace and degrades an unknown value to `info` with a
+  warning -- so a clean value always reaches both `logging.setLevel` and
+  `uvicorn.run`.
+
+* **Doc accuracy: the API-key gate covers `/api/v1` data/operation
+  routes, not the OpenAPI schema (v0.4.0 self-audit).**  Softened the
+  "every /api/v1 route" wording in `auth.py` + `SECURITY.md`:
+  `/api/v1/openapi.json` stays open so the intentionally-unauthenticated
+  `/docs` page can render it (it carries only route metadata -- no
+  config contents or credentials).  No behavioural change.
+
 ## [0.4.0] - 2026-06-19
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,10 @@ Netcanon ships in two deployment shapes:
    Access, etc.) and restrict ingress at the network layer.
 
    As an in-app backstop, set `NETCANON_API_KEY=<token>` to require an
-   `Authorization: Bearer <token>` header on every `/api/v1` route.
+   `Authorization: Bearer <token>` header on every `/api/v1`
+   data/operation route.  (The `/api/v1/openapi.json` schema stays open
+   so the intentionally-unauthenticated `/docs` page can render it; it
+   exposes only route metadata — no config contents or credentials.)
    `netcanon serve` (the Docker entry point) refuses to start on a
    non-loopback bind unless a key is set or
    `NETCANON_ALLOW_INSECURE_BIND=1` is passed, so accidental

--- a/netcanon/api/auth.py
+++ b/netcanon/api/auth.py
@@ -7,12 +7,15 @@ the insecure ``0.0.0.0`` default makes accidental public exposure one
 ``docker run -p`` away.  This module adds two opt-in, fail-closed controls:
 
 1. :func:`require_api_key` — when ``Settings.api_key`` (env
-   ``NETCANON_API_KEY``) is set, every ``/api/v1`` route requires a
-   matching ``Authorization: Bearer <key>`` header.  Empty key (the
-   default) makes the dependency a no-op, so the zero-config loopback /
-   desktop experience is unchanged.  Credentials stay write-only over the
-   API (``DeviceProfilePublic``); this is an orthogonal front door, not a
-   replacement for the reverse proxy.
+   ``NETCANON_API_KEY``) is set, every ``/api/v1`` data/operation route
+   requires a matching ``Authorization: Bearer <key>`` header.  (The
+   ``/api/v1/openapi.json`` schema is FastAPI-internal and stays open so
+   the intentionally-unauthenticated ``/docs`` page can render it; it
+   carries only route metadata — no config contents or credentials.)
+   Empty key (the default) makes the dependency a no-op, so the
+   zero-config loopback / desktop experience is unchanged.  Credentials
+   stay write-only over the API (``DeviceProfilePublic``); this is an
+   orthogonal front door, not a replacement for the reverse proxy.
 
 2. :func:`bind_refusal_reason` — used by ``netcanon serve`` to refuse to
    start when binding a non-loopback interface with no API key and no

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -11,10 +11,11 @@ Pydantic-settings automatically reads ``.env`` files if present.
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 #: Hard ceiling on per-job parallel device workers.  Chosen conservatively
@@ -101,7 +102,9 @@ class Settings(BaseSettings):
     data_dir: Path | None = None
     host: str = "0.0.0.0"
     port: int = 8000
-    log_level: str = "info"
+    log_level: Literal[
+        "debug", "info", "warning", "error", "critical"
+    ] = "info"
     open_in_editor: bool = False
     backup_concurrency: int = Field(default=MAX_BACKUP_CONCURRENCY,
                                     ge=1, le=MAX_BACKUP_CONCURRENCY)
@@ -123,6 +126,35 @@ class Settings(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
     )
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def _normalize_log_level(cls, v: object) -> object:
+        """Coerce ``NETCANON_LOG_LEVEL`` case/whitespace; fall back to
+        ``info`` for an unknown value.
+
+        ``configure_logging`` runs at import time (``main.py``), outside the
+        graceful-startup handler, and passes this value to
+        ``logging.setLevel`` (and ``netcanon serve`` to ``uvicorn.run``).  A
+        mistyped value (``verbose``, ``warn``, a stray-whitespace
+        ``"DEBUG "``, an empty string) would otherwise raise an unhandled
+        ``ValueError`` and crash every entry path with a raw traceback
+        (v0.4.0 self-audit).  Normalising here guarantees a valid level
+        reaches both sinks; an unknown value warns and degrades to ``info``
+        rather than failing closed on a non-security setting.
+        """
+        if not isinstance(v, str):
+            return v
+        norm = v.strip().lower()
+        valid = {"debug", "info", "warning", "error", "critical"}
+        if norm in valid:
+            return norm
+        warnings.warn(
+            f"Unknown NETCANON_LOG_LEVEL {v!r}; falling back to 'info' "
+            "(valid: debug, info, warning, error, critical).",
+            stacklevel=2,
+        )
+        return "info"
 
     @property
     def effective_data_dir(self) -> Path:

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -389,6 +389,12 @@ def render_intent(tree: Any) -> str:
                     # (sample doc: ``lease 0 12 0`` for 12-hour
                     # leases).  Always emit the full triple so a
                     # 12-hour lease doesn't render as bare ``lease 0``.
+                    # But a sub-minute (non-zero) lease floors to
+                    # ``lease 0 0 0`` — invalid + reparses to 0 then
+                    # drifts to the 86400 default; floor it to 1 minute
+                    # (v0.4.0 self-audit, same fix as cisco_iosxe_cli).
+                    if days == 0 and hours == 0 and minutes == 0:
+                        minutes = 1
                     out.append(
                         f"   lease {days} {hours} {minutes}"
                     )

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -243,6 +243,35 @@ class CiscoIOSXECodec(CodecBase):
             ),
         ],
         unsupported=[
+            # ── L2 switchport surface (ENG-01 completion, v0.4.0 self-audit).
+            #    This OpenConfig/NETCONF stub renders only name/enabled/type
+            #    per interface and drops every per-port VLAN-membership
+            #    attribute the walker yields.  The 5 sibling L3-style targets
+            #    (cisco_iosxr, vyos, fortigate_cli, opnsense, mikrotik_routeros)
+            #    declare these unsupported; this stub was the miss — undeclared
+            #    they defaulted to `supported`, so a switch→iosxe migration
+            #    reported `severity: ok` while the membership was silently
+            #    dropped on render. ──
+            UnsupportedPath(
+                path="/interfaces/interface/switchport-mode",
+                reason="Phase 0.5 OpenConfig stub renders no switchport model; the mode is dropped.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/access-vlan",
+                reason="Phase 0.5 OpenConfig stub renders no per-port access-VLAN; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-allowed-vlans",
+                reason="Phase 0.5 OpenConfig stub renders no switchport trunk allowed-list; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/trunk-native-vlan",
+                reason="Phase 0.5 OpenConfig stub renders no switchport native VLAN; dropped on render.",
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/voice-vlan",
+                reason="Phase 0.5 OpenConfig stub renders no voice-VLAN; dropped on render.",
+            ),
             # ── Granular Tier-1/2 drops the walker now yields (2026-06
             #    adversarial review #9): the stub already carries the
             #    underscore field-markers below for run_full_mesh, but the

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -589,6 +589,14 @@ def render_intent(tree: Any) -> str:
                 hours = rem // 3600
                 rem -= hours * 3600
                 minutes = rem // 60
+                # A sub-minute (but non-zero) lease floors all three units
+                # to 0 → the wire-invalid `lease 0 0 0`, which also reparses
+                # to lease_time=0 and then drifts to the 86400 default on the
+                # next render (v0.4.0 self-audit).  IOS-XE's finest lease
+                # granularity is one minute, so floor a sub-minute lease up
+                # to 1 minute rather than emit an invalid, unstable triple.
+                if days == 0 and hours == 0 and minutes == 0:
+                    minutes = 1
                 out.append(f" lease {days} {hours} {minutes}")
         out.append("!")
 

--- a/tests/unit/migration/codecs/arista_eos/test_dhcp_pool_round_trip.py
+++ b/tests/unit/migration/codecs/arista_eos/test_dhcp_pool_round_trip.py
@@ -270,3 +270,22 @@ class TestAristaDHCPCapability:
         assert not any(
             "dhcp" in u.path for u in caps.unsupported
         ), "DHCP path should no longer appear in `unsupported`."
+
+
+class TestAristaSubMinuteLease:
+    def test_sub_minute_lease_floors_to_one_minute_and_is_stable(self):
+        """v0.4.0 self-audit: a sub-minute lease floored to the invalid,
+        unstable ``lease 0 0 0`` (same root cause as cisco_iosxe_cli).  It
+        now floors to 1 minute and re-renders stably."""
+        codec = AristaEOSCodec()
+        rendered = codec.render(
+            CanonicalIntent(
+                dhcp_servers=[CanonicalDHCPPool(network="10.0.0.0/24",
+                                                lease_time=30)]
+            )
+        )
+        assert "lease 0 0 1" in rendered
+        assert "lease 0 0 0" not in rendered
+        reparsed = codec.parse(rendered)
+        assert reparsed.dhcp_servers[0].lease_time == 60
+        assert codec.render(reparsed) == rendered

--- a/tests/unit/migration/test_eng01_switchport_loss_visible.py
+++ b/tests/unit/migration/test_eng01_switchport_loss_visible.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import pytest
 
+from netcanon.migration.codecs.cisco_iosxe.codec import CiscoIOSXECodec
 from netcanon.migration.codecs.cisco_iosxe_cli.codec import CiscoIOSXECLICodec
 from netcanon.migration.codecs.cisco_iosxr.codec import CiscoIOSXRCodec
 from netcanon.migration.codecs.fortigate_cli.codec import FortiGateCLICodec
@@ -92,5 +93,27 @@ def test_switchport_loss_surfaces_as_unsupported(target_cls):
         f"L2 paths classified as supported instead of unsupported: {sorted(missing)}"
     )
     # Any unsupported path forces a block-severity, incompatible report.
+    assert report.severity == "block"
+    assert report.compatible is False
+
+
+def test_switchport_loss_surfaces_on_cisco_iosxe_netconf_stub():
+    """v0.4.0 self-audit: the ``cisco_iosxe`` OpenConfig/NETCONF stub was
+    the L3-style target ENG-01 missed.  It renders only name/enabled/type
+    and drops every switchport attribute, but left the 5 xpaths undeclared
+    — so ``classify`` defaulted them to ``supported`` and a switch→iosxe
+    migration reported ``severity: ok`` while VLAN membership was silently
+    discarded.  The stub now declares them unsupported like its 5 siblings.
+    """
+    source = CiscoIOSXECLICodec()
+    tree = source.parse(_SWITCH_CONFIG)
+    report = validate_against(tree, CiscoIOSXECodec(), source=source)
+    unsupported = {u.path for u in report.unsupported_paths}
+
+    missing = _DROPPED_SWITCHPORT_XPATHS - unsupported
+    assert not missing, (
+        "cisco_iosxe stub: switchport loss NOT surfaced — dropped L2 paths "
+        f"still classified supported: {sorted(missing)}"
+    )
     assert report.severity == "block"
     assert report.compatible is False

--- a/tests/unit/migration/test_eng03_cisco_dhcp_lease.py
+++ b/tests/unit/migration/test_eng03_cisco_dhcp_lease.py
@@ -68,3 +68,31 @@ def test_whole_hour_multi_day_lease_roundtrips():
     assert intent.dhcp_servers[0].lease_time == 604800
     assert " lease 7 0 0" in rendered
     assert reparsed.dhcp_servers[0].lease_time == 604800
+
+
+def test_sub_minute_lease_floors_to_one_minute_and_is_stable():
+    """v0.4.0 self-audit: a sub-minute (0<t<60s) lease floored all three
+    units to 0 → the wire-invalid ``lease 0 0 0``, which reparsed to
+    ``lease_time=0`` and then drifted to the 86400 default on the next
+    render.  It now floors to 1 minute (IOS-XE's finest granularity), so
+    the output is valid and STABLE across re-renders.
+    """
+    from netcanon.migration.canonical.intent import (
+        CanonicalDHCPPool,
+        CanonicalIntent,
+    )
+
+    codec = CiscoIOSXECLICodec()
+    # 30s comes in via e.g. a FortiGate `set lease-time 30` migration.
+    rendered = codec.render(
+        CanonicalIntent(
+            dhcp_servers=[CanonicalDHCPPool(network="10.0.0.0/24",
+                                            lease_time=30)]
+        )
+    )
+    assert " lease 0 0 1" in rendered
+    assert "lease 0 0 0" not in rendered     # the invalid/unstable form is gone
+    # Re-render must be a no-op (60s -> `lease 0 0 1` -> 60s), not drift.
+    reparsed = codec.parse(rendered)
+    assert reparsed.dhcp_servers[0].lease_time == 60
+    assert codec.render(reparsed) == rendered

--- a/tests/unit/test_obs01_log_level.py
+++ b/tests/unit/test_obs01_log_level.py
@@ -71,3 +71,43 @@ def test_default_resolves_to_info_root_level(monkeypatch):
         assert root.level == logging.INFO
 
     _run_with_clean_root(check)
+
+
+# --- v0.4.0 self-audit: an invalid level must coerce, never crash ---
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("verbose", "info"),   # unknown name
+        ("warn", "info"),      # not in our 5 (uvicorn alias, we don't accept)
+        ("DEBUG", "debug"),    # case
+        (" info ", "info"),    # stray whitespace from a .env line
+        ("", "info"),          # empty
+    ],
+)
+def test_invalid_or_messy_log_level_coerces_not_crashes(
+    monkeypatch, raw, expected
+):
+    """A mistyped ``NETCANON_LOG_LEVEL`` must normalise / fall back to
+    ``info`` (with a warning for unknown values) instead of raising an
+    unhandled ``ValueError`` at ``Settings()`` / ``configure_logging`` /
+    ``uvicorn.run`` — the import-time crash the self-audit found."""
+    monkeypatch.setenv("NETCANON_LOG_LEVEL", raw)
+    assert Settings().log_level == expected   # never raises
+
+
+def test_unknown_level_emits_warning(monkeypatch):
+    monkeypatch.setenv("NETCANON_LOG_LEVEL", "verbose")
+    with pytest.warns(UserWarning, match="Unknown NETCANON_LOG_LEVEL"):
+        assert Settings().log_level == "info"
+
+
+def test_coerced_level_still_reaches_root_logger(monkeypatch):
+    monkeypatch.setenv("NETCANON_LOG_LEVEL", "DEBUG ")  # messy but valid
+
+    def check(root):
+        configure_logging(level=Settings().log_level)
+        assert root.level == logging.DEBUG
+
+    _run_with_clean_root(check)


### PR DESCRIPTION
The remaining four findings from the post-release **v0.4.0 adversarial self-audit** (each survived independent skeptic refutation; bundled as one follow-up). **No cross-mesh disposition change — `CODEC_BUG` held at 5** (mesh regenerated).

### 🟡 #3 — `cisco_iosxe` was the L3-style target ENG-01 missed
The OpenConfig/NETCONF stub renders only name/enabled/type per interface and drops every switchport attribute, but left the 5 switchport xpaths **undeclared** — so `classify()` defaulted them to `supported` and a switch→iosxe migration reported `severity: ok` while VLAN membership was silently discarded. Now declares them `unsupported`, mirroring its 5 sibling L3-style targets. (Repro: `validate_against` went `ok`→`block`; the dropped `switchport-mode`/`access-vlan` now appear in `unsupported_paths`.)

### 🟡 #4 — sub-minute DHCP lease rendered the invalid, unstable `lease 0 0 0`
For `0 < lease_time < 60 s`, `cisco_iosxe_cli` (and `arista_eos`) floored days/hours/minutes all to 0 → `lease 0 0 0`, which is wire-invalid **and** reparses to `0` then drifts to the 86400 default on the next render — directly contradicting the ENG-03 "lossless" claim. Reachable via FortiGate→Cisco (`set lease-time 30`). Sub-minute leases now floor to **1 minute** (finest device granularity) → valid + stable across re-renders.

### 🟡 #5 — a bad `NETCANON_LOG_LEVEL` crashed startup
`configure_logging` runs at **import time**, outside the graceful-startup handler, so a mistyped level (`verbose`, a stray-whitespace `"DEBUG "`, an empty value) raised an unhandled `ValueError` and took down every entry path (bare uvicorn, `netcanon serve`, desktop) with a raw traceback. `Settings.log_level` is now a validated `Literal` with a normalising `before` validator (lower-case/strip; unknown → `info` with a warning), so a clean value always reaches both `logging.setLevel` and `uvicorn.run`.

### ⚪ #6 — doc wording
Softened "every `/api/v1` route" in `auth.py` + `SECURITY.md`: the key gates `/api/v1` **data/operation** routes; `/api/v1/openapi.json` stays open so the intentionally-unauthenticated `/docs` page can render it (route metadata only — no config contents or credentials). The skeptic correctly noted that *gating* it would break `/docs`, so this is a wording fix, **not** a behavioural change.

### Verification
- Per-fix regressions added/extended: `test_eng01_switchport_loss_visible` (cisco_iosxe case), `test_eng03_cisco_dhcp_lease` (sub-minute stability), `test_obs01_log_level` (invalid-level coercion + warning), arista `test_dhcp_pool_round_trip` (sub-minute).
- Full **unit + integration** suites green; honesty-parity green; mesh + phase4 regenerated → **`CODEC_BUG = 5`** (churn-only artifact diffs reverted).

Second of two self-audit PRs (after #132). Holding the **v0.4.1** tag until the broader adversarial re-run reports, so one patch bundles both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)