### PR TITLE
fix(migration): surface VLAN SVI/management L3 silent-loss (audit T0-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Silent loss of VLAN SVI / management L3 addresses to router / firewall
+  codecs.** A VLAN's SVI L3 carried on the VLAN record itself (the Junos
+  `irb` / Aruba SVI-on-VLAN shape, folded onto
+  `CanonicalVlan.ipv4_addresses`) was never walked by `_walk_canonical`, so
+  `validate_against` classified it `supported` and reported `severity: ok`
+  while `cisco_nxos`, `cisco_iosxr`, `aruba_aoscx`, `opnsense` and
+  `mikrotik_routeros` silently dropped it on render. The walker now yields
+  `/vlans/vlan/ipv4/address/ip` and those five codecs declare it lossy
+  (warn), so the loss is surfaced; the SVI-model codecs (Arista, IOS-XE
+  CLI, AOS-S) preserve it and FortiGate renders it on a routed
+  sub-interface. Found by an independent blind audit (`3ec11f3`, T0-2); the
+  audit named nxos+iosxr, the fix's own per-codec census also caught
+  aoscx/opnsense/mikrotik.
 * **Silent capability-loss on VLAN port membership for the router /
   firewall codecs.** `opnsense`, `mikrotik_routeros`, and `fortigate_cli`
   model a VLAN as a single-parent sub-interface and structurally cannot

--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -165,6 +165,18 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
             yield "/vlans/vlan/tagged-ports"
         for _ in vlan.untagged_ports:
             yield "/vlans/vlan/untagged-ports"
+        # VLAN SVI / management L3 address (the VLAN-record IP, distinct from
+        # interfaces[].ipv4_addresses).  The Junos ``irb`` + Aruba SVI-on-VLAN
+        # shapes fold the SVI's L3 here via project_svi_to_vlan, and only the
+        # SVI-model renderers (arista_eos, cisco_iosxe_cli) reconstruct it via
+        # synthesize_svis_from_vlan_l3.  Codecs that render L3 only from a
+        # sibling interface drop it on render — so this MUST be walked, else
+        # validate_against classifies the unwalked path as "supported" and
+        # reports severity:ok while the SVI/management IP silently vanishes
+        # (the same fail-surfaced principle as the {tagged,untagged}-ports
+        # twin above; blind-audit 3ec11f3 T0-2).  Droppers declare it lossy.
+        for _ in vlan.ipv4_addresses:
+            yield "/vlans/vlan/ipv4/address/ip"
     for route in intent.static_routes:
         yield "/routing/static-route"
         if route.vrf:

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -177,6 +177,19 @@ class ArubaAOSCXCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/ip",
+                reason=(
+                    "Renders VLAN SVI / management L3 only from a sibling "
+                    "interface stanza; an L3 address carried on the VLAN record "
+                    "itself (the Junos irb / Aruba SVI-on-VLAN shape, folded onto "
+                    "CanonicalVlan.ipv4_addresses) is dropped on render because "
+                    "this codec does not synthesize an SVI from the VLAN record. "
+                    "Declared lossy so validate_against surfaces the loss instead "
+                    "of reporting severity:ok (blind-audit 3ec11f3 T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/ipv4/address/virtual-gateway-mac",
                 reason=(
                     "Render emits the per-address active-gateway VIP "

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -124,6 +124,11 @@ class ArubaAOSSCodec(CodecBase):
             "/vlans/vlan/name",
             "/vlans/vlan/tagged-ports",
             "/vlans/vlan/untagged-ports",
+            # SVI / management L3 on the VLAN record itself — AOS-S models the
+            # SVI as a property of the VLAN (no sibling interface) and renders
+            # it straight off this surface, so it round-trips (unlike the
+            # router/firewall codecs that drop it; blind-audit 3ec11f3 T0-2).
+            "/vlans/vlan/ipv4/address/ip",
             # Per-interface switchport view — AOS-S models L2 membership
             # VLAN-centrically (``vlan N / tagged|untagged <ports>``), but
             # parse populates the transposed per-interface switchport_mode /

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -158,6 +158,19 @@ class CiscoIOSXRCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/ip",
+                reason=(
+                    "Renders VLAN SVI / management L3 only from a sibling "
+                    "interface stanza; an L3 address carried on the VLAN record "
+                    "itself (the Junos irb / Aruba SVI-on-VLAN shape, folded onto "
+                    "CanonicalVlan.ipv4_addresses) is dropped on render because "
+                    "this codec does not synthesize an SVI from the VLAN record. "
+                    "Declared lossy so validate_against surfaces the loss instead "
+                    "of reporting severity:ok (blind-audit 3ec11f3 T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/tunnel-type",
                 reason=(
                     "Render emits no `tunnel mode <kind>` for tunnel "

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -181,6 +181,19 @@ class CiscoNXOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/ip",
+                reason=(
+                    "Renders VLAN SVI / management L3 only from a sibling "
+                    "interface stanza; an L3 address carried on the VLAN record "
+                    "itself (the Junos irb / Aruba SVI-on-VLAN shape, folded onto "
+                    "CanonicalVlan.ipv4_addresses) is dropped on render because "
+                    "this codec does not synthesize an SVI from the VLAN record. "
+                    "Declared lossy so validate_against surfaces the loss instead "
+                    "of reporting severity:ok (blind-audit 3ec11f3 T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/ipv4/address/virtual-gateway-address",
                 reason=(
                     "Distributed Anycast Gateway (virtual_gateway_address "

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -161,6 +161,19 @@ class MikroTikRouterOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/ip",
+                reason=(
+                    "Renders VLAN SVI / management L3 only from a sibling "
+                    "interface stanza; an L3 address carried on the VLAN record "
+                    "itself (the Junos irb / Aruba SVI-on-VLAN shape, folded onto "
+                    "CanonicalVlan.ipv4_addresses) is dropped on render because "
+                    "this codec does not synthesize an SVI from the VLAN record. "
+                    "Declared lossy so validate_against surfaces the loss instead "
+                    "of reporting severity:ok (blind-audit 3ec11f3 T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/snmp/v3-user/engine-id",
                 reason=(
                     "The SNMPv3 USM user round-trips but a per-user "

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -167,6 +167,19 @@ class OPNsenseCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/ip",
+                reason=(
+                    "Renders VLAN SVI / management L3 only from a sibling "
+                    "interface stanza; an L3 address carried on the VLAN record "
+                    "itself (the Junos irb / Aruba SVI-on-VLAN shape, folded onto "
+                    "CanonicalVlan.ipv4_addresses) is dropped on render because "
+                    "this codec does not synthesize an SVI from the VLAN record. "
+                    "Declared lossy so validate_against surfaces the loss instead "
+                    "of reporting severity:ok (blind-audit 3ec11f3 T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/description",
                 reason=(
                     "Render emits the VLAN name but not a separate "

--- a/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
+++ b/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
@@ -82,7 +82,13 @@ def _kitchen_sink() -> CanonicalIntent:
                 tunnel_type="gre",
             ),
         ],
-        vlans=[CanonicalVlan(id=10, name="USERS")],
+        vlans=[CanonicalVlan(
+            id=10, name="USERS",
+            # SVI / management L3 on the VLAN record — the surface that was
+            # unwalked (so silently lost on render to nxos/iosxr/...) until
+            # blind-audit 3ec11f3 T0-2; exercised here so the honesty floor
+            # covers it (see test_vlan_svi_l3_is_walked).
+            ipv4_addresses=[CanonicalIPv4Address(ip="10.10.0.1", prefix_length=24)])],
         static_routes=[
             CanonicalStaticRoute(
                 destination="0.0.0.0/0", gateway="198.51.100.2", vrf="TENANT-A"
@@ -219,6 +225,20 @@ def test_per_interface_subfields_are_walked():
         "/interfaces/interface/trunk-native-vlan",
     ):
         assert xpath in emitted, f"_walk_canonical drops {xpath!r}"
+
+
+def test_vlan_svi_l3_is_walked():
+    """The VLAN-record SVI / management L3 address must be walked, else a
+    codec that drops it on render (nxos/iosxr/aoscx/opnsense/mikrotik) is
+    classified ``supported`` and the live report says severity:ok while the
+    address vanishes — the silent loss closed in blind-audit 3ec11f3 T0-2.
+    This is the surface the honesty floor was previously blind to (the
+    kitchen-sink VLAN carried no ipv4_addresses)."""
+    emitted = set(_walk_canonical(_kitchen_sink()))
+    assert "/vlans/vlan/ipv4/address/ip" in emitted, (
+        "_walk_canonical drops the VLAN SVI L3 address — the live validator "
+        "is structurally blind to it again"
+    )
 
 
 def test_snmp_v3_subfields_are_walked():

--- a/tests/unit/migration/test_silent_loss_list_subfields.py
+++ b/tests/unit/migration/test_silent_loss_list_subfields.py
@@ -270,6 +270,35 @@ def _tunnel_type_survived(reparsed: CanonicalIntent) -> bool:
     return any(i.tunnel_type == "gre" for i in reparsed.interfaces)
 
 
+def _svi_intent() -> CanonicalIntent:
+    """A VLAN carrying its SVI / management L3 on the VLAN record itself (the
+    Junos ``irb`` / Aruba SVI-on-VLAN shape, with NO sibling Vlan<N> interface)
+    — folded onto ``CanonicalVlan.ipv4_addresses`` by project_svi_to_vlan."""
+    return CanonicalIntent(
+        hostname="r",
+        vlans=[CanonicalVlan(
+            id=11, name="BLUE",
+            ipv4_addresses=[CanonicalIPv4Address(ip="10.11.0.1", prefix_length=24)])],
+    )
+
+
+def _svi_vlan_kept(reparsed: CanonicalIntent) -> bool:
+    return any(v.id == 11 for v in reparsed.vlans)
+
+
+def _svi_ip_survived(reparsed: CanonicalIntent) -> bool:
+    # The SVI address may round-trip on EITHER canonical representation: the
+    # VLAN record (SVI-model targets re-fold via project_svi_to_vlan) OR an
+    # interface (FortiGate renders it on a routed VLAN sub-interface).  Either
+    # means the L3 reached the target — no reachability loss.  A genuine
+    # dropper (nxos/iosxr/aoscx/opnsense/mikrotik) leaves it on neither.
+    on_vlan = any(a.ip == "10.11.0.1" for v in reparsed.vlans for a in v.ipv4_addresses)
+    on_iface = any(
+        a.ip == "10.11.0.1" for i in reparsed.interfaces for a in i.ipv4_addresses
+    )
+    return on_vlan or on_iface
+
+
 class _Case:
     """One (leaf, identity, targeted-intent) silent-loss probe."""
 
@@ -366,6 +395,18 @@ _CASES = [
         intent=_tunnel_intent,
         identity_kept=_tunnel_iface_kept,
         subdetail_survived=_tunnel_type_survived,
+    ),
+    # -- VLAN SVI / management L3 (blind-audit 3ec11f3 T0-2): the VLAN-record
+    # IP was unwalked, so a codec that drops it on render reported severity:ok.
+    # Now walked (/vlans/vlan/ipv4/address/ip) + declared lossy on the droppers
+    # (nxos/iosxr/aoscx/opnsense/mikrotik); SVI-model targets preserve it. --
+    _Case(
+        case_id="vlan-svi-ipv4",
+        leaf="/vlans/vlan/ipv4/address/ip",
+        identity="/vlans/vlan/id",
+        intent=_svi_intent,
+        identity_kept=_svi_vlan_kept,
+        subdetail_survived=_svi_ip_survived,
     ),
 ]
 


### PR DESCRIPTION
## What

Closes blind-audit finding **T0-2** (`3ec11f3`, verdict UNJUSTIFIED, runtime-reproduced): a VLAN's SVI / management L3 address was **silently dropped** to several codecs while `validate_against` reported `severity: ok`.

Root cause: `_walk_canonical`'s VLAN loop yielded `id`/`name`/`description`/`{tagged,untagged}-ports` but **never the VLAN-record L3** (`CanonicalVlan.ipv4_addresses`, where the Junos `irb` / Aruba SVI-on-VLAN shapes fold their SVI via `project_svi_to_vlan`). Since `classify()` defaults any unwalked path to `supported`, the loss was invisible to the live report — violating the project's own invariant that a render drop must surface as lossy/unsupported.

## Verify-first census (junos SVI → each target)

| Codec | SVI IP preserved | severity (before) | |
|---|---|---|---|
| cisco_nxos, cisco_iosxr, aruba_aoscx, opnsense, mikrotik | **no** | **ok** | **silent loss** |
| arista_eos, cisco_iosxe_cli, aruba_aoss | yes (re-fold) | ok | honest |
| fortigate_cli | yes (routed sub-if) | ok | honest |
| cisco_iosxe, vyos | no | block | already declared |

The audit named only **nxos+iosxr**; the fix's own census also caught **aoscx, opnsense, mikrotik**.

## Fix (fail-surfaced honesty, twin of #172)

- Walk `/vlans/vlan/ipv4/address/ip` whenever a VLAN carries `ipv4_addresses`.
- Declare it **lossy (warn)** on the 5 droppers — *not* unsupported/block, because these codecs **can** represent an SVI; it's a render gap, not a capability gap.
- Declare it **supported** on `aruba_aoss` (it round-trips the SVI on the VLAN record; its strict `iter_xpaths ⊆ declared` test requires the explicit entry).
- **Regression**: new `vlan-svi-ipv4` case in `test_silent_loss_list_subfields` (survival checked on **either** canonical representation — VLAN record OR interface, so FortiGate's routed-sub-interface preservation isn't a false drop), and the `cisco_iosxe_cli` honesty-floor coverage test now exercises the SVI surface (the audit flagged it was blind — its kitchen-sink VLAN had no L3).

## Result

Every dropper now reports **warn** (none silent-ok); preservers stay **ok**. Full `tests/unit` (**5242**) + `tests/integration` green — **no phase4 reclassification**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
