### PR TITLE
fix(honesty): surface dropped static-route sub-fields + secondary IPs (run3 MEDIUM)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -140,6 +140,22 @@ class AristaEOSCodec(CodecBase):
             "/anycast-gateway-mac",
         ],
         lossy=[
+            LossyPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route administrative distance (metric) is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
             # -- v0.2.0 Wave C (VARP) -- per-IP MAC overrides --
             # EOS only supports a system-wide virtual-router MAC
             # (``ip virtual-router mac-address`` — see the
@@ -207,6 +223,13 @@ class AristaEOSCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing/static-route/interface",
+                reason=(
+                    "No interface-nexthop (connected) static-route form; a "
+                    "gateway-less / interface-only route is dropped (run3)."
+                ),
+            ),
             # ── Tier-1 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -177,6 +177,14 @@ class ArubaAOSCXCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(
                     "AOS-CX declares no IANA ifType; the codec infers it "

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -152,6 +152,22 @@ class ArubaAOSSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route administrative distance (metric) is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(
                     "AOS-S does not declare IANA ifType; the codec "

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -149,6 +149,17 @@ class CiscoIOSXECLICodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Parse/render round-trip a single-token ``ip route ... "
+                    "name <X>`` route label, but an IOS-XE route name is a "
+                    "single whitespace-free token — a multi-word description "
+                    "(e.g. a Junos free-text route description) cannot be "
+                    "represented and is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(
                     "CLI parser infers interface type from the name prefix "
@@ -626,6 +637,13 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
         for addr in iface.ipv4_addresses:
             yield "/interfaces/interface/ipv4/address/ip"
             yield "/interfaces/interface/ipv4/address/prefix-length"
+            # Secondary addresses: single-address platforms (FortiGate /
+            # OPNsense) render only the primary and silently drop every
+            # is_secondary address — a whole-subnet reachability loss.
+            # Walk a secondary-specific xpath so those codecs can declare
+            # it unsupported and the loss surfaces instead of reporting ok.
+            if addr.is_secondary:
+                yield "/interfaces/interface/ipv4/address/secondary-ip"
             if addr.virtual_gateway_address:
                 yield (
                     "/interfaces/interface/ipv4/address/"
@@ -639,6 +657,8 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
         for addr6 in iface.ipv6_addresses:            # GAP-EVPN-3
             yield "/interfaces/interface/ipv6/address/ip"
             yield "/interfaces/interface/ipv6/address/prefix-length"
+            if addr6.is_secondary:
+                yield "/interfaces/interface/ipv6/address/secondary-ip"
             if addr6.virtual_gateway_address:
                 yield (
                     "/interfaces/interface/ipv6/address/"
@@ -704,6 +724,19 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
         yield "/routing/static-route"
         if route.vrf:
             yield "/routing/static-route/vrf"
+        # Sub-field losses (run3 audit): several codecs render only the
+        # destination + next-hop and silently drop the admin distance
+        # (metric), the operator route name (description), and/or
+        # interface-nexthop (connected) routes.  Walk them only when
+        # populated so the per-codec lossy/unsupported declaration fires
+        # in the live report instead of classify() defaulting to
+        # 'supported' (a silent loss reported severity: ok).
+        if route.metric:
+            yield "/routing/static-route/metric"
+        if route.description:
+            yield "/routing/static-route/description"
+        if route.interface:
+            yield "/routing/static-route/interface"
     if intent.anycast_gateway_mac:
         yield "/anycast-gateway-mac"
     # ── Tier 2 — emit only what's populated ──

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -234,7 +234,8 @@ _VLAN_RE = re.compile(r"^vlan\s+(\d+)", re.IGNORECASE)
 _VLAN_NAME_RE = re.compile(r"^\s+name\s+(.+)", re.IGNORECASE)
 _STATIC_ROUTE_RE = re.compile(
     r"^ip\s+route\s+(?:vrf\s+(\S+)\s+)?"
-    r"(\d+\.\d+\.\d+\.\d+)\s+(\d+\.\d+\.\d+\.\d+)\s+(\S+)",
+    r"(\d+\.\d+\.\d+\.\d+)\s+(\d+\.\d+\.\d+\.\d+)\s+(\S+)"
+    r"(.*)$",  # group 5: trailing tokens (admin distance / name / tag / ...)
     re.IGNORECASE,
 )
 # ``ip default-gateway X`` is the L2-switch form of a default route.
@@ -1273,11 +1274,38 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
                 gateway = gw_or_iface
             except ipaddress.AddressValueError:
                 iface = gw_or_iface
+            # Trailing tokens (run3 audit): IOS-XE permits an optional
+            # administrative distance (a bare 1-254 integer) and a
+            # ``name <NAME>`` route label after the next-hop, plus
+            # ``tag``/``track``/``permanent``.  Previously parse-and-
+            # ignored, so a cisco→cisco round-trip silently reset the
+            # admin distance and dropped the route name.  Harvest the
+            # distance onto ``metric`` (render emits it) and the name onto
+            # ``description`` (render drops it on this codec, so the loss
+            # is declared lossy — but cross-vendor targets can carry it).
+            metric = 0
+            description = ""
+            tail = (m.group(5) or "").split()
+            t = 0
+            while t < len(tail):
+                tok = tail[t].lower()
+                if tok == "name" and t + 1 < len(tail):
+                    description = tail[t + 1]
+                    t += 2
+                elif tok in ("tag", "track") and t + 1 < len(tail):
+                    t += 2  # keyword + its value — not modelled
+                elif tail[t].isdigit() and metric == 0:
+                    metric = int(tail[t])
+                    t += 1
+                else:
+                    t += 1
             routes.append(CanonicalStaticRoute(
                 destination=dest,
                 gateway=gateway,
                 interface=iface,
                 vrf=vrf,
+                metric=metric,
+                description=description,
             ))
             continue
         m = _DEFAULT_GATEWAY_RE.match(line)

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -550,11 +550,20 @@ def render_intent(tree: Any) -> str:
         target = route.gateway or route.interface
         if not target:
             continue
+        # ``name <NAME>`` route label (run3): IOS-XE route names are a
+        # single whitespace-free token, so emit it only when the
+        # description has no spaces — a multi-word description (e.g. a
+        # Junos free-text route description) cannot be represented and is
+        # dropped (the matrix declares /routing/static-route/description
+        # lossy for that case).  Single-token names round-trip losslessly.
+        name_tail = ""
+        if route.description and " " not in route.description:
+            name_tail = f" name {route.description}"
         # Per-VRF routes carry the ``vrf <NAME>`` qualifier between the
         # ``ip route`` keyword and the destination (v0.2.0 — graduated
         # /routing/static-route/vrf from unsupported to supported).
         vrf_prefix = f"vrf {route.vrf} " if route.vrf else ""
-        out.append(f"ip route {vrf_prefix}{dest} {mask} {target}{tail}")
+        out.append(f"ip route {vrf_prefix}{dest} {mask} {target}{tail}{name_tail}")
     if tree.static_routes:
         out.append("!")
 

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -158,6 +158,22 @@ class CiscoIOSXRCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route administrative distance (metric) is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(
                     "CLI parser infers interface type from the name "

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -181,6 +181,14 @@ class CiscoNXOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop + metric only; the "
+                    "static-route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(
                     "NX-OS interface-type is inferred from the name "

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -138,6 +138,7 @@ class FortiGateCLICodec(CodecBase):
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             "/routing/static-route",
+            "/routing/static-route/interface",   # run3 — `set device <iface>`
             # Tier 2 — SNMP
             "/snmp/community",
             "/snmp/location",
@@ -164,6 +165,15 @@ class FortiGateCLICodec(CodecBase):
             "/interfaces/interface/vrrp-groups/group",
         ],
         lossy=[
+            LossyPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Render emits destination + next-hop + device only; the "
+                    "static-route administrative distance (metric) is "
+                    "dropped (run3)."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/interfaces/interface/config/description",
                 reason=(
@@ -236,6 +246,21 @@ class FortiGateCLICodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/interfaces/interface/ipv4/address/secondary-ip",
+                reason=(
+                    "Render emits one IPv4 address per interface; "
+                    "is_secondary addresses are dropped — a whole-subnet "
+                    "reachability loss (run3)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/ipv6/address/secondary-ip",
+                reason=(
+                    "Render emits one IPv6 address per interface; "
+                    "is_secondary addresses are dropped (run3)."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01) — this codec has no
             #    Cisco-style access/trunk port model, so the per-port VLAN
             #    membership the walker yields is dropped on render.  Declared

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -159,6 +159,22 @@ class JunosCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route administrative distance (metric) is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/subinterfaces/subinterface",
                 reason=(
                     "Unit 0 collapses into the parent (common case "
@@ -210,6 +226,14 @@ class JunosCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing/static-route/interface",
+                reason=(
+                    "Render emits ``next-hop <gateway>`` only; a gateway-less "
+                    "/ interface-only (connected) static route is dropped "
+                    "(run3)."
+                ),
+            ),
             # ── Tier-1/2 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -141,6 +141,7 @@ class MikroTikRouterOSCodec(CodecBase):
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             "/routing/static-route",
+            "/routing/static-route/description",  # run3 — `comment=...`
             # Tier 2 — SNMP
             "/snmp/community",
             "/snmp/location",
@@ -159,6 +160,15 @@ class MikroTikRouterOSCodec(CodecBase):
             "/interfaces/interface/vrrp-groups/group",
         ],
         lossy=[
+            LossyPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Render emits destination + gateway + comment only; the "
+                    "static-route administrative distance (metric) is "
+                    "dropped (run3)."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -167,6 +167,22 @@ class OPNsenseCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route administrative distance (metric) is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop only; the static-"
+                    "route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/description",
                 reason=(
                     "OPNsense imposes no length limit on description text; "
@@ -205,6 +221,29 @@ class OPNsenseCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing/static-route/interface",
+                reason=(
+                    "Render emits gateway-based routes only; a gateway-less "
+                    "/ interface-only (connected) static route is dropped "
+                    "(run3)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/ipv4/address/secondary-ip",
+                reason=(
+                    "Render emits one IPv4 address per interface; "
+                    "is_secondary addresses are dropped — a whole-subnet "
+                    "reachability loss (run3)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/ipv6/address/secondary-ip",
+                reason=(
+                    "Render emits one IPv6 address per interface; "
+                    "is_secondary addresses are dropped (run3)."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01) — this codec has no
             #    Cisco-style access/trunk port model, so the per-port VLAN
             #    membership the walker yields is dropped on render.  Declared

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -168,6 +168,14 @@ class VyOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Render emits destination + next-hop + distance only; "
+                    "the static-route name / description is dropped (run3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(
                     "VyOS declares no IANA ifType; the codec infers it "

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -38,7 +38,7 @@ Real configs from carriers, Batfish parser tests, and vendor-published examples.
 | aruba_aoss/user_contrib_2930m_wc1611.cfg | WARN 20/21 | WARN 19/21 | OK 21/21 | OK 21/21 | WARN 19/21 | WARN 18/21 | WARN 19/21 | WARN 18/21 | WARN 20/21 | WARN 18/21 | WARN 19/21 | WARN 19/21 |
 | cisco_iosxe/batfish_cisco_aaa.txt | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 |
 | cisco_iosxe/batfish_cisco_interface.txt | WARN 19/21 | WARN 19/21 | WARN 19/21 | WARN 20/21 | OK 21/21 | WARN 18/21 | WARN 19/21 | WARN 19/21 | WARN 18/21 | WARN 19/21 | WARN 20/21 | WARN 18/21 |
-| cisco_iosxe/batfish_cisco_ip_route.txt | WARN 20/21 | WARN 20/21 | WARN 20/21 | OK 21/21 | OK 21/21 | OK 21/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 |
+| cisco_iosxe/batfish_cisco_ip_route.txt | WARN 20/21 | WARN 20/21 | WARN 20/21 | OK 21/21 | OK 21/21 | WARN 20/21 | WARN 19/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 |
 | cisco_iosxe/batfish_cisco_logging.txt | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 |
 | cisco_iosxe/batfish_cisco_snmp.txt | OK 21/21 | WARN 20/21 | OK 21/21 | OK 21/21 | OK 21/21 | WARN 20/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | OK 21/21 | WARN 20/21 |
 | cisco_iosxe/batfish_iosxe_basic_vrrp.txt | WARN 19/21 | WARN 18/21 | WARN 18/21 | WARN 20/21 | OK 21/21 | WARN 19/21 | WARN 18/21 | WARN 20/21 | WARN 19/21 | WARN 18/21 | WARN 18/21 | WARN 19/21 |
@@ -48,7 +48,7 @@ Real configs from carriers, Batfish parser tests, and vendor-published examples.
 | cisco_iosxe/ntc_carrier_interfaces.txt | WARN 20/21 | WARN 19/21 | WARN 20/21 | WARN 20/21 | OK 21/21 | WARN 20/21 | WARN 19/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 | WARN 20/21 | WARN 19/21 |
 | cisco_iosxe/racc_cat8000v_iosxe179_netconf.txt | WARN 18/21 | WARN 18/21 | WARN 17/21 | OK 21/21 | OK 21/21 | WARN 20/21 | WARN 18/21 | WARN 19/21 | WARN 18/21 | WARN 17/21 | WARN 18/21 | WARN 18/21 |
 | cisco_iosxe/racc_csr1000v_iosxe169_bgp_ospf.txt | WARN 18/21 | WARN 19/21 | WARN 18/21 | OK 21/21 | OK 21/21 | WARN 20/21 | WARN 19/21 | WARN 19/21 | WARN 18/21 | WARN 18/21 | WARN 18/21 | WARN 19/21 |
-| cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt | WARN 18/21 | WARN 19/21 | WARN 18/21 | WARN 20/21 | OK 21/21 | WARN 19/21 | WARN 19/21 | WARN 19/21 | WARN 18/21 | WARN 18/21 | WARN 18/21 | WARN 19/21 |
+| cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt | WARN 18/21 | WARN 18/21 | WARN 18/21 | WARN 20/21 | OK 21/21 | WARN 18/21 | WARN 18/21 | WARN 19/21 | WARN 18/21 | WARN 18/21 | WARN 18/21 | WARN 19/21 |
 | cisco_iosxe/user_contrib_cat9300_iosxe1712.txt | WARN 18/21 | WARN 17/21 | WARN 18/21 | WARN 20/21 | OK 21/21 | WARN 17/21 | WARN 18/21 | WARN 18/21 | WARN 17/21 | WARN 18/21 | WARN 17/21 | WARN 17/21 |
 | cisco_iosxr/batfish_ebgp_border01.txt | WARN 19/21 | WARN 18/21 | WARN 18/21 | WARN 20/21 | WARN 19/21 | OK 21/21 | WARN 18/21 | WARN 18/21 | WARN 18/21 | WARN 17/21 | WARN 19/21 | WARN 17/21 |
 | cisco_iosxr/batfish_ebgp_border02.txt | WARN 18/21 | WARN 17/21 | WARN 17/21 | WARN 20/21 | WARN 19/21 | OK 21/21 | WARN 18/21 | WARN 17/21 | WARN 18/21 | WARN 16/21 | WARN 18/21 | WARN 16/21 |
@@ -117,12 +117,12 @@ One hand-authored fixture per codec exercising every field the codec's :class:`C
 | Source fixture | arista_eos | aruba_aoscx | aruba_aoss | cisco_iosxe | cisco_iosxe_cli | cisco_iosxr | cisco_nxos | fortigate_cli | juniper_junos | mikrotik_routeros | opnsense | vyos |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
 | arista_eos/kitchen_sink.txt | OK 21/21 | WARN 12/21 | WARN 16/21 | WARN 20/21 | WARN 16/21 | WARN 12/21 | WARN 13/21 | WARN 17/21 | WARN 18/21 | WARN 15/21 | WARN 14/21 | WARN 13/21 |
-| aruba_aoscx/kitchen_sink.cfg | WARN 15/21 | OK 21/21 | WARN 14/21 | WARN 19/21 | WARN 15/21 | WARN 14/21 | WARN 16/21 | WARN 15/21 | WARN 14/21 | WARN 14/21 | WARN 15/21 | WARN 16/21 |
+| aruba_aoscx/kitchen_sink.cfg | WARN 15/21 | OK 21/21 | WARN 14/21 | WARN 19/21 | WARN 16/21 | WARN 14/21 | WARN 16/21 | WARN 15/21 | WARN 14/21 | WARN 14/21 | WARN 15/21 | WARN 16/21 |
 | aruba_aoss/kitchen_sink.cfg | WARN 18/21 | WARN 13/21 | OK 21/21 | WARN 20/21 | WARN 18/21 | WARN 13/21 | WARN 14/21 | WARN 16/21 | WARN 17/21 | WARN 17/21 | WARN 15/21 | WARN 14/21 |
 | cisco_iosxe/kitchen_sink.xml | WARN 19/21 | WARN 18/21 | WARN 20/21 | OK 21/21 | WARN 19/21 | WARN 18/21 | WARN 18/21 | WARN 19/21 | WARN 20/21 | WARN 19/21 | WARN 19/21 | WARN 18/21 |
 | cisco_iosxe_cli/kitchen_sink.txt | WARN 14/21 | WARN 10/21 | WARN 15/21 | WARN 20/21 | OK 21/21 | WARN 12/21 | WARN 13/21 | WARN 14/21 | WARN 16/21 | WARN 12/21 | WARN 13/21 | WARN 11/21 |
 | cisco_iosxr/kitchen_sink.cfg | WARN 16/21 | WARN 16/21 | WARN 16/21 | WARN 20/21 | WARN 17/21 | OK 21/21 | WARN 16/21 | WARN 17/21 | WARN 16/21 | WARN 16/21 | WARN 18/21 | WARN 15/21 |
-| cisco_nxos/kitchen_sink.cfg | WARN 15/21 | WARN 15/21 | WARN 15/21 | WARN 19/21 | WARN 16/21 | WARN 13/21 | OK 21/21 | WARN 15/21 | WARN 15/21 | WARN 15/21 | WARN 15/21 | WARN 14/21 |
+| cisco_nxos/kitchen_sink.cfg | WARN 15/21 | WARN 15/21 | WARN 15/21 | WARN 19/21 | WARN 17/21 | WARN 13/21 | OK 21/21 | WARN 15/21 | WARN 15/21 | WARN 15/21 | WARN 15/21 | WARN 14/21 |
 | fortigate_cli/kitchen_sink.conf | WARN 15/21 | WARN 12/21 | WARN 14/21 | WARN 20/21 | WARN 15/21 | WARN 12/21 | WARN 12/21 | OK 21/21 | WARN 16/21 | WARN 14/21 | WARN 14/21 | WARN 12/21 |
 | juniper_junos/kitchen_sink.set | WARN 12/21 | WARN 8/21 | WARN 12/21 | WARN 18/21 | WARN 12/21 | WARN 8/21 | WARN 9/21 | WARN 13/21 | OK 21/21 | WARN 11/21 | WARN 11/21 | WARN 9/21 |
 | mikrotik_routeros/kitchen_sink.rsc | WARN 15/21 | WARN 12/21 | WARN 15/21 | WARN 20/21 | WARN 14/21 | WARN 11/21 | WARN 12/21 | WARN 16/21 | WARN 15/21 | WARN 20/21 | WARN 14/21 | WARN 13/21 |
@@ -165,7 +165,7 @@ Same roll-up but restricted to the synthetic kitchen-sink cells.  These pairs se
 
 ## Per-cell drill-downs — real captures
 
-One section per non-OK real-capture cell (922 total).  Sections are ordered by source fixture then target codec.
+One section per non-OK real-capture cell (923 total).  Sections are ordered by source fixture then target codec.
 
 ### arista_eos/batfish_duplicateprivate_eos4211.txt → aruba_aoscx  (WARN 19/21)
 
@@ -1834,55 +1834,62 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [{"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "de... | count drift: 12 → 4 (static_routes) |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "de... | count drift: 12 → 4 (static_routes) |
 
 ### cisco_iosxe/batfish_cisco_ip_route.txt → aruba_aoscx  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | count drift: 12 → 10 (static_routes) |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | count drift: 12 → 10 (static_routes) |
 
 ### cisco_iosxe/batfish_cisco_ip_route.txt → aruba_aoss  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [{"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "de... | count drift: 12 → 4 (static_routes) |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "de... | count drift: 12 → 4 (static_routes) |
 
-### cisco_iosxe/batfish_cisco_ip_route.txt → cisco_nxos  (WARN 20/21)
+### cisco_iosxe/batfish_cisco_ip_route.txt → cisco_iosxr  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"metric": {"source": 66, "target": 0}}, "static_routes[1] {'destination': '0.0.0.0/0'}": {"metric": {"source": 150, "target": 0}}, "static_routes[... |
+
+### cisco_iosxe/batfish_cisco_ip_route.txt → cisco_nxos  (WARN 19/21)
+
+| Field | Disposition | Source | Target | Drift |
+|---|---|---|---|---|
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | {"static_routes[5] {'destination': '0.0.0.0/0'}": {"description": {"source": "boppety", "target": ""}}, "static_routes[6] {'destination': '1.2.3.0/25'}": {"description": {"source": "bippety", "targ... |
 | routing_instances | DRIFT | [] | [{"name": "myvrf", "instance_type": "vrf", "route_distinguisher": "", "rt_imports": [], "rt_exports": [], "description": "", "l3_vni": null}] | 1 routing_instances appeared in target (parser bug?) |
 
 ### cisco_iosxe/batfish_cisco_ip_route.txt → fortigate_cli  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | {"static_routes[4] {'destination': '0.0.0.0/0'}": {"vrf": {"source": "myvrf", "target": ""}}, "static_routes[5] {'destination': '0.0.0.0/0'}": {"vrf": {"source": "myvrf", "target": ""}}} |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"metric": {"source": 66, "target": 0}}, "static_routes[1] {'destination': '0.0.0.0/0'}": {"metric": {"source": 150, "target": 0}}, "static_routes[... |
 
 ### cisco_iosxe/batfish_cisco_ip_route.txt → juniper_junos  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [{"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "description": "", "vrf": "myvrf"}, {"destination": "1.2.3.0/25", "gateway": "2.3.4.5", "interface": "", "metric": ... | count drift: 12 → 3 (static_routes) |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "5.6.7.8", "interface": "", "metric": 0, "description": "", "vrf": "myvrf"}, {"destination": "1.2.3.0/25", "gateway": "2.3.4.5", "interface": "", "metric": ... | count drift: 12 → 3 (static_routes) |
 
 ### cisco_iosxe/batfish_cisco_ip_route.txt → mikrotik_routeros  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [{"destination": "0.0.0.0/0", "gateway": "loopback", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "loopback99", "interface": "", "metric": 0,... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"gateway": {"source": "", "target": "loopback"}, "interface": {"source": "loopback", "target": ""}}, "static_routes[1] {'destination': '0.0.0.0/0'... |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "loopback", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "loopback99", "interface": "", "metric": 0,... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"gateway": {"source": "", "target": "loopback"}, "interface": {"source": "loopback", "target": ""}, "metric": {"source": 66, "target": 0}}, "stati... |
 
 ### cisco_iosxe/batfish_cisco_ip_route.txt → opnsense  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [] | all 12 static_routes dropped |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [] | all 12 static_routes dropped |
 
 ### cisco_iosxe/batfish_cisco_ip_route.txt → vyos  (WARN 20/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 0,... | [{"destination": "0.0.0.0/0", "gateway": "loopback", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "loopback99", "interface": "", "metric": 0,... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"gateway": {"source": "", "target": "loopback"}, "interface": {"source": "loopback", "target": ""}}, "static_routes[1] {'destination': '0.0.0.0/0'... |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "", "interface": "loopback99", "metric": 1... | [{"destination": "0.0.0.0/0", "gateway": "loopback", "interface": "", "metric": 66, "description": "", "vrf": ""}, {"destination": "0.0.0.0/0", "gateway": "loopback99", "interface": "", "metric": 1... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"gateway": {"source": "", "target": "loopback"}, "interface": {"source": "loopback", "target": ""}}, "static_routes[1] {'destination': '0.0.0.0/0'... |
 
 ### cisco_iosxe/batfish_cisco_snmp.txt → aruba_aoscx  (WARN 20/21)
 
@@ -2408,14 +2415,15 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "Loopback1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:softwareLoopback", "mtu": null, "ipv4_addresses": [{"ip": "198.51.100.1", "prefix_length": ... | count drift: 6 → 4 (interfaces) |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | [{"destination": "172.16.0.0/12", "gateway": "172.31.32.1", "interface": "", "metric": 0, "description": "", "vrf": ""}] | count drift: 22 → 1 (static_routes) |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "172.16.0.0/12", "gateway": "172.31.32.1", "interface": "", "metric": 0, "description": "", "vrf": ""}] | count drift: 22 → 1 (static_routes) |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [] | all 1 local_users dropped |
 
-### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → aruba_aoscx  (WARN 19/21)
+### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → aruba_aoscx  (WARN 18/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:other", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchport_mode": ... | {"interfaces[0] {'name': 'GigabitEthernet1'}": {"interface_type": {"source": "ianaift:ethernetCsmacd", "target": "ianaift:other"}}, "interfaces[1] {'name': 'Loopback1'}": {"interface_type": {"sourc... |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"description": {"source": "UMBRELLA_SIG", "target": ""}}} |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [{"name": "admin", "privilege_level": 1, "hashed_password": "7", "role": "admin"}] | {"local_users[0] {'name': 'admin'}": {"hashed_password": {"source": "7 15130F010D24", "target": "7"}, "privilege_level": {"source": 15, "target": 1}}} |
 
 ### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → aruba_aoss  (WARN 18/21)
@@ -2423,7 +2431,7 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "Loopback1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [{"ip": "198.51.100.1", "prefix_length": 24... | count drift: 6 → 4 (interfaces) |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | [{"destination": "172.16.0.0/12", "gateway": "172.31.32.1", "interface": "", "metric": 0, "description": "", "vrf": ""}] | count drift: 22 → 1 (static_routes) |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "172.16.0.0/12", "gateway": "172.31.32.1", "interface": "", "metric": 0, "description": "", "vrf": ""}] | count drift: 22 → 1 (static_routes) |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [] | all 1 local_users dropped |
 
 ### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → cisco_iosxe  (WARN 20/21)
@@ -2432,21 +2440,23 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 |---|---|---|---|---|
 | hostname | UNSUPPORTED (by design) | CSR1 |  | hostname: 'CSR1' → '' |
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | {"interfaces[4] {'name': 'Tunnel100'}": {"tunnel_type": {"source": "ipsec", "target": ""}}} |
-| static_routes | UNSUPPORTED (by design) | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | [] | all 22 static_routes dropped |
+| static_routes | UNSUPPORTED (by design) | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [] | all 22 static_routes dropped |
 | local_users | UNSUPPORTED (by design) | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [] | all 1 local_users dropped |
 
-### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → cisco_iosxr  (WARN 19/21)
+### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → cisco_iosxr  (WARN 18/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | {"interfaces[3] {'name': 'Tunnel1'}": {"interface_type": {"source": "ianaift:tunnel", "target": "ianaift:other"}}, "interfaces[4] {'name': 'Tunnel100'}": {"interface_type": {"source": "ianaift:tunn... |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"description": {"source": "UMBRELLA_SIG", "target": ""}}} |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [{"name": "admin", "privilege_level": 1, "hashed_password": "7 15130F010D24", "role": "admin"}] | {"local_users[0] {'name': 'admin'}": {"privilege_level": {"source": 15, "target": 1}}} |
 
-### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → cisco_nxos  (WARN 19/21)
+### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → cisco_nxos  (WARN 18/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:other", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchport_mode": ... | {"interfaces[0] {'name': 'GigabitEthernet1'}": {"interface_type": {"source": "ianaift:ethernetCsmacd", "target": "ianaift:other"}}, "interfaces[3] {'name': 'Tunnel1'}": {"interface_type": {"source"... |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"description": {"source": "UMBRELLA_SIG", "target": ""}}} |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [{"name": "admin", "privilege_level": 1, "hashed_password": "7 15130F010D24", "role": "admin"}] | {"local_users[0] {'name': 'admin'}": {"privilege_level": {"source": 15, "target": 1}}} |
 
 ### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → fortigate_cli  (WARN 19/21)
@@ -2461,7 +2471,7 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "Loopback1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:softwareLoopback", "mtu": null, "ipv4_addresses": [{"ip": "198.51.100.1", "prefix_length": ... | count drift: 6 → 4 (interfaces) |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | [{"destination": "172.16.0.0/12", "gateway": "172.31.32.1", "interface": "", "metric": 0, "description": "", "vrf": ""}] | count drift: 22 → 1 (static_routes) |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "172.16.0.0/12", "gateway": "172.31.32.1", "interface": "", "metric": 0, "description": "", "vrf": ""}] | count drift: 22 → 1 (static_routes) |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [] | all 1 local_users dropped |
 
 ### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → mikrotik_routeros  (WARN 18/21)
@@ -2469,7 +2479,7 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchport_mode": null, "access... | {"interfaces[0] {'name': 'GigabitEthernet1'}": {"interface_type": {"source": "ianaift:ethernetCsmacd", "target": ""}}, "interfaces[1] {'name': 'Loopback1'}": {"interface_type": {"source": "ianaift:... |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | [{"destination": "0.0.0.0/0", "gateway": "Tunnel100", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "dhcp", "interface": "", "metric": 0, ... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"gateway": {"source": "", "target": "Tunnel100"}, "interface": {"source": "Tunnel100", "target": ""}}, "static_routes[1] {'destination': '100.16.0... |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "0.0.0.0/0", "gateway": "Tunnel100", "interface": "", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "dhcp", "interface": "", "... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"gateway": {"source": "", "target": "Tunnel100"}, "interface": {"source": "Tunnel100", "target": ""}}, "static_routes[1] {'destination': '100.16.0... |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [{"name": "admin", "privilege_level": 15, "hashed_password": "", "role": "admin"}] | {"local_users[0] {'name': 'admin'}": {"hashed_password": {"source": "7 15130F010D24", "target": ""}}} |
 
 ### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → opnsense  (WARN 18/21)
@@ -2477,7 +2487,7 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchport_mode": null, "access... | {"interfaces[0] {'name': 'GigabitEthernet1'}": {"interface_type": {"source": "ianaift:ethernetCsmacd", "target": ""}}, "interfaces[1] {'name': 'Loopback1'}": {"interface_type": {"source": "ianaift:... |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | [] | all 22 static_routes dropped |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [] | all 22 static_routes dropped |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "7 15130F010D24", "role": "admin"}] | [{"name": "admin", "privilege_level": 15, "hashed_password": "", "role": "admin"}] | {"local_users[0] {'name': 'admin'}": {"hashed_password": {"source": "7 15130F010D24", "target": ""}}} |
 
 ### cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt → vyos  (WARN 19/21)
@@ -2485,7 +2495,7 @@ One section per non-OK real-capture cell (922 total).  Sections are ordered by s
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchpor... | [{"name": "GigabitEthernet1", "default_name": "", "description": "", "enabled": true, "interface_type": "", "mtu": null, "ipv4_addresses": [], "ipv6_addresses": [], "switchport_mode": null, "access... | {"interfaces[0] {'name': 'GigabitEthernet1'}": {"interface_type": {"source": "ianaift:ethernetCsmacd", "target": ""}}, "interfaces[1] {'name': 'Loopback1'}": {"interface_type": {"source": "ianaift:... |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "metric": 0, ... | [{"destination": "0.0.0.0/0", "gateway": "Tunnel100", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "dhcp", "interface": "", "metric": 0, ... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"gateway": {"source": "", "target": "Tunnel100"}, "interface": {"source": "Tunnel100", "target": ""}}, "static_routes[1] {'destination': '100.16.0... |
+| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "", "interface": "Tunnel100", "metric": 0, "description": "UMBRELLA_SIG", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "", "interface": "dhcp", "... | [{"destination": "0.0.0.0/0", "gateway": "Tunnel100", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "100.16.0.0/16", "gateway": "dhcp", "interface": "", "metric": 0, ... | {"static_routes[0] {'destination': '0.0.0.0/0'}": {"description": {"source": "UMBRELLA_SIG", "target": ""}, "gateway": {"source": "", "target": "Tunnel100"}, "interface": {"source": "Tunnel100", "t... |
 
 ### cisco_iosxe/user_contrib_cat9300_iosxe1712.txt → arista_eos  (WARN 18/21)
 
@@ -8414,13 +8424,12 @@ One section per non-OK synthetic cell (133 total).  Sections are ordered by sour
 | routing_instances | UNSUPPORTED (by design) | [{"name": "BLUE", "instance_type": "vrf", "route_distinguisher": "", "rt_imports": [], "rt_exports": [], "description": "", "l3_vni": null}, {"name": "RED", "instance_type": "vrf", "route_distingui... | [] | all 2 routing_instances dropped |
 | anycast_gateway_mac | DRIFT | 02:00:0a:14:14:01 |  | anycast_gateway_mac: '02:00:0a:14:14:01' → '' |
 
-### aruba_aoscx/kitchen_sink.cfg → cisco_iosxe_cli  (WARN 15/21)
+### aruba_aoscx/kitchen_sink.cfg → cisco_iosxe_cli  (WARN 16/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "1/1/1", "default_name": "", "description": "Uplink to spine", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": 9198, "ipv4_addresses": [{"ip": "198.51.100.1", "prefix_... | [{"name": "1/1/1", "default_name": "", "description": "Uplink to spine", "enabled": true, "interface_type": "ianaift:other", "mtu": 9198, "ipv4_addresses": [{"ip": "198.51.100.1", "prefix_length": ... | count drift: 13 → 14 (interfaces) |
 | vlans | DRIFT | [{"id": 1, "name": "", "description": "", "tagged_ports": [], "untagged_ports": ["1/1/4", "lag 1"], "ipv4_addresses": []}, {"id": 10, "name": "USERS", "description": "User access VLAN", "tagged_por... | [{"id": 1, "name": "", "description": "", "tagged_ports": [], "untagged_ports": ["1/1/4", "lag"], "ipv4_addresses": []}, {"id": 10, "name": "USERS", "description": "", "tagged_ports": ["1/1/4"], "u... | {"vlans[0] {'id': 1, 'name': ''}": {"untagged_ports": {"source": ["1/1/4", "lag 1"], "target": ["1/1/4", "lag"]}}, "vlans[1] {'id': 10, 'name': 'USERS'}": {"description": {"source": "User access VL... |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "198.51.100.2", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "10.99.0.0/16", "gateway": "203.0.113.254", "interface": "", "m... | [{"destination": "0.0.0.0/0", "gateway": "198.51.100.2", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "10.99.0.0/16", "gateway": "203.0.113.254", "interface": "", "m... | {"static_routes[1] {'destination': '10.99.0.0/16'}": {"metric": {"source": 200, "target": 0}}} |
 | snmp | DRIFT | {"community": "FAKECOMMUNITY", "location": "Data Center 1", "contact": "noc@example.net", "trap_hosts": [], "v3_users": [{"name": "monitor", "group": "", "auth_protocol": "sha", "auth_passphrase": ... | {"community": "FAKECOMMUNITY", "location": "Data Center 1", "contact": "noc@example.net", "trap_hosts": [], "v3_users": [{"name": "monitor", "group": "v3group", "auth_protocol": "sha", "auth_passph... | {"only_in_source": [], "only_in_target": [], "value_drift_keys": ["v3_users"]} |
 | lags | DRIFT | [{"name": "lag 1", "members": ["1/1/5", "1/1/6"], "mode": "active"}, {"name": "lag 2", "members": [], "mode": "static"}] | [{"name": "Port-channel1", "members": ["1/1/5", "1/1/6"], "mode": "active"}] | count drift: 2 → 1 (lags) |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "FAKECIPHERTEXTBLOBADMIN", "role": "administrators"}, {"name": "netops", "privilege_level": 1, "hashed_password": "FAKECIPHERTEXTBLOBNET... | [{"name": "admin", "privilege_level": 15, "hashed_password": "FAKECIPHERTEXTBLOBADMIN", "role": "admin"}, {"name": "netops", "privilege_level": 1, "hashed_password": "FAKECIPHERTEXTBLOBNETOPS", "ro... | {"local_users[0] {'name': 'admin'}": {"role": {"source": "administrators", "target": "admin"}}, "local_users[1] {'name': 'netops'}": {"role": {"source": "operators", "target": "operator"}}} |
@@ -9033,12 +9042,11 @@ One section per non-OK synthetic cell (133 total).  Sections are ordered by sour
 | routing_instances | UNSUPPORTED (by design) | [{"name": "TENANT-A", "instance_type": "vrf", "route_distinguisher": "65001:100", "rt_imports": ["65001:100"], "rt_exports": ["65001:100"], "description": "tenant a routing instance", "l3_vni": 500... | [] | all 2 routing_instances dropped |
 | anycast_gateway_mac | DRIFT | 00:01:c7:3a:00:00 |  | anycast_gateway_mac: '00:01:c7:3a:00:00' → '' |
 
-### cisco_nxos/kitchen_sink.cfg → cisco_iosxe_cli  (WARN 16/21)
+### cisco_nxos/kitchen_sink.cfg → cisco_iosxe_cli  (WARN 17/21)
 
 | Field | Disposition | Source | Target | Drift |
 |---|---|---|---|---|
 | interfaces | DRIFT | [{"name": "Ethernet1/1", "default_name": "", "description": "routed uplink to spine", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": 9216, "ipv4_addresses": [{"ip": "192.0.2.1"... | [{"name": "Ethernet1/1", "default_name": "", "description": "routed uplink to spine", "enabled": true, "interface_type": "ianaift:ethernetCsmacd", "mtu": 9216, "ipv4_addresses": [{"ip": "192.0.2.1"... | {"interfaces[4] {'name': 'Ethernet1/5'}": {"lag_member_of": {"source": "port-channel1", "target": "Port-channel1"}}, "interfaces[5] {'name': 'Ethernet1/6'}": {"lag_member_of": {"source": "port-chan... |
-| static_routes | DRIFT | [{"destination": "0.0.0.0/0", "gateway": "192.0.2.254", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "10.100.0.0/16", "gateway": "192.0.2.253", "interface": "", "met... | [{"destination": "0.0.0.0/0", "gateway": "192.0.2.254", "interface": "", "metric": 0, "description": "", "vrf": ""}, {"destination": "10.100.0.0/16", "gateway": "192.0.2.253", "interface": "", "met... | {"static_routes[1] {'destination': '10.100.0.0/16'}": {"metric": {"source": 200, "target": 0}}} |
 | lags | DRIFT | [{"name": "port-channel1", "members": ["Ethernet1/5", "Ethernet1/6"], "mode": "active"}] | [{"name": "Port-channel1", "members": ["Ethernet1/5", "Ethernet1/6"], "mode": "active"}] | {"lags[0] {'name': 'port-channel1'}": {"name": {"source": "port-channel1", "target": "Port-channel1"}}} |
 | local_users | DRIFT | [{"name": "admin", "privilege_level": 15, "hashed_password": "5 $5$KitchenSink$adminhashvalue01", "role": "network-admin"}, {"name": "netops", "privilege_level": 1, "hashed_password": "5 $5$Kitchen... | [{"name": "admin", "privilege_level": 15, "hashed_password": "5 $5$KitchenSink$adminhashvalue01", "role": "admin"}, {"name": "netops", "privilege_level": 1, "hashed_password": "5 $5$KitchenSink$ops... | {"local_users[0] {'name': 'admin'}": {"role": {"source": "network-admin", "target": "admin"}}, "local_users[1] {'name': 'netops'}": {"role": {"source": "network-operator", "target": "operator"}}} |
 | vxlan_vnis | UNSUPPORTED (by design) | [{"vlan_id": 10, "vni": 10010, "mcast_group": "", "flood_list": [], "source_interface": "loopback0", "udp_port": 4789}, {"vlan_id": 20, "vni": 10020, "mcast_group": "", "flood_list": [], "source_in... | [] | all 2 vxlan_vnis dropped |
@@ -9776,14 +9784,14 @@ One section per non-OK synthetic cell (133 total).  Sections are ordered by sour
 
 ```
 Traceback (most recent call last):
-  File "tools\run_full_mesh.py", line 666, in process_cell
+  File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 349, in render
+  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 360, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 546, in render_intent
     dest, mask = _cidr_to_dest_mask(route.destination)
                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
-  File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 741, in _cidr_to_dest_mask
+  File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 772, in _cidr_to_dest_mask
     return (dest, _prefix_to_mask(prefix, vendor="cisco_iosxe_cli"))
                   ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 out of range
@@ -9819,9 +9827,9 @@ netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 ou
 
 ```
 Traceback (most recent call last):
-  File "tools\run_full_mesh.py", line 666, in process_cell
+  File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 346, in render
+  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 396, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\fortigate_cli\render.py", line 950, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -86,6 +86,7 @@ from netcanon.migration.codecs import (  # noqa: F401
 )
 from netcanon.migration.codecs.cisco_iosxe_cli.codec import _walk_canonical
 from netcanon.migration.codecs.registry import get_codec, list_codecs
+from netcanon.services.migration_validate import validate_against
 
 pytestmark = pytest.mark.unit
 
@@ -127,10 +128,19 @@ def _maximal_intent() -> CanonicalIntent:
         virtual_gateway_address="2001:db8::254",
         virtual_gateway_mac="00:00:5e:00:02:01",
     )
+    # Secondary addresses exercise the per-address is_secondary walk so the
+    # single-address-platform codecs (FortiGate / OPNsense) that drop them
+    # have their /…/secondary-ip unsupported declaration reachable (run3).
+    addr4_sec = CanonicalIPv4Address(
+        ip="10.0.99.1", prefix_length=24, is_secondary=True,
+    )
+    addr6_sec = CanonicalIPv6Address(
+        ip="2001:db8:99::1", prefix_length=64, is_secondary=True,
+    )
     iface = CanonicalInterface(
         name="Ethernet1", default_name="Ethernet1", description="d",
         enabled=True, interface_type="ianaift:ethernetCsmacd", mtu=9000,
-        ipv4_addresses=[addr4], ipv6_addresses=[addr6],
+        ipv4_addresses=[addr4, addr4_sec], ipv6_addresses=[addr6, addr6_sec],
         switchport_mode="trunk", access_vlan=10, trunk_allowed_vlans=[10, 20],
         trunk_native_vlan=99, voice_vlan=200, lag_member_of="Port-Channel1",
         dhcp_client=True, dhcp_client_v6="dhcp6", tunnel_type="gre",
@@ -159,7 +169,11 @@ def _maximal_intent() -> CanonicalIntent:
             tagged_ports=["Ethernet1"], untagged_ports=["Ethernet2"],
             ipv4_addresses=[addr4])],
         static_routes=[CanonicalStaticRoute(
-            destination="0.0.0.0/0", gateway="10.0.0.2", vrf="TENANT")],
+            destination="0.0.0.0/0", gateway="10.0.0.2", vrf="TENANT",
+            # metric / description / interface exercise the static-route
+            # sub-field walk so the per-codec lossy/unsupported declarations
+            # for the codecs that drop them are reachable (run3).
+            metric=200, description="primary uplink", interface="Ethernet2")],
         anycast_gateway_mac="00:1c:73:00:dc:01",
         dhcp_servers=[CanonicalDHCPPool(
             network="10.0.0.0/24", start_ip="10.0.0.10", end_ip="10.0.0.99")],
@@ -435,3 +449,122 @@ def test_maximal_intent_exercises_every_top_level_field():
     # populated (an empty CanonicalSNMP() dumps truthy but would gut the
     # /snmp/* walker coverage).
     assert intent.snmp and intent.snmp.community, "_maximal_intent snmp.community empty"
+
+
+# ---------------------------------------------------------------------------
+# run3 audit — value-fidelity (not just presence) for static-route sub-fields
+# + secondary interface addresses.
+#
+# The presence-only honesty guards above prove the walker SEES each top-level
+# surface, but not that a partial VALUE loss (a route's metric/description/
+# interface, or a second IP on an interface) is declared.  These were the
+# silent ``severity: ok`` drops the run3 audit re-found.  This block renders a
+# kitchen-sink carrying those values through each codec, re-parses, and asserts
+# every codec that DROPS a sub-value declares it lossy/unsupported.
+# ---------------------------------------------------------------------------
+
+
+def _subfield_intent() -> CanonicalIntent:
+    """Cisco-shaped kitchen sink exercising the run3 static-route sub-fields
+    (metric / description / interface-nexthop) + a secondary IPv4 and IPv6
+    address, so a render→re-parse reveals which codecs drop each one."""
+    return CanonicalIntent(
+        hostname="r1",
+        interfaces=[CanonicalInterface(
+            name="GigabitEthernet0/1", default_name="GigabitEthernet0/1",
+            ipv4_addresses=[
+                CanonicalIPv4Address(ip="10.0.0.1", prefix_length=24),
+                CanonicalIPv4Address(ip="10.0.9.1", prefix_length=24,
+                                     is_secondary=True),
+            ],
+            ipv6_addresses=[
+                CanonicalIPv6Address(ip="2001:db8::1", prefix_length=64),
+                CanonicalIPv6Address(ip="2001:db8:9::1", prefix_length=64,
+                                     is_secondary=True),
+            ],
+        )],
+        static_routes=[
+            CanonicalStaticRoute(destination="10.7.0.0/24",
+                                 gateway="172.16.0.1", metric=250,
+                                 description="BORDER-LINK"),
+            CanonicalStaticRoute(destination="10.8.0.0/24",
+                                 interface="GigabitEthernet0/1"),
+        ],
+    )
+
+
+@pytest.mark.parametrize("name", _CODEC_NAMES)
+def test_static_route_subfield_and_secondary_drops_are_declared(name: str):
+    """Render→re-parse the sub-field kitchen-sink; every sub-VALUE the codec
+    drops must be declared lossy/unsupported, else live validation reports
+    ``severity: ok`` while the data is discarded (run3 value-fidelity gap)."""
+    codec = get_codec(name)
+    caps = codec.capabilities
+    declared = {u.path for u in caps.unsupported} | {lp.path for lp in caps.lossy}
+    reparsed = codec.parse(codec.render(_subfield_intent()))
+    routes = reparsed.static_routes
+
+    # Survival is reachability-based (the SECOND address / the route value),
+    # not flag-based — a codec that re-emits both IPs but loses the
+    # ``is_secondary`` marker has no reachability loss to declare.
+    max_v4 = max((len(i.ipv4_addresses) for i in reparsed.interfaces), default=0)
+    max_v6 = max((len(i.ipv6_addresses) for i in reparsed.interfaces), default=0)
+
+    gaps = []
+    # Clean value losses (no naming / representation ambiguity).  The route
+    # metric + description are scalars and the secondary address is a count,
+    # so a drop is unambiguous.  ``interface`` is deliberately NOT auto-
+    # checked here: codecs differ on whether a gateway-less route VANISHES
+    # (a true reachability loss — declared unsupported) or merely relocates
+    # the interface into the gateway/next-hop field (no loss); that nuance
+    # is covered by ``test_connected_route_loss_blocks_on_vanishing_codecs``.
+    if "/routing/static-route" not in {u.path for u in caps.unsupported}:
+        if not any(r.metric == 250 for r in routes) \
+                and "/routing/static-route/metric" not in declared:
+            gaps.append("static-route/metric")
+        if not any(r.description == "BORDER-LINK" for r in routes) \
+                and "/routing/static-route/description" not in declared:
+            gaps.append("static-route/description")
+    if max_v4 < 2 \
+            and "/interfaces/interface/ipv4/address/secondary-ip" not in declared:
+        gaps.append("ipv4/secondary-ip")
+    if max_v6 < 2 \
+            and "/interfaces/interface/ipv6/address/secondary-ip" not in declared:
+        gaps.append("ipv6/secondary-ip")
+
+    assert not gaps, (
+        f"{name}: render→re-parse DROPS these static-route sub-value(s) / "
+        f"secondary address(es) yet the matrix declares none of them "
+        f"lossy/unsupported, so live validation reports 'ok' while the data "
+        f"is discarded: {gaps}.  Add a LossyPath/UnsupportedPath (exact "
+        f"walker spelling)."
+    )
+
+
+@pytest.mark.parametrize("name", ["arista_eos", "juniper_junos", "opnsense"])
+def test_connected_route_loss_blocks_on_vanishing_codecs(name: str):
+    """A gateway-less (interface-only / connected) static route is dropped
+    ENTIRELY by these codecs — its destination vanishes from the render, a
+    real reachability loss.  The live validation report must surface that as
+    a block via the ``/routing/static-route/interface`` unsupported
+    declaration, not a silent ``severity: ok`` (run3)."""
+    src = get_codec("cisco_iosxe_cli")
+    tree = CanonicalIntent(
+        hostname="r1",
+        interfaces=[CanonicalInterface(
+            name="GigabitEthernet0/1", default_name="GigabitEthernet0/1")],
+        static_routes=[CanonicalStaticRoute(
+            destination="10.8.0.0/24", interface="GigabitEthernet0/1")],
+    )
+    # The route genuinely vanishes from this codec's render (precondition).
+    target = get_codec(name)
+    reparsed = target.parse(target.render(tree))
+    assert not reparsed.static_routes, (
+        f"{name} unexpectedly preserved the gateway-less route — revisit "
+        f"the interface-unsupported declaration"
+    )
+    report = validate_against(tree, target, source=src)
+    assert "/routing/static-route/interface" in {
+        u.path for u in report.unsupported_paths
+    }
+    assert report.severity == "block" and report.compatible is False


### PR DESCRIPTION
## What

Closes the run3 **fidelity-honesty** cluster (4 MEDIUM findings) — silent
`severity: ok` migrations that were actually discarding data:

| Finding | Was | Now |
|---|---|---|
| `static-route-metric-desc-connected-dropped` | route admin distance / name / interface dropped silently | walked + declared lossy/unsupported per the codec that drops it |
| `secondary-ip-dropped-opnsense-fortigate` | 2nd interface IP silently dropped (whole-subnet reachability loss) | `secondary-ip` declared **unsupported** (block) on fortigate + opnsense |
| `honesty-harness-presence-not-value` | harness tested field *presence*, not *value* | value-fidelity guard: every dropped sub-VALUE must be declared |
| `classifier-silent-pass-default` (test arm) | partial drops untested | widened honesty suite (kept `classify()` default unchanged — a global flip across all 12 codecs is out of scope/too risky) |

## How (verify-first)

Declarations are grounded in an **empirical render→re-parse drop-map**, not guesswork. Per sub-path, only the codecs that genuinely drop it are declared:
- **metric** → lossy on 7 codecs; **description** → lossy on 9 (supported on mikrotik; single-token round-trips on cisco)
- **interface** → unsupported (block) on arista/junos/opnsense where a gateway-less route *vanishes*; supported on fortigate
- **secondary-ip v4+v6** → unsupported on fortigate + opnsense

`cisco_iosxe_cli` parse now harvests the trailing **admin distance → metric** and **`name <X>` → description** (previously parse-and-ignored — a cisco round-trip silently reset the distance and dropped the route name); render emits `name <X>` for single-token names so they round-trip losslessly.

## Proof

Live validation now blocks/warns instead of reporting ok — e.g. cisco→junos with a connected route + metric + description + secondary now reports **block** (`/routing/static-route/interface` unsupported) + lossy(metric, description); cisco→nxos reports **warn** (description lossy only). Two new guards lock this in.

## Behavior change

This **flips some previously-`ok` migrations to `warn`/`block`** — that is the point (the losses were real and silent). `lossy`=warn lets the migration proceed; `unsupported`=block is overridable with `force=True`.

Local gate: full `tests/unit` + `tests/integration` (5010 passed, 82 skipped); ruff clean; **regen CODEC_BUG held at 5**.

Part of the v0.4.1 run3-remediation series (PR-A of 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)