### PR TITLE
docs(fixtures): add attribution headers to the 48 headerless real captures (run3 LOW)

### DIFF
--- a/tests/fixtures/real/arista_eos/batfish_duplicateprivate_eos4211.txt
+++ b/tests/fixtures/real/arista_eos/batfish_duplicateprivate_eos4211.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/lab-validation (snapshots/eos_private_asn/configs/DuplicatePrivate/show_running-config.txt @ d40faf6)
+! License: Apache-2.0
+! Snapshot: vEOS EOS-4.21.1.1F -- light BGP-focused config: hostname, sha512 user, 1 routed interface, stub interfaces, `router bgp 65001` duplicate-private-ASN scenario.
 ! Command: show running-config
 ! device: DuplicatePrivate (vEOS, EOS-4.21.1.1F)
 !

--- a/tests/fixtures/real/arista_eos/batfish_eos_evpn_vlan_based_leaf.txt
+++ b/tests/fixtures/real/arista_eos/batfish_eos_evpn_vlan_based_leaf.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/lab-validation (snapshots/eos_evpn_l3_design_guide_vlan_based/configs/H-LEAF2A/show_running-config.txt @ d40faf6)
+! License: Apache-2.0
+! Snapshot: vEOS EOS-4.23.0.1F VLAN-based EVPN leaf (L2VNI-only, centralised L3 gw) -- vlan-aware-bundle, Vxlan1 `vxlan vlan X vni Y`, MLAG, router bgp 65102.
 ! Command: show running-config
 ! device: H-LEAF2A (vEOS, EOS-4.23.0.1F)
 !

--- a/tests/fixtures/real/arista_eos/batfish_labval_dc1_leaf2a_eos4230.txt
+++ b/tests/fixtures/real/arista_eos/batfish_labval_dc1_leaf2a_eos4230.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/lab-validation (snapshots/eos_evpn_l3_design_guide/configs/DC1-LEAF2A/show_running-config.txt @ d40faf61c940da7e225c63bb66da9e2487a1ccb8)
+! License: Apache-2.0
+! Snapshot: vEOS EOS-4.23.0.1F symmetric-IRB EVPN leaf -- MLAG across 5 Port-Channels, VXLAN1 overlay, 15 tenant VLANs, router bgp 65102, VRFs, Vlan3009 VARP virtual-router MAC, 40 interfaces.
 ! Command: show running-config
 ! device: DC1-LEAF2A (vEOS, EOS-4.23.0.1F)
 !

--- a/tests/fixtures/real/arista_eos/karneliuk_a_eos1_eos4260.txt
+++ b/tests/fixtures/real/arista_eos/karneliuk_a_eos1_eos4260.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/karneliuk-com/batfish-mvp (snapshots/nat/configs/EOS1.cfg @ 62e8ce7)
+! License: BSD-3-Clause -- Copyright 2021 karneliuk.com
+! Snapshot: vEOS EOS-4.26.0.1F EVPN/VXLAN kitchen-sink -- multi-agent routing model, mstp, sha512 AAA, VLAN100, Vxlan1 vni 100, prefix-list, route-maps, router bgp 65033 evpn + ipv4 AFs.
 ! Command: show running-config
 ! Time: Sat Jun 26 15:23:13 2021
 ! device: A-EOS1 (vEOS, EOS-4.26.0.1F)

--- a/tests/fixtures/real/arista_eos/ksator_dcs_7150s64_eos4224.txt
+++ b/tests/fixtures/real/arista_eos/ksator_dcs_7150s64_eos4224.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/ksator/arista_eos_audit (output/10.83.28.122/eos_commands/text/show running-config.txt)
+! License: unlicensed public device-output (no LICENSE file; public Arista-community audit-tool demo repo -- factual-output precedent, drop if author objects)
+! Snapshot: DCS-7150S-64-CL `show running-config` on EOS 4.22.4M -- hostname/DNS/NTP/SNMP, 5 local users, mstp, aaa, 52 Ethernet + 16 QSFP-breakout subports, Loopback0/Management1, static route, parse-and-ignore router bgp.
 ! Command: show running-config
 ! device: switch1 (DCS-7150S-64-CL, EOS-4.22.4M-2GB)
 !

--- a/tests/fixtures/real/aruba_aoss/aruba_central_5memberstack_rendered.cfg
+++ b/tests/fixtures/real/aruba_aoss/aruba_central_5memberstack_rendered.cfg
@@ -1,3 +1,6 @@
+! Source: https://github.com/aruba/central-sample-bulk-configurations (ArubaOS-Switch Templates/5MemberStack - Template/5memberStack - Template.txt; rendered via scripts/render_aruba_central_template.py)
+! License: BSD-2-Clause (upstream)
+! Snapshot: AOS-S 5-member-stack template rendered with defensible-default substitutions -- real AOS-S grammar, placeholder values (see aruba_aoss/README.md).
 ; Rendered from aruba/central-sample-bulk-configurations
 ; 5MemberStack template by scripts/render_aruba_central_template.py
 ; Values are defensible defaults, not a real deployment.

--- a/tests/fixtures/real/aruba_aoss/hpe_community_2920_wb1608_dhcp_snooping.cfg
+++ b/tests/fixtures/real/aruba_aoss/hpe_community_2920_wb1608_dhcp_snooping.cfg
@@ -1,3 +1,6 @@
+! Source: https://community.hpe.com/t5/hpe-aruba-networking-provision/a-lot-of-packet-loss-in-switching-infrastructure/td-p/7051607 (forum share, user paste for troubleshooting)
+! License: Forum share (user paste for troubleshooting)
+! Snapshot: 2920 `show running-config` on WB.16.08.0001 -- dhcp-snooping (13 authorized-server + trust ports), ntp unicast iburst, web-management ssl, ip authorized-managers, snmp-server host. RFC1918 (community already `xxxx`-obscured by poster).
 ; J9729A Configuration Editor; Created on release #WB.16.08.0001
 ; Ver #14:01.44.08.15.9b.3f.b3.b8.ee.34.79.3c.29.eb.9f.fc.f3.ff.37.ef:09
 

--- a/tests/fixtures/real/aruba_aoss/hpe_community_2930f_wc1607_intervlan.cfg
+++ b/tests/fixtures/real/aruba_aoss/hpe_community_2930f_wc1607_intervlan.cfg
@@ -1,3 +1,6 @@
+! Source: https://community.hpe.com/t5/aruba-provision-based/routing-not-working-as-expected-on-2930f-48g/td-p/7026923 (forum share, user paste for troubleshooting)
+! License: Forum share (user paste for troubleshooting)
+! Snapshot: 2930F `show running-config` on WC.16.07.0002 -- 12 VLANs with inter-VLAN L3, ip helper-address on 10 VLANs, 4 static routes, ip dns server-address, timesync ntp. Email -> netadmin@example.test; RFC1918.
 ; JL260A Configuration Editor; Created on release #WC.16.07.0002
 ; Ver #14:01.4f.f8.1d.9b.3f.bf.bb.ef.7c.59.fc.6b.fb.9f.fc.ff.ff.37.ef:02
 hostname "HP2930F-B105"

--- a/tests/fixtures/real/aruba_aoss/hpe_community_2930f_wc1610_dhcp_server.cfg
+++ b/tests/fixtures/real/aruba_aoss/hpe_community_2930f_wc1610_dhcp_server.cfg
@@ -1,3 +1,6 @@
+! Source: https://community.hpe.com/t5/aruba-provision-based/2930f-dhcp-server-vlan-setup/td-p/7084768 (forum share, user paste for troubleshooting)
+! License: Forum share (user paste for troubleshooting)
+! Snapshot: 2930F `show running-config` on WC.16.10.0005 -- `dhcp-server pool` x3 (default-router/dns-server/network/range), 4 VLANs with dhcp-server enable, allow-unsupported-transceiver. RFC1918 + 2 public ISP resolvers.
 ; JL258A Configuration Editor; Created on release #WC.16.10.0005
 ; Ver #14:27.6f.f8.1d.9b.3f.bf.bb.ef.7c.59.fc.6b.fb.9f.fc.ff.ff.37.ef:04
 

--- a/tests/fixtures/real/aruba_aoss/hpe_community_5406rzl2_kb1515.cfg
+++ b/tests/fixtures/real/aruba_aoss/hpe_community_5406rzl2_kb1515.cfg
@@ -1,3 +1,6 @@
+! Source: https://community.hpe.com/t5/Aruba-ProVision-based/DHCP-SERVER-and-multi-vlans/td-p/6935784 (forum share, user `moise` paste for troubleshooting)
+! License: Forum share (user paste for troubleshooting)
+! Snapshot: 5406Rzl2 (J9850A) modular-chassis Configuration Editor export on KB.15.15.0008 -- `module A/B type` line-cards, letter-slot-port ranges, oobm, ip helper-address, inter-VLAN ip routing. RFC1918; illustrative hostname.
 ; J9850A Configuration Editor; Created on release #KB.15.15.0008
 ; Ver #05:18.7f.ff.3f.ef:4d
 hostname "HP-5406Rzl2"

--- a/tests/fixtures/real/aruba_aoss/user_contrib_2930m_wc1611.cfg
+++ b/tests/fixtures/real/aruba_aoss/user_contrib_2930m_wc1611.cfg
@@ -1,3 +1,6 @@
+! Source: User-contributed (direct paste, operator-provided) real 2930M stack `show running-config` on WC.16.11.0025 (sanitised -- see NOTICE.md)
+! License: Operator contribution for LTS-branch validation
+! Snapshot: 2930M stack (JL323A + JL083A modules) on WC.16.11.0025 -- stacking stanza, oobm per-member IP, include-credentials + sha1 manager hash, SNMPv3 engineid, mixed slot-port / slot-letter-port VLAN lists. Password hash -> synthetic; MACs/engineids retained.
 Aruba-Stack-2930M# show running-config
 
 Running configuration:

--- a/tests/fixtures/real/cisco_iosxe/batfish_cisco_aaa.txt
+++ b/tests/fixtures/real/cisco_iosxe/batfish_cisco_aaa.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/batfish (tests/parsing-tests/networks/unit-tests/configs/cisco_aaa)
+! License: Apache-2.0
+! Snapshot: Cisco IOS AAA accounting/authentication/authorization stanzas -- parse-tolerance fixture (not canonically modelled).
 !
 hostname cisco_aaa
 !

--- a/tests/fixtures/real/cisco_iosxe/batfish_cisco_interface.txt
+++ b/tests/fixtures/real/cisco_iosxe/batfish_cisco_interface.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/batfish (tests/parsing-tests/networks/unit-tests/configs/cisco_interface)
+! License: Apache-2.0
+! Snapshot: Interface grammar kitchen-sink -- every interface sub-command Batfish's parser supports on one Ethernet.
 !
 hostname cisco_interface
 !

--- a/tests/fixtures/real/cisco_iosxe/batfish_cisco_ip_route.txt
+++ b/tests/fixtures/real/cisco_iosxe/batfish_cisco_ip_route.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/batfish (tests/parsing-tests/networks/unit-tests/configs/cisco_ip_route)
+! License: Apache-2.0
+! Snapshot: Static-route variants -- `ip route ... name`, track, administrative distance, tag, permanent.
 !
 hostname cisco_ip_route
 !

--- a/tests/fixtures/real/cisco_iosxe/batfish_cisco_logging.txt
+++ b/tests/fixtures/real/cisco_iosxe/batfish_cisco_logging.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/batfish (tests/parsing-tests/networks/unit-tests/configs/cisco_logging)
+! License: Apache-2.0
+! Snapshot: `logging host/buffered/facility` etc. -- parse-tolerance fixture (not canonically modelled).
 !
 hostname cisco_logging
 !

--- a/tests/fixtures/real/cisco_iosxe/batfish_cisco_snmp.txt
+++ b/tests/fixtures/real/cisco_iosxe/batfish_cisco_snmp.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/batfish (tests/parsing-tests/networks/unit-tests/configs/cisco_snmp)
+! License: Apache-2.0
+! Snapshot: `snmp-server community/group/user` + trap destinations.
 !
 hostname cisco_snmp
 !

--- a/tests/fixtures/real/cisco_iosxe/batfish_iosxe_basic_vrrp.txt
+++ b/tests/fixtures/real/cisco_iosxe/batfish_iosxe_basic_vrrp.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/batfish/lab-validation (snapshots/ios_basic_vrrp/configs/BR1/show_running-config.txt @ d40faf6)
+! License: Apache-2.0 (derived)
+! Snapshot: Cisco IOS BR1 -- VRRP grammar (`vrrp 12 ip`/`priority`) + 4 routed interfaces + static default; cleartext lab credential retained (RFC5737-class).
 Building configuration...
 
   

--- a/tests/fixtures/real/cisco_iosxe/ciscolive_brkops1104_evpn_leaf_iosxe1715.txt
+++ b/tests/fixtures/real/cisco_iosxe/ciscolive_brkops1104_evpn_leaf_iosxe1715.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/StayFresh-NetworkBytes/CiscoLive-BRKOPS-1104-Lab (device_configs/cml-demo-lf1.txt)
+! License: unlicensed public device-output (no LICENSE file; CML lab capture -- factual-output precedent, drop if author objects)
+! Snapshot: IOS-XE 17.15 CML EVPN leaf -- vlan, vrf definition RD/RT, switchport, l2vpn-evpn/VXLAN nve (Tier-3). Sanitised: type-9 secret + pim rp public IP -> synthetic/RFC5737.
 Building configuration...
 
 Current configuration : 6018 bytes

--- a/tests/fixtures/real/cisco_iosxe/cml_basic_forwarding_iosv_r1_ospf.txt
+++ b/tests/fixtures/real/cisco_iosxe/cml_basic_forwarding_iosv_r1_ospf.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/CiscoDevNet/cml-community (lab-topologies/basic-forwarding-behavior.yaml -- R1 IOSv node)
+! License: BSD-3-Clause
+! Snapshot: Cisco IOSv 15.x -- OSPF single-area multi-feature + dot1Q subinterfaces + banner block; lab RFC1918.
 !
 hostname R1
 !

--- a/tests/fixtures/real/cisco_iosxe/cml_saumur_iosxe1712_pvrstp.txt
+++ b/tests/fixtures/real/cisco_iosxe/cml_saumur_iosxe1712_pvrstp.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/CiscoDevNet/cml-community (lab-topologies/ccna/Domain_2/2.5-interpret_stp/saumur_PVRSTP_solution.yaml -- saumur node)
+! License: BSD-3-Clause
+! Snapshot: IOS-XE 17.12 CML ioll2-xe -- PVRST+ / spanning-tree-cost grammar, VTP, self-signed PKI trustpoint.
 Building configuration...
 
 Current configuration : 3752 bytes

--- a/tests/fixtures/real/cisco_iosxe/ntc_carrier_interfaces.txt
+++ b/tests/fixtures/real/cisco_iosxe/ntc_carrier_interfaces.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/networktocode/ntc-templates (tests/cisco_ios/show_running-config_interface/cisco_ios_show_running-config_interface.raw)
+! License: Apache-2.0
+! Snapshot: Carrier-grade IOS interfaces -- VRFs, dot1Q Q-in-Q subinterfaces, QoS service-policies, uRPF, ACL groups.
 Building configuration...
 
 Current configuration : 440 bytes

--- a/tests/fixtures/real/cisco_iosxe/racc_cat8000v_iosxe179_netconf.txt
+++ b/tests/fixtures/real/cisco_iosxe/racc_cat8000v_iosxe179_netconf.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/nickrusso42518/racc (samples_hash/csr1_20230811T074823/show_running-config.txt)
+! License: BSD-3-Clause
+! Snapshot: Cat8000V IOS-XE 17.9 `show running-config` -- NAT/PAT, telemetry ietf subscription, app-hosting, PKI, RESTCONF+NETCONF, type-9 user.
 Building configuration...
 
 Current configuration : 7173 bytes

--- a/tests/fixtures/real/cisco_iosxe/racc_csr1000v_iosxe169_bgp_ospf.txt
+++ b/tests/fixtures/real/cisco_iosxe/racc_csr1000v_iosxe169_bgp_ospf.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/nickrusso42518/racc (samples_hash/csr2_20230811T074823/show_running-config.txt)
+! License: BSD-3-Clause
+! Snapshot: CSR1000v IOS-XE 16.9 `show running-config` -- BGP (vpnv4+rtfilter), OSPF, QoS class/policy-map, NETCONF/RESTCONF, 2 local users, enable secret.
 Building configuration...
 
 Current configuration : 5545 bytes

--- a/tests/fixtures/real/cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt
+++ b/tests/fixtures/real/cisco_iosxe/racc_csr1_iosxe173_umbrella_sig.txt
@@ -1,3 +1,6 @@
+! Source: https://github.com/nickrusso42518/racc (samples_nohash/csr1_20210629T142431/show_running-config.txt)
+! License: BSD-3-Clause
+! Snapshot: CSR1000v IOS-XE 17.3 `show running-config` -- EIGRP+OSPF, 22 static routes, IKEv2/IPsec SIG tunnel, SSH pubkey-chain, guestshell, NETCONF-YANG, 2 local users.
 Building configuration...
 
 Current configuration : 10447 bytes

--- a/tests/fixtures/real/cisco_iosxe/user_contrib_cat9300_iosxe1712.txt
+++ b/tests/fixtures/real/cisco_iosxe/user_contrib_cat9300_iosxe1712.txt
@@ -1,3 +1,6 @@
+! Source: User-contributed real `show running-config` from a physical Cisco Catalyst 9300-24UX on IOS-XE 17.12 (captured via Netcanon's backup layer; sanitised -- see NOTICE.md)
+! License: CC0-1.0 (user contribution)
+! Snapshot: Physical Cat9300 -- 47 interfaces, 3 LACP EtherChannels, 6 VLANs, rapid-pvst, Cat9k CPP policer grammar, privilege-exec delegation; two type-9 user secrets -> synthetic markers.
 Building configuration...
 
 Current configuration : 14725 bytes

--- a/tests/fixtures/real/fortigate/kevinguenay_fgt_70g_branch.conf
+++ b/tests/fixtures/real/fortigate/kevinguenay_fgt_70g_branch.conf
@@ -1,3 +1,6 @@
+# Source: https://github.com/KevinGuenay/fortinet-resources (blog_resources/fortigate_ztp/fortigate_configurations/FGT-70G-BRANCH.conf)
+# License: MIT
+# Snapshot: FortiOS 7.6.6 FortiGate 70G branch ZTP config (12,317 lines) -- system global, fortilink + LAG_INTERNAL aggregates, VLAN subinterfaces, BGP loopback, SD-WAN, IPsec, firewall policies/VIPs (Tier-3 carried past).
 #config-version=FGT70G-7.6.6-FW-build3652-260127:opmode=0:vdom=0:user=admin
 #conf_file_ver=246685741669850
 #buildno=3652

--- a/tests/fixtures/real/fortigate/kevinguenay_fgt_vm_hub.conf
+++ b/tests/fixtures/real/fortigate/kevinguenay_fgt_vm_hub.conf
@@ -1,3 +1,6 @@
+# Source: https://github.com/KevinGuenay/fortinet-resources (blog_resources/fortigate_ztp/fortigate_configurations/FGT-VM-HUB.conf)
+# License: MIT
+# Snapshot: FortiOS 7.6.6 FortiGate VM hub config (13,827 lines) -- hub-side counterpart to the 70G branch; same OS version.
 #config-version=FGVM64-7.6.6-FW-build3652-260127:opmode=0:vdom=0:user=admin
 #conf_file_ver=254433862674262
 #buildno=3652

--- a/tests/fixtures/real/fortigate/user_contrib_fg100e_fos7213.conf
+++ b/tests/fixtures/real/fortigate/user_contrib_fg100e_fos7213.conf
@@ -1,3 +1,6 @@
+# Source: User-contributed real `show full-configuration` from a physical FortiGate 100E on FortiOS 7.2.13 (build 1762; captured via Netcanon's backup layer; heavily sanitised -- see NOTICE.md)
+# License: CC0-1.0 (user contribution)
+# Snapshot: Physical FG100E (35K+ lines) -- 34 interfaces, 5 VLAN subinterfaces, 2 LAGs, 6 DHCP servers, 3 admins, RADIUS, SNMP community, full firewall policy table, VIPs, SD-WAN, IPsec, SSL-VPN. 48 ENC secrets + 14 key blocks + 5 SSH pubkeys -> synthetic; WAN IP -> RFC5737; email -> example.test.
 #config-version=FG100E-7.2.13-FW-build1762-260128:opmode=1:vdom=0:user=admin
 #conf_file_ver=472622496306003
 #buildno=1762

--- a/tests/fixtures/real/junos/batfish_evpntype5_router1_junos2541.set
+++ b/tests/fixtures/real/junos/batfish_evpntype5_router1_junos2541.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/batfish/lab-validation (snapshots/junos_evpn_type5/configs/router1/show_configuration_|_display_set.txt @ d40faf6)
+# License: Apache-2.0
+# Snapshot: Junos 25.4R1.12 set-form EVPN Type-5 -- `set vlans <name> vxlan vni`, 4 IRB sub-interfaces + VRRP, routing-instances vrf RD/vrf-target, protocols evpn vxlan, bgp family evpn signaling. Type-5 routes parse-and-ignore.
 set version 25.4R1.12
 set system host-name router1
 set system root-authentication encrypted-password "$6$sr/SJsLZ$n1stApaAKubyIZNKxJxnfIfdW4/ohw9GsO7QbQSxS09jHzhNoXRy4qzfIOZZN2iza3lKfeN9wN90.cNEkIY1y/"

--- a/tests/fixtures/real/junos/batfish_l3vpn_pe1_junos2541.set
+++ b/tests/fixtures/real/junos/batfish_l3vpn_pe1_junos2541.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/batfish/lab-validation (snapshots/junos_l3vpn/configs/pe1/show_configuration_|_display_set.txt @ d40faf6)
+# License: Apache-2.0
+# Snapshot: Junos 25.4R1.12 set-form MPLS L3VPN PE -- CUSTOMERS vrf (RD 1.1.1.1:65001 + vrf-target), iBGP family inet-vpn unicast, LDP+MPLS core link, single static route.
 set version 25.4R1.12
 set system host-name pe1
 set system root-authentication encrypted-password "$6$Cz5G1E8L$Gdcvgg1vZbOWt2QqDeifCSzeUs38E6uQpVPoEqeGNyGkk22DTasOWPLjov2S8fWetwimK2Bf.P8Qb0Q67pgI2/"

--- a/tests/fixtures/real/junos/buraglio_netlab_junos184.set
+++ b/tests/fixtures/real/junos/buraglio_netlab_junos184.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/buraglio/Juniper-SR-PCE (netlab-ns-junos-set)
+# License: no declared license -- short `display set` device-output, factual-output precedent (ES.net netlab-ns demo); drop if author objects
+# Snapshot: Junos 18.4R1-S1.1 set-form (28 lines) -- set version, host-name FQDN, root-authentication (parse-and-ignore), em0/lo0 inet/inet6/iso/mpls families, routing-options autonomous-system, protocols bgp/isis/mpls (parse-and-ignore).
 set version 18.4R1-S1.1
 set groups global system services ssh
 set system root-authentication encrypted-password "$6$oJIg7Fw3$ZPzZRNcM0xQEP2LIoAtvbbOGpOybn0Lc6hJb1a656762nfypRkUgLUuABFAcH/ICqY3io/bRpQ9ocp.UkXiSJ/"

--- a/tests/fixtures/real/junos/jnprautomate_mnha_vsrx_a_junos.set
+++ b/tests/fixtures/real/junos/jnprautomate_mnha_vsrx_a_junos.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/JNPRAutomate/mnha-ipsec-and-multiple-routing-instances (full-configurations/mnha-vsrx-a.set)
+# License: MIT (Juniper Networks automation org)
+# Snapshot: Junos vSRX MNHA set-form (637 lines) -- multiple routing-instances w/ descriptions + virtual-router/vrf mix, 3-address lo0.10, st0 secure-tunnel units, security ike/ipsec, apply-groups MNHA (Tier-3). secondary-dns 8.8.8.8 -> RFC5737; PSKs are upstream $9$Fake placeholders.
 set groups global
 set groups MNHA-SYNC security ike proposal IKE-PROP-1 description MNHA-IKE-PROPOSAL_for_ICL
 set groups MNHA-SYNC security ike proposal IKE-PROP-1 authentication-method pre-shared-keys

--- a/tests/fixtures/real/junos/ksator_labmgmt_ex4550_junos151.set
+++ b/tests/fixtures/real/junos/ksator_labmgmt_ex4550_junos151.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/ksator/lab_management (backup/EX4550-190_config.2017-12-19@15:28:15 @ 37e42eb)
+# License: MIT -- Copyright Juniper Networks 2018
+# Snapshot: Junos 15.1R6.7 set-form EX4550 (52 lines, pure set-form) -- xe-0/0/0-2 trunk ports w/ ethernet-switching vlan members, 6 VLANs, chassis aggregated-devices, apply-groups POC_Lab.
 set version 15.1R6.7
 set groups POC_Lab system host-name EX4550-190
 set groups POC_Lab system backup-router 172.25.90.1

--- a/tests/fixtures/real/junos/ksator_labmgmt_qfx10k2_junos173.set
+++ b/tests/fixtures/real/junos/ksator_labmgmt_qfx10k2_junos173.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/ksator/lab_management (backup/QFX10K2-174_config.2017-12-19@15:28:23 @ 37e42eb)
+# License: MIT -- Copyright Juniper Networks 2018
+# Snapshot: Junos 17.3R1-S2.1 set-form QFX10002-72Q spine (391 lines) -- channelized break-out ports (`xe-0/0/6:2.10`), 2 ae LAGs w/ ESI + LACP system-id, 7 irb SVIs w/ VRRP, 6 vlan vxlan vni mappings, 3 vrf routing-instances, policy-options (Tier-3).
 set version 17.3R1-S2.1
 set groups POC_Lab system host-name QFX10K2-182
 set groups POC_Lab system backup-router 172.25.90.1

--- a/tests/fixtures/real/junos/ksator_labmgmt_qfx5100_junos173.set
+++ b/tests/fixtures/real/junos/ksator_labmgmt_qfx5100_junos173.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/ksator/lab_management (backup/QFX5100-183_config.2017-12-19@15:28:16 @ 37e42eb)
+# License: MIT -- Copyright Juniper Networks 2018
+# Snapshot: Junos 17.3R1.10 set-form QFX5100 leaf (106 lines, pure set-form) -- ae0/ae1 LAGs, 2 et-0/0/48-49 40G uplinks, 16 vlans, apply-groups POC_Lab inheritance, root-authentication, RADIUS + SSH.
 set version 17.3R1.10
 set groups POC_Lab system host-name QFX5100-183
 set groups POC_Lab system backup-router 172.25.90.1

--- a/tests/fixtures/real/junos/ksator_labmgmt_qfx5110_junos173.set
+++ b/tests/fixtures/real/junos/ksator_labmgmt_qfx5110_junos173.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/ksator/lab_management (backup/QFX5110-169_config.2017-12-19@15:28:19 @ 37e42eb)
+# License: MIT -- Copyright Juniper Networks 2018
+# Snapshot: Junos 17.3R1-S2.1 set-form QFX5110 48x10G+6x40G leaf (52 lines) -- basic apply-groups + lo0; platform-class coverage (newer ASIC than QFX5100).
 set version 17.3R1-S2.1
 set groups POC_Lab system host-name QFX5110-169
 set groups POC_Lab system backup-router 172.25.90.1

--- a/tests/fixtures/real/junos/saidvandeklundert_snmpv3_junos172.set
+++ b/tests/fixtures/real/junos/saidvandeklundert_snmpv3_junos172.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/saidvandeklundert/rust (projects/jsc/config_17_set.txt)
+# License: MIT (Copyright 2023 saidvandeklundert)
+# Snapshot: Junos 17.2R3.4 set-form -- SNMPv3 USM (`set snmp v3 usm local-engine user` + auth-sha + privacy-aes128 + vacm) + snmp location, ae1-ae6/ae101-202 802.3ad LAGs, trunk VLANs, static routes. IPs -> RFC5737; secrets upstream `/* SECRET-DATA */`.
 set version 17.2R3.4
 set system login class READ permissions clear
 set system login class READ permissions maintenance

--- a/tests/fixtures/real/junos/tsg8139_evpn_leaf_dhcpv6_junos232.set
+++ b/tests/fixtures/real/junos/tsg8139_evpn_leaf_dhcpv6_junos232.set
@@ -1,3 +1,6 @@
+# Source: https://github.com/TsG8139/evpn-vxlan-implementation (srx/leaf02.txt)
+# License: MIT (Copyright 2026 TsG8139)
+# Snapshot: Junos 23.2R1.14 set-form EVPN-VXLAN leaf -- DHCPv6-client (`fxp0 ... family inet6 dhcpv6-client`), vrf routing-instances (RD + vrf-target), IPv6 addressing, dot1q sub-interfaces. $6$ root hash -> synthetic; router-id 2.2.2.2 -> RFC5737.
 set version 23.2R1.14
 set system root-authentication encrypted-password "$6$fakeSalt$fakeHashExampleValueForFixtureOnlyNotARealCredential0000000000000000000000000000"
 set system services ssh root-login allow

--- a/tests/fixtures/real/mikrotik/ntc_ip_address_export.rsc
+++ b/tests/fixtures/real/mikrotik/ntc_ip_address_export.rsc
@@ -1,3 +1,6 @@
+# Source: https://github.com/networktocode/ntc-templates (tests/mikrotik_routeros/ip_address_export_verbose/mikrotik_routeros_ip_address_export_verbose.raw)
+# License: Apache-2.0
+# Snapshot: RouterOS 6.48.6 `/export verbose` snippet -- `# ... by RouterOS` banner + `/ip address` section with quoted comments.
 # jul/21/2023 09:42:42 by RouterOS 6.48.6
 # software id = 1234-ABCD
 #

--- a/tests/fixtures/real/mikrotik/routeros_diff_verbose_export.rsc
+++ b/tests/fixtures/real/mikrotik/routeros_diff_verbose_export.rsc
@@ -1,3 +1,6 @@
+# Source: https://github.com/adamcharnock/routeros-diff (tests/test_files/verbose_export.rsc)
+# License: MIT
+# Snapshot: RouterOS 6.48.1 `/export verbose` (484 lines, RB952Ui-5ac2nD) -- /interface bridge + vlan (named gn-mgmt), /ip address, /ip dhcp-server network + /ip pool, /snmp, /interface wireless, /queue tree.
 # feb/22/2021 01:08:08 by RouterOS 6.48.1
 # software id = RI0B-IPQ6
 #

--- a/tests/fixtures/real/mikrotik/taqavi_initial_provisioning.rsc
+++ b/tests/fixtures/real/mikrotik/taqavi_initial_provisioning.rsc
@@ -1,3 +1,6 @@
+# Source: https://github.com/AmirArsalanTaqavi/Mikrotik-Config-Examples (initial-provisioning.rsc)
+# License: MIT
+# Snapshot: RouterOS provisioning script (L009UiGS-2HaxD, not a /export) -- /interface bridge + bridge port, /interface ethernet w/ comments, /ip service, /user add, DHCP, WireGuard, firewall. Password is the source's own `ChangeMe123!` placeholder.
 # MikroTik RouterOS - Initial Provisioning Script
 # Based on Model: L009UiGS-2HaxD (ARM)
 # Description: Basic setup including Bridge, DHCP, WireGuard, and Firewall hardening.

--- a/tests/fixtures/real/mikrotik/user_contrib_crs310_ros7.rsc
+++ b/tests/fixtures/real/mikrotik/user_contrib_crs310_ros7.rsc
@@ -1,3 +1,6 @@
+# Source: User-contributed real `/export verbose` from a CRS310-8G+2S+ on RouterOS 7.18.2 (sanitised by scripts/ -- see NOTICE.md)
+# License: CC0-1.0 (user contribution)
+# Snapshot: Home-lab CRS310 (630 lines) -- renamed ethernet port fleet, 5 VLANs, bridge + bridge port, BGP template stub, IPv6 ND, l2tp/sstp server, MPLS settings, system clock/leds/watchdog. Serial/software-id/MACs -> placeholders; RFC1918 retained.
 # 2026-04-21 20:35:02 by RouterOS 7.18.2
 # software id = XXXX-XXXX
 #

--- a/tests/fixtures/real/opnsense/opnsense_acl_test_config.xml
+++ b/tests/fixtures/real/opnsense/opnsense_acl_test_config.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  Source: https://github.com/opnsense/core (src/opnsense/mvc/tests/app/models/OPNsense/ACL/AclConfig/config.xml)
+  License: BSD-2-Clause
+  Snapshot: ACL model test config - 4 groups (admins + 3 test groups w/ distinct priv lists) + 5 users (root + per-group testers + restricted admin). Richest local_users surface in the corpus.
+-->
 <opnsense>
   <trigger_initial_wizard/>
   <theme>opnsense</theme>

--- a/tests/fixtures/real/opnsense/opnsense_core_default.xml
+++ b/tests/fixtures/real/opnsense/opnsense_core_default.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  Source: https://github.com/opnsense/core (src/etc/config.xml.sample)
+  License: BSD-2-Clause
+  Snapshot: Upstream default `config.xml` template - system, users, groups, webgui, timeservers, bogons, firewall bits.
+-->
 <opnsense>
   <trigger_initial_wizard/>
   <theme>opnsense</theme>

--- a/tests/fixtures/real/opnsense/opnsense_docs_carp_ha_backup.xml
+++ b/tests/fixtures/real/opnsense/opnsense_docs_carp_ha_backup.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  Source: https://github.com/opnsense/docs (source/manual/how-tos/resources/Carp_example_backup.xml @ a508f63b08c9688c9aabc94f08c312a4950c1381)
+  License: BSD-2-Clause
+  Snapshot: Official OPNsense docs CARP HA backup-node example (701 lines, schema 11.2) - <virtualip> WAN VHID 1 + LAN VHID 3 in carp mode, reduced backup-side <hasync> block. Cross-validates both sides of a CARP relationship.
+-->
 <opnsense>
   <version>11.2</version>
   <lastchange/>

--- a/tests/fixtures/real/opnsense/opnsense_docs_carp_ha_master.xml
+++ b/tests/fixtures/real/opnsense/opnsense_docs_carp_ha_master.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  Source: https://github.com/opnsense/docs (source/manual/how-tos/resources/Carp_example_master.xml @ a508f63b08c9688c9aabc94f08c312a4950c1381)
+  License: BSD-2-Clause
+  Snapshot: Official OPNsense docs CARP HA master-node example (704 lines, schema 11.2) - full <virtualip> (2 carp <vip>) + master-side <hasync> pfsync settings. Docs-sample `opnsense` CARP key + empty-salt $6$ user hash.
+-->
 <opnsense>
   <version>11.2</version>
   <lastchange/>

--- a/tests/fixtures/real/opnsense/opnsense_service_test_config.xml
+++ b/tests/fixtures/real/opnsense/opnsense_service_test_config.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  Source: https://github.com/opnsense/core (src/opnsense/service/tests/config/config.xml)
+  License: BSD-2-Clause
+  Snapshot: Service-layer test config - real interface zones (wan/lan), DHCP client settings, DHCPv6 prefix delegation, gateway tracking.
+-->
 <opnsense>
   <version>1</version>
   <interfaces>

--- a/tests/fixtures/real/opnsense/user_contrib_supergate_opn25.xml
+++ b/tests/fixtures/real/opnsense/user_contrib_supergate_opn25.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  Source: User-contributed real `/conf/config.xml` from a deployed OPNsense instance (captured via Netcanon's backup layer; heavily sanitised - see NOTICE.md)
+  License: CC0-1.0 (user contribution)
+  Snapshot: Deployed OPNsense (2,302-line config.xml) - 8 interfaces, 5 <vlans>, 2 bcrypt users, per-zone DHCP w/ static reservations, Unbound DNS, NTP/SNMP/IPsec/WireGuard, self-signed CA + cert chain. 2 bcrypt hashes + apikeys + private keys -> synthetic; domain -> example.test; 13 MACs OUI-preserving-sanitised.
+-->
 
 <opnsense>
 


### PR DESCRIPTION
## What

Adds the 3-line `Source:` / `License:` / `Snapshot:` attribution header to the **48 headerless** real-capture fixtures, completing the per-file attribution convention (41 fixtures — aruba_aoscx / cisco_iosxr / cisco_nxos / vyos — already had it; the other 7 vendors didn't). The deferred run3 `fixture-attribution-headers` item. `NOTICE.md` stays the authoritative provenance ledger; headers just make each file self-describing.

## Per-vendor comment syntax (verified parse-inert)

| Vendors | Leader |
|---|---|
| arista_eos, aruba_aoss, cisco_iosxe (.txt/.cfg) | `!` line comment |
| fortigate, junos, mikrotik (.conf/.set/.rsc) | `#` line comment |
| opnsense (.xml) | XML comment **after** the `<?xml?>` prolog, hyphen-runs collapsed (`--` is illegal inside an XML comment) |

`Source` + `License` are verbatim from `NOTICE.md`; `Snapshot` condenses its Notes column.

## Why this is safe (no regen needed)

The headers are inert — they do not change any codec's canonical output, so there is **no cross-mesh / phase4 drift** (this batch was flagged "regen-sensitive"; it turns out not to be, once verified):

- **Pre-write:** for all 48 files, `parse(headered).model_dump() == parse(original).model_dump()` per codec.
- **Post-write:** `git diff --numstat` shows **pure additions, zero deletions** — line endings preserved (read+written with `newline=""`, so CRLF/LF bytes are untouched).
- `tests/unit/migration/test_real_captures.py`: **all 367 parametrized cases pass**.
- Full `tests/unit`: **4581 passed, 81 skipped**.

## Deliberately excluded

`opnsense/opnsense_paramiko_shell_capture.xml` — a synthesised regression fixture whose exact byte shape (a `cat /conf/config.xml` prefix before the `<?xml` prolog) **is** the thing under test. Any header corrupts it, and an XML comment can't precede the prolog. Provenance stays in `NOTICE.md`. (Excluding it is what lands the batch at 48.)

Docs/fixtures only — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
