### PR TITLE
fix(sanitize): redact anycast/VARP virtual-gateway-address (audit #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Security
+
+* **Anycast / VARP virtual-gateway address no longer leaks through the
+  sanitizer.** `CanonicalIPv4Address` / `CanonicalIPv6Address.virtual_gateway_address`
+  -- the anycast gateway IP rendered verbatim by Arista (`ip address
+  virtual`), Aruba (`active-gateway ip`), Junos, NX-OS DAG and IOS-XE
+  SD-Access -- was passed through `netcanon sanitize` while its primary-IP
+  sibling was redacted, so a public virtual-gateway IP could leak into a
+  shared sanitised config or bug report. It is now redacted at every
+  address site (interface + VLAN SVI, v4 + v6), mirroring the VRRP/CARP
+  VIP redaction; private gateways (the LAN-gateway common case) are
+  preserved. Found by an independent blind audit (`3ec11f3`, finding #6)
+  and runtime-reproduced.
+
 ### Fixed
 
 * **Silent capability-loss on VLAN port membership for the router /

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -372,6 +372,7 @@ on the canonical model:
 | VLAN-SVI IPv4 addresses (public) | RFC 5737 docs ranges |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
 | VRRP / CARP virtual IPs (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
+| Anycast / VARP virtual-gateway addresses (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall / NAT / VPN) | Stripped entirely |
 

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -51,6 +51,12 @@ Field-typed rules (counter-per-session):
 * ``CanonicalVRRPGroup.virtual_ips`` / ``virtual_ipv6s`` (public
   entries) → docs range — a VRRP / CARP VIP is frequently the
   public-facing HA gateway, so it is redacted like any other IP
+* ``CanonicalIPv4Address.virtual_gateway_address`` /
+  ``CanonicalIPv6Address.virtual_gateway_address`` (public) → docs range
+  — the anycast / VARP virtual-gateway IP is the structural twin of a
+  VRRP/CARP VIP (a public one reveals real routable infrastructure), and
+  is rendered verbatim by Arista/Aruba/Junos/NX-OS/IOS-XE, so it is
+  redacted at every address site (interface + VLAN SVI, v4 + v6)
 * ``CanonicalInterface.description`` → ``description redacted``
 * ``CanonicalDHCPPool.dns_servers`` (public entries) → docs range
 * ``CanonicalDHCPPool.gateway`` (public) → docs range
@@ -262,6 +268,22 @@ def sanitize_intent(
                     redacted=new_ip,
                 ))
                 addr.ip = new_ip
+            # The anycast / VARP virtual-gateway address is a SIBLING of
+            # ``.ip`` and is rendered verbatim by 5 codecs (Arista
+            # ``ip address virtual``, Aruba ``active-gateway ip``, Junos,
+            # NX-OS DAG, IOS-XE SD-Access).  A public one reveals real
+            # routable infrastructure exactly like a VRRP/CARP VIP, so
+            # redact it the same way (cache-keyed, so it tracks ``.ip``).
+            if addr.virtual_gateway_address:
+                new_vga = table.redact_ipv4(addr.virtual_gateway_address)
+                if new_vga != addr.virtual_gateway_address:
+                    subs.append(Substitution(
+                        category="ipv4-public",
+                        field=f"interfaces[{i}].ipv4_addresses[{j}].virtual_gateway_address",
+                        original=addr.virtual_gateway_address,
+                        redacted=new_vga,
+                    ))
+                    addr.virtual_gateway_address = new_vga
 
         for j, addr in enumerate(iface.ipv6_addresses):
             new_ip = table.redact_ipv6(addr.ip)
@@ -273,6 +295,16 @@ def sanitize_intent(
                     redacted=new_ip,
                 ))
                 addr.ip = new_ip
+            if addr.virtual_gateway_address:
+                new_vga = table.redact_ipv6(addr.virtual_gateway_address)
+                if new_vga != addr.virtual_gateway_address:
+                    subs.append(Substitution(
+                        category="ipv6-public",
+                        field=f"interfaces[{i}].ipv6_addresses[{j}].virtual_gateway_address",
+                        original=addr.virtual_gateway_address,
+                        redacted=new_vga,
+                    ))
+                    addr.virtual_gateway_address = new_vga
 
         # ---- VRRP / CARP / HSRP authentication ----
         # Cleartext-bearing: the ``plain:`` / ``carp-key:`` schemes
@@ -380,6 +412,19 @@ def sanitize_intent(
                     redacted=new_ip,
                 ))
                 addr.ip = new_ip
+            # Anycast/VARP virtual-gateway companion on the SVI address —
+            # same leak class as the interface site above (the SVI's
+            # ``active-gateway`` / ``ip address virtual`` line).
+            if addr.virtual_gateway_address:
+                new_vga = table.redact_ipv4(addr.virtual_gateway_address)
+                if new_vga != addr.virtual_gateway_address:
+                    subs.append(Substitution(
+                        category="ipv4-public",
+                        field=f"vlans[{i}].ipv4_addresses[{j}].virtual_gateway_address",
+                        original=addr.virtual_gateway_address,
+                        redacted=new_vga,
+                    ))
+                    addr.virtual_gateway_address = new_vga
 
     # ---- local users (usernames + hashed passwords) ----
     # Phase-3 R6.1: redact the username too.  Operator-chosen

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -982,6 +982,96 @@ class TestPiiTailRenderedOutputClean:
         assert "admin@corp.example" not in rendered   # contact leak closed
 
 
+class TestVirtualGatewayAddressRedaction:
+    """Regression guard for the anycast / VARP virtual-gateway-address leak
+    (blind audit ``3ec11f3`` #6).  ``virtual_gateway_address`` is a sibling
+    of ``.ip`` on both address models, rendered verbatim by 5 codecs
+    (Arista ``ip address virtual``, Aruba ``active-gateway ip``, Junos,
+    NX-OS DAG, IOS-XE SD-Access).  A public one bypassed sanitisation while
+    its primary-IP sibling was redacted — the identical leak class the
+    VRRP/CARP VIP fix (#134) closed for ``CanonicalVRRPGroup.virtual_ips``."""
+
+    def test_public_vga_redacted_on_interface_ipv4(self):
+        intent = CanonicalIntent(
+            hostname="sw",
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                ipv4_addresses=[CanonicalIPv4Address(
+                    ip="8.8.8.2", prefix_length=24,
+                    virtual_gateway_address="9.9.9.1")])],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        addr = sanitized.interfaces[0].ipv4_addresses[0]
+        assert addr.ip != "8.8.8.2"                       # primary redacted (baseline)
+        assert addr.virtual_gateway_address != "9.9.9.1"  # VGA redacted (the fix)
+        assert any(
+            s.field.endswith("ipv4_addresses[0].virtual_gateway_address")
+            for s in subs
+        )
+
+    def test_public_vga_redacted_on_interface_ipv6(self):
+        intent = CanonicalIntent(
+            hostname="sw",
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                ipv6_addresses=[CanonicalIPv6Address(
+                    ip="2001:4860::2", prefix_length=64,
+                    virtual_gateway_address="2001:4860::1")])],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        addr = sanitized.interfaces[0].ipv6_addresses[0]
+        assert addr.ip != "2001:4860::2"
+        assert addr.virtual_gateway_address != "2001:4860::1"
+
+    def test_public_vga_redacted_on_vlan_svi(self):
+        intent = CanonicalIntent(
+            hostname="sw",
+            vlans=[CanonicalVlan(
+                id=10, name="V10",
+                ipv4_addresses=[CanonicalIPv4Address(
+                    ip="8.8.8.2", prefix_length=24,
+                    virtual_gateway_address="9.9.9.1")])],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        addr = sanitized.vlans[0].ipv4_addresses[0]
+        assert addr.virtual_gateway_address != "9.9.9.1"
+
+    def test_private_vga_preserved(self):
+        """A private VGA (the LAN-gateway common case) is preserved, like any
+        private IP — redaction targets public/routable addresses only."""
+        intent = CanonicalIntent(
+            hostname="sw",
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                ipv4_addresses=[CanonicalIPv4Address(
+                    ip="10.0.0.2", prefix_length=24,
+                    virtual_gateway_address="10.0.0.1")])],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        assert sanitized.interfaces[0].ipv4_addresses[0].virtual_gateway_address == "10.0.0.1"
+
+    def test_public_vga_absent_from_render(self):
+        """End-to-end: the Aruba AOS-CX ``active-gateway ip`` line must not
+        emit the public VGA after sanitisation.  Precondition-asserts the
+        codec DOES emit it first, so the test can't pass vacuously."""
+        from netcanon.migration.codecs.registry import get_codec
+
+        intent = CanonicalIntent(
+            hostname="sw",
+            vlans=[CanonicalVlan(id=10, name="V10")],
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                interface_type="ianaift:l3ipvlan",
+                ipv4_addresses=[CanonicalIPv4Address(
+                    ip="8.8.8.2", prefix_length=24,
+                    virtual_gateway_address="9.9.9.1")])],
+        )
+        codec = get_codec("aruba_aoscx")
+        assert "9.9.9.1" in codec.render(intent)            # precondition: codec emits VGA
+        sanitized, _ = sanitize_intent(intent)
+        assert "9.9.9.1" not in codec.render(sanitized)     # leak closed end-to-end
+
+
 def test_raw_sections_stripped_by_sanitiser():
     """DATA-02: Tier-3 ``raw_sections`` (verbatim vendor text) is cleared.
 


### PR DESCRIPTION
## What

Closes blind-audit finding **#6** (`3ec11f3`, verdict **UNJUSTIFIED**, runtime-reproduced): the anycast / VARP **virtual-gateway address** bypassed `netcanon sanitize`.

`CanonicalIPv4Address` / `CanonicalIPv6Address.virtual_gateway_address` is a sibling of `.ip`, rendered verbatim by 5 codecs (Arista `ip address virtual`, Aruba `active-gateway ip`, Junos, NX-OS DAG, IOS-XE SD-Access). The sanitizer redacted `.ip` and the VRRP/CARP `virtual_ips` but **never referenced `virtual_gateway_address`** (zero hits in `tools/sanitize.py` at any point in history) — so a **public** anycast gateway IP passed through verbatim while its primary-IP sibling was redacted. This is the structural twin of the VRRP/CARP VIP leak fixed in #134.

**Reproduced** before fixing: primary `8.8.8.2` → `192.0.2.1` (redacted), VGA `9.9.9.1` → **leaked verbatim**, no substitution logged.

## Fix

Redact `virtual_gateway_address` at every address site (interface IPv4 + IPv6, VLAN SVI IPv4), reusing `redact_ipv4`/`redact_ipv6` so it's cache-keyed to track the primary IP and **private gateways (the LAN-gateway common case) are preserved**. Mirrors the existing VRRP-VIP path exactly.

Also updated the two docs the audit flagged as omitting it: the sanitizer module docstring rule list + the `SECURITY.md` sanitizer-coverage table.

## Tests

New `TestVirtualGatewayAddressRedaction` (interface v4/v6, VLAN SVI, private-preserved, + a **precondition-asserted** end-to-end AOS-CX render so it can't pass vacuously). Full `tests/unit` (**4776**) + sanitize integration green.

## Scope note

This is the first of several verified audit findings. Pure security improvement (redacts *more*) — not a breaking format change. Next up: T0-2 (nxos/iosxr VLAN-SVI silent loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
