### PR TITLE
fix(ci): docker-publish — stop sbom-action attaching to the Release (SBOM attestation on re-tag)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -228,6 +228,14 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           upload-artifact: true
+          # Do NOT attach the SBOM to the GitHub Release.  sbom-action
+          # auto-attaches when a Release for the tag already exists, which
+          # needs `contents: write` (we only grant `contents: read`) and so
+          # fails the step + skips the cosign attestation below — this bit
+          # the v0.4.2 re-tag, where the Release already existed from the
+          # first push's MSI run.  We publish the SBOM as a cosign
+          # attestation on the image (next step), not as a release asset.
+          upload-release-assets: false
 
       - name: Attach SBOM as a cosign attestation
         env:


### PR DESCRIPTION
Follow-up to the v0.4.2 publish. `anchore/sbom-action` auto-attaches the SBOM to an existing GitHub Release, which needs `contents: write` (workflow grants `contents: read`) — so the SBOM step failed ("Resource not accessible by integration") and the dependent cosign SBOM-attestation step was skipped. Only fires when the Release pre-exists at SBOM time: v0.4.1 (single push) didn't hit it, the v0.4.2 **re-tag** did (the first push's MSI had already created the Release).

Fix: `upload-release-assets: false` — the SBOM still uploads as a workflow artifact and is published as a **cosign attestation on the image** (the documented control). Makes v0.4.3+ correct; v0.4.2 not retagged per maintainer call (its image is published + cosign-signed, only the SBOM attestation is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)