### PR TITLE
refactor(backup): resolve Settings once per job, share across collectors (run3 LOW)

### DIFF
--- a/netcanon/collectors/base.py
+++ b/netcanon/collectors/base.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 
+from ..config import Settings
 from ..definitions.schema import DeviceDefinition
 from ..models.device import DeviceTarget
 
@@ -33,6 +34,18 @@ class BaseCollector(ABC):
     unchanged, and the pipeline gracefully falls back to the
     family-base definition.
     """
+
+    #: Job-level :class:`~netcanon.config.Settings` snapshot, injected by the
+    #: backup runner (:func:`netcanon.services.backup_runner.run_backup_job`)
+    #: so a single resolution is shared across this job's probe + collect
+    #: calls instead of re-reading env / .env on every SSH session.  ``None``
+    #: → resolve on demand (the default for standalone use and tests).
+    settings: Settings | None = None
+
+    def _effective_settings(self) -> Settings:
+        """Return the injected job-level :class:`Settings`, or a freshly
+        resolved instance when the runner did not inject one."""
+        return self.settings or Settings()
 
     @abstractmethod
     def collect(self, device: DeviceTarget, definition: DeviceDefinition) -> str:

--- a/netcanon/collectors/netmiko_collector.py
+++ b/netcanon/collectors/netmiko_collector.py
@@ -21,7 +21,6 @@ import logging
 
 from netmiko import ConnectHandler
 
-from ..config import Settings
 from ..definitions.schema import DeviceDefinition
 from ..models.device import DeviceTarget
 from .base import BaseCollector
@@ -95,7 +94,7 @@ class NetmikoCollector(BaseCollector):
         # Host-key policy (netcanon.collectors.hostkey): for tofu / reject
         # this adds system_host_keys + ssh_strict (OS ~/.ssh/known_hosts);
         # default auto_add adds nothing (Netmiko's own auto-add behaviour).
-        params.update(netmiko_host_key_params(Settings()))
+        params.update(netmiko_host_key_params(self._effective_settings()))
 
         logger.info("Connecting to %s:%d (%s)", device.host, device.port, device_type)
         logger.debug(
@@ -180,7 +179,7 @@ class NetmikoCollector(BaseCollector):
             params["secret"] = (
                 device.credentials.enable_password.get_secret_value()
             )
-        params.update(netmiko_host_key_params(Settings()))
+        params.update(netmiko_host_key_params(self._effective_settings()))
 
         logger.info(
             "Probing %s:%d (%s) with command %r",

--- a/netcanon/collectors/paramiko_collector.py
+++ b/netcanon/collectors/paramiko_collector.py
@@ -41,7 +41,6 @@ import time
 
 import paramiko
 
-from ..config import Settings
 from ..definitions.schema import DeviceDefinition
 from ..models.device import DeviceTarget
 from .base import BaseCollector
@@ -167,7 +166,7 @@ class ParamikoShellCollector(BaseCollector):
         # Host-key verification policy (see module "Security model" +
         # netcanon.collectors.hostkey): auto_add (default, legacy) / tofu /
         # reject, driven by Settings.ssh_host_key_checking.
-        settings = Settings()
+        settings = self._effective_settings()
         apply_paramiko_policy(client, settings)
 
         logger.info("Connecting (Paramiko shell) to %s:%d", device.host, device.port)
@@ -263,7 +262,7 @@ class ParamikoShellCollector(BaseCollector):
         client = paramiko.SSHClient()
         # Same host-key policy as collect() — see module "Security model"
         # and netcanon.collectors.hostkey.
-        settings = Settings()
+        settings = self._effective_settings()
         apply_paramiko_policy(client, settings)
 
         logger.info(

--- a/netcanon/services/backup_runner.py
+++ b/netcanon/services/backup_runner.py
@@ -56,7 +56,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import UTC, datetime
 
-from ..config import MAX_BACKUP_CONCURRENCY
+from ..config import MAX_BACKUP_CONCURRENCY, Settings
 from ..definitions.loader import DefinitionLoader
 from ..definitions.schema import DeviceDefinition
 from ..models.backup import BackupJob, BackupResult, JobStatus
@@ -81,6 +81,7 @@ def _process_one_device(
     definition_loader: DefinitionLoader | None = None,
     device_profiles: dict[str, DeviceProfile] | None = None,
     device_profile_store: FileDeviceProfileStore | None = None,
+    settings: Settings | None = None,
 ) -> None:
     """Run the backup for a single device and mutate ``job.results[idx]``.
 
@@ -132,6 +133,11 @@ def _process_one_device(
             ``detected_facts`` for UI display.
         device_profile_store: Optional persistence backend for the
             profile registry.
+        settings: Job-level :class:`Settings` snapshot resolved once by
+            :func:`run_backup_job` and injected onto the probe + collect
+            collectors so each device doesn't re-read env / .env per SSH
+            session.  ``None`` (direct callers / tests) leaves the
+            collectors to resolve on demand.
 
     All exceptions are caught and recorded on the ``BackupResult``; this
     function therefore never raises under normal operation.  Any exception
@@ -155,6 +161,10 @@ def _process_one_device(
     # Use the family-base collector for probe — connection-layer
     # settings (netmiko_device_type, auth) are stable across overlays.
     base_collector = _backups_route.get_collector(family_base)
+    # Share the job-level Settings snapshot so probe + collect don't each
+    # re-resolve env / .env on every SSH session (real collectors read
+    # ``self.settings``; mock collectors ignore the attribute).
+    base_collector.settings = settings
 
     detected_facts: dict[str, str] = {}
     if family_base.probe.command and definition_loader is not None:
@@ -226,6 +236,7 @@ def _process_one_device(
     # resolved overlay may have different commands or prompts than
     # the family base even though connection params are stable.
     collector = _backups_route.get_collector(definition)
+    collector.settings = settings  # share the job-level snapshot (see above)
     result = job.results[idx]
     result.status = "running"
     start = time.monotonic()
@@ -285,6 +296,7 @@ def run_backup_job(
     definition_loader: DefinitionLoader | None = None,
     device_profiles: dict[str, DeviceProfile] | None = None,
     device_profile_store: FileDeviceProfileStore | None = None,
+    settings: Settings | None = None,
 ) -> None:
     """Execute all device backups for *job* and update its state.
 
@@ -322,6 +334,10 @@ def run_backup_job(
             through for ``detected_facts`` persistence.
         device_profile_store: Optional persistence backend paired with
             ``device_profiles``.
+        settings: Optional pre-resolved :class:`Settings`.  Resolved once
+            here (``settings or Settings()``) and injected onto every
+            device's collectors so the whole job shares one snapshot
+            instead of re-reading env / .env per SSH session.
 
     Thread safety:
         * ``job.results`` is pre-populated before dispatch and is never
@@ -330,6 +346,12 @@ def run_backup_job(
           ``(device_type, host)`` pairs produce distinct paths so there
           is no contention in the common case.
     """
+    # Resolve Settings once for the whole job and inject it onto each
+    # device's collectors (via _process_one_device) so probe + collect don't
+    # each re-read env / .env per SSH session — and the whole job sees one
+    # consistent snapshot even if the environment changes mid-run.
+    job_settings = settings or Settings()
+
     # Pre-populate every device as "queued" so polling clients see the full
     # device list immediately — they can render placeholder rows before any
     # collection has started.  Each result is mutated in place (never
@@ -363,6 +385,7 @@ def run_backup_job(
             _process_one_device(
                 job, idx, device, definitions, storage,
                 definition_loader, device_profiles, device_profile_store,
+                job_settings,
             )
     else:
         # Parallel path: up to `workers` devices in flight at once; the
@@ -375,6 +398,7 @@ def run_backup_job(
                 pool.submit(
                     _process_one_device, job, idx, device, definitions, storage,
                     definition_loader, device_profiles, device_profile_store,
+                    job_settings,
                 )
                 for idx, device in enumerate(request.devices)
             ]

--- a/tests/unit/test_collector_settings_injection.py
+++ b/tests/unit/test_collector_settings_injection.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for the job-level ``Settings`` injection (run3
+``settings-reinstantiated-per-call``).
+
+Previously each collector ``collect`` / ``probe`` call constructed its own
+``Settings()`` — re-reading env / .env on every SSH session (up to 2× per
+device, ×N devices per job).  The backup runner now resolves ``Settings``
+once per job and injects it onto each device's collectors via the
+``BaseCollector.settings`` slot; collectors read it through
+:meth:`BaseCollector._effective_settings`, falling back to a fresh resolve
+when none was injected (standalone use / tests).
+
+These tests cover the new contract directly so it can't silently regress:
+
+1. :meth:`BaseCollector._effective_settings` returns the injected snapshot,
+   or a fresh :class:`Settings` when absent.
+2. :func:`run_backup_job` resolves exactly ONE snapshot and threads that same
+   object to every device (mock :func:`_process_one_device` to observe the
+   value without real SSH — per AGENTS.md the collection layer is mocked, not
+   ``paramiko`` / ``ConnectHandler``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from netcanon.collectors.base import BaseCollector
+from netcanon.config import Settings
+from netcanon.models.backup import BackupJob
+from netcanon.models.device import BackupRequest, DeviceCredentials, DeviceTarget
+from netcanon.services import backup_runner
+
+pytestmark = pytest.mark.unit
+
+
+class _StubCollector(BaseCollector):
+    """Minimal concrete collector — never connects; only exercises the
+    shared ``_effective_settings`` helper on the base class."""
+
+    def collect(self, device, definition) -> str:  # pragma: no cover - unused
+        return ""
+
+
+class TestEffectiveSettings:
+    def test_returns_injected_snapshot_when_set(self):
+        """When the runner injects a snapshot, the collector uses that exact
+        object rather than re-resolving."""
+        injected = Settings()
+        collector = _StubCollector()
+        collector.settings = injected
+        assert collector._effective_settings() is injected
+
+    def test_resolves_fresh_when_absent(self):
+        """A standalone collector (no injection) still resolves a usable
+        :class:`Settings` on demand — back-compat for direct callers/tests."""
+        collector = _StubCollector()
+        assert collector.settings is None  # class default
+        resolved = collector._effective_settings()
+        assert isinstance(resolved, Settings)
+
+
+def _one_device_request(host: str = "10.0.0.1") -> BackupRequest:
+    return BackupRequest(
+        devices=[
+            DeviceTarget(
+                type_key="X",
+                host=host,
+                credentials=DeviceCredentials(username="u", password="p"),
+            )
+        ]
+    )
+
+
+def _fresh_job() -> BackupJob:
+    return BackupJob(id="test-job", created_at=datetime.now(UTC))
+
+
+class TestRunBackupJobResolvesSettingsOnce:
+    """``run_backup_job`` is the single seam that resolves Settings; it must
+    thread one snapshot to every device.  We patch ``_process_one_device``
+    (the real collection callee) to record the injected ``settings`` argument
+    — its last positional arg — instead of attempting any SSH."""
+
+    def _patch_recorder(self, monkeypatch) -> list:
+        captured: list = []
+
+        def _recorder(*args, **kwargs):
+            # run_backup_job passes settings positionally as the final arg.
+            captured.append(kwargs.get("settings", args[-1]))
+
+        monkeypatch.setattr(backup_runner, "_process_one_device", _recorder)
+        return captured
+
+    def test_caller_supplied_settings_is_threaded_verbatim(self, monkeypatch):
+        captured = self._patch_recorder(monkeypatch)
+        sentinel = Settings()
+        backup_runner.run_backup_job(
+            _fresh_job(), _one_device_request(), {}, storage=None,
+            settings=sentinel,
+        )
+        assert captured == [sentinel]
+        assert captured[0] is sentinel
+
+    def test_resolves_a_snapshot_when_caller_omits_settings(self, monkeypatch):
+        captured = self._patch_recorder(monkeypatch)
+        backup_runner.run_backup_job(
+            _fresh_job(), _one_device_request(), {}, storage=None,
+        )
+        assert len(captured) == 1
+        assert isinstance(captured[0], Settings)
+
+    def test_same_snapshot_shared_across_all_devices(self, monkeypatch):
+        """Resolved ONCE, not once-per-device: every device in a multi-device
+        job receives the identical object."""
+        captured = self._patch_recorder(monkeypatch)
+        request = BackupRequest(
+            devices=[
+                DeviceTarget(
+                    type_key="X", host=f"10.0.0.{i}",
+                    credentials=DeviceCredentials(username="u", password="p"),
+                )
+                for i in range(1, 5)
+            ]
+        )
+        backup_runner.run_backup_job(_fresh_job(), request, {}, storage=None)
+        assert len(captured) == 4
+        first = captured[0]
+        assert all(s is first for s in captured), "settings re-resolved per device"


### PR DESCRIPTION
## What

Resolves the backup job's `Settings` **once per job** and shares that snapshot across every device's collectors, instead of each `collect` / `probe` call constructing its own `Settings()`. Closes the run3 LOW `settings-reinstantiated-per-call` finding.

Before: every SSH session re-read env / `.env` — up to 2× per device (probe + collect) × N devices per job.

## How (low blast radius)

- `BaseCollector` gains a `settings: Settings | None = None` slot + `_effective_settings()` helper (returns the injected snapshot, else resolves fresh).
- `netmiko`/`paramiko` collectors call `self._effective_settings()` instead of `Settings()` (and drop their now-unused `Settings` import).
- `run_backup_job` resolves `settings or Settings()` once and threads it through `_process_one_device`, which injects it onto both the probe and collect collectors.

The `collect`/`probe` signatures and the documented `get_collector` mock seam are **untouched** — injection is a plain instance attribute that the many mock collectors simply ignore. This keeps all `get_collector`-patching tests working without edits.

## Why it's also slightly more correct

The whole job now sees one consistent settings snapshot even if the environment changes mid-run. Host-key policy values reaching netmiko/paramiko are otherwise identical — no behaviour change.

## Tests

- New `tests/unit/test_collector_settings_injection.py`: `_effective_settings` (injected vs fresh) + `run_backup_job` resolves exactly one snapshot and shares it across all devices (incl. a multi-device "same object" assertion).
- Full `tests/integration` + `tests/e2e` + `tests/desktop` backup suites pass unchanged (96 backup/collector tests green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
