### PR TITLE
docs: README badges + surface COMPARISON on the landing page (run3 LOW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Netcanon
 
+[![CI](https://github.com/netcanon/netcanon/actions/workflows/ci.yml/badge.svg)](https://github.com/netcanon/netcanon/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/netcanon)](https://pypi.org/project/netcanon/)
+[![Python versions](https://img.shields.io/pypi/pyversions/netcanon)](https://pypi.org/project/netcanon/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Container: GHCR](https://img.shields.io/badge/ghcr.io-netcanon%2Fnetcanon-2496ED?logo=docker&logoColor=white)](https://github.com/netcanon/netcanon/pkgs/container/netcanon)
+
 **Multi-vendor network config translator with a verifiable cross-vendor audit.**
 
 Translates running-config across twelve codecs spanning Cisco (IOS-XE,
@@ -106,6 +112,30 @@ hashes, hostnames, or usernames into a public issue.
 
 For the full audit narrative + the variance-class taxonomy, see
 [`docs/HOW_WE_TEST.md`](docs/HOW_WE_TEST.md).
+
+---
+
+## How it compares
+
+Arriving from "I need a Batfish / NAPALM / Capirca alternative"?  Most
+adjacent tools occupy a different slot — Netcanon's niche is
+**bidirectional translation between vendors' native running-config
+formats**, with a per-field capability matrix and a cross-mesh audit.
+
+| Tool | What it does | Translates native config? |
+|---|---|---|
+| **Netcanon** | Multi-vendor config translation (parse + render) | ✅ bidirectional, 12 codecs |
+| [Batfish](https://github.com/batfish/batfish) | Config analysis + routing simulation | ❌ parse-only — *complements* Netcanon |
+| [Capirca](https://github.com/google/capirca) / [Aerleon](https://github.com/aerleon/aerleon) | Firewall ACL DSL → vendor syntax | ❌ render-only from a DSL — *competes* (firewall scope) |
+| [NAPALM](https://github.com/napalm-automation/napalm) / [Netmiko](https://github.com/ktbyers/netmiko) | Device get/set + SSH transport | ❌ no translation — *complements* (deploy side) |
+| [Oxidized](https://github.com/ytti/oxidized) / [RANCID](https://shrubbery.net/rancid/) | Multi-vendor config **backup** + diff | ❌ backup-only — overlaps Netcanon's backup half |
+
+Netcanon **competes** with Capirca / Aerleon (but defers firewall / NAT
+/ VPN / QoS to Tier-3) and **complements** Batfish (analyse what you
+translated), NAPALM / Netmiko (deploy it), and NetBox / Nautobot
+(desired-state vs existing-state).  Full breakdown — including the
+backup + sanitiser landscape — in
+[`docs/COMPARISON.md`](docs/COMPARISON.md).
 
 ---
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -42,6 +42,29 @@ per-field capability declarations.
 
 ---
 
+## The backup + sanitiser half
+
+Netcanon is two co-hosted tools.  Everything above is the
+**translation** engine; the other half is **backup** — pull
+running-configs from devices over SSH / NETCONF / REST, on a schedule —
+plus a built-in **config sanitiser**.  Those overlap a different set of
+tools than the translation half:
+
+| Tool | Slot | vs Netcanon |
+|---|---|---|
+| [**Oxidized**](https://github.com/ytti/oxidized) | Multi-vendor config backup + diff (the modern RANCID) | Backup-only — no translation, no per-field audit.  Far broader device-driver coverage; Netcanon's backup half is narrower and exists to *feed* the canonical translation + audit pipeline |
+| [**RANCID**](https://shrubbery.net/rancid/) | The original config-backup-and-diff daemon | Mature + battle-tested for backup/diff via a VCS; no web UI, no translation |
+| [**netconan**](https://github.com/intentionet/netconan) | Network-config anonymiser (Intentionet, the Batfish authors) | Netcanon ships its own sanitiser (`netcanon sanitize` CLI, the `/sanitize` page, and `POST /api/v1/sanitize` — all one library) wired to the same canonical model, so it scrubs structurally (interface IPs, password hashes, SNMP / RADIUS secrets, hostnames) rather than purely by regex |
+
+If config **backup + diff** is your only need, Oxidized / RANCID are
+purpose-built and more mature on device-driver breadth — Netcanon's
+backup half exists to feed translation, not to replace a dedicated
+backup daemon.  If config **anonymisation** is your only need, netconan
+is a focused standalone tool; Netcanon's sanitiser is integrated, so the
+same engine that parses a config also scrubs it.
+
+---
+
 ## Where Netcanon competes
 
 - **Capirca / Aerleon** for cross-vendor configuration translation.


### PR DESCRIPTION
## What & why

Three run3 LOW marketing-surface findings — docs-only, no code change.

### `readme-no-badges-no-screenshots`
Adds a badge row under the `# Netcanon` title: CI status (Actions `ci.yml`), PyPI version + supported Python versions (shields.io/pypi), MIT license, and the GHCR container. (The product screenshot/hero was already added in #129; this closes the badges half.)

### `comparison-buried-not-on-landing-page`
`docs/COMPARISON.md` was linked from the README exactly **once**, inside a firewall aside. Adds a condensed **"How it compares"** callout to the landing page (a 5-row table — Netcanon vs Batfish / Capirca-Aerleon / NAPALM-Netmiko / Oxidized-RANCID — plus a competes/complements one-liner) right before Install, linking out to the full breakdown.

### `comparison-omits-backup-and-sanitizer-competitors`
`COMPARISON.md` only positioned the **translation** half. Adds a **"backup + sanitiser half"** section naming:
- **Oxidized / RANCID** — the multi-vendor config-backup + diff competitors to netcanon's backup half
- **netconan** (Intentionet) — the config-anonymiser competitor to the built-in sanitiser

…with honest "if backup/diff (or anonymisation) is your *only* need, the purpose-built tool is more mature — netcanon's backup half exists to feed translation" framing.

## Verification
Docs-only. Badge URLs use the canonical shields.io / GitHub Actions endpoints; all links relative or to upstream repos. No PII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
