### PR TITLE
fix(sanitizer): redact EVPN/VXLAN/VRF overlay identifiers

### DIFF
--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -495,6 +495,15 @@ def sanitize_intent(
                     redacted=new_value,
                 ))
                 v3user.priv_passphrase = new_value
+            if v3user.engine_id:
+                new_value = table.redact_secret("SNMPV3-ENGINE-ID")
+                subs.append(Substitution(
+                    category="snmpv3-engine-id",
+                    field=f"snmp.v3_users[{j}].engine_id",
+                    original=v3user.engine_id,
+                    redacted=new_value,
+                ))
+                v3user.engine_id = new_value
 
     # ---- RADIUS server host + shared secret (field name: ``key``) ----
     for i, server in enumerate(sanitized.radius_servers):
@@ -648,7 +657,7 @@ def sanitize_intent(
         ))
         sanitized.raw_sections = {}
 
-    # ---- routing-instance descriptions ----
+    # ---- routing-instance descriptions + RD / route-targets ----
     for i, ri in enumerate(sanitized.routing_instances):
         if ri.description:
             subs.append(Substitution(
@@ -658,6 +667,56 @@ def sanitize_intent(
                 redacted="description redacted",
             ))
             ri.description = "description redacted"
+        if ri.route_distinguisher:
+            new_rd = table.redact_route_target(ri.route_distinguisher)
+            subs.append(Substitution(
+                category="route-distinguisher",
+                field=f"routing_instances[{i}].route_distinguisher",
+                original=ri.route_distinguisher,
+                redacted=new_rd,
+            ))
+            ri.route_distinguisher = new_rd
+        ri.rt_imports = _redact_route_target_list(
+            ri.rt_imports, f"routing_instances[{i}].rt_imports", table, subs
+        )
+        ri.rt_exports = _redact_route_target_list(
+            ri.rt_exports, f"routing_instances[{i}].rt_exports", table, subs
+        )
+
+    # ---- VXLAN / EVPN overlay (BUM mcast group, VTEP flood-list, Type-5
+    #      route-targets + advertised prefix) — network-identifying fabric
+    #      values that bypassed every field-typed redaction above ----
+    for i, vni in enumerate(sanitized.vxlan_vnis):
+        if vni.mcast_group:
+            new_g = table.redact_mcast_group(vni.mcast_group)
+            if new_g != vni.mcast_group:
+                subs.append(Substitution(
+                    category="mcast-group",
+                    field=f"vxlan_vnis[{i}].mcast_group",
+                    original=vni.mcast_group,
+                    redacted=new_g,
+                ))
+                vni.mcast_group = new_g
+        vni.flood_list = _redact_ip_list(
+            vni.flood_list, f"vxlan_vnis[{i}].flood_list", "vtep-flood", table, subs
+        )
+    for i, r5 in enumerate(sanitized.evpn_type5_routes):
+        r5.rt_imports = _redact_route_target_list(
+            r5.rt_imports, f"evpn_type5_routes[{i}].rt_imports", table, subs
+        )
+        r5.rt_exports = _redact_route_target_list(
+            r5.rt_exports, f"evpn_type5_routes[{i}].rt_exports", table, subs
+        )
+        if r5.prefix:
+            new_p = table.redact_cidr(r5.prefix)
+            if new_p != r5.prefix:
+                subs.append(Substitution(
+                    category="evpn-type5-prefix",
+                    field=f"evpn_type5_routes[{i}].prefix",
+                    original=r5.prefix,
+                    redacted=new_p,
+                ))
+                r5.prefix = new_p
 
     # ---- Junos apply-groups verbatim carry-through — strip entirely ----
     # v0.4.0 self-audit (HIGH): ``group_content`` holds the verbatim
@@ -724,6 +783,13 @@ class _SubstitutionTable:
         self._local_user_names: dict[str, str] = {}
         self._snmpv3_user_names: dict[str, str] = {}
         self._vlan_names: dict[str, str] = {}
+        # Overlay (EVPN/VXLAN/VRF) identifiers — network-identifying AND
+        # cross-referenced (a VRF's RD recurs as a route-target across
+        # sibling VRFs + EVPN Type-5 routes; a VXLAN BUM group recurs
+        # across VNIs), so they redact cross-reference-stable like the
+        # name maps above.
+        self._route_targets: dict[str, str] = {}
+        self._mcast_groups: dict[str, str] = {}
 
     def redact_hostname(self, name: str) -> str:
         if name not in self._hostnames:
@@ -828,6 +894,45 @@ class _SubstitutionTable:
         addr, sep, prefix = value.partition("/")
         new_addr = self.redact_ip_string(addr)
         return f"{new_addr}{sep}{prefix}" if sep else new_addr
+
+    def redact_route_target(self, value: str) -> str:
+        """Cross-reference-stable RD / route-target redaction.
+
+        A route-distinguisher and the route-targets that import/export it
+        are network-identifying — they encode the operator's ASN (or a
+        loopback IP) plus an internal index — and they are *correlated*:
+        a VRF's RD often equals its RT, and the same RT recurs on the
+        EVPN Type-5 routes and sibling VRFs that share the VPN.  Map each
+        distinct ``<left>:<right>`` token to a stable placeholder built on
+        the RFC 5398 documentation ASN ``64496`` so the correlation
+        structure survives while the real ASN/IP and index are hidden.
+        Same input → same output across the whole config.
+        """
+        if value not in self._route_targets:
+            self._route_targets[value] = f"64496:{len(self._route_targets) + 1}"
+        return self._route_targets[value]
+
+    def redact_mcast_group(self, addr: str) -> str:
+        """Redact a VXLAN underlay multicast (BUM) group address.
+
+        :meth:`redact_ipv4` deliberately *preserves* multicast (well-known
+        groups are non-identifying), but an administratively-scoped VXLAN
+        BUM group (``239.0.0.0/8``) is an operator-chosen fabric value
+        that correlates configs, so it must be redacted here.  Map each
+        distinct group to a stable address in the RFC 5771 MCAST-TEST-NET
+        documentation range (``233.252.0.0/24``).  Non-multicast / non-IP
+        values fall through to the normal IP redaction.
+        """
+        try:
+            a = ipaddress.IPv4Address(addr)
+        except ValueError:
+            return self.redact_ip_string(addr)
+        if not a.is_multicast:
+            return self.redact_ip_string(addr)
+        if addr not in self._mcast_groups:
+            host = (len(self._mcast_groups) % 254) + 1
+            self._mcast_groups[addr] = f"233.252.0.{host}"
+        return self._mcast_groups[addr]
 
     def redact_community(self, community: str) -> str:
         if community not in self._communities:
@@ -979,4 +1084,25 @@ def _redact_ip_list(
                 redacted=new_ip,
             ))
         out.append(new_ip)
+    return out
+
+
+def _redact_route_target_list(
+    values: list[str],
+    field_name: str,
+    table: _SubstitutionTable,
+    subs: list[Substitution],
+) -> list[str]:
+    """Redact a list of RD / route-target entries cross-reference-stable."""
+    out: list[str] = []
+    for j, rt in enumerate(values):
+        new_rt = table.redact_route_target(rt)
+        if new_rt != rt:
+            subs.append(Substitution(
+                category="route-target",
+                field=f"{field_name}[{j}]",
+                original=rt,
+                redacted=new_rt,
+            ))
+        out.append(new_rt)
     return out

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel
 
 from netcanon.migration.canonical.intent import (
     CanonicalDHCPPool,
+    CanonicalEvpnType5Route,
     CanonicalIntent,
     CanonicalInterface,
     CanonicalIPv4Address,
@@ -41,6 +42,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalStaticRoute,
     CanonicalVlan,
     CanonicalVRRPGroup,
+    CanonicalVxlan,
 )
 from netcanon.tools.sanitize import (
     SanitizationResult,
@@ -1255,3 +1257,164 @@ class TestDHCPRangeRedaction:
         assert p.network == "192.168.10.0/24"
         assert p.start_ip == "192.168.10.100"
         assert p.end_ip == "192.168.10.200"
+
+
+# ---------------------------------------------------------------------------
+# Overlay (EVPN / VXLAN / VRF) identifiers — non-secret but network-
+# identifying fields the sanitiser previously left untouched: VRF
+# route-distinguisher + route-targets, VXLAN BUM multicast group + VTEP
+# flood-list, EVPN Type-5 RTs + advertised prefix, and the SNMPv3
+# engineID.  A verifier leaked the trio `65501:100` / `239.7.7.7` /
+# `9.9.9.9` through these.  Like the PII-tail block above, these are NOT
+# secret-NAMED so they intentionally don't register in
+# _REGISTERED_SECRET_FIELDS; this is their forward "must not survive"
+# guard.
+# ---------------------------------------------------------------------------
+
+
+class TestOverlayFieldRedaction:
+    def test_route_distinguisher_redacted(self):
+        intent = CanonicalIntent(
+            routing_instances=[
+                CanonicalRoutingInstance(name="TENANT-A", route_distinguisher="65501:100"),
+            ],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        rd = sanitized.routing_instances[0].route_distinguisher
+        assert rd != "65501:100"
+        assert rd.startswith("64496:")  # RFC 5398 documentation ASN
+        assert any(s.category == "route-distinguisher" for s in subs)
+
+    def test_route_targets_redacted(self):
+        intent = CanonicalIntent(
+            routing_instances=[
+                CanonicalRoutingInstance(
+                    name="TENANT-A",
+                    rt_imports=["65501:100", "65001:200"],
+                    rt_exports=["65501:100"],
+                ),
+            ],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        ri = sanitized.routing_instances[0]
+        assert "65501:100" not in ri.rt_imports and "65001:200" not in ri.rt_imports
+        assert "65501:100" not in ri.rt_exports
+        assert all(rt.startswith("64496:") for rt in ri.rt_imports + ri.rt_exports)
+        assert any(s.category == "route-target" for s in subs)
+
+    def test_rd_rt_cross_reference_stable(self):
+        """An RD that recurs as a route-target (and across sibling VRFs)
+        maps to the SAME placeholder, so the VPN-correlation structure
+        survives sanitisation while the real ASN/index is hidden."""
+        intent = CanonicalIntent(
+            routing_instances=[
+                CanonicalRoutingInstance(
+                    name="A", route_distinguisher="65501:100",
+                    rt_imports=["65501:100"], rt_exports=["65501:100"],
+                ),
+                CanonicalRoutingInstance(
+                    name="B", route_distinguisher="65501:200",
+                    rt_imports=["65501:100"],  # imports A's RT
+                ),
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        a, b = sanitized.routing_instances
+        # 65501:100 everywhere → one placeholder; 65501:200 → a distinct one.
+        assert a.route_distinguisher == a.rt_imports[0] == a.rt_exports[0]
+        assert b.rt_imports[0] == a.route_distinguisher
+        assert b.route_distinguisher != a.route_distinguisher
+
+    def test_vxlan_mcast_group_redacted_to_doc_range(self):
+        intent = CanonicalIntent(
+            vxlan_vnis=[
+                CanonicalVxlan(vlan_id=100, vni=10100, mcast_group="239.7.7.7"),
+                CanonicalVxlan(vlan_id=200, vni=10200, mcast_group="239.7.7.7"),
+            ],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        g0 = sanitized.vxlan_vnis[0].mcast_group
+        g1 = sanitized.vxlan_vnis[1].mcast_group
+        assert g0 != "239.7.7.7"
+        assert g0.startswith("233.252.0.")   # RFC 5771 MCAST-TEST-NET
+        assert g0 == g1                       # same group → stable placeholder
+        assert any(s.category == "mcast-group" for s in subs)
+
+    def test_vxlan_flood_list_public_redacted_private_preserved(self):
+        intent = CanonicalIntent(
+            vxlan_vnis=[
+                CanonicalVxlan(
+                    vlan_id=100, vni=10100,
+                    flood_list=["9.9.9.9", "10.0.0.1"],
+                ),
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        flood = sanitized.vxlan_vnis[0].flood_list
+        assert flood[0] != "9.9.9.9"
+        assert flood[0].startswith(("192.0.2.", "198.51.100.", "203.0.113."))
+        assert flood[1] == "10.0.0.1"  # private VTEP preserved
+
+    def test_evpn_type5_rt_and_public_prefix_redacted(self):
+        intent = CanonicalIntent(
+            evpn_type5_routes=[
+                CanonicalEvpnType5Route(
+                    vrf="TENANT-A",
+                    prefix="8.8.0.0/16",   # public — address redacted
+                    rt_imports=["65001:100"],
+                    rt_exports=["65001:100"],
+                ),
+                CanonicalEvpnType5Route(
+                    vrf="TENANT-B",
+                    prefix="10.1.0.0/16",   # private — preserved
+                    rt_imports=["65001:200"],
+                ),
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        r0, r1 = sanitized.evpn_type5_routes
+        assert all(rt.startswith("64496:") for rt in r0.rt_imports + r0.rt_exports)
+        # Public prefix address redacted, /16 preserved; private kept whole.
+        assert r0.prefix.endswith("/16")
+        assert r0.prefix.split("/")[0].startswith(
+            ("192.0.2.", "198.51.100.", "203.0.113.")
+        )
+        assert r1.prefix == "10.1.0.0/16"
+
+    def test_snmpv3_engine_id_redacted(self):
+        intent = CanonicalIntent(
+            snmp=CanonicalSNMP(
+                community="",
+                v3_users=[
+                    CanonicalSNMPv3User(name="ops", engine_id="80001f8880e5817264"),
+                ],
+            ),
+        )
+        sanitized, subs = sanitize_intent(intent)
+        eid = sanitized.snmp.v3_users[0].engine_id
+        assert eid != "80001f8880e5817264"
+        assert "REDACTED" in eid
+        assert any(s.category == "snmpv3-engine-id" for s in subs)
+
+    def test_leaked_overlay_trio_does_not_survive(self):
+        """End-to-end: the exact values an audit verifier leaked through
+        the overlay surfaces (`65501:100`, `239.7.7.7`, `9.9.9.9`) must
+        not appear anywhere in the sanitised canonical output."""
+        intent = CanonicalIntent(
+            routing_instances=[
+                CanonicalRoutingInstance(
+                    name="A", route_distinguisher="65501:100",
+                    rt_imports=["65501:100"],
+                ),
+            ],
+            vxlan_vnis=[
+                CanonicalVxlan(
+                    vlan_id=100, vni=10100,
+                    mcast_group="239.7.7.7", flood_list=["9.9.9.9"],
+                ),
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        blob = sanitized.model_dump_json()
+        leaked = [t for t in ("65501:100", "239.7.7.7", "9.9.9.9") if t in blob]
+        assert not leaked, f"overlay identifiers survived sanitisation: {leaked}"


### PR DESCRIPTION
## Redact EVPN/VXLAN/VRF overlay identifiers (audit #12, MED data-privacy)

A sanitized config still leaked network-identifying **overlay** fields the sanitizer never walked. An audit verifier leaked the trio `65501:100` / `239.7.7.7` / `9.9.9.9` straight through. The gap: `sanitize_intent` walked routing-instance *descriptions* but not their RD/RT, and didn't touch `vxlan_vnis` / `evpn_type5_routes` / the SNMPv3 `engine_id` at all.

### Now redacted
| Field | Redaction |
|---|---|
| `routing_instances[].route_distinguisher`, `.rt_imports`, `.rt_exports` | cross-reference-stable `64496:N` (RFC 5398 doc ASN) — preserves the RD==RT / shared-RT VPN-correlation structure while hiding the real ASN/index |
| `vxlan_vnis[].mcast_group` | `233.252.0.N` (RFC 5771 MCAST-TEST-NET) — `redact_ipv4` deliberately *preserves* multicast, so this needs a dedicated redaction |
| `vxlan_vnis[].flood_list[]` | normal IP redaction (public → docs range, private VTEP preserved) |
| `evpn_type5_routes[].rt_imports/.rt_exports` | same as VRF RTs |
| `evpn_type5_routes[].prefix` | `redact_cidr` (public address redacted, prefix length kept) |
| `snmp.v3_users[].engine_id` | `REDACTED-…` placeholder |

These are network-identifying, **not** secret-NAMED, so (like the existing PII-tail) they stay out of `_REGISTERED_SECRET_FIELDS` and get a forward "must not survive" test block (`TestOverlayFieldRedaction`), including an end-to-end check that the exact leaked trio can't reappear. Full unit suite green.

Part of the Bucket C run (the audit's silent-loss/leak *class*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
