### PR TITLE
test: vacuous-skip guards + XXE/entity-bomb rejection (run3 LOW)

### DIFF
--- a/tests/unit/migration/test_real_captures.py
+++ b/tests/unit/migration/test_real_captures.py
@@ -649,3 +649,30 @@ def test_real_capture_detects_to_unique_codec(
             f"silently/alphabetically.  Ranking: "
             f"{[(c.codec, c.confidence) for c in ranked[:4]]}"
         )
+
+
+def test_every_mapped_fixture_dir_yields_at_least_one_capture() -> None:
+    """Vacuous-skip guard (run3 ``data-driven-harness-vacuous-skip``).
+
+    The parametrized real-capture suites above ``@skipif`` away to GREEN
+    if ``_discover_fixtures`` returns ``[]`` — a relocated fixture root
+    or a broken extension filter would silently erase coverage without
+    failing the build.  Assert every mapped vendor directory that exists
+    on disk contributes at least one discovered fixture.
+    """
+    if not REAL_FIXTURES_ROOT.is_dir():
+        pytest.skip(f"{REAL_FIXTURES_ROOT} does not exist")
+    covered = {codec_key for codec_key, _ in _FIXTURE_PARAMS}
+    expected = {
+        vendor_dir
+        for vendor_dir in _DIR_TO_CODEC_NAME
+        if (REAL_FIXTURES_ROOT / vendor_dir).is_dir()
+    }
+    missing = expected - covered
+    assert not missing, (
+        f"Real-capture corpus: mapped vendor dirs with no discovered "
+        f"fixture: {sorted(missing)} (discovery found "
+        f"{len(_FIXTURE_PARAMS)} fixtures across {len(covered)} dirs).  "
+        f"A populated dir contributing zero fixtures means the "
+        f"parametrized parse/round-trip coverage silently vanished."
+    )

--- a/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
+++ b/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
@@ -346,3 +346,29 @@ def test_every_synthetic_dir_maps_to_a_registered_codec() -> None:
         f"codec: {missing}.  Either rename the dir to match a codec "
         f"name or remove it.  Registered codecs: {sorted(registered)}"
     )
+
+
+def test_corpus_covers_every_round_trippable_codec() -> None:
+    """Vacuous-skip guard (run3 ``data-driven-harness-vacuous-skip``).
+
+    The parametrized round-trip suites above ``@skipif`` away to GREEN
+    if discovery returns ``[]`` — a relocated fixture root or a broken
+    glob would silently erase coverage without failing the build.  This
+    is the forward direction of
+    ``test_every_synthetic_dir_maps_to_a_registered_codec``: assert
+    every registered codec is REPRESENTED in the discovered corpus.  The
+    internal ``mock`` test codec is the sole exemption (it ships no
+    synthetic fixture).
+    """
+    if not SYNTHETIC_FIXTURES_ROOT.is_dir():
+        pytest.skip(f"{SYNTHETIC_FIXTURES_ROOT} does not exist")
+    expected = {n for n in list_codecs() if n != "mock"}
+    covered = {codec_name for codec_name, _ in _FIXTURE_PARAMS}
+    missing = expected - covered
+    assert not missing, (
+        f"Synthetic kitchen-sink corpus is missing fixtures for "
+        f"{sorted(missing)} (discovery found {len(_FIXTURE_PARAMS)} "
+        f"fixtures across {len(covered)} codecs).  A round-trippable "
+        f"codec with no synthetic fixture means its parametrized "
+        f"round-trip coverage silently vanished."
+    )

--- a/tests/unit/migration/test_xml_xxe_rejection.py
+++ b/tests/unit/migration/test_xml_xxe_rejection.py
@@ -1,0 +1,79 @@
+"""XXE / entity-bomb rejection for operator-uploaded XML configs.
+
+Netcanon parses XML config families (OPNsense ``config.xml`` + Cisco
+IOS-XE NETCONF) and routes them through defusedxml's hardened
+``fromstring``.  The dependency is pinned in ``pyproject.toml`` with a
+rationale comment, but no test previously fed a malicious payload to
+confirm the guard actually fires end-to-end through a codec's parse
+path.  These tests feed a recursive entity bomb ("billion laughs") and
+an external-entity (XXE) payload and assert they are rejected as a
+``ParseError`` rather than expanded (run3 ``no-xxe-payload-test``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.base import ParseError
+from netcanon.migration.codecs.opnsense.codec import OPNsenseCodec
+
+pytestmark = pytest.mark.unit
+
+
+# Recursive entity expansion: a naive parser would balloon memory
+# expanding &lol3; into thousands of "lol" copies.  defusedxml refuses
+# any DOCTYPE-defined entity.
+_BILLION_LAUGHS = (
+    '<?xml version="1.0"?>\n'
+    "<!DOCTYPE opnsense [\n"
+    '  <!ENTITY lol "lol">\n'
+    '  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">\n'
+    '  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">\n'
+    "]>\n"
+    "<opnsense><system><hostname>&lol3;</hostname></system></opnsense>"
+)
+
+# External-entity (XXE): a naive parser would read a local file off
+# disk and inline it.  defusedxml refuses external references.
+_XXE_FILE_READ = (
+    '<?xml version="1.0"?>\n'
+    "<!DOCTYPE opnsense [\n"
+    '  <!ENTITY xxe SYSTEM "file:///etc/passwd">\n'
+    "]>\n"
+    "<opnsense><system><hostname>&xxe;</hostname></system></opnsense>"
+)
+
+
+class TestOpnsenseXxeRejection:
+    @pytest.mark.parametrize(
+        "payload,label",
+        [
+            (_BILLION_LAUGHS, "billion-laughs"),
+            (_XXE_FILE_READ, "external-entity"),
+        ],
+    )
+    def test_malicious_doctype_is_rejected(self, payload: str, label: str) -> None:
+        with pytest.raises(ParseError):
+            OPNsenseCodec().parse(payload)
+
+    def test_benign_config_still_parses(self) -> None:
+        """The rejection is targeted at DOCTYPE / entities — a plain
+        ``config.xml`` with no DOCTYPE parses without raising."""
+        benign = (
+            '<?xml version="1.0"?>\n'
+            "<opnsense><system><hostname>fw1</hostname></system></opnsense>"
+        )
+        intent = OPNsenseCodec().parse(benign)
+        assert intent.hostname == "fw1"
+
+
+def test_shared_safe_fromstring_rejects_entity_bomb() -> None:
+    """Library-level guard: the hardened parser the XML codecs share
+    (``defusedxml.ElementTree.fromstring``) refuses the entity bomb
+    regardless of per-codec wrapping — proves the dependency is doing
+    its job, not silently no-op'd by an import swap."""
+    from defusedxml.common import DefusedXmlException
+    from defusedxml.ElementTree import fromstring as safe_fromstring
+
+    with pytest.raises(DefusedXmlException):
+        safe_fromstring(_BILLION_LAUGHS)


### PR DESCRIPTION
## What & why

Two run3 LOW **test-honesty** findings — tests-only, no codec/matrix change. Local gate: `ruff` clean; `tests/unit/migration` green.

### `data-driven-harness-vacuous-skip`
Both data-driven round-trip harnesses guard their parametrized suites with `@pytest.mark.skipif(not _FIXTURE_PARAMS, ...)` — so if fixture **discovery returns `[]`** (a relocated root, a broken glob, an extension-filter typo), the whole suite skips to **green** and coverage silently vanishes. Add a non-parametrized guard to each:

- **synthetic** harness — assert every registered codec (all bidirectional; the internal `mock` codec excepted) is represented in the discovered corpus. This is the forward direction of the existing `dir → registered` guard.
- **real-captures** harness — assert every mapped vendor dir that exists on disk contributes ≥1 discovered fixture.

### `no-xxe-payload-test`
`defusedxml` is pinned in `pyproject.toml` (with a rationale comment) and wired into the XML codecs, but **no test ever fed a malicious payload** to confirm the guard fires end-to-end. New [`tests/unit/migration/test_xml_xxe_rejection.py`](tests/unit/migration/test_xml_xxe_rejection.py):
- feeds a **billion-laughs** recursive-entity bomb and an **external-entity (file-read) XXE** payload through the OPNsense XML parse path → asserts each is rejected as a `ParseError` (not expanded);
- a **benign-config control** proves the rejection is targeted at DOCTYPE/entities, not all XML;
- a **library-level guard** that the shared `defusedxml.ElementTree.fromstring` refuses the bomb regardless of per-codec wrapping.

## Deferred from this batch
`fixture-attribution-headers-missing` (also run3 LOW) turned out to be **~48 of 90 real fixtures** (the older arista/aoss/cisco_iosxe/fortigate/junos/mikrotik/opnsense corpus), not "several" — a large, regression-sensitive fixture-content change (per-file provenance from `NOTICE.md` + per-vendor comment syntax + cross-mesh regen). It'll be its own batch; `NOTICE.md` remains the authoritative provenance record in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
