### PR TITLE
chore(ci+deps+supply-chain): concurrency guards, dep caps, optional Docker Hub mirror, notice completeness (run3 LOW)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,15 @@ permissions:
   id-token: write          # cosign keyless signing via Sigstore + GitHub OIDC
   security-events: write   # Trivy SARIF upload to Code Scanning
 
+# Serialise release runs for a given ref so a re-pushed tag (or a
+# workflow_dispatch racing the tag push) can't double-build / double-push
+# and race the `:latest` move.  Never cancel an in-flight publish — a
+# half-signed / half-attested image is worse than a queued second run
+# (run3 no-concurrency-guard-publish).
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   # GHCR is the primary, signed, SBOM-attested registry.
   REGISTRY: ghcr.io
@@ -67,7 +76,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub is an OPTIONAL convenience mirror.  Gate the login on the
+      # token being configured so a fork (or a repo that never set up the
+      # Docker Hub secret) doesn't hard-fail the whole publish on a missing
+      # credential.  The canonical repo has the secret, so this is a no-op
+      # there — login runs exactly as before (run3 dockerhub-login-unguarded).
       - name: Log in to Docker Hub
+        if: ${{ secrets.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -80,9 +95,13 @@ jobs:
           # Two images = same tag patterns applied to both registries.
           # The build-push-action below pushes a single image manifest
           # to both registries in one step (no double-build cost).
+          # The Docker Hub line is emitted only when the mirror is enabled
+          # (token configured); otherwise it resolves to an empty line,
+          # which metadata-action ignores — so build-push targets GHCR
+          # only and never attempts an unauthenticated docker.io push.
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ secrets.DOCKERHUB_TOKEN != '' && env.DOCKERHUB_IMAGE || '' }}
           tags: |
             # Semver-derived (no `v` prefix), e.g. `0.1.0-rc4` or `0.1.0`.
             # Matches the convention of official Docker Hub images

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,6 +10,14 @@ on:
 permissions:
   contents: read
 
+# Serialise release runs for a given ref so a re-pushed tag (or a
+# workflow_dispatch racing the tag push) can't double-publish.  Never
+# cancel an in-flight publish mid-upload — queue the second run instead
+# (run3 no-concurrency-guard-publish).
+concurrency:
+  group: pypi-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   # Opt-in to Node.js 24 for JavaScript actions ahead of the June 2026
   # forced cutover (https://github.blog/changelog/2025-09-19-deprecation-

--- a/README.md
+++ b/README.md
@@ -202,8 +202,10 @@ serve` refuses to start without a key (or `NETCANON_ALLOW_INSECURE_BIND=1`),
 so an unauthenticated public bind is a deliberate choice — see
 [`SECURITY.md`](SECURITY.md) "Threat Model".
 
-The published image is signed via Sigstore (`cosign verify
-ghcr.io/netcanon/netcanon ...`) with an SBOM attestation.
+The published image is signed via Sigstore with an SBOM attestation.
+Verify against the immutable digest (`ghcr.io/netcanon/netcanon@sha256:<digest>`),
+not a mutable tag — see [`SECURITY.md`](SECURITY.md) "Supply-Chain
+Integrity" for the exact `cosign verify` invocation.
 
 **Docker Hub mirror** — same image, convenience-mirrored to Docker
 Hub if your tooling defaults to `docker.io`:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -428,9 +428,15 @@ provenance can verify each:
   install.
 - **Cosign signatures via Sigstore (GHCR only).**  Published GHCR
   images (`ghcr.io/netcanon/netcanon`) are signed with keyless cosign
-  through GitHub Actions OIDC.  Verifiable with:
+  through GitHub Actions OIDC.  Verify against the **immutable digest**,
+  not a mutable tag — a tag can be repointed after you read it, and
+  because the build sets `provenance: true` the published reference is a
+  multi-arch manifest-list whose digest is what cosign signs.  Resolve
+  the digest first (the GHCR package page, `docker buildx imagetools
+  inspect ghcr.io/netcanon/netcanon:<tag>`, or `crane digest`), then
+  verify the digest:
   ```
-  cosign verify ghcr.io/netcanon/netcanon:<tag> \
+  cosign verify ghcr.io/netcanon/netcanon@sha256:<digest> \
       --certificate-identity-regexp '^https://github\.com/netcanon/netcanon/\.github/workflows/docker-publish\.yml@refs/tags/v' \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -2,7 +2,7 @@ THIRD-PARTY SOFTWARE NOTICES
 ============================
 
 Netcanon itself is distributed under the MIT License (see the bundled
-LICENSE.txt).  The Windows desktop installer (MSI), built with cx_Freeze,
+LICENSE file).  The Windows desktop installer (MSI), built with cx_Freeze,
 *redistributes* the third-party components listed below as compiled
 binaries / bundled Python packages.  This file satisfies their attribution
 requirement and, for the copyleft (LGPL) components, records the written
@@ -40,6 +40,11 @@ that component with this application as permitted by its license.
   Copyright: Jeff Forcier and contributors
   Homepage: https://www.paramiko.org  ·  https://github.com/paramiko/paramiko
 
+* scp (SCP transfer helper, pulled in transitively by netmiko)
+  License: LGPL-2.1-or-later
+  Copyright: James Bardin, Remi Rampin and contributors
+  Homepage: https://github.com/jbardin/scp.py
+
 * pystray (system-tray integration for the desktop shell)
   License: LGPL-3.0-or-later
   Copyright: Moses Palmér
@@ -60,6 +65,26 @@ Permissive components (attribution)
 * keyring           — MIT            — Jason R. Coombs    — https://github.com/jaraco/keyring
 * defusedxml        — PSF-2.0        — Christian Heimes   — https://github.com/tiran/defusedxml
 * CPython runtime   — PSF-2.0        — Python Software Foundation — https://www.python.org
+
+Additional permissive components (direct + transitive deps redistributed in the MSI)
+------------------------------------------------------------------------------------
+Licenses below were read from the components' own installed package metadata.
+* bcrypt            — Apache-2.0     — The Python Cryptographic Authority — https://github.com/pyca/bcrypt
+* PyNaCl            — Apache-2.0     — The PyNaCl developers (PyCA) — https://github.com/pyca/pynacl
+* cffi              — MIT            — Armin Rigo, Maciej Fijałkowski — https://github.com/python-cffi/cffi
+* pycparser         — BSD-3-Clause   — Eli Bendersky — https://github.com/eliben/pycparser
+* click             — BSD-3-Clause   — Pallets — https://palletsprojects.com/p/click/
+* h11               — MIT            — Nathaniel J. Smith — https://github.com/python-hyper/h11
+* MarkupSafe        — BSD-3-Clause   — Pallets — https://palletsprojects.com/p/markupsafe/
+* annotated-types   — MIT            — Adrian Garcia Badaracco and contributors — https://github.com/annotated-types/annotated-types
+* typing_extensions — PSF-2.0        — Python Software Foundation — https://github.com/python/typing_extensions
+* idna              — BSD-3-Clause   — Kim Davies and contributors — https://github.com/kjd/idna
+* textfsm           — Apache-2.0     — Google LLC — https://github.com/google/textfsm
+* ntc-templates     — Apache-2.0     — Network to Code, LLC — https://github.com/networktocode/ntc-templates
+* pyserial          — BSD-3-Clause   — Chris Liechti — https://github.com/pyserial/pyserial
+* python-multipart  — Apache-2.0     — Andrew Dunham and contributors — https://github.com/Kludex/python-multipart
+* python-dotenv     — BSD-3-Clause   — Saurabh Kumar and contributors — https://github.com/theskumar/python-dotenv
+* six               — MIT            — Benjamin Peterson — https://github.com/benjaminp/six
 
 Notes
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,15 +55,23 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
-    "pydantic>=2.0.0",
-    "pydantic-settings>=2.0.0",
+    # Upper-cap the volatile validation core at the current major: a
+    # pydantic 3.x with breaking model/validator semantics would otherwise
+    # be pulled by `>=` and silently break parse/render at runtime
+    # (run3 runtime-deps-no-upper-bounds).
+    "pydantic>=2.0.0,<3",
+    "pydantic-settings>=2.0.0,<3",
     "pyyaml>=6.0",
     "netmiko>=4.4.0",
     "paramiko>=3.4.0",
     "jinja2>=3.1.0",
     "python-multipart>=0.0.9",
     "aiofiles>=23.0.0",
-    "apscheduler>=3.10.4",
+    # Cap below the 4.x rewrite: APScheduler 4 is a ground-up API change
+    # (new scheduler/datastore model) that would break `scheduler.add_job`
+    # usage and app boot if pulled by an unbounded floor (run3
+    # apscheduler-unbounded-floor).
+    "apscheduler>=3.10.4,<4",
     # Hard runtime dep of apscheduler (imported at scheduler startup).
     # Declared explicitly — and pinned away from the yanked 5.4.2 — so a
     # bad upstream tzlocal release can't silently break app boot through


### PR DESCRIPTION
## What

The v0.4.2 run3-LOW **CI / dependency / supply-chain** batch. User-approved scope (the gated release-pipeline PR), including both optional supply-chain add-ons.

### CI / release pipeline
- **Concurrency guards** on `docker-publish.yml` + `pypi-publish.yml` (`cancel-in-progress: false`) so a re-pushed tag / racing `workflow_dispatch` can't double-publish or race the `:latest` move — never cancels an in-flight publish. (`ci.yml` + `desktop-msi-publish.yml` already had theirs.)
- **Docker Hub mirror made optional** — login gated on `secrets.DOCKERHUB_TOKEN != ''`, and the `docker.io` image line is emitted only when the token is present. A fork without the secret publishes to GHCR alone instead of hard-failing. **The canonical repo has the secret → its release path is byte-identical** (login runs, both images tagged, exactly as before).

### Dependencies (`pyproject.toml`)
Upper-cap the volatile core so a major-version transitive break can't ship via `>=`:
- `pydantic >=2.0.0,<3`, `pydantic-settings >=2.0.0,<3`
- `apscheduler >=3.10.4,<4` (4.x is a ground-up rewrite)

Installed `2.13 / 2.13.1 / 3.11.2` all satisfy the caps — no env change.

### Supply-chain docs
- `THIRD-PARTY-NOTICES.txt`: fixed the dangling `bundled LICENSE.txt` → `LICENSE file`; **added the copyleft `scp` (LGPL-2.1-or-later)** the MSI redistributes (transitive via netmiko) but the notice omitted, plus 16 additional direct/transitive permissive components. **Licenses were read from each component's installed package metadata, not asserted** (`sniffio`/`wcwidth`/`future` were confirmed *not* installed and deliberately omitted).
- `SECURITY.md` + `README.md`: verify the published image by its **immutable digest**, not a mutable tag — `provenance:true` makes the reference a manifest-list whose digest cosign signs.

## Deliberately NOT done (verify-first non-finding)

The run3 "strike false CodeQL-claim comments" item. The comments in `docker-publish.yml`/`zizmor.yml` are **accurate** — CodeQL runs via GitHub **default setup** (the `CodeQL` / `Analyze (python/actions/js)` jobs on every PR). The blind auditor only saw no `codeql.yml`. Striking them would make the docs *less* honest.

## Validation

YAML parses for both workflows (concurrency blocks + the conditional login `if` + conditional image list); `pyproject.toml` parses and installed deps satisfy the caps; no test references the old `LICENSE.txt` phrasing or pins `THIRD-PARTY-NOTICES` content; changelog guard green. Docs/CI/metadata only — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
