### PR TITLE
fix(desktop): construct the Preferences dialog on the Qt GUI thread

### DIFF
--- a/netcanon_desktop/app.py
+++ b/netcanon_desktop/app.py
@@ -129,12 +129,36 @@ class DesktopApp:
         self._server.stop()
 
     def _show_preferences(self) -> None:
-        """Open the Preferences dialog (modal, blocks until closed).
+        """Open the Preferences dialog, marshalling onto the Qt GUI thread.
 
-        Imports PySide6 and the dialog lazily so this method is safe to
-        call from the pystray background thread on Windows even though
-        the dialog itself must be constructed on the main Qt thread —
-        Qt's invokeMethod machinery handles the marshalling.
+        This is wired as the tray ``on_preferences`` callback, so it fires
+        on **pystray's background thread**.  The dialog is a ``QWidget`` and
+        Qt forbids constructing or ``exec``-ing widgets off the GUI thread
+        (cross-thread UB / hard crash).  When we detect we're not on the GUI
+        thread we post the work to the GUI thread's event loop via
+        ``QMetaObject.invokeMethod`` (the same marshalling ``window.py`` uses
+        for ``show`` / ``hide`` / ``quit``); the call returns immediately and
+        the modal dialog runs on the GUI thread, keeping the tray responsive.
+        On the GUI thread already (or with no ``QApplication`` yet, e.g. unit
+        tests) we run inline.
+        """
+        from PySide6.QtCore import QMetaObject, Qt, QThread
+        from PySide6.QtWidgets import QApplication
+
+        app = QApplication.instance()
+        if app is not None and app.thread() is not QThread.currentThread():
+            QMetaObject.invokeMethod(
+                app,
+                self._open_preferences_dialog,
+                Qt.ConnectionType.QueuedConnection,
+            )
+        else:
+            self._open_preferences_dialog()
+
+    def _open_preferences_dialog(self) -> None:
+        """Construct + exec the Preferences dialog (modal, blocks until
+        closed).  MUST run on the Qt GUI thread — ``_show_preferences``
+        marshals here when invoked from the pystray background thread.
         """
         from netcanon_desktop.preferences import DesktopPreferences
         from netcanon_desktop.preferences_dialog import PreferencesDialog

--- a/tests/desktop/test_app.py
+++ b/tests/desktop/test_app.py
@@ -211,3 +211,37 @@ class TestDesktopAppShowPreferences:
         MockDialog.assert_called_once()
         instance.create.assert_called_once()
         instance.exec.assert_called_once()
+
+    def test_show_preferences_marshals_to_gui_thread_off_thread(self, app):
+        """Regression: the tray fires ``_show_preferences`` on pystray's
+        background thread, but a QWidget dialog must be constructed + exec'd
+        on the Qt GUI thread (cross-thread construction is UB / a crash).
+        When off the GUI thread we post the work via
+        ``QMetaObject.invokeMethod`` (QueuedConnection) instead of building
+        the dialog inline — the same marshalling ``window.py`` uses for
+        ``show`` / ``hide`` / ``quit``.
+        """
+        from PySide6.QtCore import Qt
+
+        gui_thread = object()
+        bg_thread = object()
+        with (
+            patch("PySide6.QtWidgets.QApplication") as MockQApp,
+            patch("PySide6.QtCore.QThread") as MockQThread,
+            patch("PySide6.QtCore.QMetaObject") as MockQMeta,
+            patch(
+                "netcanon_desktop.preferences_dialog.PreferencesDialog"
+            ) as MockDialog,
+        ):
+            fake_app = MockQApp.instance.return_value
+            fake_app.thread.return_value = gui_thread
+            MockQThread.currentThread.return_value = bg_thread
+            app._show_preferences()
+
+        # Posted onto the GUI thread; the dialog was NOT constructed inline.
+        MockQMeta.invokeMethod.assert_called_once()
+        ctx, functor, conn = MockQMeta.invokeMethod.call_args.args
+        assert ctx is fake_app
+        assert functor == app._open_preferences_dialog
+        assert conn == Qt.ConnectionType.QueuedConnection
+        MockDialog.assert_not_called()


### PR DESCRIPTION
## Build the Preferences dialog on the Qt GUI thread (audit T0-NEW: desktop Qt threading)

`DesktopApp._show_preferences` is wired as the tray's `on_preferences` callback, so it fires on **pystray's background thread**. It constructed and `exec()`'d a `PreferencesDialog` (a `QWidget`) **directly on that thread** — constructing/executing a widget off the Qt GUI thread is undefined behaviour (a hard crash on some Qt builds).

The method's docstring even claimed *"Qt's invokeMethod machinery handles the marshalling"* — but **no marshalling existed**. By contrast, `window.py` correctly posts `show`/`hide`/`quit` to the GUI thread via `QMetaObject.invokeMethod(..., QueuedConnection)`.

### Fix
- When `_show_preferences` detects it's **not** on the GUI thread, post the dialog construct+exec to the GUI thread's event loop via `QMetaObject.invokeMethod(app, self._open_preferences_dialog, QueuedConnection)` — mirroring `window.py`.
- Run inline when already on the GUI thread, or when there's no `QApplication` yet (e.g. unit tests).
- Split the actual construct+exec into `_open_preferences_dialog` (the GUI-thread target).
- Make the docstring honest.

The tray callback now returns immediately and the modal dialog runs on the GUI thread, so the tray stays responsive.

### Test
Adds `test_show_preferences_marshals_to_gui_thread_off_thread`: asserts the off-thread path posts via `invokeMethod(QueuedConnection)` and does **not** construct the dialog inline. The existing inline test (on-thread / no-app) still passes. Full desktop suite green.

Part of the Bucket A+B audit-remediation pass → v0.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
