### PR TITLE
refactor: Literal-type codec metadata + hide internal mock codec (run3 LOW)

### DIFF
--- a/netcanon/api/routes/_migration_helpers.py
+++ b/netcanon/api/routes/_migration_helpers.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 from fastapi import HTTPException, Request
 
-from ...migration.codecs.registry import get_codec, list_codecs
+from ...migration.codecs.registry import get_codec, list_public_codecs
 from ...migration.target_profiles import TargetProfile
 from ...models.migration import CodecInfo, MigrationPlanRequest
 from ...storage.base import BaseConfigStore
@@ -132,7 +132,7 @@ def build_codec_info_list(vendors: dict) -> list[CodecInfo]:
         registry-iteration order.
     """
     result: list[CodecInfo] = []
-    for name in list_codecs():
+    for name in list_public_codecs():
         codec = get_codec(name)
         caps = codec.capabilities
         vendor = vendors.get(caps.vendor_id)

--- a/netcanon/api/routes/sanitize.py
+++ b/netcanon/api/routes/sanitize.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from ...migration.codecs.base import ParseError
-from ...migration.codecs.registry import list_codecs
+from ...migration.codecs.registry import list_public_codecs
 from ...tools.sanitize import sanitize_text
 
 router = APIRouter()
@@ -45,7 +45,7 @@ async def post_sanitize(
     config: UploadFile = File(...),
     dry_run: bool = Form(False),
 ):
-    available = sorted(list_codecs())
+    available = list_public_codecs()
     if source_vendor not in available:
         raise HTTPException(
             status_code=400,

--- a/netcanon/migration/codecs/_mock/codec.py
+++ b/netcanon/migration/codecs/_mock/codec.py
@@ -43,6 +43,9 @@ class MockCodec(CodecBase):
     direction: ClassVar[str] = "bidirectional"
     certainty: ClassVar[str] = "experimental"
     canonical_model: ClassVar[str] = "openconfig-lite"
+    # Internal reference/test adapter — never offered on user-facing
+    # surfaces (target dropdown, sanitize source list, auto-detection).
+    hidden: ClassVar[bool] = True
     description: ClassVar[str] = (
         "Paste a JSON object mapping xpath strings to values — the "
         "reference mock adapter's format.  Not meaningful for any "

--- a/netcanon/migration/codecs/base.py
+++ b/netcanon/migration/codecs/base.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from ...models.migration import CapabilityMatrix
 
@@ -140,18 +140,31 @@ class CodecBase(ABC):
     #: codec can both parse AND render.  ``"parse_only"`` means render()
     #: raises NotImplementedError — the UI should only offer the codec as
     #: a SOURCE, never as a TARGET.  ``"render_only"`` is the reverse.
-    direction: ClassVar[str] = "bidirectional"
+    direction: ClassVar[Literal["bidirectional", "parse_only", "render_only"]] = (
+        "bidirectional"
+    )
 
     #: Certainty tier (see translator-plans.txt "Certainty Model").
     #:   ``"certified"``     — round-trip tested against ≥3 real captures.
     #:   ``"best_effort"``   — tested against synthetic samples only.
     #:   ``"experimental"``  — parse-only or incomplete; human review needed.
-    certainty: ClassVar[str] = "experimental"
+    certainty: ClassVar[Literal["experimental", "best_effort", "certified"]] = (
+        "experimental"
+    )
 
     #: Which canonical intent model this codec's tree shape targets.
     #: Default ``"openconfig-lite"`` covers the L2/L3 subset we support;
-    #: firewall codecs will declare ``"netcanon-firewall-ext"`` etc.
-    canonical_model: ClassVar[str] = "openconfig-lite"
+    #: a firewall canonical model (``"netcanon-firewall-ext"`` etc.) would
+    #: extend this Literal when those codecs land.
+    canonical_model: ClassVar[Literal["openconfig-lite"]] = "openconfig-lite"
+
+    #: Whether this codec is INTERNAL (test/reference) and must not be
+    #: offered on user-facing surfaces — the target dropdown, the sanitize
+    #: source list, or source auto-detection.  The ``mock`` reference
+    #: adapter sets this ``True``; every shipped vendor codec leaves it
+    #: ``False``.  Filtered by
+    #: :func:`netcanon.migration.codecs.registry.list_public_codecs`.
+    hidden: ClassVar[bool] = False
 
     #: Human-readable description of what :meth:`parse` expects.  Shown
     #: in the /migrate UI's format-hint banner.  One short paragraph,

--- a/netcanon/migration/codecs/registry.py
+++ b/netcanon/migration/codecs/registry.py
@@ -68,5 +68,25 @@ def get_codec(name: str) -> CodecBase:
 
 
 def list_codecs() -> list[str]:
-    """Return registered adapter names, sorted alphabetically."""
+    """Return registered adapter names, sorted alphabetically.
+
+    Includes internal/hidden adapters (the ``mock`` reference codec) —
+    for test harnesses + cross-codec invariants that must see every
+    registered adapter.  User-facing surfaces want
+    :func:`list_public_codecs` instead.
+    """
     return sorted(_REGISTRY)
+
+
+def list_public_codecs() -> list[str]:
+    """Return user-facing adapter names, sorted alphabetically.
+
+    Excludes adapters whose class sets ``hidden = True`` (the internal
+    ``mock`` reference codec).  Use this for the target-vendor dropdown,
+    the sanitize source-vendor list, and source auto-detection so the
+    internal test adapter is never offered as a production translation
+    target (run3 ``mock-codec-exposed-prod``).
+    """
+    return sorted(
+        name for name, cls in _REGISTRY.items() if not getattr(cls, "hidden", False)
+    )

--- a/netcanon/services/migration_detect.py
+++ b/netcanon/services/migration_detect.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from ..migration.codecs.registry import get_codec, list_codecs
+from ..migration.codecs.registry import get_codec, list_public_codecs
 
 #: Bytes of input passed to each codec's probe.  Longer gives better
 #: signal for ambiguous formats but most real signatures fit in the
@@ -73,7 +73,7 @@ def detect_codec(
     """
     prefix = raw[:probe_bytes] if len(raw) > probe_bytes else raw
     candidates: list[DetectCandidate] = []
-    for name in list_codecs():
+    for name in list_public_codecs():
         try:
             codec_cls = type(get_codec(name))
             result = codec_cls.probe(prefix)

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -23,11 +23,14 @@ class TestListMigrationAdapters:
         body = resp.json()
         assert isinstance(body, list)
 
-    def test_includes_mock_adapter(self, client):
-        """Phase 0 ships the mock adapter; it must appear in the list."""
+    def test_excludes_hidden_mock_adapter(self, client):
+        """The internal ``mock`` reference codec is hidden from the
+        user-facing adapters list (run3 mock-codec-exposed-prod) — it is
+        still registered + reachable by exact name on the capabilities
+        detail endpoint, but never offered as a translation target."""
         resp = client.get("/api/v1/migration/adapters")
         names = [a["name"] for a in resp.json()]
-        assert "mock" in names
+        assert "mock" not in names
 
     def test_each_entry_has_required_fields(self, client):
         resp = client.get("/api/v1/migration/adapters")
@@ -38,11 +41,13 @@ class TestListMigrationAdapters:
             ):
                 assert field in entry, f"missing {field} in {entry}"
 
-    def test_mock_adapter_device_classes_surface(self, client):
-        """MockCodec declares [switch, router] — both must come back via the
-        API so frontend code can filter the target-picker to compatible adapters."""
+    def test_device_classes_surface(self, client):
+        """A codec's device_classes come back via the API so frontend code
+        can filter the target-picker to compatible adapters.  cisco_nxos
+        declares [switch, router] (formerly asserted via the now-hidden
+        mock codec)."""
         resp = client.get("/api/v1/migration/adapters")
-        info = next(a for a in resp.json() if a["name"] == "mock")
+        info = next(a for a in resp.json() if a["name"] == "cisco_nxos")
         assert "switch" in info["device_classes"]
         assert "router" in info["device_classes"]
 
@@ -205,14 +210,16 @@ class TestListMigrationAdapters:
         supp_paths = caps["supported"]
         assert "/interfaces/interface/ipv6/address/ip" in supp_paths
 
-    def test_mock_adapter_counts_match_capability_matrix(self, client):
-        """The summary counts in the list view must match the detail view."""
+    def test_summary_counts_match_capability_detail(self, client):
+        """The summary counts in the list view must match the detail view
+        (formerly asserted via the now-hidden mock codec; cisco_nxos is a
+        public codec with all three triads populated)."""
         info = next(
             a for a in client.get("/api/v1/migration/adapters").json()
-            if a["name"] == "mock"
+            if a["name"] == "cisco_nxos"
         )
         caps = client.get(
-            "/api/v1/migration/adapters/mock/capabilities"
+            "/api/v1/migration/adapters/cisco_nxos/capabilities"
         ).json()
         assert info["supported_count"] == len(caps["supported"])
         assert info["lossy_count"] == len(caps["lossy"])

--- a/tests/unit/api/test_migration_helpers.py
+++ b/tests/unit/api/test_migration_helpers.py
@@ -188,12 +188,16 @@ class TestGetTargetProfiles:
 
 
 class TestBuildCodecInfoList:
-    def test_returns_one_entry_per_registered_codec(self):
+    def test_returns_one_entry_per_public_codec(self):
         result = build_codec_info_list(vendors={})
         names = [info.name for info in result]
-        assert "mock" in names
         # Real codecs registered by the import side-effects:
         assert any(n.startswith("cisco") for n in names)
+        # The internal ``mock`` reference codec is hidden from the
+        # user-facing codec list (run3 mock-codec-exposed-prod) — it is
+        # still registered (``list_codecs`` sees it) but build_codec_info_list
+        # consumes ``list_public_codecs``, which filters ``hidden`` adapters.
+        assert "mock" not in names
 
     def test_vendor_display_name_resolved_when_vendor_present(self):
         """When the vendors map contains the codec's vendor_id, its


### PR DESCRIPTION
## What & why

Two run3 LOW findings on `CodecBase`.

### `stringly-typed-codec-metadata`
Type the three classification fields as `Literal` closed sets so a typo'd value is a type error, not a silent string:
- `direction: Literal["bidirectional", "parse_only", "render_only"]`
- `certainty: Literal["experimental", "best_effort", "certified"]`
- `canonical_model: Literal["openconfig-lite"]`

### `mock-codec-exposed-prod`
The internal `mock` reference adapter was offered as a real translation **target**. Add `hidden: ClassVar[bool] = False` on `CodecBase` (`True` on `MockCodec`) and a registry **`list_public_codecs()`** that filters hidden adapters. Switch the three user-facing surfaces to it:
- the migration **target dropdown** (`build_codec_info_list`)
- the **sanitize** source-vendor list
- source **auto-detection**

`list_codecs()` is unchanged (still sees every registered adapter — test harnesses + cross-codec invariants rely on that), and the `/adapters/{name}/capabilities` **detail** endpoint still resolves `mock` by exact name — only the **lists** hide it.

## Test updates
The migration-helpers unit test + three integration adapter-list tests pinned the old "mock is listed" behaviour. Flipped the inclusion test to assert mock is hidden, and re-pointed the device-classes + count-match assertions to the public `cisco_nxos` codec (the detail-endpoint tests are unchanged — mock detail still resolves).

## Verification
- **No regen** — no codec matrix/walker change; the cross-mesh harness uses its own explicit codec list, not `list_public_codecs`.
- `ruff` clean; `tests/unit` + the adapter-list/detail integration tests green. *(The broader `copytree` integration tests were disk-blocked on the local box — `WinError 112`, an environment limit, not this change — so CI is the authoritative full gate here.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
