### PR TITLE
docs: 4 vendor pages + RESULTS/WANTED corpus honesty (run3 LOW)

### DIFF
--- a/docs/vendors/README.md
+++ b/docs/vendors/README.md
@@ -17,12 +17,16 @@ rather than duplicate.
 | Vendor family | Page | Codecs | Certification |
 |---|---|---|---|
 | Cisco IOS-XE | [`cisco_iosxe.md`](cisco_iosxe.md) | `cisco_iosxe_cli`, `cisco_iosxe` | certified (CLI), best_effort (NETCONF) |
+| Cisco NX-OS | [`cisco_nxos.md`](cisco_nxos.md) | `cisco_nxos` | certified |
+| Cisco IOS-XR | [`cisco_iosxr.md`](cisco_iosxr.md) | `cisco_iosxr` | certified |
 | Juniper Junos | [`juniper_junos.md`](juniper_junos.md) | `juniper_junos` | certified |
 | Aruba AOS-S | [`aruba_aoss.md`](aruba_aoss.md) | `aruba_aoss` | certified |
+| Aruba AOS-CX | [`aruba_aoscx.md`](aruba_aoscx.md) | `aruba_aoscx` | certified |
 | Arista EOS | [`arista_eos.md`](arista_eos.md) | `arista_eos` | certified |
 | Fortinet FortiGate | [`fortigate.md`](fortigate.md) | `fortigate_cli` | certified |
 | MikroTik RouterOS | [`mikrotik_routeros.md`](mikrotik_routeros.md) | `mikrotik_routeros` | certified |
 | OPNsense | [`opnsense.md`](opnsense.md) | `opnsense` | certified |
+| VyOS | [`vyos.md`](vyos.md) | `vyos` | certified |
 
 ## Page format
 

--- a/docs/vendors/aruba_aoscx.md
+++ b/docs/vendors/aruba_aoscx.md
@@ -1,0 +1,186 @@
+# Aruba AOS-CX — What works for me?
+
+If you operate modern Aruba (AOS-CX) switches — the 6300 / 6400 /
+8320 / 8325 / 8400 class — and want to know what Netcanon does for
+you, this is the page.
+
+## TL;DR
+
+- **`aruba_aoscx`** — `show running-config` text **bidirectional**
+  (parse AND render).  **Certification: certified.**
+
+AOS-CX is the modern Aruba NOS, **distinct from the legacy
+`aruba_aoss`** (ProVision / AOS-Switch) codec — different grammar,
+different codec, different `CapabilityMatrix`.  The codec targets the
+AOS-CX 10.x surface: L2 switchport + VLAN port membership, `interface
+lag N` LAGs, VRFs, `active-gateway` anycast (the VSX / EVPN
+distributed gateway), and VXLAN L2VNI bindings.
+
+## What translates well
+
+[Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable)
+— auto-translatable:
+
+- `hostname`
+- Interfaces — name, description, enabled state, MTU, IPv4 + IPv6
+  addresses, VRF binding
+- L2 switchport — access / trunk mode, access-VLAN, trunk allowed-VLAN
+  list, trunk native VLAN, `lag` membership
+- VLANs — ID, name, description, tagged/untagged port lists
+- Static routes — default VRF (`ip route`)
+- VRFs — name (a bare `vrf <name>` stanza in v1)
+
+[Tier 2](../CAPABILITIES.md#tier-2--translatable-with-caveats) —
+translatable with caveats:
+
+- LAGs (`interface lag N`, reconciled with cross-vendor names like
+  `Port-channel<N>` / `ae<N>`)
+- SNMP v2c community + v3 USM (community, location, contact, v3 users)
+- Local users — named AOS-CX `group` (administrators / operators /
+  auditors / custom) + `password ciphertext` blob
+- VXLAN — VLAN↔VNI binding (`interface vxlan 1 / vni <VNI>` with
+  nested `vlan <VLAN>`)
+
+> **Management-plane caveat.**  When AOS-CX is the **target**, the
+> codec renders no `ip domain-name` / `ip dns` / `ntp server` /
+> `logging` / `dhcp-server` / `radius-server` config — those surfaces
+> are declared `unsupported` (the live validation report flags the
+> loss rather than reporting `severity: ok`).  See
+> [What we don't do](#what-we-dont-do).
+
+## L3 redundancy: active-gateway anycast
+
+AOS-CX models the VSX / EVPN distributed gateway as `active-gateway`
+under the SVI — an Arista-VARP-style anycast (a stable IP present on
+every switch, no group ID):
+
+```text
+interface vlan 100
+    ip address 10.1.100.2/24
+    active-gateway ip mac 12:01:00:00:01:00
+    active-gateway ip 10.1.100.1
+```
+
+Canonical mapping:
+
+- `active-gateway ip <vip>` mirrors into
+  `CanonicalIPv4Address.virtual_gateway_address`.
+- `active-gateway ip mac <mac>` lands on
+  `CanonicalIntent.anycast_gateway_mac`.
+
+This co-exists with — and is the inverse of — classic FHRP: **VRRP**
+(`vrrp <vrid> address-family` under an SVI) is a later phase and stays
+`unsupported`; the `active-gateway` anycast surface IS the supported
+distributed-gateway path.  **IPv6 active-gateway** parses-and-ignores
+in v1 (parity with the NX-OS / IOS-XE IPv6-anycast deferral).
+
+## Lossy paths
+
+- **`/routing/static-route/description`** — render emits destination +
+  next-hop only; the static-route name / description drops.
+- **`/interfaces/interface/config/type`** — AOS-CX declares no IANA
+  ifType; the codec infers it from the name shape (`1/1/1` →
+  ethernetCsmacd, `vlan N` → l3ipvlan, `lag N` → ieee8023adLag,
+  `loopback N` → softwareLoopback, `vxlan N` → tunnel).
+- **`/local-users/user/privilege-level`** — the named `group` maps to
+  numeric privilege (administrators → 15, else → 1) for cross-vendor
+  targets; the named group round-trips losslessly same-vendor.  The
+  `password ciphertext` blob is AES-encrypted with the device key
+  (portable same-device only) — cross-vendor migration requires
+  re-keying.
+- **`/snmp/v3-user/auth-passphrase`** — SNMPv3 auth/priv keys are
+  device-key `ciphertext` blobs; emitted verbatim cross-vendor but the
+  operator must re-key on the target.
+- **`/vxlan-vnis/source-interface`** — AOS-CX states the VTEP source
+  as an IPv4 *address* (`interface vxlan 1 / source ip <X>`), not an
+  interface name like NX-OS / Arista.  A cross-vendor source carrying
+  an interface *name* has no AOS-CX `source ip` form, so the `source
+  ip` line is omitted on render (the VLAN↔VNI bindings still emit).
+- **`/system/raw-sections/version-banner`** — the `!Version
+  ArubaOS-CX <release>` banner + management-plane service footer
+  (`ssh server`, `https-server`, `clock`, `ntp`, `spanning-tree`) is
+  discarded on parse; a synthesised banner is emitted on render.
+
+## What we don't do
+
+**Surfaces AOS-CX render drops** (declared `unsupported` so the loss
+is visible, not silent):
+
+- **Management plane** — `domain`, `timezone`, DNS / NTP / syslog
+  servers, DHCP server pools, RADIUS servers (host + secret), SNMP
+  trap-hosts (`snmp-server host`)
+- **VRF detail** — VRF description, route-distinguisher, route-target,
+  and per-VRF static routes (these live under the deferred `evpn` /
+  `router bgp` blocks; only the bare `vrf <name>` + default-VRF `ip
+  route` are wired)
+- **VRRP** (FHRP) and **IPv6 active-gateway**
+- **VXLAN control plane** — per-VLAN L2VNI RD/RT (almost always
+  `auto`-derived) and symmetric-IRB **L3VNI** (`vni N / vrf <name>`);
+  the L2 VLAN↔VNI binding itself IS supported
+
+Deliberately deferred to [Tier
+3](../CAPABILITIES.md#tier-3--opaque-carry--not-auto-rendered):
+
+- **Routing protocols** — `router bgp` (incl. the EVPN
+  address-family) / `router ospf` (surfaced on the
+  `dropped_tier3_sections` banner; not auto-rendered)
+- **ACLs** — standard / extended
+- **QoS** — `class` / `policy` / `apply qos`
+- **NAT** — AOS-CX does not host typical edge NAT
+
+If your migration involves these surfaces, plan to hand-translate
+them or pair Netcanon with a complementary tool — see
+[`../COMPARISON.md`](../COMPARISON.md).
+
+## Real-world fixtures we've validated against
+
+Provenance + per-fixture detail in
+[`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md).
+Four configs from Aruba's published `aruba/aoscx-ansible-dcn-workflows`
+reference fabric (Apache-2.0), spanning two grammar families and two
+AOS-CX majors:
+
+- **`aoscx_dcn_arch3_ibgp_leaf1a.cfg`** / **`…ebgp_leaf1a.cfg`** —
+  EVPN-VXLAN leaves (iBGP + eBGP), `interface vxlan` L2VNI, `rd auto`
+  vs explicit `route-target 1:11` (GL.10.04.0020)
+- **`aoscx_dcn_arch4_core1_1.cfg`** / **`…core1_2.cfg`** — L3-agg
+  cores with real `active-gateway` SVIs + multi-chassis LAGs; the
+  arch4 cores are the first **real** `active-gateway` capture (the
+  anycast surface was synthetic-only through Phase 3) — the
+  `core1_2` VSX-secondary peer has a dense 42-interface table
+  (GL.10.13.1000)
+
+The corpus is single-source; an operator capture from a different
+source, plus configs exercising symmetric-IRB **L3VNI**, **VSX**, and
+**VRRP**, are welcomed via
+[`WANTED.md`](../../tests/fixtures/real/WANTED.md).
+
+## Common gotchas
+
+- **AOS-CX is L3-by-default; `no routing` opts into L2.**  This is the
+  **inverse** of NX-OS (where ports are L2 by default).  A physical
+  port with no `no routing` is a routed interface; the switchport L2
+  model engages only when the port opts out of routing.
+- **`active-gateway` is the anycast, not VRRP.**  The supported
+  distributed-gateway surface is `active-gateway ip` / `active-gateway
+  ip mac`; classic VRRP (`vrrp <vrid>`) is a later phase and drops.
+- **Distinct from `aruba_aoss`.**  AOS-CX (10.x) and AOS-Switch /
+  ProVision (16.x, the `aruba_aoss` codec) are different NOSes — the
+  `!Version ArubaOS-CX` banner is the probe discriminator.  Pick the
+  right vendor in the target dropdown.
+- **Management services don't carry.**  DNS / NTP / syslog / DHCP /
+  RADIUS / domain / timezone are render-dropped on an AOS-CX target —
+  the validation panel flags each; re-apply them on the device.
+
+## See also
+
+- [`../CAPABILITIES.md`](../CAPABILITIES.md) — full capability matrix
+- [`../../tests/fixtures/real/RESULTS.md`](../../tests/fixtures/real/RESULTS.md)
+  — live certification state
+- [`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md)
+  — fixture provenance
+- [`../../BUG_REPORTING.md`](../../BUG_REPORTING.md) — when something
+  doesn't translate cleanly
+- [`../TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) — diagnostic
+  flowchart
+- [`../HOW_WE_TEST.md`](../HOW_WE_TEST.md) — the cross-mesh audit

--- a/docs/vendors/cisco_iosxr.md
+++ b/docs/vendors/cisco_iosxr.md
@@ -1,0 +1,167 @@
+# Cisco IOS-XR — What works for me?
+
+If you operate Cisco IOS-XR service-provider routers (ASR 9000 / NCS
+5500 / NCS 540 / XRd) and want to know what Netcanon does for you,
+this is the page.
+
+## TL;DR
+
+- **`cisco_iosxr`** — `show running-config` text **bidirectional**
+  (parse AND render).  **Certification: certified.**
+
+IOS-XR is a routing-only platform with grammar distinct from both
+IOS-XE and NX-OS — it gets its own codec and `CapabilityMatrix`.  The
+codec targets the IOS-XR 6.x / 7.x surface: 4-segment interface
+naming, Bundle-Ether LAGs, top-level `vrf` stanzas with route-targets
+(and route-distinguishers harvested from the BGP block), dot1q
+sub-interface VLANs, and the `username` block.  The SP-routing /
+policy stanzas (`router bgp` / `router ospf` / `router isis` / `mpls
+ldp` / `route-policy` / `prefix-set`) are surfaced on the migrate
+banner via `dropped_tier3_sections`, **not** translated.
+
+## What translates well
+
+[Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable)
+— auto-translatable:
+
+- `hostname`
+- Interfaces — name, description, enabled state, MTU, IPv4 + IPv6
+  addresses, per-interface VRF membership (bare `vrf <name>`)
+- VLANs — id + name, synthesised from `encapsulation dot1q` on
+  sub-interfaces (no port-membership model; the name is always empty)
+- Static routes — default VRF **and** per-VRF (`router static / vrf
+  <name>`)
+
+[Tier 2](../CAPABILITIES.md#tier-2--translatable-with-caveats) —
+translatable with caveats:
+
+- VRFs — name, description, route-target import/export (the
+  route-distinguisher is harvested from / rendered to the `router bgp`
+  block; see [lossy](#lossy-paths))
+- LAGs — Bundle-Ether (`bundle id <N> mode <m>` on member interfaces),
+  reconciled with cross-vendor names like `Port-channel<N>` / `ae<N>`
+- Local users — `username` block (group → role + secret hash),
+  form-preserving
+
+> **Management-plane caveat.**  When IOS-XR is the **target**, the
+> codec renders no `clock timezone` / `domain name-server` / `ntp` /
+> `logging` / `dhcp` / `radius-server` / SNMP config — those surfaces
+> are declared `unsupported` (the live validation report flags the
+> loss rather than reporting `severity: ok`).  See
+> [What we don't do](#what-we-dont-do).
+
+## Lossy paths
+
+- **`/routing/static-route/metric`** — render emits destination +
+  next-hop only; the administrative distance (metric) drops.
+- **`/routing/static-route/description`** — the static-route name /
+  description drops on render.
+- **`/routing-instances/instance`** — VRF name / description /
+  route-target round-trip cleanly, but the **route-distinguisher**
+  lives in the BGP block (`router bgp <asn> / vrf <name> / rd <rd>`),
+  not the `vrf` stanza.  The codec wires a minimal BGP-RD harvest +
+  a minimal `router bgp` RD-carrier on render whose ASN is derived
+  from the RD administrator field (`<asn>:<nn>` convention).  A config
+  whose BGP ASN differs from the RD administrator re-emits the
+  normalised ASN (cosmetic — the RD value itself round-trips).  An XR
+  source with no `router bgp` stanza keeps `route_distinguisher=""`.
+  `l3_vni` (EVPN Type-5) is not modelled — IOS-XR EVPN is a Tier-3
+  `l2vpn` / `evpn` surface.
+- **`/interfaces/interface/4th-port-segment`** — IOS-XR port names
+  have **4 segments** (rack/slot/instance/port) while the
+  cross-vendor `PortIdentity` supports 3 (stack/module/port).  The
+  4th segment is preserved via `PortIdentity.meta['iosxr_port_index']`
+  for the same-vendor round-trip but **drops to `0`** when renaming to
+  a 3-segment target (IOS-XE / Arista).  Verify port mappings via the
+  rename modal.
+- **`/interfaces/interface/config/type`** — interface type is
+  inferred from the name prefix (GigabitEthernet → ethernetCsmacd,
+  Bundle-Ether → ieee8023adLag, etc.); sub-interfaces with
+  vendor-specific encapsulation classify as `other`.
+
+## What we don't do
+
+**Surfaces IOS-XR render drops** (declared `unsupported` so the loss
+is visible, not silent):
+
+- **L2 switchport** — IOS-XR has no Cisco-style access/trunk model
+  (VLANs are dot1q sub-interfaces); switchport mode / access-VLAN /
+  trunk allowed-list / native VLAN / voice-VLAN all drop on render
+- **Management plane** — `timezone`, DNS / NTP / syslog servers, DHCP
+  server pools, RADIUS servers (host + secret)
+- **SNMP** — parse + render is out of the v1 XR scope
+
+Deliberately deferred to [Tier
+3](../CAPABILITIES.md#tier-3--opaque-carry--not-auto-rendered):
+
+- **Routing protocols** — `router bgp` / `router ospf` / `router
+  isis` / `mpls ldp` / `mpls traffic-eng` (surfaced on the
+  `dropped_tier3_sections` banner; not auto-rendered)
+- **Routing policy** — `route-policy` (the structured
+  if/elseif/else/endif DSL), `prefix-set` / `community-set` /
+  `as-path-set` set-form lists
+- **EVPN / VXLAN** — IOS-XR EVPN runs under top-level `l2vpn` +
+  `evpn` + `bridge group` stanzas, grammatically distant from the
+  IOS-XE / Arista / NX-OS model; no canonical mapping in v1
+- **ACLs / firewall / NAT** — `ipv4 access-list` / stateful firewall
+  / `nat64` / `cgnat`
+
+If your migration involves these surfaces, plan to hand-translate
+them or pair Netcanon with a complementary tool — see
+[`../COMPARISON.md`](../COMPARISON.md).
+
+## Real-world fixtures we've validated against
+
+Provenance + per-fixture detail in
+[`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md).
+Ten configs from **two independent sources** (both Apache-2.0):
+
+- **`batfish/lab-validation`** (7 configs) — `cisco_xr_ios_vpnv4` PEs
+  (`batfish_vpnv4_pe1/2/3.txt`), `iosxr_ebgp_basic` borders
+  (`batfish_ebgp_border01/02.txt`), `iosxr_ibgp_rr_over_ospf` RR +
+  client (`batfish_ibgp_rr.txt` / `batfish_ibgp_border01.txt`).  IP-
+  based RDs (`10.254.1.1:65102`) harvested from `router bgp / vrf /
+  rd`; dot1q `.35` sub-interface → synthesised VLAN.
+- **`ios-xr/xrd-tools` `xr_compose_topos`** (3 configs) —
+  `xrdtools_srv6_pe1.cfg` (SRv6 L3VPN PE), `xrdtools_sr_xrd1.cfg`
+  (SR-MPLS), `xrdtools_isis_r1.cfg` (IS-IS IP-FRR).  These add the
+  IS-IS / SR / SRv6 grammar the batfish trio lacks.
+
+Collectively the corpus exercises 4-segment ports, Bundle-Ether LAGs,
+MgmtEth / Loopback, the top-level `vrf` stanza with RT import/export,
+RD-from-BGP harvest, per-interface `vrf` membership, per-VRF + default
+`router static`, and the `username` block.  The certification spans
+two independent upstreams so it doesn't rest on one source's grammar
+conventions.  Further grammar diversity (flex-algo, L2VPN
+bridge-groups, ACL, QoS) is welcomed via
+[`WANTED.md`](../../tests/fixtures/real/WANTED.md).
+
+## Common gotchas
+
+- **4-segment port names.**  `GigabitEthernet0/0/0/3` is
+  rack/slot/instance/port.  Same-vendor round-trip preserves all four;
+  renaming to a 3-segment vendor (IOS-XE / Arista) drops the 4th
+  segment to `0` — confirm via the rename modal.
+- **The RD lives in `router bgp`, not `vrf`.**  IOS-XR keeps the VRF
+  route-distinguisher under `router bgp <asn> / vrf <name> / rd <rd>`.
+  The codec harvests it from there and re-emits a minimal RD-carrier
+  `router bgp` block on render.
+- **VLANs are sub-interfaces.**  There is no VLAN database — a tagged
+  VLAN appears as `encapsulation dot1q <vid>` on a sub-interface and
+  is synthesised into the canonical VLAN id-list (no port membership).
+- **SP routing is Tier-3.**  BGP / OSPF / IS-IS / MPLS / route-policy
+  are surfaced on the migrate banner but never auto-rendered — every
+  fixture's routing stanzas show up there.
+
+## See also
+
+- [`../CAPABILITIES.md`](../CAPABILITIES.md) — full capability matrix
+- [`../../tests/fixtures/real/RESULTS.md`](../../tests/fixtures/real/RESULTS.md)
+  — live certification state
+- [`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md)
+  — fixture provenance
+- [`../../BUG_REPORTING.md`](../../BUG_REPORTING.md) — when something
+  doesn't translate cleanly
+- [`../TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) — diagnostic
+  flowchart
+- [`../HOW_WE_TEST.md`](../HOW_WE_TEST.md) — the cross-mesh audit

--- a/docs/vendors/cisco_nxos.md
+++ b/docs/vendors/cisco_nxos.md
@@ -1,0 +1,209 @@
+# Cisco NX-OS — What works for me?
+
+If you operate Cisco Nexus (NX-OS) data-center switches and want to
+know what Netcanon does for you, this is the page.
+
+## TL;DR
+
+- **`cisco_nxos`** — `show running-config` text **bidirectional**
+  (parse AND render).  **Certification: certified.**
+
+NX-OS is a distinct grammar from IOS-XE — it gets its own codec, its
+own `CapabilityMatrix`, and its own render path.  The codec targets
+the NX-OS 9.x+ data-center surface (Nexus 3000/9000-class): L2
+switchport + VLAN database, port-channel LAGs, VRFs with RD /
+route-target, VXLAN-EVPN (L2VNI + symmetric-IRB L3VNI), HSRP, and the
+IPv4 Distributed Anycast Gateway.
+
+## What translates well
+
+[Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable)
+— auto-translatable:
+
+- `hostname`
+- Interfaces — name, description, enabled state, MTU, IPv4 + IPv6
+  addresses, VRF binding
+- L2 switchport — access / trunk mode, access-VLAN, trunk allowed-VLAN
+  list, trunk native VLAN, port-channel (`channel-group`) membership
+- VLANs — ID, name, tagged/untagged port lists (VLAN-centric
+  projection from the per-interface `switchport` form)
+- Static routes — default VRF **and** per-VRF (`ip route … vrf X`)
+- LAGs (`port-channel<N>` reconciled with cross-vendor names like
+  `ae<N>` / `Port-channel<N>` / `trk<N>`)
+
+[Tier 2](../CAPABILITIES.md#tier-2--translatable-with-caveats) —
+translatable with caveats:
+
+- SNMP v2c community + v3 USM (community, location, contact,
+  trap-hosts, v3 users with auth + priv)
+- Local users — named NX-OS `role` (network-admin / network-operator
+  / custom) + hashed password, form-preserving
+- VRFs — name, description, route-distinguisher, route-target
+  import/export
+- VXLAN-EVPN — VLAN↔VNI binding (`vlan N / vn-segment`), the `nve1`
+  VTEP (source-interface, UDP port, multicast group, flood list), and
+  the symmetric-IRB **L3VNI** (`vrf context X / vni N`)
+
+> **Management-plane caveat.**  When NX-OS is the **target**, the
+> codec renders no `ip domain-name` / `ip name-server` / `ntp server`
+> / `logging server` / `ip dhcp` / `radius-server` config — those
+> Tier-1/2 surfaces are declared `unsupported` (the live validation
+> report flags the loss rather than reporting `severity: ok`).  See
+> [What we don't do](#what-we-dont-do).
+
+## L3 redundancy: HSRP + IPv4 Distributed Anycast Gateway
+
+### HSRP (FHRP)
+
+NX-OS expresses first-hop redundancy as HSRP, nested under the SVI:
+
+```text
+interface Vlan10
+  hsrp 10
+    priority 110
+    preempt
+    ip 10.1.10.1
+```
+
+The canonical model is vendor-neutral (`CanonicalVRRPGroup` with a
+`mode in {"vrrp", "hsrp", "carp"}` discriminator).  On render, the
+codec emits **every** group as an `hsrp` block regardless of the
+source `mode` — so a cross-vendor VRRP / CARP group normalises to
+HSRP on NX-OS.  The operator's redundancy intent for the virtual IP
+survives; the wire protocol changes (this is declared
+[lossy](#lossy-paths)).  Same-vendor HSRP round-trips losslessly.
+
+### IPv4 Distributed Anycast Gateway
+
+Fabric-mode anycast: a chassis-wide MAC plus a per-SVI marker.
+
+```text
+fabric forwarding anycast-gateway-mac 0001.c73a.0000
+!
+interface Vlan100
+  ip address 10.1.100.1/24
+  fabric forwarding mode anycast-gateway
+```
+
+Canonical mapping:
+
+- `fabric forwarding anycast-gateway-mac AABB.CCDD.EEFF` lands on
+  `CanonicalIntent.anycast_gateway_mac` (dotted-triplet ↔ canonical
+  colon-hex).
+- Per-SVI `fabric forwarding mode anycast-gateway` mirrors the
+  primary IP as the anycast (`virtual_gateway_address = ip`).  This
+  is the same IP-mirror semantic shared with the IOS-XE SD-Access
+  codec.
+
+**IPv6 anycast is unsupported** — IPv4 DAG is fully wired; the IPv6
+companion parses-and-ignores in v1 (parity with the IOS-XE codec's
+identical IPv6-anycast deferral).
+
+## Lossy paths
+
+- **`/interfaces/interface/vrrp-groups/group`** — VRRP / CARP groups
+  normalise to HSRP on render (see above); sub-second timers,
+  virtual-MAC, and track objects are not modelled in v1.
+- **`/routing/static-route/description`** — render emits destination
+  + next-hop + metric only; the static-route name/description drops.
+- **`/routing-instances/instance/route-distinguisher`** — `rd auto`
+  is preserved verbatim as a sentinel; cross-vendor renderers that
+  don't recognise it must synthesise an explicit RD.  An explicit RD
+  round-trips losslessly.
+- **`/routing-instances/instance/rt-imports`** — `route-target both
+  <rt> evpn` preserves the RT value but the L2VPN-EVPN address-family
+  discriminator reverts to IPv4-unicast cross-vendor.
+- **`/vxlan-vnis/vni`** — per-VNI sub-flags (`suppress-arp`,
+  alternate ingress-replication) don't round-trip; the codec emits
+  the modern BGP-EVPN head-end-replication shape on every render.
+  The VLAN↔VNI binding itself round-trips.
+- **`/local-users/user/privilege-level`** — NX-OS named roles map to
+  numeric privilege (network-admin / vdc-admin → 15, else → 1) for
+  cross-vendor targets; the named role round-trips losslessly
+  same-vendor.
+- **SNMPv3 `auth-passphrase` / `engine-id`** — the 10.x
+  `localizedV2key` digest normalises to the older `localizedkey`
+  form, and engineIDs are colon-decimal; cross-vendor / cross-version
+  migration requires re-keying the v3 user on the target.
+- **`/system/raw-sections/vdc`** and **`…/features`** — N7K VDC
+  virtualisation grammar is discarded (a default single-VDC wrapper
+  is synthesised on render); `feature <name>` lines are derived on
+  render from the canonical-tree shape, so source `feature` lines not
+  motivated by a canonical surface (e.g. `feature scp-server`) drop.
+
+## What we don't do
+
+**Management-plane Tier-1/2 surfaces NX-OS render drops** (declared
+`unsupported` so the loss is visible, not silent):
+
+- `domain`, `timezone`, DNS / NTP / syslog servers
+- DHCP server pools
+- RADIUS servers (host + shared secret)
+- IPv6 anycast-gateway
+
+Deliberately deferred to [Tier
+3](../CAPABILITIES.md#tier-3--opaque-carry--not-auto-rendered):
+
+- **Routing protocols** — `router bgp` / `router ospf` / `eigrp` /
+  `isis` stanzas (surfaced on the `dropped_tier3_sections` banner;
+  not auto-rendered)
+- **ACLs** — standard / extended / IPv6 (auto-translating ACL
+  semantics across vendors risks shipping subtly-permissive rules)
+- **Firewall / NAT** — NX-OS does not host a stateful firewall or
+  typical edge NAT
+- **QoS** — `class-map type qos` / `policy-map type qos` /
+  `service-policy`
+
+If your migration involves these surfaces, plan to hand-translate
+them or pair Netcanon with a complementary tool — see
+[`../COMPARISON.md`](../COMPARISON.md).
+
+## Real-world fixtures we've validated against
+
+Provenance + per-fixture detail in
+[`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md).
+Six `batfish/lab-validation` configs (Apache-2.0), all NX-OS 9.2(3),
+spanning four scenarios:
+
+- **`batfish_nxos_hsrp_nxos1.txt`** / **`…nxos2.txt`** — HSRP (FHRP)
+  HA pair + port-channel LAG
+- **`batfish_nxos_evpn_l3vni_nx1.txt`** / **`…nx2.txt`** —
+  VXLAN-EVPN symmetric-IRB **L3VNI** + `nve1` VTEP
+- **`batfish_nxos_evpn_l2vni_nx1.txt`** — VXLAN-EVPN **L2VNI**
+  (`vn-segment`)
+- **`batfish_nxos_bgp_redist_d1.txt`** — BGP redistribute-connected
+  + VRF
+
+(The high interface counts in these captures reflect batfish's full
+chassis dumps — every Ethernet port appears, most unconfigured.)
+Operator captures from a **newer NX-OS major** (10.x) and a second
+source are the highest-value contributions — see
+[`WANTED.md`](../../tests/fixtures/real/WANTED.md).
+
+## Common gotchas
+
+- **HSRP is the FHRP, not VRRP.**  Cross-vendor VRRP / CARP groups
+  render as `hsrp` blocks; same-vendor HSRP round-trips cleanly.
+- **`nve1` is the VTEP, not a routed port.**  The codec intercepts
+  `interface nve1` as the VXLAN tunnel-endpoint container (`tunnel`
+  kind), not an L3 interface.
+- **Management services don't carry.**  DNS / NTP / syslog / DHCP /
+  RADIUS / domain / timezone are render-dropped on an NX-OS target —
+  re-apply them on the device.  The validation panel flags each.
+- **`feature` lines are regenerated.**  The renderer derives `feature
+  interface-vlan` / `feature lacp` / `feature hsrp` etc. from the
+  canonical shape; it does not preserve arbitrary source `feature`
+  declarations.
+
+## See also
+
+- [`../CAPABILITIES.md`](../CAPABILITIES.md) — full capability matrix
+- [`../../tests/fixtures/real/RESULTS.md`](../../tests/fixtures/real/RESULTS.md)
+  — live certification state
+- [`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md)
+  — fixture provenance
+- [`../../BUG_REPORTING.md`](../../BUG_REPORTING.md) — when something
+  doesn't translate cleanly
+- [`../TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) — diagnostic
+  flowchart
+- [`../HOW_WE_TEST.md`](../HOW_WE_TEST.md) — the cross-mesh audit

--- a/docs/vendors/vyos.md
+++ b/docs/vendors/vyos.md
@@ -1,0 +1,186 @@
+# VyOS — What works for me?
+
+If you operate VyOS routers / firewalls (the open-source Vyatta
+successor) and want to know what Netcanon does for you, this is the
+page.
+
+## TL;DR
+
+- **`vyos`** — `config.boot` (curly-brace) **bidirectional** (parse
+  AND render).  **Certification: certified.**
+
+VyOS is Netcanon's 12th codec and its **first curly-brace parser** (a
+brace-stack walker, distinct from the `set`-form `juniper_junos`
+codec).  The codec targets VyOS 1.3 / 1.4 / 1.5: interfaces with
+`vif` VLAN sub-interfaces and DHCP clients, `system login` users, NTP,
+`interfaces bonding` LAGs, `service snmp`, VRFs, and `interfaces
+vxlan` netdevs.  Routing-protocol + firewall stanzas (`protocols bgp`
+/ `protocols ospf` / `firewall`) are surfaced on the migrate banner
+via `dropped_tier3_sections`, **not** translated.
+
+> **Input forms.**  Both `config.boot` (curly-brace) and `show
+> configuration commands` (set-form) are accepted — set-form is
+> converted to curly-brace up front so the brace-stack walker is
+> reused.  The probe disambiguates VyOS set-form from the Junos
+> set-form that the `juniper_junos` codec owns.
+
+## What translates well
+
+[Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable)
+— auto-translatable:
+
+- `hostname`
+- Interfaces — name, description, enabled state, MTU, IPv4 + IPv6
+  addresses, `dhcp` / `dhcpv6` client, per-interface VRF binding.
+  802.1Q VLANs are `vif <vid>` sub-interfaces, modelled as
+  `ethN.<vid>` interfaces (there is **no** top-level VLAN database).
+- Static routes — default VRF (with administrative `distance`)
+- NTP servers (`system ntp` / `service ntp`, bare + block form)
+
+[Tier 2](../CAPABILITIES.md#tier-2--translatable-with-caveats) —
+translatable with caveats:
+
+- Local users — `system login user` (name + role +
+  `encrypted-password` hash)
+- LAGs — `interfaces bonding bondN` (members + `lag-member-of`
+  back-link)
+- SNMP — `service snmp` v1/v2c community + v3 USM (community,
+  location, contact, v3 users)
+- VRFs — `vrf name <X>` instances + the per-interface binding
+  (`interfaces ethernet ethN { vrf X }`)
+- VXLAN — `interfaces vxlan vxlanN` netdevs (one VNI per netdev:
+  VNI, source, multicast group / flood list, UDP port)
+
+> **Management-plane caveat.**  When VyOS is the **target**, the codec
+> renders no `system domain-name` / `system name-server` / `system
+> syslog` / DHCP-server / `radius-server` / `time-zone` config — those
+> surfaces are declared `unsupported` (the live validation report
+> flags the loss rather than reporting `severity: ok`).  **NTP is the
+> exception** — it IS translated.  See
+> [What we don't do](#what-we-dont-do).
+
+## Lossy paths
+
+- **`/routing/static-route/description`** — render emits destination +
+  next-hop + distance only; the static-route name / description drops.
+- **`/lags/lag/mode`** — bonding `mode 802.3ad` (LACP) maps to
+  `active`; the non-LACP modes (`active-backup` / `balance-rr` /
+  `balance-xor` / …) collapse to `static` (the specific balancing
+  algorithm drops — re-select it on the target).
+- **`/routing-instances/instance/table`** — VyOS requires a numeric
+  `table <id>` on every `vrf name <X>`; the canonical model carries no
+  table number, so the codec synthesises a deterministic id
+  (`100 + sort-index`) on render.  The original table id is not
+  preserved.
+- **`/vxlan-vnis/source-interface`** — the VTEP source is
+  `source-address <ip>` (or `source-interface <if>`); a cross-vendor
+  source (e.g. `Loopback0`) is re-emitted verbatim and may need an
+  operator port-rename.
+- **`/vxlan-vnis/vlan-id`** — VyOS models one VNI per `vxlan vxlanN`
+  netdev with no on-device VLAN (the L2 binding lives on a separate
+  `bridge`); the canonical `vlan_id` is synthesised from the VNI and
+  the netdev name regenerated `vxlan<index>` on render (deterministic;
+  same-vendor round-trip stable, cross-vendor advisory).
+- **`/local-users/user/privilege-level`** — VyOS login users have no
+  numeric privilege in the common case; the codec maps every login
+  user to privilege 15 / role `admin`.  The `encrypted-password` hash
+  round-trips verbatim same-vendor; cross-vendor requires re-keying.
+- **SNMPv3 `auth-passphrase` / `engine-id`** — v3 USM keys are opaque
+  `encrypted-password` blobs (re-key cross-vendor); VyOS declares a
+  single config-wide `engineid`, which the codec maps onto every v3
+  user.
+- **`/interfaces/interface/config/type`** — inferred from the name
+  shape (`ethN` → ethernetCsmacd, `lo`/`dumN` → softwareLoopback,
+  `bondN` → ieee8023adLag); best-effort.
+
+## What we don't do
+
+**Surfaces VyOS render drops** (declared `unsupported` so the loss is
+visible, not silent):
+
+- **L2 switchport** — VyOS has no access/trunk model (L2 via
+  `bridge` / `vif`); switchport mode / access-VLAN / trunk
+  allowed-list / native VLAN / voice-VLAN all drop on render
+- **Management plane** — `domain`, `timezone`, DNS / syslog servers,
+  DHCP server pools, RADIUS servers (host + secret).  *(NTP IS
+  supported.)*
+- **Top-level VLAN database** — VyOS has none; 802.1Q VLANs are `vif`
+  sub-interfaces (which ARE supported)
+- **Per-VRF static routes** — the `vrf name <X>` instances + the
+  per-interface binding are supported, but `vrf name <X> { protocols
+  static route … }` is deferred past the Phase-3 VRF wire-up
+- **VXLAN control plane** — per-VNI EVPN RD/RT and symmetric-IRB
+  **L3VNI**; the L2 VLAN↔VNI binding itself IS supported
+
+Deliberately deferred to [Tier
+3](../CAPABILITIES.md#tier-3--opaque-carry--not-auto-rendered):
+
+- **Routing protocols** — `protocols bgp` / `protocols ospf`
+  (surfaced on the `dropped_tier3_sections` banner; not auto-rendered)
+- **Firewall** — `firewall` rule-sets (auto-translating firewall
+  policy across vendors risks subtly-permissive rules)
+- **NAT** — `nat source` / `nat destination`
+- **Policy** — `policy` route-maps / prefix-lists
+
+If your migration involves these surfaces, plan to hand-translate
+them or pair Netcanon with a complementary tool — see
+[`../COMPARISON.md`](../COMPARISON.md).
+
+## Real-world fixtures we've validated against
+
+Provenance + per-fixture detail in
+[`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md).
+Ten real `config.boot` files from **four sources**, spanning three
+VyOS majors (1.3 / 1.4 / 1.5):
+
+- **`cisagov/prescup-challenges`** (6 configs, MIT (SEI), VyOS
+  1.4-rolling) — round-1 IPv4 / OSPF border + core (`pc5-round1-*`)
+  and round-3b IPv6 / BGP routers (`pc5-round3b-*`, AS65001-65005;
+  the `routere` capture is a dense 8-interface / 8-neighbor box)
+- **`zhouleyan/wcni-kind`** (2 configs, Apache-2.0, VyOS 1.4-rolling)
+  — `wcni-kind-gw0/gw1`, the two ends of one `vni 10` VXLAN tunnel
+- **`scottlaird/vyos-parser`** (Apache-2.0, VyOS **1.5**) —
+  `service snmp` (`community public`); 5 block-form NTP
+- **`rapid7/metasploit-framework`** (BSD-3, VyOS **1.3**) — `service
+  snmp` (`community ro` / `write`)
+
+The round-tripping surface is interfaces + hostname + local-users +
+NTP (bare + block form) + `interfaces vxlan` + `service snmp`;
+OSPF / BGP / firewall are Tier-3.  **Honest scope:** only **VRF**
+round-trip remains validated by the synthetic kitchen-sink alone — a
+2026-06 hunt found no permissive + curly-brace real capture carrying
+`vrf name` (only GPL `vyos-1x` smoketests or unlicensed configs), so
+VRF stays synthetic-validated.  A permissive real `vrf name` (and a
+real set-form) capture are welcomed via
+[`WANTED.md`](../../tests/fixtures/real/WANTED.md).
+
+## Common gotchas
+
+- **VLANs are `vif` sub-interfaces.**  There is no VLAN database — a
+  tagged VLAN is `interfaces ethernet ethN vif <vid>`, modelled as an
+  `ethN.<vid>` interface.  A switch-source's per-port VLAN membership
+  drops (declared `unsupported`).
+- **`protocols bgp` / `protocols ospf` are SHARED with Junos.**  Both
+  VyOS and Junos use `set protocols …` — the probe disambiguates by
+  config shape, not by that keyword alone.  Pick the right vendor in
+  the target dropdown if detection is ambiguous.
+- **Curly-brace vs set-form.**  Either input works — `config.boot`
+  (curly-brace) is the native form; `show configuration commands`
+  (set-form) is converted up front.  Distinct from the `juniper_junos`
+  codec, which owns the Junos set-form.
+- **VRF table ids are synthesised.**  Render emits a deterministic
+  `table <id>` per VRF (`100 + sort-index`); the source table id is
+  not preserved.
+
+## See also
+
+- [`../CAPABILITIES.md`](../CAPABILITIES.md) — full capability matrix
+- [`../../tests/fixtures/real/RESULTS.md`](../../tests/fixtures/real/RESULTS.md)
+  — live certification state
+- [`../../tests/fixtures/real/NOTICE.md`](../../tests/fixtures/real/NOTICE.md)
+  — fixture provenance
+- [`../../BUG_REPORTING.md`](../../BUG_REPORTING.md) — when something
+  doesn't translate cleanly
+- [`../TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) — diagnostic
+  flowchart
+- [`../HOW_WE_TEST.md`](../HOW_WE_TEST.md) — the cross-mesh audit

--- a/tests/fixtures/real/RESULTS.md
+++ b/tests/fixtures/real/RESULTS.md
@@ -112,12 +112,12 @@ All 5 real captures start with authoritative
 `Building configuration...` / `Current configuration : NNNN bytes` /
 `! Last configuration change at ...` / `version X.X` banners that
 prove they're device outputs rather than hand-crafted grammar tests.
-`parse_only` direction means round-trip is N/A — the cert bar for
-`parse_only` codecs is ≥3 real captures from ≥2 OS versions that
-parse cleanly and produce populated canonical trees.  Across 4 real
-OS-version anchors (16.9 + 17.3 + 17.9 + 17.12) and two distinct
-device domains (virtual routers + physical switch + virtual switch),
-the bar is met on both grammar fronts.
+The cert bar — ≥3 real captures from ≥2 OS versions that parse
+cleanly, produce populated canonical trees, and round-trip stably
+(`cisco_iosxe_cli` is bidirectional) — is cleared on both grammar
+fronts: across 4 real OS-version anchors (16.9 + 17.3 + 17.9 +
+17.12) and two distinct device domains (virtual routers + physical
+switch + virtual switch).
 
 ---
 
@@ -820,7 +820,11 @@ synthetic-validated (tracked in `WANTED.md`).
 | **aruba_aoss** | **6** (5 real + 1 rendered) | **5** (WC.16.07 + WB.16.08 + WC.16.10 + WC.16.11 + **KB.15.15**) | 2 (port-range slot drop; LAG-member link ordering) | **certified** ✅ | — |
 | **arista_eos** | **5** real | **4** (EOS 4.21.1F + 4.22.4M + 4.23.0.1F + 4.26.0.1F) | 3 (username regex line-bleed; render hash-delimiter drift; LAG render dropped channel-group lines) | **certified** ✅ | — (nice-to-have: even-newer EOS LTS 4.28+/4.30+ fixture) |
 | **juniper_junos** | **7** real | **4** (Junos 15.1R6 + 17.3R1 + 18.4R1 + 25.4R1) | 1 (render dropped bare interfaces) | **certified** ✅ | — (post-cert: GAP 6/8/9 codec enrichment) |
-| **TOTAL** | **45** | — | **17** | — | — |
+| **cisco_nxos** | **6** real | **1** (NX-OS 9.2(3)) | 0 | **certified** ✅ | — (nice-to-have: newer NX-OS 10.x major + a 2nd source) |
+| **cisco_iosxr** | **10** real | **2 sources** (batfish/lab-validation + ios-xr/xrd-tools) | 0 | **certified** ✅ | — (nice-to-have: flex-algo / L2VPN bridge-groups / QoS) |
+| **aruba_aoscx** | **4** real | **2** (AOS-CX 10.04 + 10.13) | 0 | **certified** ✅ | — (nice-to-have: non-Aruba-published source; L3VNI / VSX / VRRP) |
+| **vyos** | **10** real | **3** (VyOS 1.3 + 1.4 + 1.5) | 0 | **certified** ✅ | — (VRF round-trip remains synthetic-validated; real `vrf name` capture wanted) |
+| **TOTAL** | **75** | — | **17** | — | — |
 
 > **Note (2026-05-21 docs-audit):** the per-codec **Coverage matrix
 > tables above** in this file are pending a row-level refresh for 5
@@ -836,8 +840,10 @@ synthetic-validated (tracked in `WANTED.md`).
 > vlans, users etc.) need a parse pass to fill accurately rather
 > than estimation.  Tracked under docs-audit cluster F finding F3.
 
-17 total bugs surfaced by the real-capture harness across all seven
-codecs.  Every one would have survived arbitrarily long against our
+17 total bugs surfaced by the real-capture harness across seven of
+the twelve codecs (the four batfish/xrd-corpus codecs — cisco_nxos,
+cisco_iosxr, aruba_aoscx, vyos — surfaced none on first contact).
+Every one would have survived arbitrarily long against our
 synthetic fixtures — exactly the regression class the harness was
 built to catch.  All fixes include regression tests so reverting
 them breaks CI.

--- a/tests/fixtures/real/WANTED.md
+++ b/tests/fixtures/real/WANTED.md
@@ -25,6 +25,10 @@ grammar.
 | **junos** | 9 | 15.1 / **17.2** / 17.3 / 18.4 / **23.2** / 25.4 | SRX security platform; vJunos / cMX from CML *(19–22.x bridge now partly covered by `tsg8139_evpn_leaf_dhcpv6` 23.2, added 2026-06-15)* |
 | **mikrotik** | 4 | RouterOS 6.48.1 / 6.48.6 / 7.18.2 | RouterOS 7.0-7.10 (early v7); CHR (cloud-hosted router); CCR variants |
 | **opnsense** | 7 | OPNsense 25.x + config-schema 11.2 CARP HA pair | 22.x / 23.x / 24.x branches (HA-pair gap closed in commit 4686198 via `opnsense/docs` CARP examples; production-deployed HA pairs still welcome) |
+| **cisco_nxos** | 6 | NX-OS 9.2(3) | newer **10.x** major; a 2nd source (corpus is all `batfish/lab-validation`); `nxos_ebgp_loop_prevention` |
+| **cisco_iosxr** | 10 | IOS-XR (2 sources: `batfish/lab-validation` + `ios-xr/xrd-tools`) | flex-algo; L2VPN bridge-groups; ACL extended; QoS class-maps (remaining `xrd-tools` topos `simple-bgp` / `ospf-bgp-rr` / 8-node `segment-routing` are easy pulls) |
+| **aruba_aoscx** | 4 | AOS-CX 10.04 / 10.13 | symmetric-IRB **L3VNI** (`vni N / vrf`); **VSX** stanza; **VRRP**; an operator capture from a non-Aruba-published source |
+| **vyos** | 10 | VyOS 1.3 / 1.4 / 1.5 | a **permissive + curly-brace** real capture exercising **`vrf name`** (VRF stays synthetic-validated — see below); a permissive real **set-form** capture |
 
 ---
 
@@ -116,13 +120,18 @@ parser regression fixture once the codec ships.
 
 | Platform | Why it's missing | Highest-value capture source |
 |---|---|---|
-| Cisco NX-OS | Data center switches with completely distinct grammar from IOS-XE | **Codec shipped + `certified`** (`cisco_nxos`, bidirectional) — a 6-config `batfish/lab-validation` corpus (Apache-2.0) is committed under `tests/fixtures/real/cisco_nxos/`: `nxos_hsrp` ×2 (HSRP + LAG), `nxos_evpn_l3vni` ×2 (VRF + nve1 VTEP + L3VNI), `nxos_evpn_l2vni` (L2VNI), `nxos_bgp_redist_connected` (BGP).  Additional grammar coverage welcomed for a **newer NX-OS major** (the corpus is all 9.2(3)), `nxos_ebgp_loop_prevention`, and the T2 anycast-gateway already landed.  Operator captures from 10.x boxes are the highest-value contribution. |
 | Cisco IOS classic | Pre-IOS-XE; still in production at SMB | NTC-templates `tests/cisco_ios/`, NAPALM IOS fixtures |
 | Juniper SRX | Security platform; distinct from EX/QFX/MX grammar | Juniper Day One Books PDFs (© Juniper, free download — discovery-only, not direct-import), Junos Genius |
-| Aruba AOS-CX | Modern Aruba replacing AOS-S; includes the 8400 chassis class (AOS-CX-only — never shipped AOS-S) | **Codec shipped + `certified`** (`aruba_aoscx`, bidirectional) — a 4-config corpus from the Apache-2.0 `aruba/aoscx-ansible-dcn-workflows` reference fabric is committed under `tests/fixtures/real/aruba_aoscx/`: 2 EVPN-VXLAN leaves (`arch3` iBGP + eBGP — `interface vxlan` L2VNI) + 2 L3-agg cores (`arch4` — real `active-gateway` SVIs + multi-chassis LAGs), spanning AOS-CX 10.04 / 10.13.  Additional grammar coverage welcomed for symmetric-IRB **L3VNI** (`vni N / vrf`), **VSX** (`vsx` stanza), **VRRP**, and an operator capture from a non-Aruba-published source. |
-| Cisco IOS-XR | Service provider routing | **Codec shipped + `certified`** (`cisco_iosxr`, bidirectional) — 10-config corpus from two Apache-2.0 sources committed under `tests/fixtures/real/cisco_iosxr/`: the `batfish/lab-validation` trio (`cisco_xr_ios_vpnv4`, `iosxr_ebgp_basic`, `iosxr_ibgp_rr_over_ospf`) + 3 `ios-xr/xrd-tools` `xr_compose_topos` configs (SRv6-L3VPN, SR-MPLS, IS-IS IP-FRR).  Additional grammar coverage still welcomed for flex-algo, L2VPN bridge-groups, ACL extended, and QoS class-maps — remaining `ios-xr/xrd-tools` topologies (`simple-bgp`, `ospf-bgp-rr`, `segment-routing` 8-node) are easy pulls. |
-| VyOS | OSS Vyatta successor | **Codec shipped + `certified`** (`vyos`, bidirectional) — netcanon's 12th codec, a curly-brace `config.boot` parser (distinct from the set-form `juniper_junos`).  Real corpus under `tests/fixtures/real/vyos/` (10 files, 4 sources, VyOS 1.3 + 1.4 + 1.5): 6 MIT `cisagov/prescup-challenges` (IPv4/OSPF + IPv6/BGP) + 2 Apache-2.0 `zhouleyan/wcni-kind` (`interfaces vxlan` tunnel pair) + `scottlaird/vyos-parser` (Apache-2.0, 1.5) + `rapid7/metasploit-framework` (BSD-3, 1.3) — the last two real-validate `service snmp`.  Covered surfaces: interfaces / static / users / NTP (bare + block form) / `service snmp` / VRF / `interfaces vxlan`.  Still welcomed: a **permissive + curly-brace** real capture exercising **`vrf name`** — a 2026-06 hunt found such configs only under GPL (`vyos-1x` smoketests) or unlicensed, so **VRF alone remains synthetic-validated**.  `set`-form input (`show configuration commands`) now **ships** (the probe disambiguates VyOS set-form from the Junos set-form the `juniper_junos` codec owns; converted to curly-brace up front so the brace-stack walker is reused) — a permissive real set-form capture is welcomed to retire its synthetic-only validation. |
 | pfSense | Apache-2.0 (per `pfsense/pfsense` repo); structurally similar to OPNsense `config.xml`, could share codec layer | `sheridans/pfopn-convert` fixtures (BSD-2), `pfsense/pfsense` factory default, pfSense forum captures |
+
+> **Already shipped (no longer Tier-D).**  `cisco_nxos`, `cisco_iosxr`,
+> `aruba_aoscx`, and `vyos` graduated from this list — they are
+> certified codecs with real-capture corpora, now tracked in the
+> [Current corpus snapshot](#current-corpus-snapshot) above.  Their
+> remaining per-codec grammar gaps live in that table's "Notable gaps"
+> column; the VyOS **`vrf name`** gap (VRF stays synthetic-validated
+> until a permissive curly-brace real capture lands) is the
+> highest-leverage outstanding ask.
 
 If you're a maintainer at any of these vendors and would like to
 collaborate on bringing your platform into Netcanon's matrix, open


### PR DESCRIPTION
## What & why

Three run3 LOW doc-honesty findings left netcanon's **12-codec mesh** documented as if it were ~7-8 codecs. This closes all three (docs-only; no code or matrix change).

### `vendor-pages-lag-certified-codecs`
Adds the four missing operator "What works for me?" pages, following the existing 8-section template and grounded in each codec's live `CapabilityMatrix` + real-capture corpus:

- [`docs/vendors/cisco_nxos.md`](docs/vendors/cisco_nxos.md) — HSRP + IPv4 Distributed Anycast Gateway; VXLAN-EVPN L2/L3VNI
- [`docs/vendors/cisco_iosxr.md`](docs/vendors/cisco_iosxr.md) — SP routing; 4-segment ports; RD-from-BGP harvest
- [`docs/vendors/aruba_aoscx.md`](docs/vendors/aruba_aoscx.md) — `active-gateway` anycast; L3-by-default (`no routing` opts into L2)
- [`docs/vendors/vyos.md`](docs/vendors/vyos.md) — curly-brace `config.boot`; `vif` VLAN sub-interfaces

Each page is **honest about the management-plane Tier-1 surfaces these switch/SP codecs render-drop** (DNS / NTP / syslog / DHCP / RADIUS — declared `unsupported`, flagged by the validation panel, not silently dropped). Index `docs/vendors/README.md` grows 7 → 11 rows.

### `results-summary-omits-4-certified-codecs`
`RESULTS.md` Summary table gains the 4 certified codecs (cisco_nxos 6 / cisco_iosxr 10 / aruba_aoscx 4 / vyos 10 fixtures); **TOTAL 45 → 75**. Corrected the adjacent "17 bugs across all seven codecs" line to "seven of the twelve" (the 4 batfish/xrd codecs surfaced none on first contact). Also drops the residual `parse_only direction means round-trip is N/A` cert-decision prose on `cisco_iosxe_cli` — it is bidirectional; completes the #140 fix.

### `wanted-tier-d-mislabels-shipped-codecs`
`WANTED.md` — the 4 shipped+certified codecs move out of the "Tier-D entirely-new codec opportunities" table into the **Current corpus snapshot**. Tier-D now lists only the genuinely-unmodelled platforms (Cisco IOS classic, Juniper SRX, pfSense). Per-codec grammar gaps preserved in the snapshot's "Notable gaps" column.

## Verification
Docs-only. No Python/test reads these files structurally (the cross-mesh expectation YAMLs are unaffected). Anchors + relative links verified against existing sibling pages; no PII paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
