### PR TITLE
ci: run the PySide6 desktop-shell test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,66 @@ jobs:
         # a release tag) undetected; the previous policy ran e2e locally only.
         run: pytest tests/e2e -m e2e -q --no-header
 
+  desktop:
+    name: Desktop (PySide6)
+    runs-on: ubuntu-latest
+
+    # Exercises the PySide6/pystray desktop shell (netcanon_desktop) on a
+    # headless Linux runner.  The 123-test suite mocks Qt/pystray/uvicorn via
+    # sys.modules injection so it needs no real display — except the two
+    # `TestDesktopAppShowPreferences` cases (the #159 cross-thread Preferences
+    # regression) which patch `PySide6.QtWidgets.QApplication` and assert
+    # against the real `Qt.ConnectionType.QueuedConnection` enum, so they need
+    # PySide6 genuinely installed + importable.  Running here (the previous
+    # policy ran the desktop suite locally only) closes the last untested-in-CI
+    # surface and gives real signal that the `[desktop]` extra imports on Linux
+    # — which the Windows-only MSI build can't provide.
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          # Full history + tags so setuptools_scm derives a real version on
+          # `pip install -e .` (matches the test/e2e jobs).
+          fetch-depth: 0
+          # No git push from any ci.yml job; clear the token-in-.git/config
+          # default to limit the blast radius of a compromised step.
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install Qt runtime libraries
+        # PySide6 wheels bundle the Qt libs but link against these system
+        # shared objects; `import PySide6.QtWidgets` dlopens libQt6Gui, which
+        # needs libEGL/libGL/libxkbcommon/fontconfig/dbus present even when no
+        # display is used.  Offscreen (set below) avoids the xcb/X11 stack, so
+        # no xvfb is required.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libegl1 libgl1 libxkbcommon0 libfontconfig1 libdbus-1-3 libglib2.0-0
+
+      - name: Install dependencies
+        # The `desktop` extra adds PySide6 + pystray + Pillow; `dev` brings
+        # pytest et al.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,desktop]"
+
+      - name: Run desktop tests
+        # QT_QPA_PLATFORM=offscreen: any incidental QApplication construction
+        # uses the headless platform plugin instead of needing an X server
+        # (the suite never builds one, but this is cheap insurance).
+        # PYSTRAY_BACKEND=dummy: force pystray's no-op backend so nothing in the
+        # import graph reaches for a real system tray (pystray selects its
+        # backend lazily, and the tests mock Icon, but this keeps it explicit).
+        env:
+          QT_QPA_PLATFORM: offscreen
+          PYSTRAY_BACKEND: dummy
+        run: pytest tests/desktop -m desktop -q --no-header
+
   build-distribution:
     name: Build sdist + wheel
     runs-on: ubuntu-latest

--- a/tests/desktop/test_single_instance.py
+++ b/tests/desktop/test_single_instance.py
@@ -82,7 +82,10 @@ class TestWindowsAcquisition:
         windll, kernel32 = self._patch_kernel32(last_error=0)
         with (
             patch.object(sys, "platform", "win32"),
-            patch("ctypes.windll", windll),
+            # create=True: ctypes.windll only exists on Windows, so on a
+            # Linux/macOS CI runner there is no original attribute to
+            # replace/restore — create it for the duration of the patch.
+            patch("ctypes.windll", windll, create=True),
         ):
             assert single_instance.acquire_singleton() is True
         kernel32.CreateMutexW.assert_called_once()
@@ -95,7 +98,10 @@ class TestWindowsAcquisition:
         )
         with (
             patch.object(sys, "platform", "win32"),
-            patch("ctypes.windll", windll),
+            # create=True: ctypes.windll only exists on Windows, so on a
+            # Linux/macOS CI runner there is no original attribute to
+            # replace/restore — create it for the duration of the patch.
+            patch("ctypes.windll", windll, create=True),
         ):
             assert single_instance.acquire_singleton() is False
 
@@ -108,7 +114,10 @@ class TestWindowsAcquisition:
         windll, kernel32 = self._patch_kernel32(last_error=0)
         with (
             patch.object(sys, "platform", "win32"),
-            patch("ctypes.windll", windll),
+            # create=True: ctypes.windll only exists on Windows, so on a
+            # Linux/macOS CI runner there is no original attribute to
+            # replace/restore — create it for the duration of the patch.
+            patch("ctypes.windll", windll, create=True),
         ):
             single_instance.acquire_singleton()
 
@@ -134,7 +143,10 @@ class TestWindowsAcquisition:
         windll, kernel32 = self._patch_kernel32(last_error=0)
         with (
             patch.object(sys, "platform", "win32"),
-            patch("ctypes.windll", windll),
+            # create=True: ctypes.windll only exists on Windows, so on a
+            # Linux/macOS CI runner there is no original attribute to
+            # replace/restore — create it for the duration of the patch.
+            patch("ctypes.windll", windll, create=True),
         ):
             single_instance.acquire_singleton()
         # Third positional arg is the LPCWSTR mutex name


### PR DESCRIPTION
## What

Adds a dedicated **`Desktop (PySide6)`** job to `ci.yml` that runs the
`netcanon_desktop` test suite (123 tests) on a headless Linux runner. This
was the last test surface with no CI gate — the desktop shell ran locally
only.

## Why now

The parked follow-up from the 4th blind-audit remediation. Verify-first
findings flipped the original "needs xvfb / flaky headless-Qt" assumption:

- The suite **mocks Qt/pystray/uvicorn via `sys.modules` injection**, so 121
  of 123 tests need no real display.
- **pystray import is display-clean** — it selects its backend lazily (a
  `backend()` fn with a `_dummy` backend + `PYSTRAY_BACKEND` override), and
  `tray.py` already guards the import (`try/except ModuleNotFoundError`).
- Only the two `TestDesktopAppShowPreferences` cases (the #159 cross-thread
  Preferences regression) need PySide6 *genuinely* installed: they
  `patch("PySide6.QtWidgets.QApplication")` and assert against the real
  `Qt.ConnectionType.QueuedConnection` enum. No test constructs a real
  `QApplication`.

So **no xvfb is required** — `QT_QPA_PLATFORM=offscreen` covers the
(non-existent) QApplication path as cheap insurance.

## The job

- `ubuntu-latest`, Python 3.13 (single version — the shell isn't
  version-sensitive and ships on the MSI's bundled Python).
- `apt-get install` the Qt runtime libs PySide6 dlopens on import
  (`libegl1 libgl1 libxkbcommon0 libfontconfig1 libdbus-1-3 libglib2.0-0`).
- `pip install -e ".[dev,desktop]"`.
- `env: QT_QPA_PLATFORM=offscreen, PYSTRAY_BACKEND=dummy`.
- `pytest tests/desktop -m desktop`.

Mirrors the `e2e` job's shape. Bonus signal: confirms the `[desktop]` extra
**imports cleanly on Linux**, which the Windows-only MSI build can't catch.

## Verification

- `tests/desktop` is **123 passed** locally with the extra installed; **121
  passed / 2 failed** in a clean `[dev]`-only venv (the 2 that need real
  PySide6) — confirming the extra is the right install set.
- Suite stays **123-green** with `QT_QPA_PLATFORM=offscreen
  PYSTRAY_BACKEND=dummy` set.
- The real headless-Linux verification is this PR's `Desktop (PySide6)`
  check itself.

## Follow-up (user-owned)

This new check is **not yet in ruleset `18059323`**, so it runs
informationally until added. Once green here, add `Desktop (PySide6)` to the
required-checks list to make it a merge/publish gate alongside the other 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
