### PR TITLE
refactor(fortigate): dedup _prefix_to_mask + stop swallowing RenderError (run3 LOW)

### DIFF
--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -65,6 +65,7 @@ from ...canonical.intent import (
     CanonicalVRRPGroup,
 )
 from .._helpers import _mask_to_prefix
+from .._helpers import _prefix_to_mask as _shared_prefix_to_mask
 from .._input_shape import detect_input_shape
 from ..base import ParseError
 from .vlan_heuristics import infer_iface_type as _infer_iface_type
@@ -78,19 +79,16 @@ logger = logging.getLogger(__name__)
 
 
 def _prefix_to_mask(prefix: int) -> str:
-    """Convert CIDR prefix length to dotted-decimal mask."""
-    # Import kept local to the function that actually raises — the
-    # module-level import is enough for the isinstance check the
-    # render path does, and keeping this here avoids a circular
-    # dependency with base.py.
-    from ..base import RenderError
-    if prefix < 0 or prefix > 32:
-        raise RenderError(
-            f"fortigate_cli: invalid CIDR prefix {prefix}",
-            yang_path="/interfaces/interface/ipv4/address/prefix-length",
-        )
-    mask_int = (0xFFFFFFFF << (32 - prefix)) & 0xFFFFFFFF
-    return str(ipaddress.IPv4Address(mask_int))
+    """Convert CIDR prefix length to dotted-decimal mask.
+
+    Thin fortigate-vendor binding over
+    :func:`netcanon.migration.codecs._helpers._prefix_to_mask` so the
+    dotted-mask range-check + math have a single home (run3
+    ``duplicated-prefix-to-mask-fortigate``).  Kept as a no-arg shim so
+    the render-side call sites + ``_split_cidr`` API stay stable; raises
+    the same :class:`RenderError` on an out-of-range prefix.
+    """
+    return _shared_prefix_to_mask(prefix, vendor="fortigate_cli")
 
 
 def _split_cidr(destination: str) -> tuple[str, int]:

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -82,6 +82,19 @@ _RFC1918_NETWORKS = (
 )
 
 
+def _svi_ip_mask(addr: Any) -> tuple[str, str]:
+    """Return ``(ip, dotted-mask)`` for an SVI IPv4 address.
+
+    Consolidates the three near-identical addr -> ip -> mask SVI sites
+    and — unlike the prior inline ``try/except Exception: mask = ""``
+    idiom — lets a :class:`RenderError` from an out-of-range prefix
+    PROPAGATE rather than silently emitting an empty netmask (run3
+    ``fortigate-render-swallowed-rendererror``).  Valid prefixes (every
+    real config) are unaffected.
+    """
+    return addr.ip, _prefix_to_mask(addr.prefix_length)
+
+
 def _has_private_ipv4(iface: CanonicalInterface) -> bool:
     """Return True when *iface* has at least one RFC1918 IPv4
     address.  Used as a LAN-side signal in the VLAN-parent scorer."""
@@ -271,12 +284,7 @@ def _build_vlan_children(
         ip = ""
         mask = ""
         if vlan.ipv4_addresses:
-            addr = vlan.ipv4_addresses[0]
-            ip = addr.ip
-            try:
-                mask = _prefix_to_mask(addr.prefix_length)
-            except Exception:
-                mask = ""
+            ip, mask = _svi_ip_mask(vlan.ipv4_addresses[0])
         else:
             # Step 2a: Cisco/FortiGate-native exact-name lookup
             # (kept as fast-path for clarity even though the vlan-id
@@ -284,24 +292,14 @@ def _build_vlan_children(
             for cand_name in (f"Vlan{vlan.id}", f"vlan{vlan.id}"):
                 cand = iface_by_name.get(cand_name)
                 if cand and cand.ipv4_addresses:
-                    addr = cand.ipv4_addresses[0]
-                    ip = addr.ip
-                    try:
-                        mask = _prefix_to_mask(addr.prefix_length)
-                    except Exception:
-                        mask = ""
+                    ip, mask = _svi_ip_mask(cand.ipv4_addresses[0])
                     break
             # Step 2b: walk by resolved vlan_id for foreign SVI
             # iface shapes (OPNsense ``vlan0.<id>`` etc.).
             if not ip:
                 cand = iface_by_vlan_id.get(vlan.id)
                 if cand and cand.ipv4_addresses:
-                    addr = cand.ipv4_addresses[0]
-                    ip = addr.ip
-                    try:
-                        mask = _prefix_to_mask(addr.prefix_length)
-                    except Exception:
-                        mask = ""
+                    ip, mask = _svi_ip_mask(cand.ipv4_addresses[0])
 
         children.append({
             "name": f"vlan{vlan.id}",

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -9823,7 +9823,7 @@ netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 ou
 
 ### vyos/kitchen_sink.conf → fortigate_cli  (RENDER)
 
-**Error:** render failed: RenderError('fortigate_cli: invalid CIDR prefix 48')
+**Error:** render failed: RenderError('fortigate_cli: prefix length 48 out of range')
 
 ```
 Traceback (most recent call last):
@@ -9831,13 +9831,11 @@ Traceback (most recent call last):
     rendered = target_codec.render(canonical_source)
   File "netcanon\migration\codecs\fortigate_cli\codec.py", line 396, in render
     return render_intent(tree)
-  File "netcanon\migration\codecs\fortigate_cli\render.py", line 950, in render_intent
+  File "netcanon\migration\codecs\fortigate_cli\render.py", line 948, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)
-  File "netcanon\migration\codecs\fortigate_cli\parse.py", line 88, in _prefix_to_mask
-    raise RenderError(
-    ...<2 lines>...
-    )
-netcanon.migration.codecs.base.RenderError: fortigate_cli: invalid CIDR prefix 48
+  File "netcanon\migration\codecs\fortigate_cli\parse.py", line 91, in _prefix_to_mask
+    return _shared_prefix_to_mask(prefix, vendor="fortigate_cli")
+netcanon.migration.codecs.base.RenderError: fortigate_cli: prefix length 48 out of range
 ```
 
 ### vyos/kitchen_sink.conf → juniper_junos  (WARN 15/21)


### PR DESCRIPTION
## What & why

Two run3 LOW code-quality findings in the `fortigate_cli` codec. Behaviour on valid configs is **unchanged**; cross-mesh regen holds **CODEC_BUG at 5**.

### `duplicated-prefix-to-mask-fortigate`
`parse.py` carried a private `_prefix_to_mask` byte-equivalent to the shared `_helpers._prefix_to_mask` (the one mask helper never lifted to `_helpers`). Replaced the local range-check + mask-math with a thin no-arg vendor binding that delegates to the shared helper — single home for the dotted-mask logic. The no-arg shim keeps the render-side call sites + `_split_cidr` API stable.

### `fortigate-render-swallowed-rendererror`
The three near-identical SVI sites did `addr → ip → try: mask = _prefix_to_mask(...) except Exception: mask = ""`, silently turning an out-of-range prefix into an **empty netmask**. Extracted `_svi_ip_mask(addr) -> (ip, mask)` used by all three, and let `RenderError` **propagate** (fail loud).

## Verification
- `ruff` clean; fortigate unit + real-capture + synthetic round-trip green.
- Cross-mesh regen: **CODEC_BUG = 5** (baseline held). Valid prefixes (0..32) never raise, so render output is identical on every fixture.
- The only artifact delta is one already-failing incompatible cell — `vyos` kitchen-sink (`/48` prefix) → `fortigate_cli` (IPv4 mask) — whose captured `CROSS_MESH_RESULTS.md` error message + traceback line numbers shift to the shared helper's wording. Regenerated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
