### PR TITLE
fix(sanitize): redact IPv6, VRRP virtual-IPs, and DHCP range bounds (run3 MEDIUM)

### DIFF
--- a/BUG_REPORTING.md
+++ b/BUG_REPORTING.md
@@ -145,9 +145,11 @@ the same redacted value all 5 times).
 | SNMPv3 user names (USM securityName) | `snmpv3userN` (independent counter from local-user-name) |
 | SNMPv3 auth/priv passphrases | `REDACTED-AUTH-N` / `REDACTED-PRIV-N` |
 | RADIUS shared secrets | `REDACTED-RADIUS-N` |
-| RADIUS server / SNMP trap-target / DHCP-gateway hosts | Public IPv4 → docs ranges; private / hostname preserved |
+| RADIUS server / SNMP trap-target / DHCP gateway+range+subnet hosts | Public IPv4 / IPv6 → docs ranges; private / hostname preserved |
+| Interface IPv6 addresses | Public / global IPv6 → `2001:db8::`; ULA / link-local / loopback / multicast preserved |
 | VLAN-SVI IPv4 addresses (the VLAN interface's L3 config) | Public IPv4 → docs ranges; private preserved |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
+| VRRP / CARP virtual IPs (v4 + v6) | Public → docs ranges; private / ULA preserved |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall, NAT, VPN) | Stripped entirely |
 
@@ -164,13 +166,12 @@ Full rules and limitations in the sanitiser's module docstring at
 - **Banner / comment text not redacted.**  These aren't in the
   canonical model.  Most are parse-and-ignored.  If your config has
   sensitive banner text, hand-edit it after sanitising.
-- **IPv6-public redaction is IPv4-only at v0.1.0.**  IPv6 addresses
-  pass through verbatim.  If your config has public IPv6 addresses,
-  hand-redact those before submitting.
 - **Host fields given as DNS names pass through.**  IP-typed
-  redaction (RADIUS server, SNMP trap target, DHCP gateway) acts on
-  bare IPv4 only; a target written as a hostname (`nms.corp.example`)
-  is preserved.  Hand-edit name-form hosts if they are identifying.
+  redaction (interface / SVI / VRRP-VIP / RADIUS server / SNMP trap
+  target / DHCP gateway+range) covers bare IPv4 *and* IPv6 literals
+  (v0.4.1); a target written as a hostname (`nms.corp.example`) is
+  free text the model does not classify, so it is preserved.
+  Hand-edit name-form hosts if they are identifying.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -359,14 +359,16 @@ on the canonical model:
 | Hostname | `device-N` |
 | Domain | `example-N.test` |
 | Public IPv4 | RFC 5737 docs ranges |
+| Public / global IPv6 | RFC 3849 docs range (`2001:db8::`) — ULA / link-local / loopback / multicast / docs preserved |
 | Hashed passwords | Format-preserving fakes (Junos `$9$`, FortiGate `ENC`, crypt `$5$`/`$6$`, bcrypt `$2y$`, Cisco type-7 hex, Aruba SHA-1) |
 | SNMP communities | `public_redacted_N` |
 | SNMP contact / location (operator PII) | `<contact redacted>` / `<location redacted>` |
 | SNMPv3 auth/priv passphrases | `REDACTED-AUTH-N` / `REDACTED-PRIV-N` |
 | RADIUS shared secrets | `REDACTED-RADIUS-N` |
-| RADIUS server / SNMP trap-target / DHCP-gateway hosts (public IPv4) | RFC 5737 docs ranges |
+| RADIUS server / SNMP trap-target / DHCP gateway+range+subnet hosts (public IPv4 / IPv6) | RFC 5737 / RFC 3849 docs ranges |
 | VLAN-SVI IPv4 addresses (public) | RFC 5737 docs ranges |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
+| VRRP / CARP virtual IPs (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall / NAT / VPN) | Stripped entirely |
 
@@ -376,10 +378,10 @@ gets the same redacted value all 5 times).  `--dry-run` prints the
 substitution table for operator review before writing output.
 
 Known limitations are listed in
-[`BUG_REPORTING.md`](BUG_REPORTING.md) — notably IPv6-public redaction
-is IPv4-only at v0.1.0; host fields given as DNS names (a RADIUS / trap
-target like `nms.corp.example`) pass through; banner / comment text is
-parse-and-ignored rather than redacted.
+[`BUG_REPORTING.md`](BUG_REPORTING.md) — IP-typed redaction now covers
+both IPv4 and IPv6, but host fields given as DNS names (a RADIUS / trap
+target like `nms.corp.example`) still pass through, and banner / comment
+text is parse-and-ignored rather than redacted.
 
 ---
 
@@ -543,7 +545,7 @@ regulated environments.
 | Key loss (keyring entry deleted / env var unset on restart / `.fernet_key` deleted) | Encrypted profiles become unreadable | Accepted | User must re-enter credentials; profiles are low-volume.  Operators using tier 1 / tier 3 should back the key up alongside their other infrastructure secrets |
 | SSH host-key not verified by default | A MITM on the management path could harvest the SSH password + enable secret on first connect | Yes (default) / opt-in hardening available | Default `ssh_host_key_checking=auto_add` trusts any key (legacy; assumes a trusted management VLAN).  Set `NETCANON_SSH_HOST_KEY_CHECKING=tofu` (record first key under `{data_dir}/known_hosts`, reject later changes) or `reject` (only known hosts) to harden.  Netmiko collectors map the strict modes onto the OS `~/.ssh/known_hosts` (no custom-store API). |
 | Banner / comment text not sanitised | Operator-submitted bug reports may leak banner content | Documented | Sanitiser is canonical-model-driven; banner text is parse-and-ignored.  See `BUG_REPORTING.md`; hand-redact banners before submission. |
-| IPv6-public redaction not implemented | Operator-submitted public IPv6 addresses pass through verbatim | Documented | v0.1.0 limitation; sanitiser is IPv4-only.  Hand-redact public IPv6 before submission. |
+| DNS-name host fields not redacted | A RADIUS / SNMP-trap / NTP target given as a DNS name (`nms.corp.example`) passes through verbatim | Documented | IP-typed redaction covers IPv4 + IPv6 literals (v0.4.1); name-form hosts are free text the model does not classify.  Hand-redact named targets before submission. |
 | Backup artifacts (`configs/`) stored plaintext | Fetched device configs contain device secrets (`$9$`/type-7/`$6$`, SNMP/RADIUS/IKE) written verbatim | Yes (deliberate) | A backup must be the real, complete, diffable config; recommended at-rest control is an OS-encrypted volume (covers `configs/` + the key in one layer; offline-threat only).  See "Credential Storage → Backup artifacts" |
 
 ---

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -20,6 +20,10 @@ Field-typed rules (counter-per-session):
 * Public IPv4 anywhere → RFC 5737 docs ranges (192.0.2.x /
   198.51.100.x / 203.0.113.x); private IPs (RFC 1918, ULA, link-local,
   loopback, multicast, CGNAT 100.64/10) preserved
+* Public/global IPv6 anywhere → RFC 3849 docs range (``2001:db8::``);
+  ULA (fc00::/7), link-local (fe80::/10), loopback (``::1``),
+  unspecified (``::``), multicast (ff00::/8), and the docs range
+  itself preserved
 * ``CanonicalLocalUser.name`` → ``localuserN`` (Phase-3 R6.1 addition —
   the username is operator-identifying when chosen by the operator,
   e.g. ``alice``, ``john.smith``, or ``user12``)
@@ -44,9 +48,15 @@ Field-typed rules (counter-per-session):
   metadata and is preserved so the renderer still emits valid syntax;
   only the secret value (cleartext for ``plain:`` / ``carp-key:``, a
   key-string for ``md5:``) is replaced
+* ``CanonicalVRRPGroup.virtual_ips`` / ``virtual_ipv6s`` (public
+  entries) → docs range — a VRRP / CARP VIP is frequently the
+  public-facing HA gateway, so it is redacted like any other IP
 * ``CanonicalInterface.description`` → ``description redacted``
 * ``CanonicalDHCPPool.dns_servers`` (public entries) → docs range
 * ``CanonicalDHCPPool.gateway`` (public) → docs range
+* ``CanonicalDHCPPool.start_ip`` / ``end_ip`` (public) → docs range
+* ``CanonicalDHCPPool.network`` (public host portion) → docs range,
+  prefix length preserved
 * ``CanonicalVlan.ipv4_addresses`` (public SVI L3 addresses) → docs
   range — SEPARATE field from ``interfaces[].ipv4_addresses``; the
   Aruba / Junos SVI-on-VLAN model renders these directly
@@ -61,10 +71,11 @@ Limitations:
   Tier-3 stanzas in the source bytes are not field-typed redacted —
   Tier-3 content is dropped on parse, banners are typically
   parse-and-ignore.
-* IP-typed redaction (interface / SVI / DHCP / RADIUS / trap-target
-  addresses) acts on IPv4 only.  IPv6 addresses and host fields given
-  as DNS NAMES (e.g. a RADIUS / trap target of ``nms.corp.example``)
-  pass through verbatim — hand-edit those before sharing.
+* IP-typed redaction covers both IPv4 and IPv6 (interface / SVI /
+  DHCP / RADIUS / trap-target / VRRP-VIP addresses).  Host fields
+  given as DNS NAMES (e.g. a RADIUS / trap target of
+  ``nms.corp.example``) still pass through verbatim — hand-edit those
+  before sharing.
 * Round-trip is sub-lossless: parse drops Tier-3 content, and render
   emits only what the codec models.  Operators sharing a sanitized
   config get the supported subset, not a byte-identical-shape
@@ -252,6 +263,17 @@ def sanitize_intent(
                 ))
                 addr.ip = new_ip
 
+        for j, addr in enumerate(iface.ipv6_addresses):
+            new_ip = table.redact_ipv6(addr.ip)
+            if new_ip != addr.ip:
+                subs.append(Substitution(
+                    category="ipv6-public",
+                    field=f"interfaces[{i}].ipv6_addresses[{j}].ip",
+                    original=addr.ip,
+                    redacted=new_ip,
+                ))
+                addr.ip = new_ip
+
         # ---- VRRP / CARP / HSRP authentication ----
         # Cleartext-bearing: the ``plain:`` / ``carp-key:`` schemes
         # hold the literal secret and ``md5:`` holds a key-string, all
@@ -277,6 +299,41 @@ def sanitize_intent(
                     redacted="description redacted",
                 ))
                 group.description = "description redacted"
+
+            # The virtual IP is frequently the public-facing HA gateway
+            # address — redact it like every other IP field (the sibling
+            # ``authentication`` secret above was redacted, but the VIP
+            # bypassed sanitisation entirely before this).  ``redact_ip_
+            # string`` handles both the IPv4 and IPv6 VIP lists; private
+            # VIPs (the LAN-gateway common case) are preserved.
+            if group.virtual_ips:
+                new_vips: list[str] = []
+                for m, vip in enumerate(group.virtual_ips):
+                    new_vip = table.redact_ip_string(vip)
+                    if new_vip != vip:
+                        subs.append(Substitution(
+                            category="ipv4-public",
+                            field=(f"interfaces[{i}].vrrp_groups[{k}]"
+                                   f".virtual_ips[{m}]"),
+                            original=vip,
+                            redacted=new_vip,
+                        ))
+                    new_vips.append(new_vip)
+                group.virtual_ips = new_vips
+            if group.virtual_ipv6s:
+                new_vip6s: list[str] = []
+                for m, vip in enumerate(group.virtual_ipv6s):
+                    new_vip = table.redact_ip_string(vip)
+                    if new_vip != vip:
+                        subs.append(Substitution(
+                            category="ipv6-public",
+                            field=(f"interfaces[{i}].vrrp_groups[{k}]"
+                                   f".virtual_ipv6s[{m}]"),
+                            original=vip,
+                            redacted=new_vip,
+                        ))
+                    new_vip6s.append(new_vip)
+                group.virtual_ipv6s = new_vip6s
 
     # ---- VLAN SVI IPv4 addresses ----
     # R-16 / CF-04: SVI L3 addressing lives on ``CanonicalVlan.
@@ -493,6 +550,43 @@ def sanitize_intent(
                 ))
                 pool.gateway = new_gw
 
+        # Pool range bounds + served subnet are network-location PII
+        # (sibling of the already-redacted gateway / dns_servers on the
+        # same record — the trust asymmetry the audit flagged).  Public
+        # IPv4/IPv6 → docs range; private (the common LAN case) preserved.
+        # ``network`` is a CIDR, so redact only its host portion and keep
+        # the prefix length.
+        if pool.start_ip:
+            new_start = table.redact_ip_string(pool.start_ip)
+            if new_start != pool.start_ip:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"dhcp_servers[{i}].start_ip",
+                    original=pool.start_ip,
+                    redacted=new_start,
+                ))
+                pool.start_ip = new_start
+        if pool.end_ip:
+            new_end = table.redact_ip_string(pool.end_ip)
+            if new_end != pool.end_ip:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"dhcp_servers[{i}].end_ip",
+                    original=pool.end_ip,
+                    redacted=new_end,
+                ))
+                pool.end_ip = new_end
+        if pool.network:
+            new_net = table.redact_cidr(pool.network)
+            if new_net != pool.network:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"dhcp_servers[{i}].network",
+                    original=pool.network,
+                    redacted=new_net,
+                ))
+                pool.network = new_net
+
         # v0.4.0 self-audit: the DHCP domain-name is an internal DNS
         # suffix (``corp.acme.example``) — operator/org-identifying PII.
         # Reuse the domain table so it matches the top-level domain
@@ -612,6 +706,8 @@ class _SubstitutionTable:
         self._hostnames: dict[str, str] = {}
         self._domains: dict[str, str] = {}
         self._ipv4: dict[str, str] = {}
+        self._ipv6: dict[str, str] = {}
+        self._ipv6_counter: int = 0
         self._communities: dict[str, str] = {}
         self._secret_counters: dict[str, int] = {}
         self._hash_counter: int = 0
@@ -673,13 +769,65 @@ class _SubstitutionTable:
         self._ipv4[ip] = new_ip
         return new_ip
 
+    def redact_ipv6(self, ip: str) -> str:
+        """Redact a public/global IPv6 address; preserve ULA / link-local /
+        loopback / unspecified / multicast / documentation.
+
+        Mirrors :meth:`redact_ipv4`.  Global unicast maps to a
+        deterministic RFC 3849 documentation address (``2001:db8::N``),
+        cache-keyed by the source string so the same address redacts
+        identically everywhere (cross-reference stable).  Preserved
+        as-is: ULA ``fc00::/7``, link-local ``fe80::/10``, loopback
+        ``::1``, unspecified ``::``, multicast ``ff00::/8``, reserved,
+        and the documentation range ``2001:db8::/32`` itself.
+        """
+        if ip in self._ipv6:
+            return self._ipv6[ip]
+        try:
+            addr = ipaddress.IPv6Address(ip)
+        except ValueError:
+            return ip
+        # ``is_private`` already covers ULA, link-local, loopback,
+        # unspecified, and the 2001:db8::/32 docs range; the rest are
+        # listed explicitly for self-documentation / defensive belt.
+        if (
+            addr.is_private
+            or addr.is_loopback
+            or addr.is_link_local
+            or addr.is_multicast
+            or addr.is_reserved
+            or addr.is_unspecified
+        ):
+            return ip
+        if addr in ipaddress.ip_network("2001:db8::/32"):
+            return ip
+        # Public global unicast — substitute a deterministic docs address.
+        self._ipv6_counter += 1
+        new_ip = f"2001:db8::{self._ipv6_counter:x}"
+        self._ipv6[ip] = new_ip
+        return new_ip
+
     def redact_ip_string(self, value: str) -> str:
-        """Redact public IPv4 in a free-form string field; preserve other content."""
+        """Redact a public IPv4 *or* IPv6 address in a free-form string
+        field; preserve private addresses and non-IP content."""
         try:
             ipaddress.IPv4Address(value)
             return self.redact_ipv4(value)
         except ValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(value)
+            return self.redact_ipv6(value)
+        except ValueError:
             return value
+
+    def redact_cidr(self, value: str) -> str:
+        """Redact the address portion of a ``host/prefix`` CIDR string,
+        preserving the prefix length.  Bare addresses (no ``/``) are
+        redacted whole; non-IP content is returned verbatim."""
+        addr, sep, prefix = value.partition("/")
+        new_addr = self.redact_ip_string(addr)
+        return f"{new_addr}{sep}{prefix}" if sep else new_addr
 
     def redact_community(self, community: str) -> str:
         if community not in self._communities:

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -32,6 +32,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalIntent,
     CanonicalInterface,
     CanonicalIPv4Address,
+    CanonicalIPv6Address,
     CanonicalLocalUser,
     CanonicalRADIUSServer,
     CanonicalRoutingInstance,
@@ -1093,3 +1094,164 @@ class TestFreeTextPiiRedaction:
         assert "SECRET-VLAN" not in names and "OTHER" not in names
         assert names[0] == names[1]      # same source name → same redaction
         assert names[0] != names[2]      # distinct names stay distinct
+
+
+# ---------------------------------------------------------------------------
+# v0.4.1 run3 audit — IP-typed redaction gaps (extends the IPv4-only tail)
+#
+# Three "same class, new surface" leaks the IPv4-only redaction missed:
+#   * interface / DNS / NTP / syslog IPv6 (ipv6-sanitizer-leak)
+#   * VRRP / CARP virtual IPs, v4 and v6 (vrrp-vip-leak)
+#   * DHCP pool range bounds + served subnet (dhcp-range-leak)
+# These are network-location PII, not secrets, so they live here as a
+# forward "must not survive" block rather than in the secret-coverage
+# guard.
+# ---------------------------------------------------------------------------
+
+
+class TestIPv6Redaction:
+    """Global/public IPv6 is redacted to the RFC 3849 docs range; ULA,
+    link-local, loopback, unspecified, multicast, and the docs range
+    itself are preserved (mirrors the IPv4 policy)."""
+
+    def test_public_interface_ipv6_redacted(self):
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(
+                name="Vlan10",
+                ipv6_addresses=[
+                    CanonicalIPv6Address(ip="2606:4700:4700::1111",
+                                         prefix_length=64),
+                ],
+            )],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        new_ip = sanitized.interfaces[0].ipv6_addresses[0].ip
+        assert new_ip != "2606:4700:4700::1111"
+        assert new_ip.startswith("2001:db8::")
+        assert any(
+            s.category == "ipv6-public"
+            and s.original == "2606:4700:4700::1111"
+            for s in subs
+        )
+
+    @pytest.mark.parametrize(
+        "preserved",
+        ["fe80::1", "fd00::dead:beef", "::1", "ff02::1", "2001:db8::5"],
+    )
+    def test_non_global_ipv6_preserved(self, preserved):
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(
+                name="Vlan10",
+                ipv6_addresses=[
+                    CanonicalIPv6Address(ip=preserved, prefix_length=64),
+                ],
+            )],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        assert sanitized.interfaces[0].ipv6_addresses[0].ip == preserved
+
+    def test_ipv6_in_dns_ntp_syslog_lists_redacted(self):
+        intent = CanonicalIntent(
+            dns_servers=["2001:4860:4860::8888"],
+            ntp_servers=["2606:4700:4700::64"],
+            syslog_servers=["2620:fe::fe"],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        blob = sanitized.model_dump_json()
+        for leaked in (
+            "2001:4860:4860::8888", "2606:4700:4700::64", "2620:fe::fe",
+        ):
+            assert leaked not in blob, f"public IPv6 survived: {leaked!r}"
+
+    def test_ipv6_redaction_is_cross_reference_stable(self):
+        """Same source IPv6 → same docs substitute everywhere."""
+        table = _SubstitutionTable()
+        a = table.redact_ipv6("2606:4700:4700::1111")
+        b = table.redact_ipv6("2606:4700:4700::1111")
+        c = table.redact_ipv6("2001:4860:4860::8888")
+        assert a == b           # stable
+        assert a != c           # distinct sources stay distinct
+
+
+class TestVRRPVirtualIPRedaction:
+    """v0.4.1: the VRRP / CARP virtual IP — frequently the public HA
+    gateway — was passed through verbatim while its sibling auth secret
+    was redacted.  Both v4 and v6 VIPs are now redacted."""
+
+    def test_public_virtual_ips_redacted_private_preserved(self):
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(
+                name="Vlan10",
+                vrrp_groups=[CanonicalVRRPGroup(
+                    group_id=10,
+                    virtual_ips=["8.8.4.4", "10.0.0.254"],
+                    virtual_ipv6s=["2606:4700:4700::64", "fd00::64"],
+                )],
+            )],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        g = sanitized.interfaces[0].vrrp_groups[0]
+        assert "8.8.4.4" not in g.virtual_ips          # public v4 gone
+        assert "10.0.0.254" in g.virtual_ips           # private preserved
+        assert "2606:4700:4700::64" not in g.virtual_ipv6s  # public v6 gone
+        assert "fd00::64" in g.virtual_ipv6s           # ULA preserved
+        assert any("virtual_ips" in s.field for s in subs)
+        assert any("virtual_ipv6s" in s.field for s in subs)
+
+    def test_rendered_output_omits_public_vip(self):
+        """End-to-end via a codec that renders VRRP: a genuinely public
+        VIP must not appear in the sanitised render output."""
+        from netcanon.migration.codecs.registry import get_codec
+
+        intent = CanonicalIntent(
+            hostname="r1",
+            interfaces=[CanonicalInterface(
+                name="Vlan10",
+                ipv4_addresses=[
+                    CanonicalIPv4Address(ip="10.0.0.2", prefix_length=24)],
+                vrrp_groups=[CanonicalVRRPGroup(
+                    group_id=10, virtual_ips=["8.8.4.4"])],
+            )],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        rendered = get_codec("cisco_iosxe_cli").render(sanitized)
+        assert "8.8.4.4" not in rendered
+
+
+class TestDHCPRangeRedaction:
+    """v0.4.1: DHCP pool range bounds (start_ip/end_ip) and the served
+    subnet (network) leaked while the same record's gateway / dns_servers
+    were redacted — the trust-asymmetry trap.  Public → docs range,
+    network prefix length preserved, private LAN ranges untouched."""
+
+    def test_public_range_and_network_redacted(self):
+        intent = CanonicalIntent(
+            dhcp_servers=[CanonicalDHCPPool(
+                network="9.9.9.0/24",
+                start_ip="9.9.9.10",
+                end_ip="9.9.9.20",
+                gateway="9.9.9.1",
+            )],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        p = sanitized.dhcp_servers[0]
+        assert "9.9.9.10" not in p.start_ip
+        assert "9.9.9.20" not in p.end_ip
+        assert "9.9.9.0" not in p.network
+        assert p.network.endswith("/24")   # prefix length preserved
+        for fld in ("start_ip", "end_ip", "network"):
+            assert any(s.field.endswith(fld) for s in subs)
+
+    def test_private_lan_range_preserved(self):
+        intent = CanonicalIntent(
+            dhcp_servers=[CanonicalDHCPPool(
+                network="192.168.10.0/24",
+                start_ip="192.168.10.100",
+                end_ip="192.168.10.200",
+            )],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        p = sanitized.dhcp_servers[0]
+        assert p.network == "192.168.10.0/24"
+        assert p.start_ip == "192.168.10.100"
+        assert p.end_ip == "192.168.10.200"


### PR DESCRIPTION
## What

Closes three run3-verified MEDIUM sanitiser leaks — all the "same class,
new surface" pattern where the IPv4-only IP redaction missed a canonical
field:

| Finding | Leak | Fix |
|---|---|---|
| `ipv6-sanitizer-leak` | interface IPv6 + any IPv6 in DNS/NTP/syslog/trap/radius/dhcp-dns lists passed through verbatim | new `redact_ipv6` (global → RFC 3849 `2001:db8::N`, cross-ref stable); `redact_ip_string` now tries IPv6 (covers every list site); walk `interface.ipv6_addresses` |
| `vrrp-vip-leak` | VRRP/CARP virtual IP (often the public HA gateway) bypassed sanitisation while its sibling auth secret was redacted | redact `virtual_ips` + `virtual_ipv6s` |
| `dhcp-range-leak` | pool `start_ip`/`end_ip`/`network` leaked while same-record gateway/dns were redacted | redact range bounds + served subnet (new `redact_cidr` keeps the prefix) |

## Preservation (mirrors the IPv4 policy)

ULA `fc00::/7`, link-local `fe80::/10`, loopback `::1`, unspecified `::`,
multicast `ff00::/8`, and the `2001:db8::/32` docs range are preserved;
private LAN DHCP ranges untouched. Cross-reference stability holds (same
source address → same docs substitute everywhere, v4 and v6).

## Tests & docs

- Forward "must not survive" regression tests for all three surfaces +
  preservation + cross-ref-stability + an end-to-end render-clean check.
- `sanitize.py` docstring, `SECURITY.md`, and `BUG_REPORTING.md` updated
  to drop the stale "IPv4-only / v0.1.0" framing; the residual
  DNS-name-host passthrough is now the documented limitation.

Local gate: full `tests/unit` (4541 passed, 81 skipped) + sanitize
integration green; ruff clean. No codec/matrix/schema change, so no
mesh regen needed.

Part of the v0.4.1 run3-remediation series (PR-B of 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)