### PR TITLE
fix(honesty): anycast VARP + tunnel-type silent-loss (Bucket-C stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,18 @@ No cross-mesh behaviour change; the `CODEC_BUG` baseline stays at 5.
   user) but silently dropped the sub-detail.  Both are now declared
   `lossy`.  Matrix declarations only -- no render change, `CODEC_BUG`
   stays 5.  (`#166`)
+* **Anycast VARP + tunnel-type sub-detail drops now surface** (silent-
+  loss class, Bucket-C stage 3).  The nuanced final stage, verified per-
+  codec by an adversarial agent workflow.  Adds 5 guard cases + 12
+  declarations: the anycast `virtual-gateway-address` (separate VARP VIP)
+  is `unsupported` on `cisco_iosxr` / `vyos` (no anycast grammar) and
+  **demoted supported -> lossy** on `cisco_iosxe_cli` / `cisco_nxos`
+  (their DAG / SD-Access render round-trips only the primary-IP-as-
+  gateway shape; a separate cross-vendor VIP drops); `virtual-gateway-
+  mac` is `lossy` on `aruba_aoscx`; and `tunnel-type` is `lossy` on
+  `cisco_iosxe` / `cisco_iosxr` / `cisco_nxos` / `vyos` / `aruba_aoscx`
+  (interface survives, encapsulation discriminator dropped).  Matrix
+  declarations only -- no render change, `CODEC_BUG` stays 5.  (`#167`)
 
 ### Added
 

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -177,6 +177,30 @@ class ArubaAOSCXCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "Render emits the per-address active-gateway VIP "
+                    "(`active-gateway ip <vip>`) and hoists the anycast MAC "
+                    "to the switch-wide `active-gateway ip mac <mac>` "
+                    "(canonical anycast_gateway_mac), but the per-address "
+                    "virtual_gateway_mac is not emitted, so per-address MAC "
+                    "granularity drops while the VIP + switch-wide MAC "
+                    "survive (silent-loss guard, Bucket-C stage 3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/tunnel-type",
+                reason=(
+                    "AOS-CX Phase 1 does not model generic GRE/IPsec tunnel "
+                    "interfaces; a `Tunnel<N>` interface renders as a "
+                    "generic interface with no tunnel encapsulation, so the "
+                    "canonical tunnel_type drops while the interface name "
+                    "survives (silent-loss guard, Bucket-C stage 3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/snmp/v3-user/engine-id",
                 reason=(
                     "The SNMPv3 USM user round-trips but a per-user "

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -233,6 +233,18 @@ class CiscoIOSXECodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/tunnel-type",
+                reason=(
+                    "The OpenConfig/NETCONF render emits only "
+                    "name/enabled/type/description + IP addresses and models "
+                    "no tunnel-encapsulation augment, so a canonical "
+                    "tunnel_type drops on render while the interface "
+                    "identity survives (silent-loss guard, Bucket-C "
+                    "stage 3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/config/mtu",
                 reason=(
                     "IOS-XE OC model tracks MTU but some platform-specific "

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -135,13 +135,10 @@ class CiscoIOSXECLICodec(CodecBase):
             # stanzas; renders the classic single-line per-attribute
             # form (broadest IOS-XE compatibility, 15.x onward).
             "/interfaces/interface/vrrp-groups/group",
-            # Wave C (v0.2.0) — SD-Access anycast-gateway.  Per-SVI
-            # ``fabric forwarding mode anycast-gateway`` mirrors the
-            # primary IP into ``virtual_gateway_address`` and round-
-            # trips back out on render.  IPv6 form intentionally
-            # unsupported (no fixture coverage today; see UnsupportedPath
-            # below).
-            "/interfaces/interface/ipv4/address/virtual-gateway-address",
+            # NB: ``/interfaces/interface/ipv4/address/virtual-gateway-address``
+            # is declared LOSSY below — SD-Access anycast only round-trips the
+            # primary-IP-as-gateway shape (vga == ip); a separate cross-vendor
+            # VARP VIP (vga != ip) drops on render.
             # Wave C (v0.2.0) — top-level ``fabric forwarding
             # anycast-gateway-mac <MAC>`` declares the chassis-wide
             # anycast MAC.  Round-trips between Cisco dotted-triplet
@@ -149,6 +146,22 @@ class CiscoIOSXECLICodec(CodecBase):
             "/anycast-gateway-mac",
         ],
         lossy=[
+            LossyPath(
+                path="/interfaces/interface/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "SD-Access anycast (virtual_gateway_address == the "
+                    "interface's primary IP) round-trips via `fabric "
+                    "forwarding mode anycast-gateway`, but a SEPARATE "
+                    "cross-vendor VARP virtual IP (virtual_gateway_address "
+                    "!= the interface IP, the Arista/Junos shape) has no "
+                    "IOS-XE equivalent and drops on render (emitted as a "
+                    "review comment only).  Demoted from supported to lossy "
+                    "so the separate-VIP loss is surfaced instead of "
+                    "reported severity:ok (silent-loss guard, Bucket-C "
+                    "stage 3)."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/vlans/vlan/description",
                 reason=(

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -158,6 +158,18 @@ class CiscoIOSXRCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/tunnel-type",
+                reason=(
+                    "Render emits no `tunnel mode <kind>` for tunnel "
+                    "interfaces (the parser infers ianaift:tunnel from the "
+                    "`tunnel-ip`/`tunnel-te` name prefix, but tunnel_type is "
+                    "never emitted), so a canonical tunnel_type drops on "
+                    "render while the interface name survives (silent-loss "
+                    "guard, Bucket-C stage 3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop only; the static-"
@@ -225,6 +237,25 @@ class CiscoIOSXRCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/interfaces/interface/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "IOS-XR has no VARP / anycast-gateway grammar; render "
+                    "emits only the standard `ipv4 address` line, so a "
+                    "canonical anycast virtual-gateway address is dropped "
+                    "entirely on render while the interface + primary "
+                    "address survive (silent-loss guard, Bucket-C stage 3)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/ipv6/address/virtual-gateway-address",
+                reason=(
+                    "Mirror of the IPv4 case — no IOS-XR IPv6 anycast-"
+                    "gateway grammar; the canonical anycast virtual-gateway "
+                    "address drops on render (silent-loss guard, Bucket-C "
+                    "stage 3)."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01) — this codec has no
             #    Cisco-style access/trunk port model, so the per-port VLAN
             #    membership the walker yields is dropped on render.  Declared

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -172,14 +172,41 @@ class CiscoNXOSCodec(CodecBase):
             "/vxlan-vnis/mcast-group",
             "/vxlan-vnis/flood-list",
             "/routing-instances/instance/l3-vni",
-            # Distributed Anycast Gateway (T2) — per-SVI `fabric forwarding
-            # mode anycast-gateway` mirrors the primary IP into
-            # virtual_gateway_address; `fabric forwarding anycast-gateway-mac`
-            # is the chassis-wide MAC (dotted-triplet ↔ canonical colon-hex).
-            "/interfaces/interface/ipv4/address/virtual-gateway-address",
+            # Distributed Anycast Gateway (T2) — `fabric forwarding
+            # anycast-gateway-mac` is the chassis-wide MAC (dotted-triplet ↔
+            # canonical colon-hex).  The per-SVI `fabric forwarding mode
+            # anycast-gateway` (virtual_gateway_address == primary IP) is
+            # declared LOSSY below — a separate cross-vendor VARP VIP drops.
             "/anycast-gateway-mac",
         ],
         lossy=[
+            LossyPath(
+                path="/interfaces/interface/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "Distributed Anycast Gateway (virtual_gateway_address "
+                    "== the interface's primary IP) round-trips via `fabric "
+                    "forwarding mode anycast-gateway`, but a SEPARATE "
+                    "cross-vendor VARP virtual IP (virtual_gateway_address "
+                    "!= the interface IP, the Arista/Junos shape) has no "
+                    "NX-OS equivalent and drops on render.  Demoted from "
+                    "supported to lossy so the separate-VIP loss is "
+                    "surfaced instead of reported severity:ok (silent-loss "
+                    "guard, Bucket-C stage 3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/tunnel-type",
+                reason=(
+                    "Render emits `interface Tunnel<N>` with no `tunnel "
+                    "mode <kind>` sub-command, so the canonical tunnel_type "
+                    "(gre/ipip/ipsec) drops on render while the interface "
+                    "name survives.  NX-OS supports the `tunnel mode` "
+                    "grammar; this is a render-coverage gap (silent-loss "
+                    "guard, Bucket-C stage 3)."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/vlans/vlan/description",
                 reason=(

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -168,6 +168,18 @@ class VyOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/tunnel-type",
+                reason=(
+                    "VyOS models tunnels (GRE/IPIP/IPsec) as separate "
+                    "`interfaces tunnel` / `vti` Tier-3 sections, not as an "
+                    "encapsulation property of the interface; render emits "
+                    "no tunnel-type discriminator, so a canonical "
+                    "tunnel_type drops while the interface name survives "
+                    "(silent-loss guard, Bucket-C stage 3)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/description",
                 reason=(
                     "Render emits destination + next-hop + distance only; "
@@ -279,6 +291,24 @@ class VyOSCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/interfaces/interface/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VyOS has no anycast-gateway / VARP grammar; render "
+                    "emits only the `address <ip>/<plen>` line, so a "
+                    "canonical anycast virtual-gateway address drops "
+                    "entirely while the interface + primary address survive "
+                    "(silent-loss guard, Bucket-C stage 3)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/ipv6/address/virtual-gateway-address",
+                reason=(
+                    "Mirror of the IPv4 case — no VyOS IPv6 anycast-gateway "
+                    "grammar; the canonical anycast virtual-gateway address "
+                    "drops on render (silent-loss guard, Bucket-C stage 3)."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01) — this codec has no
             #    Cisco-style access/trunk port model, so the per-port VLAN
             #    membership the walker yields is dropped on render.  Declared

--- a/tests/unit/audit/test_run_phase4_reconciliation.py
+++ b/tests/unit/audit/test_run_phase4_reconciliation.py
@@ -1109,17 +1109,22 @@ def test_real_ip_drift_to_unsupported_target_stays_codec_bug() -> None:
     assert fv["severity"] == "high"
 
 
-def test_anycast_only_drift_to_supporting_target_stays_codec_bug() -> None:
-    """When the target SUPPORTS anycast (cisco_iosxe_cli renders SD-Access),
-    an anycast drift is a genuine bug, not expected — stays CODEC_BUG."""
+def test_anycast_companion_drift_to_lossy_target_is_expected_lossy() -> None:
+    """cisco_iosxe_cli renders SD-Access anycast only for the primary-IP-as-
+    gateway shape (virtual_gateway_address == ip); a SEPARATE cross-vendor
+    VARP VIP (vga != ip, as here) has no IOS-XE equivalent and drops on
+    render, so the matrix declares the IPv4 virtual-gateway-address LOSSY
+    (Bucket-C stage 3 — demoted from supported).  An anycast-companion-only
+    drift to it is therefore an EXPECTED_LOSSY drop, not a CODEC_BUG."""
     cell = _anycast_cell(
         "cisco_iosxe_cli",
         source_addrs=[_addr(ip="10.0.0.1", vga="10.1.10.1")],
-        target_addrs=[_addr(ip="10.0.0.1")],  # dropped the (supported) anycast
+        target_addrs=[_addr(ip="10.0.0.1")],  # dropped the separate VARP VIP
     )
     result = reconcile_cell(cell, _EXPECT_IPV4)
     fv = result["field_variances"]["interfaces[].ipv4_addresses"]
-    assert fv["variance"] == recon.VAR_CODEC_BUG
+    assert fv["variance"] == recon.VAR_EXPECTED_LOSSY
+    assert fv["severity"] == "ok"
 
 
 def test_drift_is_anycast_companion_only_predicate() -> None:

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -1488,18 +1488,28 @@ class TestAnycastGateway:
         ) == 1
 
     def test_anycast_capability_matrix_lists_supported_paths(self):
-        """Capability matrix declares the three new SD-Access paths
-        supported (Wave C) — keeping the IPv6 form unsupported as
-        documented."""
+        """Capability matrix declares the SD-Access anycast paths (Wave C):
+        the chassis MAC supported, the IPv4 virtual-gateway-address LOSSY
+        (Bucket-C stage 3 demotion — only the primary-IP-as-gateway shape
+        round-trips; a separate cross-vendor VARP VIP drops), and the IPv6
+        form unsupported."""
         codec = CiscoIOSXECLICodec()
         caps = codec.capabilities
         supported = set(caps.supported)
+        lossy = {lp.path for lp in caps.lossy}
         unsupported = {u.path for u in caps.unsupported}
         # Wave B + C wire-up.
         assert "/interfaces/interface/vrrp-groups/group" in supported
+        # Demoted supported -> lossy (Bucket-C stage 3): SD-Access anycast
+        # round-trips only vga == primary-IP; a separate cross-vendor VARP
+        # VIP has no IOS-XE equivalent and drops on render.
         assert (
             "/interfaces/interface/ipv4/address/virtual-gateway-address"
-            in supported
+            in lossy
+        )
+        assert (
+            "/interfaces/interface/ipv4/address/virtual-gateway-address"
+            not in supported
         )
         assert "/anycast-gateway-mac" in supported
         # IPv6 anycast intentionally unsupported.

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -1136,9 +1136,12 @@ interface nve1
         assert caps.classify("/evpn-type5-routes/route") == "lossy"
         # IPv4 DAG anycast graduated; only the IPv6 companion is deferred.
         assert caps.classify("/anycast-gateway-mac") == "supported"
+        # Demoted supported -> lossy (Bucket-C stage 3): DAG round-trips only
+        # vga == primary-IP; a separate cross-vendor VARP VIP has no NX-OS
+        # equivalent and drops on render.
         assert caps.classify(
             "/interfaces/interface/ipv4/address/virtual-gateway-address"
-        ) == "supported"
+        ) == "lossy"
         assert caps.classify(
             "/interfaces/interface/ipv6/address/virtual-gateway-address"
         ) == "unsupported"

--- a/tests/unit/migration/test_silent_loss_list_subfields.py
+++ b/tests/unit/migration/test_silent_loss_list_subfields.py
@@ -50,6 +50,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalIntent,
     CanonicalInterface,
     CanonicalIPv4Address,
+    CanonicalIPv6Address,
     CanonicalSNMP,
     CanonicalSNMPv3User,
     CanonicalVlan,
@@ -195,6 +196,80 @@ def _v3_engineid_survived(reparsed: CanonicalIntent) -> bool:
     return any(u.engine_id == "80000009ff" for u in users)
 
 
+def _varp_intent() -> CanonicalIntent:
+    """An SVI carrying a SEPARATE anycast/VARP virtual IP + MAC (the
+    Arista/Junos shape where the virtual gateway address differs from the
+    interface's own address), on both IPv4 and IPv6."""
+    return CanonicalIntent(
+        hostname="sw",
+        vlans=[CanonicalVlan(id=10, name="V10")],
+        interfaces=[
+            CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                interface_type="ianaift:l3ipvlan",
+                ipv4_addresses=[CanonicalIPv4Address(
+                    ip="10.0.0.2", prefix_length=24,
+                    virtual_gateway_address="10.0.0.1",
+                    virtual_gateway_mac="00:00:5e:00:01:01")],
+                ipv6_addresses=[CanonicalIPv6Address(
+                    ip="2001:db8::2", prefix_length=64,
+                    virtual_gateway_address="2001:db8::1",
+                    virtual_gateway_mac="00:00:5e:00:02:01")],
+            )
+        ],
+    )
+
+
+def _v4_addrs(reparsed: CanonicalIntent):
+    return [a for i in reparsed.interfaces for a in i.ipv4_addresses]
+
+
+def _v6_addrs(reparsed: CanonicalIntent):
+    return [a for i in reparsed.interfaces for a in i.ipv6_addresses]
+
+
+def _v4_ip_kept(reparsed: CanonicalIntent) -> bool:
+    return any(a.ip == "10.0.0.2" for a in _v4_addrs(reparsed))
+
+
+def _v6_ip_kept(reparsed: CanonicalIntent) -> bool:
+    return any(a.ip == "2001:db8::2" for a in _v6_addrs(reparsed))
+
+
+def _v4_vga_survived(reparsed: CanonicalIntent) -> bool:
+    return any(a.virtual_gateway_address for a in _v4_addrs(reparsed))
+
+
+def _v6_vga_survived(reparsed: CanonicalIntent) -> bool:
+    return any(a.virtual_gateway_address for a in _v6_addrs(reparsed))
+
+
+def _v4_vgm_survived(reparsed: CanonicalIntent) -> bool:
+    return any(a.virtual_gateway_mac for a in _v4_addrs(reparsed))
+
+
+def _v6_vgm_survived(reparsed: CanonicalIntent) -> bool:
+    return any(a.virtual_gateway_mac for a in _v6_addrs(reparsed))
+
+
+def _tunnel_intent() -> CanonicalIntent:
+    """A GRE tunnel interface carrying a tunnel_type discriminator."""
+    return CanonicalIntent(
+        hostname="r",
+        interfaces=[CanonicalInterface(
+            name="Tunnel0", default_name="Tunnel0",
+            interface_type="ianaift:tunnel", tunnel_type="gre")],
+    )
+
+
+def _tunnel_iface_kept(reparsed: CanonicalIntent) -> bool:
+    return any(i.name == "Tunnel0" for i in reparsed.interfaces)
+
+
+def _tunnel_type_survived(reparsed: CanonicalIntent) -> bool:
+    return any(i.tunnel_type == "gre" for i in reparsed.interfaces)
+
+
 class _Case:
     """One (leaf, identity, targeted-intent) silent-loss probe."""
 
@@ -249,6 +324,48 @@ _CASES = [
         intent=_v3_engineid_intent,
         identity_kept=_v3_user_kept,
         subdetail_survived=_v3_engineid_survived,
+    ),
+    # -- Stage 3: anycast/VARP + tunnel value sub-details (per-codec
+    # representation nuance verified by an adversarial workflow) --
+    _Case(
+        case_id="varp-vga-v4",
+        leaf="/interfaces/interface/ipv4/address/virtual-gateway-address",
+        identity="/interfaces/interface/ipv4/address/ip",
+        intent=_varp_intent,
+        identity_kept=_v4_ip_kept,
+        subdetail_survived=_v4_vga_survived,
+    ),
+    _Case(
+        case_id="varp-vga-v6",
+        leaf="/interfaces/interface/ipv6/address/virtual-gateway-address",
+        identity="/interfaces/interface/ipv6/address/ip",
+        intent=_varp_intent,
+        identity_kept=_v6_ip_kept,
+        subdetail_survived=_v6_vga_survived,
+    ),
+    _Case(
+        case_id="varp-vgm-v4",
+        leaf="/interfaces/interface/ipv4/address/virtual-gateway-mac",
+        identity="/interfaces/interface/ipv4/address/virtual-gateway-address",
+        intent=_varp_intent,
+        identity_kept=_v4_vga_survived,
+        subdetail_survived=_v4_vgm_survived,
+    ),
+    _Case(
+        case_id="varp-vgm-v6",
+        leaf="/interfaces/interface/ipv6/address/virtual-gateway-mac",
+        identity="/interfaces/interface/ipv6/address/virtual-gateway-address",
+        intent=_varp_intent,
+        identity_kept=_v6_vga_survived,
+        subdetail_survived=_v6_vgm_survived,
+    ),
+    _Case(
+        case_id="tunnel-type",
+        leaf="/interfaces/interface/tunnel-type",
+        identity="/interfaces/interface/name",
+        intent=_tunnel_intent,
+        identity_kept=_tunnel_iface_kept,
+        subdetail_survived=_tunnel_type_survived,
     ),
 ]
 


### PR DESCRIPTION
## Silent-loss class (Bucket-C) — Stage 3: anycast VARP + tunnel-type

The nuanced final stage. These leaves are real silent losses but carry
per-codec representation nuance (NX-OS global-vs-per-address anycast,
SP-router SVI-less interfaces, tunnel-interface modeling), so I verified
each with an **adversarial workflow** (analyze → refute, 12 agents) on top
of the empirical single-mode-intent probe. The guard gains 5 `_CASES`
(VARP v4/v6 address + mac, tunnel-type); the declarations are exactly what
it flags.

### Declarations (12, across 6 codecs)

**`virtual-gateway-address` (anycast VARP VIP)**
- `cisco_iosxr`, `vyos` → **unsupported** — no anycast/VARP grammar at all; the VIP drops entirely.
- `cisco_iosxe_cli`, `cisco_nxos` → **demoted supported → lossy**. Their DAG / SD-Access render round-trips *only* the primary-IP-as-gateway shape (`vga == ip`); a separate cross-vendor VARP VIP (`vga != ip`, the Arista/Junos shape) has no equivalent and drops. Leaving it `supported` **was** the silent loss; `unsupported` would over-block the working DAG case; **`lossy` is the honest middle** — and it resolves the two skeptic agents' split verdict (one said "do-not-declare", the other "unsupported"; both binary choices were wrong for a partial-support surface).

**`virtual-gateway-mac`**
- `aruba_aoscx` → **lossy** — the per-address MAC drops while the VIP + switch-wide `active-gateway ip mac` (canonical `anycast_gateway_mac`) survive. Matches arista's existing precedent.

**`tunnel-type`**
- `cisco_iosxe`, `cisco_iosxr`, `cisco_nxos`, `vyos`, `aruba_aoscx` → **lossy** — the interface name survives but the GRE/IPIP/IPsec encapsulation discriminator drops on render. Matches aoss/fortigate/opnsense's existing precedent.

### Verification
- Empirical probe + adversarial workflow agreed; the guard then failed on **exactly these 12** combos pre-fix (TDD), green after.
- The `supported → lossy` demotions required updating the iosxe_cli + nxos codec tests (they asserted `vga-v4` supported).
- Matrix declarations only — **no render change**, `CODEC_BUG` stays 5. Full `tests/unit` + `tests/integration` green locally.

This completes the value-detail silent-loss sweep. Remaining (not in scope): the naming-*sensitive* surfaces (LAG, switchport beyond ENG-01) would need per-codec native-named intents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
