### PR TITLE
test(e2e): de-flake theme-toggle background assertion (poll past the CSS transition)

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -150,6 +150,17 @@ class TestThemeToggle:
             "() => getComputedStyle(document.body).backgroundColor"
         )
         page.get_by_test_id("nav-theme-toggle").click()
+        # ``body`` animates ``background-color`` over a ~.15s CSS transition,
+        # so reading the computed value *immediately* after the click returns
+        # the pre-/mid-transition (still-light) colour — a flaky read.  Poll
+        # until the rendered background has actually moved off the light token
+        # before asserting; if it genuinely never changes this times out and
+        # the failure points at a real var(--page-bg) regression, not timing.
+        page.wait_for_function(
+            "light => getComputedStyle(document.body).backgroundColor !== light",
+            arg=light_bg,
+            timeout=3000,
+        )
         dark_bg = page.evaluate(
             "() => getComputedStyle(document.body).backgroundColor"
         )


### PR DESCRIPTION
## What

De-flakes `tests/e2e/test_navigation.py::TestThemeToggle::test_body_background_reflects_theme`.

## Root cause (timing flake, not an app bug)

The test read `getComputedStyle(document.body).backgroundColor` **immediately** after clicking the theme toggle and asserted it differed from the light value. `body` animates `background-color` over a ~.15s CSS transition, so the immediate read captured the pre-/mid-transition (still-light) colour → deterministic failure. The sibling `test_theme_toggle_aria_label` clicks the same toggle and passes (the `data-theme` flip itself is correct) — only the rendered-colour read was racing the transition.

## Fix

`page.wait_for_function` now polls until the computed body background has moved off the captured light token before asserting. A genuine `var(--page-bg)` regression would still fail loudly (the wait times out) — the race is gone, the regression coverage is kept.

## Why CI never caught it

`.github/workflows/ci.yml` runs only `tests/unit` + `tests/integration`, not `tests/e2e` (Playwright). Found while running the e2e suite locally.

## Verification

Fixed test passes; full local `tests/e2e` suite is green (**168 passed, 0 failures**) — this plus the #151 migrate fixes clean up the e2e tier. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
