### PR TITLE
fix(honesty): VXLAN BUM-replication silent-loss (Bucket-C stage 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,19 @@ No cross-mesh behaviour change; the `CODEC_BUG` baseline stays at 5.
   dialog onto the GUI thread via
   `QMetaObject.invokeMethod(QueuedConnection)`, matching the pattern
   `window.py` already uses for show/hide/quit.  (`#159`, commit 2331b9c)
+* **VXLAN BUM-replication detail no longer ships a green banner when
+  dropped** (silent-loss class, Bucket-C stage 1).  `arista_eos`,
+  `aruba_aoscx`, and `juniper_junos` render the VLAN<->VNI binding
+  (`/vxlan-vnis/vni`, declared supported) but not the BUM-replication
+  underlay, so a VNI's multicast group (`/vxlan-vnis/mcast-group`) and
+  ingress-replication flood list (`/vxlan-vnis/flood-list`) dropped on
+  render while `validate_against` -- exact-string `classify` defaulting
+  the undeclared sub-leaves to "supported" -- reported `severity: ok`
+  (verified live: cisco_nxos -> arista_eos).  Both sub-leaves are now
+  declared `lossy` on those three codecs, so the migrate banner warns;
+  a new registry guard (`test_silent_loss_list_subfields`) enforces the
+  base-identity-coverage rule with single-mode targeted intents.  Matrix
+  declarations only -- no render change, `CODEC_BUG` stays 5.  (`#165`)
 
 ### Added
 

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -187,6 +187,37 @@ class AristaEOSCodec(CodecBase):
                 ),
                 severity="warn",
             ),
+            # -- VXLAN BUM-replication underlay (silent-loss guard) --
+            # Render emits the ``interface Vxlan1`` VLAN<->VNI bindings
+            # (+ source-interface + udp-port) but not the flood/multicast
+            # underlay, so those sub-details drop while the VNI binding
+            # (declared supported above) survives — declared here so the
+            # validation report warns instead of reporting ``severity: ok``.
+            LossyPath(
+                path="/vxlan-vnis/mcast-group",
+                reason=(
+                    "Render emits the per-VNI VLAN<->VNI bindings "
+                    "(``vxlan vlan <V> vni <N>``) + source-interface + "
+                    "udp-port, but not the multicast underlay "
+                    "(``vxlan vlan <V> multicast-group <ip>``): the BUM "
+                    "multicast group drops on render while the VLAN<->VNI "
+                    "binding survives.  Cross-vendor sources carrying a "
+                    "multicast underlay surface a review banner so the "
+                    "operator can re-apply flood/multicast on the target."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vxlan-vnis/flood-list",
+                reason=(
+                    "Companion to /vxlan-vnis/mcast-group: the ingress-"
+                    "replication (head-end) flood list "
+                    "(``vxlan flood vtep <ip> …``) is not emitted, so a "
+                    "source using static VTEP flood-lists loses them on "
+                    "render while the VLAN<->VNI binding survives."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/interfaces/interface/config/type",
                 reason=(

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -256,6 +256,34 @@ class ArubaAOSCXCodec(CodecBase):
                 ),
                 severity="warn",
             ),
+            # -- VXLAN BUM-replication underlay (silent-loss guard) --
+            # Render emits the ``interface vxlan 1`` VTEP (source ip +
+            # per-VNI ``vni``/``vlan`` bindings) but not the flood/multicast
+            # underlay, so those sub-details drop while the VNI binding
+            # (declared supported above) survives — declared here so the
+            # validation report warns instead of reporting ``severity: ok``.
+            LossyPath(
+                path="/vxlan-vnis/mcast-group",
+                reason=(
+                    "Render emits the VTEP `source ip` + per-VNI "
+                    "`vni <N>` / nested `vlan <V>` bindings, but not the "
+                    "BUM-replication underlay: a per-VNI multicast group "
+                    "drops on render while the VLAN↔VNI binding survives.  "
+                    "The operator re-applies the multicast/flood underlay "
+                    "on the target."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vxlan-vnis/flood-list",
+                reason=(
+                    "Companion to /vxlan-vnis/mcast-group: head-end / "
+                    "ingress-replication VTEP flood-lists are not emitted, "
+                    "so a source carrying static flood VTEPs loses them on "
+                    "render while the VLAN↔VNI binding survives."
+                ),
+                severity="warn",
+            ),
         ],
         unsupported=[
             # ── Tier-1/2 surfaces this codec drops on render — declared so the

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -174,6 +174,36 @@ class JunosCodec(CodecBase):
                 ),
                 severity="warn",
             ),
+            # -- VXLAN BUM-replication underlay (silent-loss guard) --
+            # Render emits ``set vlans <V> vxlan vni <N>`` + switch-options
+            # vtep-source-interface / vxlan-port, but not the flood/multicast
+            # underlay, so those sub-details drop while the VNI binding
+            # (declared supported above) survives — declared here so the
+            # validation report warns instead of reporting ``severity: ok``.
+            LossyPath(
+                path="/vxlan-vnis/mcast-group",
+                reason=(
+                    "Render emits the VLAN<->VNI bindings "
+                    "(``set vlans <V> vxlan vni <N>``) + switch-options "
+                    "vtep-source-interface / vxlan-port, but not the "
+                    "multicast underlay: the per-VNI multicast group drops "
+                    "on render while the VLAN<->VNI binding survives.  A "
+                    "cross-vendor source carrying a multicast underlay "
+                    "surfaces a review banner so the operator can re-apply "
+                    "EVPN multicast-mode on the target."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vxlan-vnis/flood-list",
+                reason=(
+                    "Companion to /vxlan-vnis/mcast-group: ingress-"
+                    "replication / head-end flood VTEP lists are not "
+                    "emitted, so a source carrying static flood VTEPs loses "
+                    "them on render while the VLAN<->VNI binding survives."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/interfaces/interface/subinterfaces/subinterface",
                 reason=(

--- a/tests/unit/migration/test_silent_loss_list_subfields.py
+++ b/tests/unit/migration/test_silent_loss_list_subfields.py
@@ -1,0 +1,257 @@
+"""Silent-loss guard for list sub-detail VALUE fields (Bucket-C).
+
+``CapabilityMatrix.classify`` defaults any walker-yielded xpath not
+explicitly declared lossy/unsupported to ``"supported"`` (see
+``netcanon/models/migration.py``).  For a list's identity leaf that is
+fine — the registry honesty guards in
+``test_registry_capability_honesty`` already cover whole-field +
+naming-independent drops.  The residual silent-loss gap this guard
+closes is a VALUE *sub-detail* of a list entry that a codec drops on
+render while still rendering — and declaring ``supported`` — the list's
+*identity* leaf.
+
+Concrete case verified live (cisco_nxos → arista_eos): a VXLAN VNI's
+BUM-replication multicast-group + ingress-replication flood-list drop on
+render, but the VLAN↔VNI binding (``/vxlan-vnis/vni``) survives and is
+declared supported.  Because ``classify`` is exact-string match, the
+dropped sub-details default to ``supported`` → ``validate_against``
+reports ``severity: ok`` and the migrate banner is green while the
+overlay reachability config silently vanishes.
+
+**Base-identity-coverage rule.**  A codec must declare a sub-detail leaf
+lossy/unsupported only when it KEEPS (renders, and does not loss-declare)
+the list's identity leaf yet DROPS the sub-detail.  A codec that already
+loss-declares the identity leaf surfaces the whole-surface loss there, so
+the sub-detail defaulting to ``supported`` is harmless noise — exempt.
+Likewise, a codec whose render does not keep the identity leaf at all has
+a *whole-surface* drop (a different guard's concern), not a sub-detail
+silent loss.
+
+**Why targeted intents.**  The universal kitchen-sink in
+``test_registry_capability_honesty`` deliberately sets mutually-exclusive
+fields together (trunk + access VLAN, dhcp-client + static IP,
+multicast-group + flood-list) to maximise walker coverage — which
+manufactures *false* sub-detail drops (whichever mode the codec doesn't
+pick "drops").  Each case here uses a single-mode, non-contradictory
+intent so a drop is unambiguous.
+
+Stage 2+ extends ``_CASES`` with more clean naming-independent value
+sub-details (e.g. ``/snmp/v3-user/engine-id``, anycast
+``virtual-gateway-mac``) — each with its own targeted intent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalInterface,
+    CanonicalIPv4Address,
+    CanonicalVlan,
+    CanonicalVxlan,
+)
+
+# Explicit imports so every codec is registered when this module runs
+# standalone (mirrors run_full_mesh.py / test_registry_capability_honesty).
+from netcanon.migration.codecs import (  # noqa: F401
+    arista_eos,
+    aruba_aoscx,
+    aruba_aoss,
+    cisco_iosxe,
+    cisco_iosxe_cli,
+    cisco_iosxr,
+    cisco_nxos,
+    fortigate_cli,
+    juniper_junos,
+    mikrotik_routeros,
+    opnsense,
+    vyos,
+)
+from netcanon.migration.codecs.registry import get_codec, list_codecs
+
+pytestmark = pytest.mark.unit
+
+
+def _bidirectional_codec_names() -> list[str]:
+    names = []
+    for name in sorted(list_codecs()):
+        if name == "mock":
+            continue
+        codec = get_codec(name)
+        if getattr(codec, "direction", "bidirectional") == "bidirectional":
+            names.append(name)
+    return names
+
+
+_CODEC_NAMES = _bidirectional_codec_names()
+
+
+# ---------------------------------------------------------------------------
+# Targeted single-mode intents — one BUM-replication mode each so a drop is
+# unambiguous (a VNI uses multicast OR ingress-replication, never both).
+# ---------------------------------------------------------------------------
+
+
+def _vxlan_intent(vx: CanonicalVxlan) -> CanonicalIntent:
+    return CanonicalIntent(
+        hostname="leaf1",
+        interfaces=[
+            CanonicalInterface(
+                name="Ethernet1",
+                default_name="Ethernet1",
+                ipv4_addresses=[CanonicalIPv4Address(ip="10.0.0.1", prefix_length=24)],
+            )
+        ],
+        vlans=[CanonicalVlan(id=10, name="V10")],
+        vxlan_vnis=[vx],
+    )
+
+
+def _mcast_intent() -> CanonicalIntent:
+    return _vxlan_intent(
+        CanonicalVxlan(
+            vlan_id=10, vni=10010, mcast_group="239.1.1.1",
+            source_interface="Loopback0", udp_port=4789,
+        )
+    )
+
+
+def _flood_intent() -> CanonicalIntent:
+    return _vxlan_intent(
+        CanonicalVxlan(
+            vlan_id=10, vni=10010, flood_list=["10.0.0.5", "10.0.0.6"],
+            source_interface="Loopback0", udp_port=4789,
+        )
+    )
+
+
+def _vni_kept(reparsed: CanonicalIntent) -> bool:
+    return bool(reparsed.vxlan_vnis)
+
+
+def _mcast_survived(reparsed: CanonicalIntent) -> bool:
+    return any(v.mcast_group == "239.1.1.1" for v in reparsed.vxlan_vnis)
+
+
+def _flood_survived(reparsed: CanonicalIntent) -> bool:
+    return any(
+        sorted(v.flood_list) == ["10.0.0.5", "10.0.0.6"]
+        for v in reparsed.vxlan_vnis
+    )
+
+
+class _Case:
+    """One (leaf, identity, targeted-intent) silent-loss probe."""
+
+    def __init__(
+        self,
+        *,
+        case_id: str,
+        leaf: str,
+        identity: str,
+        intent: Callable[[], CanonicalIntent],
+        identity_kept: Callable[[CanonicalIntent], bool],
+        subdetail_survived: Callable[[CanonicalIntent], bool],
+    ) -> None:
+        self.id = case_id
+        self.leaf = leaf
+        self.identity = identity
+        self.intent = intent
+        self.identity_kept = identity_kept
+        self.subdetail_survived = subdetail_survived
+
+
+_CASES = [
+    _Case(
+        case_id="vxlan-mcast-group",
+        leaf="/vxlan-vnis/mcast-group",
+        identity="/vxlan-vnis/vni",
+        intent=_mcast_intent,
+        identity_kept=_vni_kept,
+        subdetail_survived=_mcast_survived,
+    ),
+    _Case(
+        case_id="vxlan-flood-list",
+        leaf="/vxlan-vnis/flood-list",
+        identity="/vxlan-vnis/vni",
+        intent=_flood_intent,
+        identity_kept=_vni_kept,
+        subdetail_survived=_flood_survived,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_non_empty():
+    """Sanity: the bidirectional registry resolved to the expected fleet."""
+    assert len(_CODEC_NAMES) >= 11, _CODEC_NAMES
+
+
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.id)
+@pytest.mark.parametrize("name", _CODEC_NAMES)
+def test_dropped_list_subdetail_is_declared(name: str, case: _Case):
+    """A list sub-detail VALUE the codec drops on render — while keeping the
+    list's identity leaf supported — must be declared lossy/unsupported,
+    else live validation reports ``severity: ok`` while the data is
+    discarded (silent-loss class; base-identity-coverage rule)."""
+    codec = get_codec(name)
+    caps = codec.capabilities
+    loss_declared = (
+        {lp.path for lp in caps.lossy} | {u.path for u in caps.unsupported}
+    )
+
+    # Exempt: whole-surface loss already surfaced via the identity leaf.
+    if case.identity in loss_declared:
+        return
+
+    reparsed = codec.parse(codec.render(case.intent()))
+
+    # Exempt: render did not keep the identity leaf → whole-surface drop,
+    # which is a different guard's concern (not a sub-detail silent loss).
+    if not case.identity_kept(reparsed):
+        return
+
+    # Sub-detail round-trips → no loss.
+    if case.subdetail_survived(reparsed):
+        return
+
+    # Identity kept but sub-detail dropped: MUST be declared.
+    assert case.leaf in loss_declared, (
+        f"{name}: render keeps the {case.identity} identity leaf but DROPS "
+        f"the {case.leaf} sub-detail, and the matrix declares it neither "
+        f"lossy nor unsupported — so validate_against reports 'supported' "
+        f"(severity ok) while the value is silently discarded.  Add a "
+        f"LossyPath/UnsupportedPath for {case.leaf} (exact walker spelling)."
+    )
+
+
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.id)
+def test_some_codec_demonstrates_each_case(case: _Case):
+    """Guard the guard: for every probe at least one codec must actually
+    keep the identity leaf yet drop the sub-detail, else the case is
+    vacuous (its intent never triggers the assertion path anywhere)."""
+    triggered = False
+    for name in _CODEC_NAMES:
+        codec = get_codec(name)
+        caps = codec.capabilities
+        loss_declared = (
+            {lp.path for lp in caps.lossy} | {u.path for u in caps.unsupported}
+        )
+        if case.identity in loss_declared:
+            continue
+        reparsed = codec.parse(codec.render(case.intent()))
+        if case.identity_kept(reparsed) and not case.subdetail_survived(reparsed):
+            triggered = True
+            break
+    assert triggered, (
+        f"case {case.id!r} never finds a codec that keeps {case.identity} "
+        f"while dropping {case.leaf} — the probe is vacuous; revisit the "
+        f"targeted intent."
+    )


### PR DESCRIPTION
## Silent-loss class (Bucket-C) — Stage 1: VXLAN BUM-replication detail

The 4th blind audit's meta-finding was that `CapabilityMatrix.classify`
defaults any walker-yielded xpath not explicitly declared lossy/unsupported
to `"supported"` (exact-string match), so a codec can silently drop a
surface and still report a green `severity: ok` banner. The global
default-flip was judged too risky (#135), so this is a **staged, verify-first**
close-out of the residual class — no runtime change to `classify`.

### Verified finding (reproduced live)

`cisco_nxos → arista_eos` carrying a VXLAN VNI with `mcast_group="239.1.1.1"`
+ `flood_list`:

```
validate_against → severity: ok, compatible: True
  /vxlan-vnis/mcast-group in supported_paths   (defaulted)
round-trip → mcast_group='', flood_list=[]      (silently dropped)
```

Three codecs **render the VLAN↔VNI binding** (`/vxlan-vnis/vni`, declared
supported) **but drop the BUM-replication underlay** — the per-VNI
multicast group and the ingress-replication / head-end flood-VTEP list:
**arista_eos, aruba_aoscx, juniper_junos**. (The other 7 bidirectional
codecs loss-declare `/vxlan-vnis/vni` itself, so the whole-surface loss is
already surfaced there — exempt; `cisco_nxos` + `vyos` support both BUM
modes losslessly.)

### Change

* Declare `/vxlan-vnis/mcast-group` + `/vxlan-vnis/flood-list` **`lossy`
  (warn)** on the three offending codecs, with accurate per-vendor reasons.
  Matrix declarations only — **no render change**, `CODEC_BUG` stays 5.
* New guard `tests/unit/migration/test_silent_loss_list_subfields.py`
  enforcing the **base-identity-coverage rule**: a list sub-detail must be
  declared lossy/unsupported when the codec keeps (and supports) the list's
  identity leaf but drops the detail. It uses **single-mode targeted
  intents** because the universal kitchen-sink in
  `test_registry_capability_honesty` sets `mcast-group` + `flood-list` on
  one VNI (contradictory — a VNI uses multicast *or* ingress-replication,
  never both), which manufactures false drops. The guard found
  `juniper_junos` on first run — a real offender I'd missed by eye.
* `_CASES` is the explicit extension point for Stage 2+ (e.g.
  `/snmp/v3-user/engine-id`, anycast `virtual-gateway-mac`), each with its
  own targeted intent.

### Why this scope

The raw "defaulted-supported-but-dropped" census over all 12 codecs is
noisy with three methodology artifacts (cross-vendor port-naming;
ancestor/identity coverage; mutually-exclusive kitchen-sink fields). After
filtering, the VXLAN BUM detail is the cleanest verified cluster with zero
naming sensitivity and zero representation ambiguity — the right first
stage. Follow-on clusters are deferred to keep each PR verifiable.

### Tests

`tests/unit/migration` green locally (full dir), incl. the new guard, the
registry honesty suite, ENG-01, and the arista/aoscx/junos codec suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
