### PR TITLE
refactor: relocate _walk_canonical to canonical/xpath_walker.py (run3 LOW)

### DIFF
--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -1,0 +1,243 @@
+"""Canonical-tree xpath walker — the shared ``iter_xpaths`` source.
+
+Every codec's :meth:`iter_xpaths` yields from :func:`_walk_canonical`,
+which emits a schema xpath for each populated field of a
+:class:`CanonicalIntent`.  The walker is the sole input to
+``migration_validate.validate_against``, so the honesty contract
+("loss is visible in the report, not hidden") depends on it yielding
+an xpath for every populated surface.
+
+Relocated here from ``codecs/cisco_iosxe_cli/codec.py`` (run3
+``walk-canonical-vendor-leaf``) so the shared walker no longer lives
+inside a single vendor codec; ``cisco_iosxe_cli.codec`` re-exports it
+for the historical import path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .intent import CanonicalIntent
+
+
+def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
+    """Yield schema xpaths for every populated field of a CanonicalIntent.
+
+    This is the input to :func:`netcanon.services.migration_validate.
+    validate_against` — the validator classifies each yielded xpath
+    against the *target* codec's :class:`CapabilityMatrix` so the
+    interactive migration report can surface lossy / unsupported
+    surfaces before the operator commits.  The honesty contract
+    ("loss is visible in the report, not hidden") therefore depends on
+    this walker yielding an xpath for **every** populated surface — a
+    field the walker skips can never be flagged, no matter how the
+    target declares it.  So the walker covers all of Tier 1 + Tier 2:
+    system scalars, every interface sub-field, VLANs, static routes,
+    SNMP (incl. v3 sub-fields), DHCP pools, LAGs, local users, RADIUS
+    servers, VXLAN VNIs, EVPN Type-5 routes, and routing-instances.
+
+    Each yield is guarded on the field being populated, so the walker
+    emits xpaths only for data the source config actually carried — an
+    empty surface yields nothing and so classifies as neither lossy nor
+    unsupported (there is nothing to lose).
+
+    The xpath vocabulary is the granular hyphenated shape the codec
+    capability matrices declare (e.g. ``/lags/lag/mode``,
+    ``/local-users/user/role``); :meth:`CapabilityMatrix.classify` is
+    exact-string-match, so the walker and the matrices must speak the
+    same strings for a declaration to be reachable.
+
+    Kept at module level (rather than relocating to :mod:`.parse` or
+    :mod:`.render`) so that the
+    ``from netcanon.migration.codecs.cisco_iosxe_cli.codec import _walk_canonical``
+    import surface every cross-codec ``iter_xpaths`` consumer relies
+    on stays intact.  Used by the OPNsense / Aruba / FortiGate / Arista /
+    Juniper / MikroTik / Cisco-NETCONF codecs.
+
+    Note: ``run_full_mesh.py``'s cross-mesh field-disposition matrix
+    does NOT consume this walker — it compares ``model_dump()`` output
+    and reads each matrix's ``unsupported`` declarations directly — so
+    expanding this walker affects only the live validation report.
+    """
+    # ── Tier 1 — system scalars ──
+    if intent.hostname:
+        yield "/system/hostname"
+    if intent.domain:
+        yield "/system/domain"
+    for _ in intent.dns_servers:
+        yield "/system/dns-server"
+    for _ in intent.ntp_servers:
+        yield "/system/ntp-server"
+    if intent.timezone:
+        yield "/system/timezone"
+    for _ in intent.syslog_servers:
+        yield "/system/syslog-server"
+    for iface in intent.interfaces:
+        yield "/interfaces/interface/name"
+        if iface.description:
+            yield "/interfaces/interface/config/description"
+        yield "/interfaces/interface/config/enabled"
+        if iface.interface_type:
+            yield "/interfaces/interface/config/type"
+        for addr in iface.ipv4_addresses:
+            yield "/interfaces/interface/ipv4/address/ip"
+            yield "/interfaces/interface/ipv4/address/prefix-length"
+            # Secondary addresses: single-address platforms (FortiGate /
+            # OPNsense) render only the primary and silently drop every
+            # is_secondary address — a whole-subnet reachability loss.
+            # Walk a secondary-specific xpath so those codecs can declare
+            # it unsupported and the loss surfaces instead of reporting ok.
+            if addr.is_secondary:
+                yield "/interfaces/interface/ipv4/address/secondary-ip"
+            if addr.virtual_gateway_address:
+                yield (
+                    "/interfaces/interface/ipv4/address/"
+                    "virtual-gateway-address"
+                )
+            if addr.virtual_gateway_mac:
+                yield (
+                    "/interfaces/interface/ipv4/address/"
+                    "virtual-gateway-mac"
+                )
+        for addr6 in iface.ipv6_addresses:            # GAP-EVPN-3
+            yield "/interfaces/interface/ipv6/address/ip"
+            yield "/interfaces/interface/ipv6/address/prefix-length"
+            if addr6.is_secondary:
+                yield "/interfaces/interface/ipv6/address/secondary-ip"
+            if addr6.virtual_gateway_address:
+                yield (
+                    "/interfaces/interface/ipv6/address/"
+                    "virtual-gateway-address"
+                )
+            if addr6.virtual_gateway_mac:
+                yield (
+                    "/interfaces/interface/ipv6/address/"
+                    "virtual-gateway-mac"
+                )
+        if iface.dhcp_client_v6:
+            yield "/interfaces/interface/dhcp-client-v6"
+        if iface.tunnel_type:
+            yield "/interfaces/interface/tunnel-type"
+        if iface.mtu is not None:
+            yield "/interfaces/interface/config/mtu"
+        if iface.vrf:
+            yield "/interfaces/interface/config/vrf"
+        if iface.lag_member_of:
+            yield "/interfaces/interface/lag-member-of"
+        if iface.dhcp_client:
+            yield "/interfaces/interface/dhcp-client"
+        # Per-interface switchport view (the transpose of the VLAN-centric
+        # ``/vlans/vlan/{tagged,untagged}-ports`` surface).  Switch codecs
+        # declare these ``supported``; router / firewall codecs that drop
+        # them declare ``unsupported`` — so walking them surfaces the L2
+        # loss when a switch config is migrated to a routed target.  The
+        # spelling matches the existing nxos / aoscx matrix declarations
+        # (no ``config/`` segment).
+        if iface.switchport_mode:
+            yield "/interfaces/interface/switchport-mode"
+        if iface.access_vlan is not None:
+            yield "/interfaces/interface/access-vlan"
+        if iface.trunk_allowed_vlans:
+            yield "/interfaces/interface/trunk-allowed-vlans"
+        if iface.trunk_native_vlan is not None:
+            yield "/interfaces/interface/trunk-native-vlan"
+        if iface.voice_vlan is not None:
+            yield "/interfaces/interface/voice-vlan"
+        for grp in iface.vrrp_groups:
+            yield "/interfaces/interface/vrrp-groups/group"
+            # Sub-field losses several codecs declare lossy (FortiGate /
+            # AOS-S keep one VIP + drop secondaries / virtual-mac / track
+            # objects).  Walk them only when the loss condition holds, so
+            # the lossy declaration actually fires in the live report
+            # instead of being unreachable (2026-06 adversarial review #9).
+            if len(grp.virtual_ips) > 1:
+                yield "/interfaces/interface/vrrp-groups/group/virtual-ips"
+            if grp.virtual_mac:
+                yield "/interfaces/interface/vrrp-groups/group/virtual-mac"
+            if grp.track_interfaces:
+                yield "/interfaces/interface/vrrp-groups/group/track-interfaces"
+    for vlan in intent.vlans:
+        yield "/vlans/vlan/id"
+        yield "/vlans/vlan/name"
+        if vlan.description:
+            yield "/vlans/vlan/description"
+        for _ in vlan.tagged_ports:
+            yield "/vlans/vlan/tagged-ports"
+        for _ in vlan.untagged_ports:
+            yield "/vlans/vlan/untagged-ports"
+    for route in intent.static_routes:
+        yield "/routing/static-route"
+        if route.vrf:
+            yield "/routing/static-route/vrf"
+        # Sub-field losses (run3 audit): several codecs render only the
+        # destination + next-hop and silently drop the admin distance
+        # (metric), the operator route name (description), and/or
+        # interface-nexthop (connected) routes.  Walk them only when
+        # populated so the per-codec lossy/unsupported declaration fires
+        # in the live report instead of classify() defaulting to
+        # 'supported' (a silent loss reported severity: ok).
+        if route.metric:
+            yield "/routing/static-route/metric"
+        if route.description:
+            yield "/routing/static-route/description"
+        if route.interface:
+            yield "/routing/static-route/interface"
+    if intent.anycast_gateway_mac:
+        yield "/anycast-gateway-mac"
+    # ── Tier 2 — emit only what's populated ──
+    if intent.snmp is not None:
+        if intent.snmp.community:
+            yield "/snmp/community"
+        if intent.snmp.location:
+            yield "/snmp/location"
+        if intent.snmp.contact:
+            yield "/snmp/contact"
+        for _ in intent.snmp.trap_hosts:
+            yield "/snmp/trap-host"
+        for v3 in intent.snmp.v3_users:
+            yield "/snmp/v3-user"
+            if v3.auth_passphrase:
+                yield "/snmp/v3-user/auth-passphrase"
+            if v3.engine_id:
+                yield "/snmp/v3-user/engine-id"
+    for _ in intent.dhcp_servers:
+        yield "/dhcp-servers/pool"
+    for _ in intent.lags:
+        yield "/lags/lag/name"
+        yield "/lags/lag/members"
+        yield "/lags/lag/mode"
+    for user in intent.local_users:
+        yield "/local-users/user/name"
+        if user.role:
+            yield "/local-users/user/role"
+        if user.hashed_password:
+            yield "/local-users/user/hashed-password"
+        yield "/local-users/user/privilege-level"
+    for _ in intent.radius_servers:
+        yield "/radius-servers/server/host"
+        yield "/radius-servers/server/key"
+    for vx in intent.vxlan_vnis:
+        yield "/vxlan-vnis/vni"
+        if vx.source_interface:
+            yield "/vxlan-vnis/source-interface"
+        if vx.mcast_group:
+            yield "/vxlan-vnis/mcast-group"
+        if vx.flood_list:
+            yield "/vxlan-vnis/flood-list"
+        yield "/vxlan-vnis/udp-port"
+        yield "/vxlan-vnis/vlan-id"
+    for _ in intent.evpn_type5_routes:
+        yield "/evpn-type5-routes/route"
+    for inst in intent.routing_instances:
+        yield "/routing-instances/instance"
+        yield "/routing-instances/instance/name"
+        if inst.description:
+            yield "/routing-instances/instance/description"
+        if inst.route_distinguisher:
+            yield "/routing-instances/instance/route-distinguisher"
+        if inst.rt_imports:
+            yield "/routing-instances/instance/rt-imports"
+        if inst.rt_exports:
+            yield "/routing-instances/instance/rt-exports"
+        if inst.l3_vni is not None:
+            yield "/routing-instances/instance/l3-vni"

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -21,12 +21,12 @@ Module layout (post-split):
   ``_split_cisco_hash``).
 * ``port_names.py`` — cross-vendor port-name bridge.
 
-``_walk_canonical`` (the canonical-tree xpath walker reused by
-several other codecs' ``iter_xpaths`` implementations) is kept here
-at module level rather than in :mod:`.parse` or :mod:`.render` to
-preserve the
+``_walk_canonical`` (the canonical-tree xpath walker reused by every
+other codec's ``iter_xpaths`` implementation) now lives in
+:mod:`netcanon.migration.canonical.xpath_walker` and is **re-exported**
+here, so the historical
 ``from netcanon.migration.codecs.cisco_iosxe_cli.codec import _walk_canonical``
-import surface every cross-codec consumer relies on.
+import surface every cross-codec consumer relies on stays intact.
 
 Parser strategy
 ---------------
@@ -57,6 +57,7 @@ from ....models.migration import (
     UnsupportedPath,
 )
 from ...canonical.intent import CanonicalIntent
+from ...canonical.xpath_walker import _walk_canonical
 from .._input_shape import detect_input_shape
 from ..base import CodecBase
 from ..registry import register
@@ -575,224 +576,10 @@ _IOS_BANNER_HITS: tuple[tuple[str, int], ...] = (
 )
 
 
-def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
-    """Yield schema xpaths for every populated field of a CanonicalIntent.
-
-    This is the input to :func:`netcanon.services.migration_validate.
-    validate_against` — the validator classifies each yielded xpath
-    against the *target* codec's :class:`CapabilityMatrix` so the
-    interactive migration report can surface lossy / unsupported
-    surfaces before the operator commits.  The honesty contract
-    ("loss is visible in the report, not hidden") therefore depends on
-    this walker yielding an xpath for **every** populated surface — a
-    field the walker skips can never be flagged, no matter how the
-    target declares it.  So the walker covers all of Tier 1 + Tier 2:
-    system scalars, every interface sub-field, VLANs, static routes,
-    SNMP (incl. v3 sub-fields), DHCP pools, LAGs, local users, RADIUS
-    servers, VXLAN VNIs, EVPN Type-5 routes, and routing-instances.
-
-    Each yield is guarded on the field being populated, so the walker
-    emits xpaths only for data the source config actually carried — an
-    empty surface yields nothing and so classifies as neither lossy nor
-    unsupported (there is nothing to lose).
-
-    The xpath vocabulary is the granular hyphenated shape the codec
-    capability matrices declare (e.g. ``/lags/lag/mode``,
-    ``/local-users/user/role``); :meth:`CapabilityMatrix.classify` is
-    exact-string-match, so the walker and the matrices must speak the
-    same strings for a declaration to be reachable.
-
-    Kept at module level (rather than relocating to :mod:`.parse` or
-    :mod:`.render`) so that the
-    ``from netcanon.migration.codecs.cisco_iosxe_cli.codec import _walk_canonical``
-    import surface every cross-codec ``iter_xpaths`` consumer relies
-    on stays intact.  Used by the OPNsense / Aruba / FortiGate / Arista /
-    Juniper / MikroTik / Cisco-NETCONF codecs.
-
-    Note: ``run_full_mesh.py``'s cross-mesh field-disposition matrix
-    does NOT consume this walker — it compares ``model_dump()`` output
-    and reads each matrix's ``unsupported`` declarations directly — so
-    expanding this walker affects only the live validation report.
-    """
-    # ── Tier 1 — system scalars ──
-    if intent.hostname:
-        yield "/system/hostname"
-    if intent.domain:
-        yield "/system/domain"
-    for _ in intent.dns_servers:
-        yield "/system/dns-server"
-    for _ in intent.ntp_servers:
-        yield "/system/ntp-server"
-    if intent.timezone:
-        yield "/system/timezone"
-    for _ in intent.syslog_servers:
-        yield "/system/syslog-server"
-    for iface in intent.interfaces:
-        yield "/interfaces/interface/name"
-        if iface.description:
-            yield "/interfaces/interface/config/description"
-        yield "/interfaces/interface/config/enabled"
-        if iface.interface_type:
-            yield "/interfaces/interface/config/type"
-        for addr in iface.ipv4_addresses:
-            yield "/interfaces/interface/ipv4/address/ip"
-            yield "/interfaces/interface/ipv4/address/prefix-length"
-            # Secondary addresses: single-address platforms (FortiGate /
-            # OPNsense) render only the primary and silently drop every
-            # is_secondary address — a whole-subnet reachability loss.
-            # Walk a secondary-specific xpath so those codecs can declare
-            # it unsupported and the loss surfaces instead of reporting ok.
-            if addr.is_secondary:
-                yield "/interfaces/interface/ipv4/address/secondary-ip"
-            if addr.virtual_gateway_address:
-                yield (
-                    "/interfaces/interface/ipv4/address/"
-                    "virtual-gateway-address"
-                )
-            if addr.virtual_gateway_mac:
-                yield (
-                    "/interfaces/interface/ipv4/address/"
-                    "virtual-gateway-mac"
-                )
-        for addr6 in iface.ipv6_addresses:            # GAP-EVPN-3
-            yield "/interfaces/interface/ipv6/address/ip"
-            yield "/interfaces/interface/ipv6/address/prefix-length"
-            if addr6.is_secondary:
-                yield "/interfaces/interface/ipv6/address/secondary-ip"
-            if addr6.virtual_gateway_address:
-                yield (
-                    "/interfaces/interface/ipv6/address/"
-                    "virtual-gateway-address"
-                )
-            if addr6.virtual_gateway_mac:
-                yield (
-                    "/interfaces/interface/ipv6/address/"
-                    "virtual-gateway-mac"
-                )
-        if iface.dhcp_client_v6:
-            yield "/interfaces/interface/dhcp-client-v6"
-        if iface.tunnel_type:
-            yield "/interfaces/interface/tunnel-type"
-        if iface.mtu is not None:
-            yield "/interfaces/interface/config/mtu"
-        if iface.vrf:
-            yield "/interfaces/interface/config/vrf"
-        if iface.lag_member_of:
-            yield "/interfaces/interface/lag-member-of"
-        if iface.dhcp_client:
-            yield "/interfaces/interface/dhcp-client"
-        # Per-interface switchport view (the transpose of the VLAN-centric
-        # ``/vlans/vlan/{tagged,untagged}-ports`` surface).  Switch codecs
-        # declare these ``supported``; router / firewall codecs that drop
-        # them declare ``unsupported`` — so walking them surfaces the L2
-        # loss when a switch config is migrated to a routed target.  The
-        # spelling matches the existing nxos / aoscx matrix declarations
-        # (no ``config/`` segment).
-        if iface.switchport_mode:
-            yield "/interfaces/interface/switchport-mode"
-        if iface.access_vlan is not None:
-            yield "/interfaces/interface/access-vlan"
-        if iface.trunk_allowed_vlans:
-            yield "/interfaces/interface/trunk-allowed-vlans"
-        if iface.trunk_native_vlan is not None:
-            yield "/interfaces/interface/trunk-native-vlan"
-        if iface.voice_vlan is not None:
-            yield "/interfaces/interface/voice-vlan"
-        for grp in iface.vrrp_groups:
-            yield "/interfaces/interface/vrrp-groups/group"
-            # Sub-field losses several codecs declare lossy (FortiGate /
-            # AOS-S keep one VIP + drop secondaries / virtual-mac / track
-            # objects).  Walk them only when the loss condition holds, so
-            # the lossy declaration actually fires in the live report
-            # instead of being unreachable (2026-06 adversarial review #9).
-            if len(grp.virtual_ips) > 1:
-                yield "/interfaces/interface/vrrp-groups/group/virtual-ips"
-            if grp.virtual_mac:
-                yield "/interfaces/interface/vrrp-groups/group/virtual-mac"
-            if grp.track_interfaces:
-                yield "/interfaces/interface/vrrp-groups/group/track-interfaces"
-    for vlan in intent.vlans:
-        yield "/vlans/vlan/id"
-        yield "/vlans/vlan/name"
-        if vlan.description:
-            yield "/vlans/vlan/description"
-        for _ in vlan.tagged_ports:
-            yield "/vlans/vlan/tagged-ports"
-        for _ in vlan.untagged_ports:
-            yield "/vlans/vlan/untagged-ports"
-    for route in intent.static_routes:
-        yield "/routing/static-route"
-        if route.vrf:
-            yield "/routing/static-route/vrf"
-        # Sub-field losses (run3 audit): several codecs render only the
-        # destination + next-hop and silently drop the admin distance
-        # (metric), the operator route name (description), and/or
-        # interface-nexthop (connected) routes.  Walk them only when
-        # populated so the per-codec lossy/unsupported declaration fires
-        # in the live report instead of classify() defaulting to
-        # 'supported' (a silent loss reported severity: ok).
-        if route.metric:
-            yield "/routing/static-route/metric"
-        if route.description:
-            yield "/routing/static-route/description"
-        if route.interface:
-            yield "/routing/static-route/interface"
-    if intent.anycast_gateway_mac:
-        yield "/anycast-gateway-mac"
-    # ── Tier 2 — emit only what's populated ──
-    if intent.snmp is not None:
-        if intent.snmp.community:
-            yield "/snmp/community"
-        if intent.snmp.location:
-            yield "/snmp/location"
-        if intent.snmp.contact:
-            yield "/snmp/contact"
-        for _ in intent.snmp.trap_hosts:
-            yield "/snmp/trap-host"
-        for v3 in intent.snmp.v3_users:
-            yield "/snmp/v3-user"
-            if v3.auth_passphrase:
-                yield "/snmp/v3-user/auth-passphrase"
-            if v3.engine_id:
-                yield "/snmp/v3-user/engine-id"
-    for _ in intent.dhcp_servers:
-        yield "/dhcp-servers/pool"
-    for _ in intent.lags:
-        yield "/lags/lag/name"
-        yield "/lags/lag/members"
-        yield "/lags/lag/mode"
-    for user in intent.local_users:
-        yield "/local-users/user/name"
-        if user.role:
-            yield "/local-users/user/role"
-        if user.hashed_password:
-            yield "/local-users/user/hashed-password"
-        yield "/local-users/user/privilege-level"
-    for _ in intent.radius_servers:
-        yield "/radius-servers/server/host"
-        yield "/radius-servers/server/key"
-    for vx in intent.vxlan_vnis:
-        yield "/vxlan-vnis/vni"
-        if vx.source_interface:
-            yield "/vxlan-vnis/source-interface"
-        if vx.mcast_group:
-            yield "/vxlan-vnis/mcast-group"
-        if vx.flood_list:
-            yield "/vxlan-vnis/flood-list"
-        yield "/vxlan-vnis/udp-port"
-        yield "/vxlan-vnis/vlan-id"
-    for _ in intent.evpn_type5_routes:
-        yield "/evpn-type5-routes/route"
-    for inst in intent.routing_instances:
-        yield "/routing-instances/instance"
-        yield "/routing-instances/instance/name"
-        if inst.description:
-            yield "/routing-instances/instance/description"
-        if inst.route_distinguisher:
-            yield "/routing-instances/instance/route-distinguisher"
-        if inst.rt_imports:
-            yield "/routing-instances/instance/rt-imports"
-        if inst.rt_exports:
-            yield "/routing-instances/instance/rt-exports"
-        if inst.l3_vni is not None:
-            yield "/routing-instances/instance/l3-vni"
+# ``_walk_canonical`` was relocated to
+# ``netcanon/migration/canonical/xpath_walker.py`` (run3
+# ``walk-canonical-vendor-leaf``) so the shared canonical-tree walker
+# no longer lives inside a vendor codec.  It is imported at module top
+# and re-exported from here, keeping the historical
+# ``from ...cisco_iosxe_cli.codec import _walk_canonical`` path that the
+# cross-codec ``iter_xpaths`` consumers + honesty tests rely on intact.


### PR DESCRIPTION
## What & why

run3 **`walk-canonical-vendor-leaf`**: the shared canonical-tree xpath walker `_walk_canonical` — the sole input to `migration_validate.validate_against`, and the source every codec's `iter_xpaths` yields from — lived inside the **`cisco_iosxe_cli` vendor codec**. The other 11 codecs + the honesty tests reached into it via `from ..cisco_iosxe_cli.codec import _walk_canonical` — an architectural wart (shared infra living in a vendor leaf).

## Change
- Move the function **verbatim** (extracted, not retyped) to a new vendor-neutral home: [`netcanon/migration/canonical/xpath_walker.py`](netcanon/migration/canonical/xpath_walker.py), alongside `intent.py`.
- **Re-export** it from `cisco_iosxe_cli.codec` (`from ...canonical.xpath_walker import _walk_canonical`), so every historical import path keeps resolving unchanged — the 11 lazy codec imports, the two honesty tests, `models/migration.py`. (Verified: the two symbols are the *same object*.)

## Verification
- **No behaviour change** — the walker body is byte-identical; output unchanged.
- **No regen** — the cross-mesh matrix does **not** consume the walker (`run_full_mesh` compares `model_dump()` output directly; noted in the walker's own docstring). The live-validation honesty suite that *does* exercise it is green: `test_registry_capability_honesty`, `test_walk_canonical_coverage`, cisco_iosxe capability-matrix honesty.
- Full `tests/unit` + `tests/integration` gate green (exercises all 11 lazy importers); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
