### PR TITLE
docs(security): accurate credential fail-closed contract (audit T0-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ timestamp if your timezone matters for an audit.
   No behavior change -- the UI was, and remains, intentionally
   proxy-fronted (a native in-app UI login was deliberately not added).
   Found by an independent blind audit (`3ec11f3`, T0-1).
+* **Credential fail-closed behavior documented accurately.** The
+  `credentials.py` docstrings said the loader "skips the profile" on a
+  wrong / rotated / lost Fernet key, and `SECURITY.md` still described only
+  the pre-fix legacy-plaintext migration path. Corrected to the actual
+  (already-shipped, safe) behavior: a token-shaped value that won't decrypt
+  raises `CredentialDecryptError`; the field is left untouched and the
+  re-save skipped (no double-encryption); the profile still loads but that
+  credential fails SSH auth at backup time (logged) and is stripped from
+  API output. No behavior change -- the security hole (ciphertext returned
+  as plaintext + double-encryption) was fixed in #136; this is the
+  contract/doc-accuracy residual (`3ec11f3`, T0-3).
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -167,11 +167,23 @@ setting them as `NETCANON_FERNET_KEY`, and deleting the file.
 
 ### Migration
 
-On first startup after upgrading from a pre-encryption version, any
-credential field that fails Fernet decryption is assumed to be a legacy
-plaintext value.  `decrypt_field()` returns the plaintext and signals the
-caller to re-save the file with encryption applied.  Migration is
-transparent and logged at `INFO`.
+On first startup after upgrading from a pre-encryption version, a
+credential field that fails Fernet decryption **and does not have the
+structural shape of a Fernet token** is treated as a legacy plaintext
+value: `decrypt_field()` returns it and signals the caller to re-save the
+file with encryption applied.  That migration is transparent and logged
+at `INFO`.
+
+A value that *is* token-shaped but fails to decrypt means the wrong /
+rotated / lost key, so `decrypt_field()` **fails closed** — it raises
+`CredentialDecryptError` instead of returning the ciphertext as if it
+were plaintext.  The migration helper logs loudly, leaves the field
+untouched, and skips the re-save, so the still-ciphertext value is never
+double-encrypted.  The profile still loads, but the undecryptable
+credential fails SSH auth at backup time and is stripped from API output
+(`DeviceProfilePublic`) — it is never silently accepted as a password.
+Restore the original key (or re-enter the credential) to recover; see the
+"Key loss" row under Known Limitations.
 
 ### In-memory model
 

--- a/netcanon/security/credentials.py
+++ b/netcanon/security/credentials.py
@@ -50,9 +50,13 @@ On first load after upgrading from an unencrypted version, a field that
 fails to decrypt is treated as legacy plaintext **only when it does not
 have the structural shape of a Fernet token**.  A value that *is* token-
 shaped but fails to decrypt means the wrong / rotated / lost key — fail
-closed: ``decrypt_field()`` raises :class:`CredentialDecryptError` so the
-caller logs loudly and skips the profile rather than loading the
-ciphertext verbatim as the password and double-encrypting it on re-save.
+closed: ``decrypt_field()`` raises :class:`CredentialDecryptError`, so the
+caller logs loudly and leaves the field untouched, skipping the re-save
+so the still-ciphertext value is never double-encrypted.  The profile
+still loads (the undecryptable value is left as-is); that credential then
+fails SSH auth at backup time — surfaced loudly, never a silent success —
+and is stripped from API responses by ``DeviceProfilePublic``.  It is
+never treated as a valid plaintext password.
 """
 
 from __future__ import annotations
@@ -71,10 +75,13 @@ class CredentialDecryptError(Exception):
 
     Distinct from the legacy-plaintext case (a non-token value written
     before encryption existed).  Raising this — rather than returning the
-    undecryptable ciphertext as if it were plaintext — keeps the storage
-    layer from (a) handing the ciphertext to the collector as the SSH
-    password and (b) re-encrypting it on save (double-encryption /
-    corruption).
+    undecryptable ciphertext as if it were valid plaintext — keeps the
+    storage layer from re-encrypting it on save (double-encryption /
+    corruption) and from accepting a wrong-key field as a successfully
+    migrated password.  The profile still loads with the value left
+    untouched; the bad credential surfaces as an SSH auth failure at
+    backup time (logged loudly) and is stripped from API output by
+    ``DeviceProfilePublic`` — it is never silently accepted.
     """
 
 


### PR DESCRIPTION
## What

Closes blind-audit **T0-3** (`3ec11f3`, verdict **~ALREADY-FIXED / contract nit**). The dangerous part (undecryptable ciphertext returned as plaintext → re-saved → double-encryption/corruption) was **already fixed in #136** and is test-covered. The residual is purely wording inaccuracy:

- `credentials.py` docstrings said the caller **"skips the profile"** and that raising `CredentialDecryptError` keeps the storage layer **"from handing the ciphertext to the collector as the SSH password"**. Neither holds: the profile **does** load (ciphertext left untouched) and **is** handed to the collector, where it fails SSH auth (logged loudly) and is stripped from API output via `DeviceProfilePublic`. The raise prevents the *double-encryption / silent-plaintext-acceptance*, not the load.
- `SECURITY.md "### Migration"` still described only the pre-fix legacy-plaintext path.

## Fix

Reworded both to the actual, safe, already-shipped behavior. **No code change** — the current *load-but-fail-SSH-with-loud-log* behavior is intentional and arguably better UX than the docstring's "skip" promise (the device stays visible with a clear auth failure rather than silently vanishing on a key-loss event), so this is a docs-accuracy fix.

Full `tests/unit` (4783) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
