### PR TITLE
ci(release): publish-time test gate on all 3 publish workflows (audit T0-4)

### DIFF
--- a/.github/workflows/desktop-msi-publish.yml
+++ b/.github/workflows/desktop-msi-publish.yml
@@ -55,8 +55,43 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  # ── Publish-time test gate (blind-audit 3ec11f3 T0-4) ──
+  # See pypi-publish.yml for the full rationale.  The MSI just packages
+  # already-tested Python code, but the same off-tree/admin-bypass and
+  # workflow_dispatch holes apply, so we re-run the unit + integration suite
+  # inside the publish run before building.  It checks out the SAME ref the
+  # build does (`inputs.tag || github.ref`) so a workflow_dispatch backfill
+  # tests exactly what it ships.  Runs on ubuntu (the suite is OS-agnostic
+  # and green on Linux in CI) — faster + cheaper than a Windows runner; only
+  # the MSI build itself needs windows-latest.  NOTE: backfilling a *very
+  # old* tag re-runs today's suite against that tag's code, which can fail on
+  # environment drift — expected, the gate is doing its job.  Fast subset (no
+  # e2e/desktop matrix); no pip cache (single-shot).
+  test:
+    name: Test gate (unit + integration)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run unit tests
+        run: pytest tests/unit -q --no-header
+      - name: Run integration tests
+        run: pytest tests/integration -q --no-header
+
   build-msi:
     name: Build Windows MSI
+    needs: [test]
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,8 +37,38 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  # ── Publish-time test gate (blind-audit 3ec11f3 T0-4) ──
+  # See pypi-publish.yml for the full rationale.  In short: the release gate
+  # is gate-at-merge (ruleset-protected `main` + on-main ancestry check), but
+  # that lives off-tree (admin-bypassable) and `workflow_dispatch` can publish
+  # a never-PR'd ref.  Re-running the unit + integration suite inside the
+  # publish run puts the gate in the artefact and holds even if the merge gate
+  # was bypassed.  Fast subset (single Python, no e2e/desktop) — defense in
+  # depth, not a re-run of the full CI matrix.  No pip cache (single-shot).
+  test:
+    name: Test gate (unit + integration)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run unit tests
+        run: pytest tests/unit -q --no-header
+      - name: Run integration tests
+        run: pytest tests/integration -q --no-header
+
   build-and-publish:
     name: Build, push, sign, attest
+    needs: [test]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -26,8 +26,46 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  # ── Publish-time test gate (blind-audit 3ec11f3 T0-4) ──
+  # The release pipeline is gate-at-merge: `main` is ruleset-protected with a
+  # required-check set (unit/integration/e2e/desktop/build/docker-smoke/PII),
+  # release tags are only cut from `main`, and the ancestry check in `build`
+  # refuses any off-main tag — so every published artefact normally derives
+  # from a commit that already passed the full CI matrix.  But that guarantee
+  # lives in branch protection (off-tree, admin-bypassable) and
+  # `workflow_dispatch` can publish a ref that never went through a PR.  This
+  # job re-runs the unit + integration suite *inside the publish run* so the
+  # gate is in the artefact an auditor can read and holds even if the merge
+  # gate was bypassed.  It is a fast subset (single Python, no e2e/desktop
+  # matrix) — the full matrix already ran at merge; this is defense-in-depth,
+  # not a re-run of CI.  No pip cache (single-shot publish job — same
+  # cache-poisoning-surface reasoning as the build job below).
+  test:
+    name: Test gate (unit + integration)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+        with:
+          # setuptools_scm needs full history/tags or `pip install -e .`
+          # falls back to a 0.0.0 version (matches the build job).
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run unit tests
+        run: pytest tests/unit -q --no-header
+      - name: Run integration tests
+        run: pytest tests/integration -q --no-header
+
   build:
     name: Build sdist + wheel
+    needs: [test]
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ timestamp if your timezone matters for an audit.
   single job's behavior is unchanged; raise it via
   `NETCANON_MAX_GLOBAL_BACKUP_CONCURRENCY`. Found by an independent blind
   audit (`3ec11f3`, r7).
+* **Release artefacts now gated on tests inside the publish run, not only
+  at merge.** The publish workflows (PyPI, Docker, desktop MSI) trigger on
+  a `v*.*.*` tag push (and `workflow_dispatch`) and previously ran no tests
+  in the publish run -- the test gate lived entirely in branch protection on
+  `main` (off-tree, admin-bypassable) plus an on-main ancestry check. Each
+  publish workflow now begins with a `Test gate (unit + integration)` job
+  the build/publish jobs `needs:`, re-running the suite on the exact ref
+  being shipped, so a manual dispatch or a bypassed merge still can't ship
+  red code. Layer 1 (the full 4-Python + e2e + desktop matrix at merge)
+  still covers the surfaces this fast subset omits. SECURITY.md documents
+  both layers + the residual `workflow_dispatch` / admin-bypass risks. Found
+  by an independent blind audit (`3ec11f3`, T0-4).
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -534,6 +534,46 @@ hardening.
   secret scanning runs on history + blocks credential pushes at
   commit time.
 
+### Release gate — how every published artefact is tied to green tests
+
+The release pipeline gates on tests in **two independent layers**, so a
+published artefact (PyPI wheel, GHCR / Docker Hub image, Windows MSI) is
+tied to passing tests even if one layer is bypassed.
+
+1. **Gate-at-merge (branch protection).**  `main` is protected by an active
+   GitHub *ruleset* requiring a fixed set of status checks to pass on every
+   PR before merge, plus PR-required, no force-push, and no branch deletion.
+   The required checks are: `Lint (ruff)`, `Tests (Python 3.11/3.12/3.13/
+   3.14)`, `E2E (Playwright)`, `Desktop (PySide6)`, `Build sdist + wheel`,
+   `Docker build smoke test`, and `No leaked personal identifiers`.  Release
+   tags are only ever cut from `main` (a CHANGELOG PR merged to `main`, then
+   the tag pushed on `main`), and each publish workflow's **on-main ancestry
+   check** (`git merge-base --is-ancestor`) refuses any tag whose commit is
+   not an ancestor of `origin/main`.  So a release tag normally derives from
+   a commit that passed the full CI matrix.
+
+2. **Gate-at-publish (in-workflow test job).**  Each publish workflow
+   (`pypi-publish.yml`, `docker-publish.yml`, `desktop-msi-publish.yml`)
+   begins with a `Test gate (unit + integration)` job that the build /
+   publish jobs `needs:`.  It re-runs the unit + integration suite *inside
+   the publish run* on the exact ref being shipped, so the gate is
+   verifiable from the repository itself and holds even if layer 1 was
+   bypassed.  It is a fast single-Python subset (the full 4-version matrix +
+   e2e + desktop already ran at merge) — defense-in-depth, not a re-run of
+   CI.
+
+**Residual risks (explicitly accepted).**  Layer 1 lives in GitHub
+branch-protection settings, which are not committed to the tree, and the
+repo-admin role can bypass the ruleset (`bypass_mode: always`) — a
+single-maintainer reality, not a defended boundary.  All three publish
+workflows also expose `workflow_dispatch`, which can publish a ref that
+never went through a PR (e.g. the MSI backfill path that builds an
+operator-supplied `inputs.tag`).  Layer 2 mitigates both: a manual dispatch
+or a bypassed merge still runs the publish-time test job before anything is
+shipped.  What layer 2 does **not** cover is the e2e / desktop / multi-Python
+surface (only layer 1 does) and a defect that no test catches.  See
+blind-audit `3ec11f3` (T0-4).
+
 ### Distribution channels and what each provides
 
 | Channel | Image bytes | Cosign signature | SBOM attestation |


### PR DESCRIPTION
## What

Adds a **`Test gate (unit + integration)`** job to the front of each of the three publish workflows (`pypi-publish.yml`, `docker-publish.yml`, `desktop-msi-publish.yml`); the build/publish jobs now `needs:` it. So a publish **re-runs the unit + integration suite inside the publish run**, on the exact ref being shipped, before anything is built or pushed.

## Why (blind audit `3ec11f3`, finding T0-4)

The publish workflows trigger on a `v*.*.*` tag push (and `workflow_dispatch`) and ran **no tests in the publish run**. The only test gate was:
- **branch protection on `main`** — real and active (ruleset `18059323`, 10 required checks), but it lives off-tree (not auditable from the repo) and the **repo-admin role can bypass it** (`bypass_mode: always`); and
- an **on-main ancestry check** — which proves ancestry, not CI success.

So a tag on a bypassed-merge commit, or a `workflow_dispatch` on a never-PR'd ref, could publish red code, and the guarantee couldn't be verified from the repository itself.

This is **defense-in-depth for the deliberate gate-at-merge design, not a replacement.** Layer 1 (the full 4-Python + e2e + desktop matrix at merge) still covers the surfaces this fast subset omits.

## How

- Each publish workflow gains a `test` job: checkout (MSI checks out `inputs.tag || github.ref` to match its build), `pip install -e ".[dev]"`, `pytest tests/unit` + `pytest tests/integration`.
- `needs: [test]` on `build` (PyPI), `build-and-publish` (Docker), `build-msi` (MSI).
- **Single Python (3.13), no e2e/desktop matrix** — fast (~2-3 min); the full matrix already ran at merge.
- **No `cache: "pip"`** — matches the existing single-shot publish-job posture (zizmor cache-poisoning surface); diverges deliberately from the CI test job, which caches because it runs on every PR.
- Adding jobs to **tag-only** workflows does **not** touch the main-PR required-check set — the ruleset is unchanged.

## Residual (documented, not silently shipped)

`workflow_dispatch` backfill of a *very old* tag re-runs today's suite against that tag's code and can fail on environment drift — that's the gate working as intended. SECURITY.md's new "Release gate" subsection documents both gate layers + the explicitly-accepted `workflow_dispatch` / admin-bypass residuals.

## Validation

YAML parses; `needs` wiring confirmed; changelog guard green. The publish workflows run only on tags, so they don't execute on this PR — this PR's own `ci.yml` run validates that `pytest tests/unit tests/integration` (the exact gate command) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
