### PR TITLE
fix(honesty): vlan/description + SNMPv3 engineID silent-loss (Bucket-C stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ No cross-mesh behaviour change; the `CODEC_BUG` baseline stays at 5.
   a new registry guard (`test_silent_loss_list_subfields`) enforces the
   base-identity-coverage rule with single-mode targeted intents.  Matrix
   declarations only -- no render change, `CODEC_BUG` stays 5.  (`#165`)
+* **More silent-loss sub-detail drops now warn** (silent-loss class,
+  Bucket-C stage 2).  Extends #165's guard with two more clean
+  naming-independent value sub-details: a VLAN's `description` (distinct
+  from its name) on `arista_eos` / `aruba_aoss` / `cisco_iosxe_cli` /
+  `cisco_nxos` / `fortigate_cli` / `juniper_junos` / `opnsense`, and an
+  SNMPv3 USM user's `engine-id` on `arista_eos` / `aruba_aoscx` /
+  `aruba_aoss` / `cisco_iosxe_cli` / `fortigate_cli` / `juniper_junos` /
+  `mikrotik_routeros` -- each rendered the identity leaf (VLAN id / v3
+  user) but silently dropped the sub-detail.  Both are now declared
+  `lossy`.  Matrix declarations only -- no render change, `CODEC_BUG`
+  stays 5.  (`#166`)
 
 ### Added
 

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -141,6 +141,26 @@ class AristaEOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "Render emits the VLAN name but not a separate "
+                    "description line, so the canonical VLAN description "
+                    "(distinct from the name) drops on render (silent-loss "
+                    "guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/engine-id",
+                reason=(
+                    "The SNMPv3 USM user round-trips but a per-user "
+                    "engineID is not emitted on render (engineIDs are "
+                    "device-assigned / global), so the canonical engine_id "
+                    "drops (silent-loss guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -177,6 +177,16 @@ class ArubaAOSCXCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/snmp/v3-user/engine-id",
+                reason=(
+                    "The SNMPv3 USM user round-trips but a per-user "
+                    "engineID is not emitted on render (engineIDs are "
+                    "device-assigned / global), so the canonical engine_id "
+                    "drops (silent-loss guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/description",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -152,6 +152,26 @@ class ArubaAOSSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "Render emits the VLAN name but not a separate "
+                    "description line, so the canonical VLAN description "
+                    "(distinct from the name) drops on render (silent-loss "
+                    "guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/engine-id",
+                reason=(
+                    "The SNMPv3 USM user round-trips but a per-user "
+                    "engineID is not emitted on render (engineIDs are "
+                    "device-assigned / global), so the canonical engine_id "
+                    "drops (silent-loss guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -150,6 +150,26 @@ class CiscoIOSXECLICodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "Render emits the VLAN name but not a separate "
+                    "description line, so the canonical VLAN description "
+                    "(distinct from the name) drops on render (silent-loss "
+                    "guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/engine-id",
+                reason=(
+                    "The SNMPv3 USM user round-trips but a per-user "
+                    "engineID is not emitted on render (engineIDs are "
+                    "device-assigned / global), so the canonical engine_id "
+                    "drops (silent-loss guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/description",
                 reason=(
                     "Parse/render round-trip a single-token ``ip route ... "

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -181,6 +181,16 @@ class CiscoNXOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "Render emits the VLAN name but not a separate "
+                    "description line, so the canonical VLAN description "
+                    "(distinct from the name) drops on render (silent-loss "
+                    "guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/description",
                 reason=(
                     "Render emits destination + next-hop + metric only; the "

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -166,6 +166,26 @@ class FortiGateCLICodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "Render emits the VLAN name but not a separate "
+                    "description line, so the canonical VLAN description "
+                    "(distinct from the name) drops on render (silent-loss "
+                    "guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/engine-id",
+                reason=(
+                    "The SNMPv3 USM user round-trips but a per-user "
+                    "engineID is not emitted on render (engineIDs are "
+                    "device-assigned / global), so the canonical engine_id "
+                    "drops (silent-loss guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop + device only; the "

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -159,6 +159,26 @@ class JunosCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "Render emits the VLAN name but not a separate "
+                    "description line, so the canonical VLAN description "
+                    "(distinct from the name) drops on render (silent-loss "
+                    "guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/engine-id",
+                reason=(
+                    "The SNMPv3 USM user round-trips but a per-user "
+                    "engineID is not emitted on render (engineIDs are "
+                    "device-assigned / global), so the canonical engine_id "
+                    "drops (silent-loss guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -161,6 +161,16 @@ class MikroTikRouterOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/snmp/v3-user/engine-id",
+                reason=(
+                    "The SNMPv3 USM user round-trips but a per-user "
+                    "engineID is not emitted on render (engineIDs are "
+                    "device-assigned / global), so the canonical engine_id "
+                    "drops (silent-loss guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + gateway + comment only; the "

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -167,6 +167,16 @@ class OPNsenseCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/description",
+                reason=(
+                    "Render emits the VLAN name but not a separate "
+                    "description line, so the canonical VLAN description "
+                    "(distinct from the name) drops on render (silent-loss "
+                    "guard, Bucket-C stage 2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/tests/unit/migration/test_silent_loss_list_subfields.py
+++ b/tests/unit/migration/test_silent_loss_list_subfields.py
@@ -50,6 +50,8 @@ from netcanon.migration.canonical.intent import (
     CanonicalIntent,
     CanonicalInterface,
     CanonicalIPv4Address,
+    CanonicalSNMP,
+    CanonicalSNMPv3User,
     CanonicalVlan,
     CanonicalVxlan,
 )
@@ -143,6 +145,56 @@ def _flood_survived(reparsed: CanonicalIntent) -> bool:
     )
 
 
+def _vlan_desc_intent() -> CanonicalIntent:
+    """A VLAN carrying a description distinct from its name, plus an access
+    port so codecs that only render referenced VLANs still emit it."""
+    return CanonicalIntent(
+        hostname="sw",
+        interfaces=[
+            CanonicalInterface(
+                name="Ethernet1", default_name="Ethernet1",
+                switchport_mode="access", access_vlan=10,
+            )
+        ],
+        vlans=[CanonicalVlan(id=10, name="ENG", description="Engineering-VLAN")],
+    )
+
+
+def _vlan_kept(reparsed: CanonicalIntent) -> bool:
+    return any(v.id == 10 for v in reparsed.vlans)
+
+
+def _vlan_desc_survived(reparsed: CanonicalIntent) -> bool:
+    return any(v.description == "Engineering-VLAN" for v in reparsed.vlans)
+
+
+def _v3_engineid_intent() -> CanonicalIntent:
+    """A single SNMPv3 USM user carrying an explicit engineID."""
+    return CanonicalIntent(
+        hostname="r",
+        interfaces=[CanonicalInterface(name="Ethernet1", default_name="Ethernet1")],
+        snmp=CanonicalSNMP(
+            v3_users=[
+                CanonicalSNMPv3User(
+                    name="u1", group="g1",
+                    auth_protocol="sha", auth_passphrase="authpass12345",
+                    priv_protocol="aes", priv_passphrase="privpass12345",
+                    engine_id="80000009ff",
+                )
+            ]
+        ),
+    )
+
+
+def _v3_user_kept(reparsed: CanonicalIntent) -> bool:
+    return bool(reparsed.snmp and reparsed.snmp.v3_users)
+
+
+def _v3_engineid_survived(reparsed: CanonicalIntent) -> bool:
+    users = reparsed.snmp.v3_users if reparsed.snmp else []
+    return any(u.engine_id == "80000009ff" for u in users)
+
+
 class _Case:
     """One (leaf, identity, targeted-intent) silent-loss probe."""
 
@@ -180,6 +232,23 @@ _CASES = [
         intent=_flood_intent,
         identity_kept=_vni_kept,
         subdetail_survived=_flood_survived,
+    ),
+    # -- Stage 2: clean naming-independent value sub-details --
+    _Case(
+        case_id="vlan-description",
+        leaf="/vlans/vlan/description",
+        identity="/vlans/vlan/id",
+        intent=_vlan_desc_intent,
+        identity_kept=_vlan_kept,
+        subdetail_survived=_vlan_desc_survived,
+    ),
+    _Case(
+        case_id="snmp-v3-engine-id",
+        leaf="/snmp/v3-user/engine-id",
+        identity="/snmp/v3-user",
+        intent=_v3_engineid_intent,
+        identity_kept=_v3_user_kept,
+        subdetail_survived=_v3_engineid_survived,
     ),
 ]
 


### PR DESCRIPTION
## Silent-loss class (Bucket-C) — Stage 2: vlan/description + SNMPv3 engineID

Builds on Stage 1 (#165). Same verify-first method: a targeted single-mode
intent per surface + the **base-identity-coverage rule** (declare a list
sub-detail lossy only when the codec keeps + supports the list's identity
leaf but drops the detail). The guard `test_silent_loss_list_subfields`
gains two `_CASES` entries; the declarations below are exactly what it
flags.

### Surfaces closed

* **`/vlans/vlan/description`** → `lossy` on **arista_eos, aruba_aoss,
  cisco_iosxe_cli, cisco_nxos, fortigate_cli, juniper_junos, opnsense**.
  Render emits the VLAN name but not a separate description line; the VLAN
  id survives, so it's `warn`, not a block. (`aruba_aoscx` round-trips it;
  `mikrotik` already declared it; `cisco_iosxe`/`vyos` loss-declare the
  VLAN identity; `cisco_iosxr` models VLANs as sub-interface encap — all
  exempt.)
* **`/snmp/v3-user/engine-id`** → `lossy` on **arista_eos, aruba_aoscx,
  aruba_aoss, cisco_iosxe_cli, fortigate_cli, juniper_junos,
  mikrotik_routeros**. The v3 USM user round-trips but a per-user engineID
  is not emitted on render. (`cisco_nxos`/`vyos` round-trip it;
  `cisco_iosxe`/`opnsense` loss-declare `/snmp/v3-user`; `cisco_iosxr`
  drops the whole v3 surface — all exempt.)

### Verification

The new guard cases **failed on exactly the 14 codec/leaf combos** above
before the declarations (TDD checkpoint), and pass after. Matrix
declarations only — **no render change**, `CODEC_BUG` stays 5. Full
`tests/unit` + `tests/integration` suites green locally.

### Scope

`virtual-gateway-mac` and `tunnel-type` are real silent losses too but
carry per-codec representation nuance (SVI naming, NX-OS global-vs-per-
address anycast MAC, tunnel-interface modeling) that needs the same
careful per-codec design the original anycast work used — deferred to
Stage 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
