### PR TITLE
docs: test-methodology honesty (run3 LOW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ docker run --rm --entrypoint netcanon ghcr.io/netcanon/netcanon:latest demo --pa
 
 (Installed via pip instead? Just `netcanon demo --pair cisco__junos`.)
 
-Paste this:
+The `demo` command above translates a built-in sample. To translate your
+own, start the server (see [Install](#install)) and paste a config like
+this into the browser migrate page:
 
 ```
 hostname access-sw-01
@@ -78,15 +80,18 @@ FortiGate→MikroTik, Aruba→Arista, OPNsense→Junos).
 
 ## The trust signal — and the invitation
 
-Across every supported vendor pair × every field declared as
-`supported`, the cross-mesh audit tracks `CODEC_BUG` drift cell by cell.
-The live reconciliation (`tests/fixtures/real/PHASE4_RECONCILIATION.md` —
-the authoritative count) currently reports a small number of residual
-high-severity cells (5 at last run), each triaged as a benign comparator
-artifact on a synthetic fixture rather than a translation error, and every
-one is enumerated in that file.  That's not "we think it works"; that's
-every cell that should translate, checked by automated test against
-vendor-doc-grounded expectations, with nothing swept under the rug.
+Across every vendor pair we ship a fixture **and** a cross-vendor
+expectation for — 8 of the 12 codecs today; `aruba_aoscx`, `cisco_iosxr`,
+`cisco_nxos`, and `vyos` have fixtures but not yet cross-vendor
+expectations — the cross-mesh audit tracks `CODEC_BUG` drift cell by
+cell.  The live reconciliation (`tests/fixtures/real/PHASE4_RECONCILIATION.md`
+for the roll-up, `tests/fixtures/real/phase4_findings_residuals.md` for
+the per-cell triage) currently reports a small number of residual
+high-severity cells (5 at last run) — each triaged as a benign
+modelling/structural artifact (4 on real fixtures, 1 synthetic) rather
+than a translation error, and every one is enumerated.  That's not "we
+think it works"; that's every covered cell, checked by automated test
+against vendor-doc-grounded expectations, with nothing swept under the rug.
 
 The honest follow-up: **the audit only covers cells we have fixtures
 for.**  Real-world configs exercise paths the synthetic fixtures
@@ -289,7 +294,7 @@ That's the contribution this project values most.  Workflow:
 1. Sanitise your config — open the `/sanitize` browser page (easiest
    if the server's running), or run the `netcanon sanitize` CLI
    (no server required).  Both strip hostnames, usernames, IPs,
-   hashes, certs, SNMP communities, etc., with a counter-per-session
+   hashes, SNMP communities, etc., with a counter-per-session
    stable substitution table you can audit before submission.
 2. Open a [bug report](https://github.com/netcanon/netcanon/issues/new?template=bug_report.yml)
    or [fixture submission](https://github.com/netcanon/netcanon/issues/new?template=fixture_submission.yml).

--- a/docs/HOW_WE_TEST.md
+++ b/docs/HOW_WE_TEST.md
@@ -13,8 +13,9 @@ contributor / methodology level.
 
 ## TL;DR
 
-Netcanon ships with **four independent test layers** that gate every
-release:
+Netcanon ships with **four test layers**.  CI gates every release on the
+**unit + integration** tiers; the **E2E** (Playwright) and **desktop**
+(PySide6) tiers run locally and on demand, not on every PR:
 
 | Layer | What it tests | Speed |
 |---|---|---|
@@ -38,7 +39,9 @@ spot until the device behaves wrong in production.
 
 ## The matrix
 
-The cross-mesh audit runs on every PR and on every fixture import.
+The cross-mesh audit runs locally / on demand — it is a maintainer tool
+re-generated on every codec change (per the doc-sync checklist), NOT a CI
+gate on every PR (only the unit + integration tiers gate).
 Its results live in
 [`tests/fixtures/real/PHASE4_RECONCILIATION.md`](../tests/fixtures/real/PHASE4_RECONCILIATION.md)
 (machine-generated; not hand-edited).
@@ -65,9 +68,11 @@ classified honestly rather than smoothed over.
 
 ## The trust claim, quantified
 
-> Across every supported vendor pair × every field declared as
-> `supported`, the cross-mesh audit holds **zero CODEC_BUG cells**
-> as of the current commit.
+> Across every vendor pair we ship a fixture + cross-vendor expectation
+> for, the cross-mesh audit holds **5 CODEC_BUG cells** at last run —
+> each triaged as a benign modelling/structural artifact in
+> [`phase4_findings_residuals.md`](../tests/fixtures/real/phase4_findings_residuals.md),
+> none a genuine translation error.
 
 That's not "we think it works"; that's "every cell that should
 translate, does, by automated test against vendor-doc-grounded
@@ -133,8 +138,9 @@ permutation).
 variance taxonomy and generates
 `tests/fixtures/real/PHASE4_RECONCILIATION.md` (the matrix).
 
-Both run in CI on every PR; the matrix gets regenerated on every
-codec change per the
+Both run locally / on demand — the cross-mesh audit is a maintainer tool,
+NOT a CI gate (only the unit + integration tiers gate every PR).  The
+matrix gets regenerated on every codec change per the
 [doc-sync checklist](../AGENTS.md#documentation-sync-checklist).
 
 ---

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -52,11 +52,12 @@ Schema extensions (ship-before-wire):
     added to support EVPN-VXLAN fabric migrations (Arista ↔ NX-OS ↔
     Junos).  ``routing_instances`` + :attr:`CanonicalInterface.vrf`
     are the cross-vendor VRF primitive (Junos ``routing-instances``,
-    Cisco ``vrf definition``, Arista ``vrf instance``).  No codec
-    populates any of these in v1 — each codec's
-    :class:`CapabilityMatrix` lists them under ``unsupported`` until
-    wired up.  This lets the UI's Unsupported-path banner surface the
-    gap even before any codec knows how to parse the bytes.
+    Cisco ``vrf definition``, Arista ``vrf instance``).  Shipped
+    schema-first; the codecs that have wired these up now populate them
+    (e.g. cisco_nxos, cisco_iosxr, arista_eos, juniper_junos), while
+    codecs without the wire-up still list them under ``unsupported`` in
+    their :class:`CapabilityMatrix` — so the UI's Unsupported-path
+    banner surfaces the gap on those targets.
 
 Schema extensions (wire-through in same commit as schema):
     :class:`CanonicalSNMPv3User` + :attr:`CanonicalSNMP.v3_users`
@@ -816,9 +817,10 @@ class CanonicalIntent(BaseModel):
         local_users: Tier 2 — local user accounts.
         radius_servers: Tier 2 — RADIUS server definitions.
         vxlan_vnis: Tier 2 (ship-before-wire) — VLAN-to-VNI mappings
-            for EVPN-VXLAN overlay.  No codec populates these in v1;
-            each codec's CapabilityMatrix lists them under
-            ``unsupported`` until wired up per-vendor.
+            for EVPN-VXLAN overlay.  Populated by the codecs that have
+            wired VXLAN (e.g. cisco_nxos, vyos); codecs without the
+            wire-up list them under ``unsupported`` in their
+            CapabilityMatrix.
         evpn_type5_routes: Tier 2 (ship-before-wire) — EVPN Type-5
             IP-prefix advertisements.  Same wire-up status as
             ``vxlan_vnis``.

--- a/tests/fixtures/real/RESULTS.md
+++ b/tests/fixtures/real/RESULTS.md
@@ -27,7 +27,7 @@ equal trees).
 ## cisco_iosxe_cli
 
 **Codec:** `netcanon.migration.codecs.cisco_iosxe_cli.CiscoIOSXECLICodec`
-**Direction:** `parse_only` *(round-trip N/A)*
+**Direction:** `bidirectional`
 **Certainty:** `certified` ✅
 
 ### Coverage matrix


### PR DESCRIPTION
Test-methodology + canonical-schema doc honesty (run3 LOW, re-verified on main):
- HOW_WE_TEST.md: only unit+integration gate in CI (not all 4 layers / not the cross-mesh audit); trust claim states the live 5 CODEC_BUG (each benign), not "zero".
- RESULTS.md: cisco_iosxe_cli is `bidirectional`, not `parse_only`.
- intent.py: drop the false "No codec populates these in v1" ship-before-wire docstrings.

Doc/docstring-only. Part of the v0.4.2 run3-LOW sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)