### PR TITLE
fix(security): default the bind address to 127.0.0.1 (loopback)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,8 +45,11 @@ Netcanon ships in two deployment shapes:
    netcanon_desktop` shell binds the embedded server exclusively to
    `127.0.0.1`.  Security controls assume a single-user local
    machine.
-2. **Web / Docker deployment.**  Operators who pass `--host 0.0.0.0`
-   (or run the published GHCR image) are deploying outside the
+2. **Web / Docker deployment.**  The configured default bind is
+   `127.0.0.1` (loopback), so exposing the API on a network interface
+   is always an explicit choice.  Operators who set
+   `NETCANON_HOST=0.0.0.0` / pass `--host 0.0.0.0` (the published GHCR
+   image sets the former) are deploying outside the
    single-user-local-machine threat model.  Netcanon does NOT ship
    API authentication, TLS, or rate-limiting — operators in this
    shape must front the app with a reverse proxy that provides those

--- a/netcanon/api/auth.py
+++ b/netcanon/api/auth.py
@@ -1,10 +1,13 @@
 """Optional API authentication + bind-safety guard (audit finding SEC-01).
 
-Netcanon ships with **no** authentication by default: the desktop shell
-binds ``127.0.0.1`` and web/Docker operators are told to front the app
-with a reverse proxy.  That posture is documented in ``SECURITY.md``, but
-the insecure ``0.0.0.0`` default makes accidental public exposure one
-``docker run -p`` away.  This module adds two opt-in, fail-closed controls:
+Netcanon ships with **no** authentication by default, but binds
+``127.0.0.1`` by default (both the desktop shell and the zero-config
+server posture), and web/Docker operators are told to front the app with a
+reverse proxy.  That posture is documented in ``SECURITY.md``.  A
+deployment that binds a non-loopback interface (the published Docker image
+sets ``NETCANON_HOST=0.0.0.0``; an operator may pass ``--host 0.0.0.0``)
+is one ``docker run -p`` away from exposing an unauthenticated API.  This
+module adds two opt-in, fail-closed controls:
 
 1. :func:`require_api_key` — when ``Settings.api_key`` (env
    ``NETCANON_API_KEY``) is set, every ``/api/v1`` data/operation route

--- a/netcanon/cli.py
+++ b/netcanon/cli.py
@@ -104,9 +104,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Run the Netcanon web server (host/port/auth from NETCANON_* env)",
         description=(
             "Start the FastAPI app via uvicorn, binding Settings.host:port "
-            "(NETCANON_HOST / NETCANON_PORT, default 0.0.0.0:8000).  Refuses "
-            "to start on a non-loopback bind unless NETCANON_API_KEY is set "
-            "or NETCANON_ALLOW_INSECURE_BIND=1 (SEC-01 fail-closed)."
+            "(NETCANON_HOST / NETCANON_PORT, default 127.0.0.1:8000).  "
+            "Refuses to start on a non-loopback bind unless NETCANON_API_KEY "
+            "is set or NETCANON_ALLOW_INSECURE_BIND=1 (SEC-01 fail-closed)."
         ),
     )
 

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -38,7 +38,13 @@ class Settings(BaseSettings):
             falls back to ``configs_dir.parent`` for backward compatibility.
             Setting this explicitly lets the desktop preferences UI relocate
             the per-user data root independently of ``configs_dir``.
-        host: Bind address for the Uvicorn server.
+        host: Bind address for the Uvicorn server.  Defaults to
+            ``127.0.0.1`` (loopback) so the zero-config posture is never
+            network-exposed by accident; binding all interfaces is an
+            explicit opt-in via ``NETCANON_HOST=0.0.0.0`` (which the Docker
+            image sets) or ``uvicorn … --host 0.0.0.0``.  ``netcanon serve``
+            then gates a non-loopback bind behind ``NETCANON_API_KEY`` or
+            ``NETCANON_ALLOW_INSECURE_BIND`` (see netcanon/api/auth.py).
         port: TCP port for the Uvicorn server.
         log_level: Logging verbosity.  Sets the stdlib root logger level via
             ``configure_logging`` (so application logs honour it on every
@@ -100,7 +106,7 @@ class Settings(BaseSettings):
     definitions_dir: Path = Path("definitions")
     configs_dir: Path = Path("configs")
     data_dir: Path | None = None
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8000
     log_level: Literal[
         "debug", "info", "warning", "error", "critical"

--- a/tests/unit/test_sec01_auth_bind.py
+++ b/tests/unit/test_sec01_auth_bind.py
@@ -126,3 +126,20 @@ def test_serve_refuses_insecure_bind(monkeypatch, capsys):
     rc = cli_main(["serve"])
     assert rc == 2
     assert "Refusing to start" in capsys.readouterr().err
+
+
+def test_default_bind_is_loopback(monkeypatch):
+    """Zero-config posture is loopback-safe by default: with no
+    ``NETCANON_HOST`` the bind address is ``127.0.0.1``, so a bare
+    ``uvicorn netcanon.main:app`` or ``netcanon serve`` never exposes the
+    API on a network interface by accident — binding ``0.0.0.0`` is an
+    explicit opt-in.  Guards against a regression back to the historical
+    ``0.0.0.0`` default (audit T0-2: insecure-by-default bind)."""
+    for var in ("NETCANON_HOST", "NETCANON_API_KEY", "NETCANON_ALLOW_INSECURE_BIND"):
+        monkeypatch.delenv(var, raising=False)
+    s = Settings()
+    assert s.host == "127.0.0.1"
+    assert is_loopback_host(s.host)
+    # The bind guard passes for the zero-config default — `netcanon serve`
+    # serves on loopback rather than refusing.
+    assert bind_refusal_reason(s.host, s.api_key, s.allow_insecure_bind) is None


### PR DESCRIPTION
## Default the bind address to `127.0.0.1` (audit T0-2: insecure-by-default bind)

The configured default `host` was `0.0.0.0`, advertising an all-interfaces bind as the zero-config posture. While **uvicorn's own default is already `127.0.0.1`**, `netcanon serve` / `NETCANON_HOST` read this setting — so the misleading default meant the only thing between a zero-config deployment and a network-exposed unauthenticated API was the SEC-01 `netcanon serve` guard.

### Why not "add the guard to `create_app()`"
The audit suggested calling `bind_refusal_reason` inside `create_app()`. That doesn't work: **`create_app()` cannot see uvicorn's `--host`** (uvicorn binds the socket itself and never tells the app), and keying a guard on `settings.host` would false-positive the documented `uvicorn … --host 127.0.0.1` path *and* break every TestClient test. A bare `uvicorn netcanon.main:app --host 0.0.0.0` is genuinely uncatchable at the app layer.

### The real fix
Flip the default to `127.0.0.1` so **every zero-config entry path is loopback-safe** and binding all interfaces is an explicit opt-in (`NETCANON_HOST=0.0.0.0` or `--host 0.0.0.0`). This is the audit's own "to actually clear it" item #1.

- **Docker**: unchanged — the image sets `NETCANON_HOST=0.0.0.0` explicitly and the entrypoint still fails closed without a key / opt-out.
- **Desktop**: already pinned loopback.
- **Tests**: unaffected — TestClient doesn't bind; SEC-01 tests use explicit hosts.
- **`netcanon serve`** with no `NETCANON_HOST` now serves on loopback instead of *refusing* — better zero-config UX, still safe.

### Also
Updates the config / `auth.py` / CLI-help docstrings + the SECURITY.md threat model to state the loopback default, and adds `test_default_bind_is_loopback` pinning it (guards against a regression back to `0.0.0.0`).

Part of the Bucket A+B audit-remediation pass → v0.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
