### PR TITLE
fix(security,ci,docs): credential fail-closed, anchored cosign, gating Trivy, egress off-loop + doc honesty (run3 MEDIUM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,22 @@ jobs:
       - name: Build image
         run: docker build -t netcanon-smoke:pr .
 
+      # Gating CVE scan (run3): the docker-publish.yml Trivy step is
+      # informational (exit-code 0) AND runs AFTER push, so a CRITICAL CVE
+      # would already be shipped + signed.  This scan runs pre-merge on the
+      # locally-built image and FAILS the PR (exit-code 1) on a fixable
+      # CRITICAL, so a vulnerable image can never reach a release tag.
+      # ignore-unfixed drops CVEs with no upstream patch (un-actionable
+      # noise).  Pinned to the same SHA as docker-publish.yml.
+      - name: Scan image for CRITICAL CVEs (gating)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: netcanon-smoke:pr
+          format: table
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
       - name: Boot image and check /health + dashboard renders
         run: |
           # SEC-01: the smoke container binds 0.0.0.0 with no API key;

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -205,6 +205,12 @@ jobs:
         env:
           IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
         run: |
+          # The identity regexp is passed to Go's regexp (substring match,
+          # NO implicit anchors), so it MUST be anchored + dot-escaped +
+          # fully qualified to this workflow file — otherwise a SAN like
+          # https://github.com/netcanon/netcanon-attacker/... would also
+          # match (run3).  The keyless signer identity for a tag-triggered
+          # run is .../.github/workflows/docker-publish.yml@refs/tags/vX.Y.Z.
           cosign verify "${IMAGE_DIGEST}" \
-            --certificate-identity-regexp "https://github.com/${{ github.repository }}" \
+            --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/docker-publish\.yml@refs/tags/v" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,13 @@ RUN pip install --no-cache-dir --upgrade pip wheel \
 FROM python:3.14.5-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS runtime
 
 # curl is the only runtime addition — used by HEALTHCHECK.  No build tools.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# ``apt-get upgrade`` applies Debian security point-releases on top of the
+# digest-pinned base (run3): the base tag is rebuilt less often than the
+# point-releases land, so it can ship a stale package (e.g. libgnutls30
+# behind a fixed CRITICAL CVE).  The gating Trivy scan in ci.yml fails the
+# PR on exactly that, so patch it here at build time — the digest still
+# pins the base layer; this is an explicit, auditable hardening layer.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r app --gid=1000 \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -431,7 +431,7 @@ provenance can verify each:
   through GitHub Actions OIDC.  Verifiable with:
   ```
   cosign verify ghcr.io/netcanon/netcanon:<tag> \
-      --certificate-identity-regexp 'github.com/netcanon/netcanon' \
+      --certificate-identity-regexp '^https://github\.com/netcanon/netcanon/\.github/workflows/docker-publish\.yml@refs/tags/v' \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```
 - **SBOM via syft + cosign attestation (GHCR only).**  An SPDX-format

--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -56,6 +56,31 @@ def register_schedule_job(scheduler, schedule: BackupSchedule, app) -> None:
     )
 
 
+def _filter_egress_allowed(devices: list, schedule_name: str) -> list:
+    """Return only the *devices* whose host passes the egress allow-list.
+
+    Synchronous on purpose: ``assert_egress_allowed`` does a blocking
+    ``socket.getaddrinfo``, so the scheduled coroutine offloads this whole
+    loop to a worker thread via ``asyncio.to_thread`` (run3) instead of
+    stalling the event loop once per device.
+    """
+    from ...services.egress import EgressBlocked, assert_egress_allowed
+
+    kept = []
+    for d in devices:
+        try:
+            assert_egress_allowed(d.host)
+            kept.append(d)
+        except EgressBlocked as exc:
+            logger.warning(
+                "Schedule '%s': skipping target %s — %s",
+                schedule_name,
+                d.host,
+                exc,
+            )
+    return kept
+
+
 async def _run_scheduled_backup(schedule_id: str, app) -> None:
     """Coroutine executed by APScheduler for each scheduled run.
 
@@ -179,23 +204,15 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
 
     # Egress allow-list (opt-in via Settings.block_private_egress): drop any
     # scheduled target that resolves to loopback / link-local rather than
-    # failing the whole run (review finding #3).
+    # failing the whole run (review finding #3).  ``assert_egress_allowed``
+    # does a blocking, timeout-less ``socket.getaddrinfo`` per host; this
+    # coroutine runs ON the APScheduler/asyncio event loop, so the whole
+    # filter is offloaded to a worker thread (run3) — otherwise a slow DNS
+    # answer stalls the loop, scaling with the device count.
     if app.state.settings.block_private_egress:
-        from ...services.egress import EgressBlocked, assert_egress_allowed
-
-        kept = []
-        for d in devices:
-            try:
-                assert_egress_allowed(d.host)
-                kept.append(d)
-            except EgressBlocked as exc:
-                logger.warning(
-                    "Schedule '%s': skipping target %s — %s",
-                    schedule.name,
-                    d.host,
-                    exc,
-                )
-        devices = kept
+        devices = await asyncio.to_thread(
+            _filter_egress_allowed, devices, schedule.name
+        )
         if not devices:
             logger.warning(
                 "Schedule '%s': all targets blocked by egress policy — "

--- a/netcanon/security/credentials.py
+++ b/netcanon/security/credentials.py
@@ -46,19 +46,43 @@ storage-layer concern only.
 
 Migration
 ---------
-On first load after upgrading from an unencrypted version, any field
-that fails to decrypt (``InvalidToken``) is assumed to be a legacy
-plaintext value.  ``decrypt_field()`` returns the plaintext and signals
-that the file should be re-saved with encryption applied.
+On first load after upgrading from an unencrypted version, a field that
+fails to decrypt is treated as legacy plaintext **only when it does not
+have the structural shape of a Fernet token**.  A value that *is* token-
+shaped but fails to decrypt means the wrong / rotated / lost key — fail
+closed: ``decrypt_field()`` raises :class:`CredentialDecryptError` so the
+caller logs loudly and skips the profile rather than loading the
+ciphertext verbatim as the password and double-encrypting it on re-save.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class CredentialDecryptError(Exception):
+    """A token-shaped credential failed to decrypt — wrong/rotated/lost key.
+
+    Distinct from the legacy-plaintext case (a non-token value written
+    before encryption existed).  Raising this — rather than returning the
+    undecryptable ciphertext as if it were plaintext — keeps the storage
+    layer from (a) handing the ciphertext to the collector as the SSH
+    password and (b) re-encrypting it on save (double-encryption /
+    corruption).
+    """
+
+
+#: First byte of a Fernet token after base64url-decoding — the version
+#: marker (0x80).  A token is ``version(1) || ts(8) || iv(16) ||
+#: ciphertext || hmac(32)`` so the minimum decoded length is 57 bytes.
+_FERNET_VERSION = 0x80
+_FERNET_MIN_LEN = 57
 
 _SERVICE = "Netcanon"
 _ACCOUNT = "master_key"
@@ -243,6 +267,21 @@ def decrypt(token: str) -> str:
     return _get_fernet().decrypt(token.encode()).decode()
 
 
+def _looks_like_fernet_token(value: str) -> bool:
+    """True if *value* has the structural shape of a Fernet token.
+
+    Positive detection (base64url that decodes to >= 57 bytes whose first
+    byte is the 0x80 version marker) so a token we simply can't decrypt
+    (wrong key) is distinguishable from genuine legacy plaintext — the
+    fail-open bug was treating every undecryptable value as plaintext.
+    """
+    try:
+        raw = base64.urlsafe_b64decode(value.encode("ascii"))
+    except (binascii.Error, ValueError, UnicodeEncodeError):
+        return False
+    return len(raw) >= _FERNET_MIN_LEN and raw[0] == _FERNET_VERSION
+
+
 def decrypt_field(value: str) -> tuple[str, bool]:
     """Decrypt *value* if it is a Fernet token; return as-is if plaintext.
 
@@ -253,13 +292,27 @@ def decrypt_field(value: str) -> tuple[str, bool]:
     Returns:
         ``(plaintext, was_encrypted)`` — ``was_encrypted`` is ``False`` when
         the stored value is a legacy plaintext credential that needs migrating.
+
+    Raises:
+        CredentialDecryptError: *value* is token-shaped but does not
+            decrypt under the active key (wrong / rotated / lost key).
+            Fail closed rather than returning the ciphertext as plaintext.
     """
     from cryptography.fernet import InvalidToken
 
     try:
         return _get_fernet().decrypt(value.encode()).decode(), True
     except InvalidToken:
-        # Value is not a valid Fernet token — treat as legacy plaintext.
+        if _looks_like_fernet_token(value):
+            # Token-shaped but undecryptable: wrong/rotated/lost key, NOT
+            # legacy plaintext.  Fail closed (the fail-open bug returned
+            # the ciphertext here as `(value, False)`).
+            raise CredentialDecryptError(
+                "credential is Fernet-token-shaped but failed to decrypt "
+                "under the active key (wrong / rotated / lost key?)"
+            ) from None
+        # Not token-shaped — genuine legacy plaintext from a pre-encryption
+        # version; signal the caller to re-save with encryption applied.
         return value, False
 
 

--- a/netcanon/security/migration.py
+++ b/netcanon/security/migration.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 
-from .credentials import decrypt_field
+from .credentials import CredentialDecryptError, decrypt_field
 
 logger = logging.getLogger(__name__)
 
@@ -22,14 +22,36 @@ def migrate_credential_fields(
     """Decrypt credential *fields* in *data* in-place.
 
     Returns ``True`` if any field was plaintext (needs re-save with
-    encryption), ``False`` if all were already encrypted.
+    encryption), ``False`` if all were already encrypted **or** any field
+    could not be decrypted under the active key.
+
+    A token-shaped field that fails to decrypt (wrong / rotated / lost
+    key) is left untouched, logged loudly, and forces the return to
+    ``False`` so the store does NOT re-save the profile — re-saving would
+    double-encrypt the surviving ciphertext and corrupt it.
     """
     needs_resave = False
+    decrypt_failed = False
     for field in fields:
         value = data.get(field)
-        if value:
+        if not value:
+            continue
+        try:
             plaintext, was_encrypted = decrypt_field(value)
-            data[field] = plaintext
-            if not was_encrypted:
-                needs_resave = True
-    return needs_resave
+        except CredentialDecryptError as exc:
+            logger.warning(
+                "CREDENTIAL DECRYPT FAILED for field %r: %s.  Leaving the "
+                "stored value untouched and skipping re-save (avoids double-"
+                "encryption).  Restore the original encryption key or "
+                "re-enter the credential.",
+                field,
+                exc,
+            )
+            decrypt_failed = True
+            continue
+        data[field] = plaintext
+        if not was_encrypted:
+            needs_resave = True
+    # Never re-save a profile we could not fully decrypt — a re-save would
+    # re-encrypt the still-ciphertext field and corrupt it.
+    return needs_resave and not decrypt_failed

--- a/tests/fixtures/real/NOTICE.md
+++ b/tests/fixtures/real/NOTICE.md
@@ -248,7 +248,13 @@ round-trip cleanly (the codec keeps the canonical single `community`).
 
 ## Adding new captures
 
-1. Fetch from an unambiguously-licensed public source (Apache, MIT, BSD).
+1. Fetch from an unambiguously-licensed public source (Apache, MIT, BSD)
+   **or** an operator forum-share thread (factual device-output precedent —
+   see the entries above).  **Do NOT add new captures from a repository
+   with no LICENSE file.**  The no-LICENSE entries above are grandfathered
+   under the factual-device-output (non-creative) precedent and each carries
+   an explicit "drop if author objects" note; new all-rights-reserved
+   upstreams are not accepted — replace with a synthetic capture instead.
 2. Drop into `<vendor>/` with a filename that encodes origin + feature.
 3. Update this NOTICE with an entry covering origin URL, license, and
    what the file stresses.

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -6,7 +6,7 @@ Total cells reconciled: **1224**.  Each cell carries one ``field_variances`` ent
 
 Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross-vendor only): **102** cell(s).  Their fields show up in the per-run JSON with empty ``field_variances``.
 
-**Warning:** 723 cross-vendor cell(s) had no matching pair YAML.  Phase 3 ships 56/56 cross-vendor pairs validated; if this number is non-zero, check ``tests/fixtures/cross_vendor_expectations/`` for missing files.  Detail in the per-run JSON.
+**Coverage note:** 723 cross-vendor cell(s) have no matching pair YAML.  The 56 expectation YAMLs cover only an 8-codec subset (8 of the 12 codecs); **aruba_aoscx / cisco_iosxr / cisco_nxos / vyos have ZERO expectation coverage** as both source and target, so any drift into or out of those codecs is structurally invisible to this residual.  That makes these 723 of 1224 cells expected, NOT a missing-files error — the headline residual is computed over the covered subset, not the full mesh.  Detail in the per-run JSON.
 
 ## Aggregate variance counts
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -187,6 +187,87 @@ class TestDecryptField:
         assert val == ""
         assert was_enc is False
 
+    def test_token_shaped_wrong_key_fails_closed(self):
+        """run3: a value that IS a Fernet token but fails to decrypt under
+        the active key (wrong / rotated / lost key) must RAISE rather than
+        be returned as legacy plaintext.  The fail-open bug returned the
+        ciphertext verbatim with ``was_encrypted=False``, so the store
+        loaded it as the SSH password and double-encrypted it on re-save."""
+        from cryptography.fernet import Fernet
+
+        from netcanon.security.credentials import (
+            CredentialDecryptError,
+            decrypt_field,
+        )
+
+        # Encrypt under a DIFFERENT key than the fixture's active key.
+        foreign = Fernet(Fernet.generate_key())
+        token = foreign.encrypt(b"SuperSecret").decode()
+        with pytest.raises(CredentialDecryptError):
+            decrypt_field(token)
+
+    def test_looks_like_fernet_token_discriminates(self):
+        from netcanon.security.credentials import (
+            _looks_like_fernet_token,
+            encrypt,
+        )
+
+        assert _looks_like_fernet_token(encrypt("x")) is True
+        # Genuine legacy plaintext passwords are not token-shaped.
+        for plain in ("hunter2", "admin", "P@ssw0rd!", "", "not base64 €€"):
+            assert _looks_like_fernet_token(plain) is False
+
+
+class TestMigrateCredentialFields:
+    """run3: the storage-layer migration helper must fail closed on a
+    wrong-key field and never re-save (which would double-encrypt)."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_keyring(self):
+        key = _make_fernet_key()
+        with (
+            patch("keyring.get_password", return_value=key),
+            patch("keyring.set_password"),
+        ):
+            yield
+
+    def test_plaintext_field_flags_resave(self):
+        from netcanon.security.migration import migrate_credential_fields
+
+        data = {"password": "legacyplain"}
+        needs = migrate_credential_fields(data, ["password"])
+        assert needs is True
+        assert data["password"] == "legacyplain"
+
+    def test_encrypted_field_no_resave(self):
+        from netcanon.security.credentials import encrypt
+        from netcanon.security.migration import migrate_credential_fields
+
+        data = {"password": encrypt("secret")}
+        needs = migrate_credential_fields(data, ["password"])
+        assert needs is False
+        assert data["password"] == "secret"
+
+    def test_wrong_key_field_left_untouched_and_no_resave(self, caplog):
+        import logging
+
+        from cryptography.fernet import Fernet
+
+        from netcanon.security.migration import migrate_credential_fields
+
+        foreign = Fernet(Fernet.generate_key())
+        ciphertext = foreign.encrypt(b"secret").decode()
+        data = {"password": ciphertext, "enable": "legacyplain"}
+        with caplog.at_level(logging.WARNING):
+            needs = migrate_credential_fields(data, ["password", "enable"])
+        # Must NOT re-save (would double-encrypt the surviving ciphertext).
+        assert needs is False
+        # The undecryptable field is left exactly as-is.
+        assert data["password"] == ciphertext
+        # The sibling plaintext field is still decrypted normally.
+        assert data["enable"] == "legacyplain"
+        assert any("DECRYPT FAILED" in r.message for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # Tier 1: NETCANON_FERNET_KEY env var (operator-explicit override)

--- a/tests/unit/test_egress.py
+++ b/tests/unit/test_egress.py
@@ -61,3 +61,21 @@ def test_unresolvable_host_is_not_blocked() -> None:
     # here would turn DNS hiccups into spurious backup failures.  The
     # `.invalid` TLD is guaranteed non-resolvable (RFC 6761).
     assert assert_egress_allowed("netcanon-egress-test.invalid") is None
+
+
+def test_scheduled_filter_egress_allowed_drops_blocked_hosts() -> None:
+    """run3: the scheduled-backup egress filter (now a sync helper offloaded
+    to a worker thread so its blocking getaddrinfo doesn't stall the event
+    loop) keeps allowed targets and drops loopback/link-local ones."""
+    from types import SimpleNamespace
+
+    from netcanon.api.routes.schedules import _filter_egress_allowed
+
+    devices = [
+        SimpleNamespace(host="8.8.8.8"),          # public — allowed
+        SimpleNamespace(host="10.0.0.5"),         # RFC-1918 — allowed
+        SimpleNamespace(host="127.0.0.1"),        # loopback — blocked
+        SimpleNamespace(host="169.254.169.254"),  # metadata — blocked
+    ]
+    kept = _filter_egress_allowed(devices, "test-schedule")
+    assert [d.host for d in kept] == ["8.8.8.8", "10.0.0.5"]

--- a/tools/run_phase4_reconciliation.py
+++ b/tools/run_phase4_reconciliation.py
@@ -92,10 +92,11 @@ Constraints honoured
 --------------------
 * Standalone executable — no pytest dependency at runtime.
 * Self-contained — no internet, no external API calls.
-* Honest about misses — cells whose pair YAML doesn't exist (shouldn't
-  happen since Phase 3 ships 56/56 pairs validated) are reported in
-  the JSON's ``cells_without_expectation_yaml`` field rather than
-  silently dropped.
+* Honest about misses — cells whose pair YAML doesn't exist (the 56
+  expectation YAMLs cover only an 8-codec subset; aruba_aoscx /
+  cisco_iosxr / cisco_nxos / vyos have none, so ~59% of mesh cells are
+  uncovered) are reported in the JSON's
+  ``cells_without_expectation_yaml`` field rather than silently dropped.
 * Idempotent — re-running produces a new timestamped JSON; the
   skeleton .md gets overwritten on every invocation.
 """
@@ -1136,12 +1137,18 @@ def render_skeleton_md(result: dict[str, Any]) -> str:
         )
     if result.get("cells_without_expectation_yaml"):
         n = len(result["cells_without_expectation_yaml"])
+        m = result.get("expectation_yamls_loaded", 0)
+        total = result.get("cells_total", 0)
         lines.append(
-            f"**Warning:** {n} cross-vendor cell(s) had no matching "
-            f"pair YAML.  Phase 3 ships 56/56 cross-vendor pairs "
-            f"validated; if this number is non-zero, check "
-            f"``tests/fixtures/cross_vendor_expectations/`` for "
-            f"missing files.  Detail in the per-run JSON.\n"
+            f"**Coverage note:** {n} cross-vendor cell(s) have no matching "
+            f"pair YAML.  The {m} expectation YAMLs cover only an 8-codec "
+            f"subset (8 of the 12 codecs); **aruba_aoscx / cisco_iosxr / "
+            f"cisco_nxos / vyos have ZERO expectation coverage** as both "
+            f"source and target, so any drift into or out of those codecs "
+            f"is structurally invisible to this residual.  That makes "
+            f"these {n} of {total} cells expected, NOT a missing-files "
+            f"error — the headline residual is computed over the covered "
+            f"subset, not the full mesh.  Detail in the per-run JSON.\n"
         )
 
     lines.append("## Aggregate variance counts\n")


### PR DESCRIPTION
## What

Closes the run3 **security / supply-chain / doc-honesty** cluster (6 MEDIUM):

| Finding | Fix | Behaviour change? |
|---|---|---|
| `credential-decrypt-fails-open` | positively detect Fernet token shape (base64url → `0x80` ver byte, ≥57B); a token-shaped value that won't decrypt under the active key now **raises `CredentialDecryptError`** instead of being returned as the SSH password; the migration helper logs loudly, leaves the field untouched, and **skips re-save** (no double-encryption) | ⚠️ **yes** |
| `trivy-non-blocking-post-publish` | add a **gating** Trivy scan (exit-code 1, CRITICAL, ignore-unfixed) to ci.yml's `docker-build-smoke` job on the locally-built image — a CRITICAL CVE now fails the PR **before** it can reach a release tag (the publish-side scan stays informational, post-push) | ⚠️ **yes** (CI gate) |
| `cosign-verify-unanchored-regexp` | anchor + dot-escape + fully-qualify the identity regexp to the workflow path `@refs/tags/v` (Go regexp is a substring match — the old pattern matched `<repo>-attacker/...`) | no |
| `scheduled-egress-blocking-dns-on-loop` | the per-device egress allow-list ran a blocking `getaddrinfo` **on the asyncio event loop**; extracted to a sync helper offloaded via `asyncio.to_thread` | no |
| `cross-mesh-shrunken-denominator` | PHASE4 generator claimed "56/56 pairs validated"; corrected to "56 YAMLs cover only 8 of 12 codecs; aoscx/iosxr/nxos/vyos have **zero** coverage → 723/1224 cells expected-uncovered, not a missing-files error" | no |
| `fixtures-unlicensed-source-redistribution` | tightened NOTICE.md "Adding new captures" to forbid new no-LICENSE upstreams (existing ones grandfathered + "drop if author objects") | no |

## The two behaviour-changing items (flagged for review)

1. **Credential fail-closed** — the only at-rest behaviour change. Wrong/rotated/lost key → loud warning + the profile is left as-is (backup will fail to authenticate, which is correct) rather than silently corrupting it. Legacy plaintext migration is unchanged.
2. **Gating Trivy in CI** — a fixable CRITICAL CVE in the built image now fails the PR. Placed in ci.yml (not the publish pipeline) so it gates **pre-merge** without restructuring the build→push ordering.

## Tests

New: wrong-key-raises, plaintext-still-migrates, no-double-encrypt, token-shape discriminator, egress-filter helper. Full `tests/unit` + `tests/integration` green (5016 passed); ruff clean; both workflows YAML-valid; regen CODEC_BUG held at 5.

Part of the v0.4.1 run3-remediation series (PR-C of 3, final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)