### PR TITLE
ci: run the Playwright e2e suite in CI (publish-gating + e2e-in-CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,47 @@ jobs:
       - name: Run integration tests
         run: pytest tests/integration -q --no-header
 
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          # Full history + tags so setuptools_scm derives a real version on
+          # `pip install -e .` (matches the test job; a `0.0.0` fallback can
+          # skew version-dependent UI strings).
+          fetch-depth: 0
+          # No git push from any ci.yml job; clear the token-in-.git/config
+          # default to limit the blast radius of a compromised step.
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Install Playwright Chromium + OS deps
+        # `--with-deps` pulls the apt libraries headless Chromium needs on the
+        # runner.  Only Chromium is installed (the suite is single-browser) to
+        # keep the download small.
+        run: python -m playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        # The suite starts its own session-scoped Uvicorn server in a daemon
+        # thread (tests/e2e/conftest.py) with the SSH collector mocked, so it
+        # needs no external server, display, or network — headless Chromium
+        # against 127.0.0.1.  Gating these in CI closes the gap where a
+        # UI/template regression could merge to main (and, transitively, reach
+        # a release tag) undetected; the previous policy ran e2e locally only.
+        run: pytest tests/e2e -m e2e -q --no-header
+
   build-distribution:
     name: Build sdist + wheel
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Run the Playwright e2e suite in CI (publish-gating + e2e-in-CI)

CI previously ran **only** `tests/unit` + `tests/integration`. The
Playwright **e2e** suite ran locally only — so a UI/template regression
could merge to `main` and, since release tags are cut from `main`, reach a
**published** release undetected. This is the parked Bucket-C
"publish-gating-on-green + e2e-in-CI" item; bringing e2e into `ci.yml`
closes it transitively (protected `main` ⇒ no commit, and thus no tag,
lands without e2e passing).

### Change
A single `e2e` job in `ci.yml`:
- `pip install -e ".[dev]"` (already carries `pytest-playwright`)
- `playwright install --with-deps chromium`
- `pytest tests/e2e -m e2e`

The suite is **self-contained** — a session-scoped Uvicorn server in a
daemon thread with the SSH collector mocked (`tests/e2e/conftest.py`) — so
it needs no external server, display, or network (headless Chromium against
`127.0.0.1`). Full suite (**168 tests**) is green locally; **this PR is its
first run on Linux CI.**

### Scope
e2e only. The **desktop** (PySide6/pywebview) suite needs headless Qt and
is deliberately left for a separate follow-up — it's the flakier half.

### Note
Making this a *required* status check (true merge-blocking) is a
branch-protection repo setting, separate from this workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
