### PR TITLE
docs(transforms): drop phantom forbidden_ports from project_vlan_to_switchport docstring

### DIFF
--- a/netcanon/migration/canonical/transforms.py
+++ b/netcanon/migration/canonical/transforms.py
@@ -32,9 +32,9 @@ Public surface:
   lists on each :class:`CanonicalVlan`.  Called by Cisco-style codecs
   whose native config is per-port.
 * :func:`project_vlan_to_switchport` — the inverse: read VLAN-centric
-  ``tagged_ports`` / ``untagged_ports`` / ``forbidden_ports`` lists
-  and synthesise ``switchport_mode`` + ``access_vlan`` +
-  ``trunk_allowed_vlans`` on each :class:`CanonicalInterface`.
+  ``tagged_ports`` / ``untagged_ports`` lists and synthesise
+  ``switchport_mode`` + ``access_vlan`` + ``trunk_allowed_vlans`` on each
+  :class:`CanonicalInterface`.
   Called by VLAN-centric codecs (Aruba AOS-S, OPNsense, MikroTik)
   before handing the tree to a per-port-shape target renderer.
 * :func:`project_svi_to_vlan` — synthesise a :class:`CanonicalVlan`


### PR DESCRIPTION
## What

One-line doc-honesty fix. The `transforms.py` module docstring claimed
`project_vlan_to_switchport` reads "`tagged_ports` / `untagged_ports` /
`forbidden_ports` lists" — but `forbidden_ports` is a phantom:

- `CanonicalVlan` has only `tagged_ports` + `untagged_ports` (no `forbidden_ports`).
- The function body never references it.
- No codec parses or renders ProCurve `vlan … forbid`.
- The walker yields no `/vlans/vlan/forbidden-ports` xpath.

Removed the stale reference so the docstring matches what the transform does.

## Why

Surfaced while scoping the silent-loss naming-sensitive sweep (#172): asked
whether `forbidden-ports` was a silent-loss gap like `tagged`/`untagged-ports`.
It isn't — the surface doesn't exist in the canonical model, so
`validate_against` can never see or mis-classify it. The only artifact was
this stale docstring. Adding a real `forbidden_ports` field would be
speculative (zero codecs source or sink it), against the project's
"don't model what no codec uses" ethos.

Docstring-only; no behavior or test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
