### PR TITLE
fix(security): warn at startup when SSH host-key checking is auto_add

### DIFF
--- a/netcanon/collectors/hostkey.py
+++ b/netcanon/collectors/hostkey.py
@@ -101,3 +101,32 @@ def netmiko_host_key_params(settings: Settings) -> dict:
     if settings.ssh_host_key_checking == "auto_add":
         return {}
     return {"system_host_keys": True, "ssh_strict": True}
+
+
+def host_key_warning_reason(settings: Settings) -> str | None:
+    """Return a startup-warning message when the host-key policy is the
+    insecure ``auto_add`` default, else ``None``.
+
+    ``auto_add`` trusts any SSH host key on every connect with no
+    persistence, so a man-in-the-middle on the management path could
+    harvest the SSH password + enable secret.  The default stays
+    ``auto_add`` for backward-compatibility — and because the strict
+    ``tofu`` / ``reject`` modes require the *Netmiko* collector's targets
+    to be pre-seeded in the operator's OS ``~/.ssh/known_hosts`` (Netmiko
+    exposes no TOFU-persist API), so flipping the default would break
+    first-run backups of unknown devices.  But a running server should at
+    least surface the posture once at startup, so it is a conscious choice
+    rather than a silent default (mirrors :func:`bind_refusal_reason`).
+    See SECURITY.md.
+    """
+    if settings.ssh_host_key_checking != "auto_add":
+        return None
+    return (
+        "SSH host-key checking is 'auto_add' (the default): the backup "
+        "collectors trust any device host key on first connect with no "
+        "persistence, so a man-in-the-middle on the management path could "
+        "capture SSH/enable credentials. Set NETCANON_SSH_HOST_KEY_CHECKING="
+        "'tofu' to pin keys on first use (the Paramiko shell collector "
+        "persists them; the Netmiko collector then requires targets to "
+        "already be in the operator's ~/.ssh/known_hosts). See SECURITY.md."
+    )

--- a/netcanon/main.py
+++ b/netcanon/main.py
@@ -211,6 +211,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             len([s for s in _app.state.schedules.values() if s.enabled]),
         )
 
+        # Surface an insecure SSH host-key posture once at startup so
+        # 'auto_add' (the back-compat default) is a conscious choice, not
+        # a silent one (audit T0-4 — the "most repeatable miss").
+        from .collectors.hostkey import host_key_warning_reason
+        if hk_warning := host_key_warning_reason(settings):
+            logger.warning(hk_warning)
+
         yield
 
         scheduler.shutdown(wait=False)

--- a/tests/unit/test_hostkey.py
+++ b/tests/unit/test_hostkey.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 import pytest
 
-from netcanon.collectors.hostkey import known_hosts_path, netmiko_host_key_params
+from netcanon.collectors.hostkey import (
+    host_key_warning_reason,
+    known_hosts_path,
+    netmiko_host_key_params,
+)
 from netcanon.config import Settings
 
 pytestmark = pytest.mark.unit
@@ -35,3 +39,19 @@ def test_known_hosts_path_under_data_dir(tmp_path) -> None:
 def test_default_is_auto_add() -> None:
     # No env override → legacy behaviour, so existing deployments are unchanged.
     assert Settings().ssh_host_key_checking == "auto_add"
+
+
+def test_warning_reason_fires_for_auto_add_default(tmp_path) -> None:
+    """The insecure-default (auto_add) is surfaced once at startup — a
+    server logs this so the posture is a conscious choice (audit T0-4)."""
+    s = Settings(ssh_host_key_checking="auto_add", data_dir=tmp_path)
+    reason = host_key_warning_reason(s)
+    assert reason is not None
+    assert "auto_add" in reason
+    assert "NETCANON_SSH_HOST_KEY_CHECKING" in reason
+
+
+@pytest.mark.parametrize("mode", ["tofu", "reject"])
+def test_no_warning_reason_for_strict_modes(tmp_path, mode) -> None:
+    s = Settings(ssh_host_key_checking=mode, data_dir=tmp_path)
+    assert host_key_warning_reason(s) is None


### PR DESCRIPTION
## Warn at startup when SSH host-key checking is `auto_add` (audit T0-4)

The backup collectors default to `ssh_host_key_checking='auto_add'` — trust any device host key on first connect, no persistence — so a man-in-the-middle on the management path can capture SSH/enable credentials. The audit called this its **single most repeatable miss**.

### Why warn instead of flipping the default to `tofu`
A blanket flip is unsafe as a default. The two collector paths handle `tofu` asymmetrically:
- **Paramiko shell path** — real TOFU: first connect learns + persists the key to `{data_dir}/known_hosts`, a later changed key is rejected. First-run **succeeds**.
- **Netmiko path** (Cisco/Arista/Juniper/… — the majority) — Netmiko has no TOFU-persist API, so `tofu` maps to **strict checking against the operator's OS `~/.ssh/known_hosts`**. A first-time backup of an unknown device **fails**.

So defaulting to `tofu` would break zero-config first-run backups for most vendors. A true tofu-default needs Netmiko TOFU-persistence (a separate, larger effort).

### What this does
Add `host_key_warning_reason(settings)` (mirrors `bind_refusal_reason`) and log it once from the lifespan: a clear, actionable WARNING naming `NETCANON_SSH_HOST_KEY_CHECKING='tofu'` and the Netmiko pre-seed caveat. The insecure default is now a conscious, surfaced choice rather than a silent one — without breaking backups. + unit tests (`auto_add` → message; `tofu`/`reject` → `None`); the integration suite exercises the lifespan wiring.

Part of the Bucket C run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
