### PR TITLE
test: fail-surfaced completeness guards — kill the silent-loss + sanitizer-bypass classes (meta-finding)

### DIFF
--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/00-blackboard.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/00-blackboard.md
@@ -1,0 +1,256 @@
+# Blackboard seed — Fail-surfaced defaults (the meta-finding)
+
+**Run:** 2026-06-24 · ultracode blackboard · netcanon
+**Main thread:** Claude (synthesizes 99-synthesis.md, then PROTOTYPES + VERIFIES + commits — agents do NOT)
+
+---
+
+## Mission
+
+Design the **durable, structural fix** for the *meta-finding* surfaced by five
+successive blind audits of netcanon: the **covered-subset blind spot**. Every
+audit round patches the *named instance* of a recurring class of defect, and the
+next blind pass finds a **new surface of the same class**. We want to stop
+playing whack-a-mole and make the *class* unable to silently recur — i.e.
+**fail-surfaced defaults**: a new field should DEFAULT to "surfaced/flagged",
+not to "silently fine".
+
+This is a **design + quantify + prototype-readiness** run, not a ship-it run.
+Output a concrete, minimal, low-risk, *verified-on-paper* design + blast-radius
+numbers + a PR plan the main thread can actuate. Favor the option that converts
+the blind spot into a **CI failure** (caught at test time) over a risky runtime
+behavior change — but evaluate all options honestly against the user's stated
+goal.
+
+## The two recurring classes (the disease, not the symptoms)
+
+1. **Silent capability-loss class.** The migration walker
+   `_walk_canonical` (`netcanon/migration/canonical/xpath_walker.py`) yields a
+   *subset* of the canonical model's leaves. `classify()`
+   (`netcanon/models/migration.py`) treats any xpath that is neither walked nor
+   explicitly declared (supported/lossy/unsupported) as **`supported` by
+   default**. So any canonical field a codec silently drops on render is
+   reported `severity: ok` — a SILENT data loss — until a human notices and adds
+   it to the walker + declares it per-codec. Instances fixed across rounds:
+   switchport → static-route → VXLAN → VLAN port-membership (#172) → VLAN-SVI
+   L3 (#175). Root cause = **default-to-supported on an unwalked leaf.**
+
+2. **Sanitizer-bypass class.** `sanitize_intent`
+   (`netcanon/tools/sanitize.py`) redacts secrets/public-IPs via an **explicit
+   allow-list of known fields**. Any *new* IP-bearing (or secret-bearing) field
+   added to the canonical model leaks verbatim into a shared/sanitised config or
+   bug report until a human names it in the sanitizer. Instances fixed across
+   rounds: IPv4 → IPv6 → overlay RD/RT → anycast virtual-gateway-address (#174).
+   Root cause = **redact-from-an-allow-list (default-to-passthrough).**
+
+Both share the same shape: **a hand-maintained subset + a permissive default.**
+
+## The durable fix the user described (the goal)
+
+> "fail-surfaced defaults — the walker yields EVERY leaf (or the codec must
+> declare it); the sanitizer redacts on `ip_address()` of ANY IP-typed field,
+> not an allow-list."
+
+The user's explicit caution: this is a big behavior change with
+**over-redaction / over-flagging risk** — *prototype against the fixture corpus
+first, especially the sanitizer over-redaction risk.*
+
+## The design space to evaluate (be honest about trade-offs)
+
+For EACH class, weigh at least these forms:
+
+- **(A) Runtime behavior change** — walker auto-yields every leaf; sanitizer
+  blanket-redacts any `ip_address()`-parseable string field. Maximally durable
+  but maximal churn/risk (phase4 reclassification storm; over-redaction of
+  private/docs IPs and free-text fields that falsely parse).
+- **(B) Structural completeness GUARD (CI meta-test)** — a reflection-driven
+  test that enumerates the canonical model's leaves and **FAILS** when a leaf is
+  neither walked-and-declared (class 1) / neither redacted-nor-exempt (class 2),
+  unless it is in an *explicit, self-justifying exemption set*. No runtime
+  change; converts the blind spot into a red CI run the moment someone adds an
+  un-handled field. Lower risk; the open question is whether the exemption list
+  just *relocates* the blind spot.
+- **(C) Fail-surfaced by construction** — annotate IP/secret-bearing model
+  fields with a typed marker (e.g. `Annotated[str, IPField]` / pydantic field
+  metadata) so the walker AND the sanitizer can MECHANICALLY enumerate "every
+  IP-typed leaf" from the model itself. The most intrinsic ("defaults" in the
+  truest sense), but assess churn + whether it's over-engineering vs (B).
+
+The recommendation may differ per class (e.g. guard for the walker, typed-marker
+for the sanitizer) — say so and justify.
+
+## Hard constraints (load-bearing)
+
+- **Read-only agents.** Each writes ONLY its own report file. The MAIN THREAD
+  builds, runs the suites/regen, and commits. Do NOT edit source/tests/fixtures,
+  run git, or run the regen tools (`tools/run_full_mesh.py`,
+  `tools/run_phase4_reconciliation.py`).
+- **Respect the existing partial guards** — don't propose something that
+  duplicates or contradicts them; build ON them:
+  - `tests/unit/migration/test_silent_loss_list_subfields.py` (value-detail `_CASES`)
+  - `tests/unit/migration/test_silent_loss_naming_sensitive.py` (`_NATIVE` map)
+  - `tests/unit/migration/test_registry_capability_honesty.py` (reverse-parity)
+  - the reverse-parity guard `test_lossy_unsupported_nonwalkable_is_documented_synthetic`
+    (PR #149) — ⚠️ it teaches the load-bearing lesson: **Tier-3 routing-protocol
+    `unsupported` paths are INTENTIONALLY non-walkable**; a naive "every declared
+    path must be walkable" FALSE-FAILS on them. Its `_SYNTHETIC_NONWALKABLE`
+    allowlist + 3 structural rules are the precedent for a self-justifying
+    exemption mechanism.
+  - the per-codec honesty floor `tests/unit/migration/cisco_iosxe_cli/test_walk_canonical_coverage.py`.
+- **The sanitizer PRESERVES private / documentation-range IPs by design**
+  (RFC-1918 LAN gear is the common case; redacting it would destroy a useful
+  shared config). Any class-2 design must NOT over-redact those.
+- **phase4 reconciliation is sensitive**: a new walker yield or matrix
+  declaration can reclassify cells in `tests/unit/audit/`. Any class-1 design
+  that changes walker yields must account for the full-`tests/unit` (incl
+  `tests/unit/audit`) impact. QUANTIFY it; do not hand-wave.
+- **No secrets / no PII in your report.** Analyze the model/walker/sanitizer
+  structure; do NOT paste real device configs. NEVER read or write under
+  `docs/codebase-review/`.
+
+## File roster (read these; cite file:line)
+
+- `netcanon/migration/canonical/intent.py` — the canonical model (17 classes,
+  root `CanonicalIntent`, ~930 lines). The denominator for both gaps.
+- `netcanon/migration/canonical/xpath_walker.py` — `_walk_canonical` (~255 lines).
+- `netcanon/models/migration.py` — `classify()` + the capability-matrix types
+  (`CapabilityMatrix`, `LossyPath`, `UnsupportedPath`); the default-to-supported
+  rule lives here (confirm it).
+- `netcanon/tools/sanitize.py` — `sanitize_intent` (~1153 lines); the redaction
+  allow-list + the private/docs-preservation logic.
+- The 5 guard tests listed above.
+- `AGENTS.md` (repo doctrine) + `docs/agent-workflow.md` (blackboard protocol).
+- Capability matrices are inline per codec at
+  `netcanon/migration/codecs/<name>/codec.py` (`supported`/`lossy`/`unsupported`).
+
+## Deliverable per phase
+
+- **Phase 1 (Census + Gap):** ground truth — the complete model-leaf set; the
+  walker's exact yields + the blind-leaf gap (with per-codec population); the
+  sanitizer's exact redaction set + the IP/secret leak-candidate gap + a sober
+  over-redaction analysis.
+- **Phase 2 (Design):** concrete designs (A/B/C) per class, with exact
+  test/code shape, exemption mechanism, and **quantified blast radius** (leaves
+  to walk/declare, phase4 cells reclassified, fixture-corpus diffs).
+- **Phase 3 (Review):** adversarial — does the recommended guard actually catch
+  a *synthetic new* unwalked-leaf / unredacted-IP-field? does the exemption list
+  relocate the blind spot? over-fire risk? GO / GO-WITH-FIXES / NO-GO + must-fixes.
+
+The main thread will read all reports, write `99-synthesis.md`, then prototype
+the recommended design, verify it against the fixture corpus + full `tests/unit`,
+and land it (pausing for the user as the risk warrants).
+
+---
+
+## Per-agent assignments
+
+Find your `id` below and execute exactly that brief. Write your long-form report
+to your own file; return only the structured summary.
+
+### Phase 1 — Census (parallel; do NOT read peers — you run concurrently)
+
+**`10-model-leaf-census`** — Produce the COMPLETE leaf census of the canonical
+model, the shared denominator both gap analyses depend on. Read
+`netcanon/migration/canonical/intent.py` end to end; from the root
+`CanonicalIntent` walk EVERY nested model (CanonicalInterface, CanonicalIPv4Address,
+CanonicalIPv6Address, CanonicalVlan, CanonicalStaticRoute, CanonicalDHCPPool,
+CanonicalSNMP, CanonicalSNMPv3User, CanonicalLAG, CanonicalVRRPGroup,
+CanonicalLocalUser, CanonicalRADIUSServer, CanonicalVxlan, CanonicalRoutingInstance,
+CanonicalEvpnType5Route, and any others). Study `xpath_walker.py` to learn the exact
+xpath spelling (e.g. `/interfaces/interface/ipv4/address/ip`), then emit a TABLE of
+every leaf as an xpath in that convention. Per leaf: xpath, owning `Class.field`,
+python type, default, and booleans `IP_OR_HOST_BEARING` (could hold an
+IPv4/IPv6/hostname) and `SECRET_BEARING` (passphrase/hash/community/key).
+Distinguish scalar vs list-of-scalar vs nested-model containers. Be exhaustive — a
+missed leaf makes both downstream gaps wrong. End with counts (total leaves, #
+IP/host-bearing, # secret-bearing).
+
+**`11-walker-gap`** — Quantify the SILENT-LOSS gap (class 1). Read `_walk_canonical`
+(`xpath_walker.py`); enumerate EXACTLY the xpaths it yields, quoting each yield site
+file:line. Read `classify()` in `netcanon/models/migration.py`; CONFIRM or correct
+that an xpath neither walked nor declared defaults to `supported` (quote the branch).
+Build your own sufficient leaf list from `intent.py` to compute the gap (you run
+parallel to the census agent); flag uncertain leaves. GAP = leaves expressible but
+NEVER walked → default `supported` → silent-loss candidates; list them all. For each
+gap leaf, grep codec parse paths to see which codecs POPULATE it (separate real risk
+from dead leaves). Catalogue the 5 existing partial guards: what slice each covers /
+leaves open. Account for the #149 lesson: which `unsupported` paths are INTENTIONALLY
+non-walkable (Tier-3 routing protocols) and must be exempt from any walk-everything
+rule.
+
+**`12-sanitizer-gap`** — Quantify the SANITIZER-BYPASS gap (class 2) AND the
+over-redaction risk. Read `sanitize_intent` (`netcanon/tools/sanitize.py`) fully;
+enumerate the EXACT set of fields it redacts (the allow-list), quoting each site
+file:line; note the redaction primitives (redact_ipv4/ipv6, secret handling) and the
+private/documentation-range PRESERVATION logic (what is deliberately kept). Build your
+own IP/host-bearing + secret-bearing field list from `intent.py`; flag uncertainties.
+GAP = IP/host/secret-bearing leaves the sanitizer NEVER touches → leak candidates;
+classify each (a) realistically public/secret-bearing (true leak) vs (b) structurally
+always-private/non-sensitive. CRITICAL over-redaction analysis of the user's proposed
+blanket rule (redact any string field whose value parses as `ip_address()`): which
+fields are FREE TEXT (description/name/domain_name/banner) that could falsely parse or
+contain IP-like substrings and be mangled? Does a blanket rule break the deliberate
+private/docs-IP preservation, or can it reuse the same preserve-private predicate?
+Roughly what fraction of the real fixture corpus would change vs today (reason from
+the census; you MAY sample fixtures READ-ONLY)? Conclude: which class-2 form is safest
+(blanket / guard / typed-marker) and why.
+
+### Phase 2 — Design (read ALL phase-1 reports first)
+
+**`20-design-walker-guard`** — Design the durable class-1 fix. Compare (A) walker
+auto-yields every leaf vs (B) a reflection-driven COMPLETENESS GUARD test that FAILS
+when a model leaf is neither walked-and-declared nor in a documented exemption set.
+Recommend one (or hybrid) with reasoning. Provide the EXACT shape: where the test
+lives; how it reflects model leaves (pydantic `model_fields` recursion handling
+list/nested + `from __future__ import annotations` string types); how it checks
+'walked' (run `_walk_canonical` on a kitchen-sink intent, collect yields) and
+'declared' (per-codec matrices); the self-justifying exemption design (each exemption
+carries a reason; model it on #149's `_SYNTHETIC_NONWALKABLE`). QUANTIFY blast radius
+to make the guard GREEN today: blind leaves to walk+declare across how many codecs;
+estimated phase4 (`tests/unit/audit`) reclassifications; flag behavior-change vs
+pure-declaration. Spell out PR sequencing; note regen-tool needs.
+
+**`21-design-sanitizer-guard`** — Design the durable class-2 fix. Compare (A) blanket
+`ip_address()` redaction, (B) reflection-driven completeness guard, (C)
+typed-marker-driven enumeration. Recommend one (may differ from the walker
+recommendation), grounded in the over-redaction analysis. Provide the EXACT shape: how
+IP/secret-bearing fields are identified at test time (type hints / naming heuristic /
+typed marker — coordinate with agent 22); redact-vs-exempt classification; exemption
+mechanism; how it preserves the existing private/docs-IP behavior. Address
+over-redaction head-on. If recommending a guard, SHOW it would have FAILED before #174
+(the VGA leak). QUANTIFY: fields to add now; fixture-corpus diff if any runtime change;
+test cost.
+
+**`22-design-typed-marker`** — Evaluate fail-surfaced BY CONSTRUCTION: annotate
+IP/host-bearing + secret-bearing canonical fields with a typed marker (e.g.
+`Annotated[str, IPField()]` / pydantic `Field(json_schema_extra=...)` / a small
+metadata class) so the walker AND sanitizer (AND the guards) can MECHANICALLY
+enumerate the relevant leaves from the model itself — no hand-maintained list. Show
+the exact annotation mechanism that survives pydantic v2 + `from __future__ import
+annotations` (introspecting `model_fields[...].metadata` reliably). Assess: churn to
+annotate; whether it SUBSUMES or complements the guard tests; maintenance ergonomics;
+and HONESTLY whether it is over-engineering vs the lighter guard (B). Verdict: worth it
+for class-2, class-1, both, or neither — and the minimal version capturing most value.
+
+### Phase 3 — Review (read ALL phase-1 + phase-2 reports first; use the review schema)
+
+**`30-review-correctness`** — Adversarial CORRECTNESS review: does the recommended fix
+kill the CLASS, not today's instances? Decisive test: would the recommended class-1
+guard FAIL if a dev adds a NEW unwalked leaf and forgets to walk/declare it? Would the
+class-2 design FAIL if a dev adds a NEW IP-bearing field and forgets to redact it? Walk
+both synthetic scenarios concretely; if either PASSES (misses the new field) → NO-GO
+must-fix. Does the exemption mechanism merely RELOCATE the blind spot? Propose how to
+make exemptions self-justifying / costly-to-abuse. Reconcile with the user's literal
+goal ('fail-surfaced *defaults*'): is a CI guard faithful, or does the goal demand the
+behavior-change/by-construction form? Take a position. Verdict + must_fixes.
+
+**`31-review-pragmatism`** — Adversarial PRAGMATISM / over-engineering / maintenance
+review. Is the recommended design the MINIMAL thing that closes the class, or
+gold-plated? Flag over-engineering (typed-marker if a 30-line guard suffices).
+Over-fire / false-positive risk: would the guard break on legitimate model evolution,
+refactors, or the intentional exemptions (#149 Tier-3 non-walkable; sanitizer
+private-IP preservation)? Would a blanket sanitizer rule mangle real fixtures?
+Maintenance burden: who keeps the exemption list honest; friction on ordinary model
+changes; is the failure message actionable? Blast-radius sanity-check: are the phase-2
+churn estimates realistic? One PR or several? Anything to stage/defer? Verdict +
+must_fixes.

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/10-model-leaf-census.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/10-model-leaf-census.md
@@ -1,0 +1,578 @@
+# 10 — Canonical-model leaf census (the shared denominator)
+
+**Agent:** `10-model-leaf-census` · Phase 1 (Census) · read-only
+**Run:** 2026-06-24 · fail-surfaced-defaults · netcanon
+**Scope:** the COMPLETE leaf set of `CanonicalIntent`, the denominator both
+gap analyses (`11-walker-gap`, `12-sanitizer-gap`) depend on.
+
+---
+
+## 0. Method & conventions
+
+- Source of truth read end-to-end: `netcanon/migration/canonical/intent.py`
+  (17 model classes, root `CanonicalIntent`, lines 1–931).
+- Xpath spelling taken from the **walker** (`netcanon/migration/canonical/
+  xpath_walker.py`, `_walk_canonical`, lines 23–256) and confirmed against
+  the per-codec capability matrices (e.g. `cisco_iosxe_cli/codec.py:106–260`)
+  and the honesty-floor guard `tests/unit/migration/codecs/cisco_iosxe_cli/
+  test_walk_canonical_coverage.py`. `CapabilityMatrix.classify` is
+  exact-string-match, so the matrix/walker/census must speak the same strings.
+- **Naming rule observed in the codebase:** python field `snake_case` →
+  xpath segment `kebab-case`; nested models collapse to a hyphenated leaf
+  (e.g. `CanonicalLAG.mode` → `/lags/lag/mode`); container plurals keep the
+  `container/element` shape (`/interfaces/interface/...`, `/vlans/vlan/...`,
+  `/routing-instances/instance/...`). System scalars/lists live under
+  `/system/...`. A few list leaves are spelled singular at the element
+  (`/system/dns-server` for `dns_servers`).
+- Where the walker does NOT yet emit an xpath for a real model leaf, I give
+  the **projected** xpath in the prevailing convention and mark it
+  `WALKED = no`. Those projected spellings are the candidate strings a
+  walk-everything design (class 1) would have to emit and the matrices would
+  have to declare; agents 11/20 own that gap. Here they are census rows.
+
+### Column legend
+
+- **xpath** — schema xpath in the walker's convention (projected where the
+  walker does not emit it; flagged in WALKED).
+- **Class.field** — owning pydantic `Model.attribute`.
+- **type** — python type hint as written (post `from __future__ import
+  annotations`, all hints are strings; resolved type given).
+- **default** — declared default (`Field(...)` default / literal / factory).
+- **kind** — `scalar` / `list[scalar]` / `list[model]` (container) /
+  `nested-model` / `dict`.
+- **IP/HOST** — `IP_OR_HOST_BEARING`: the field can hold an IPv4/IPv6
+  literal, a CIDR, a MAC, or a DNS hostname/domain (anything that identifies
+  a real network or host). MAC is included because the sanitizer treats
+  `anycast_gateway_mac`/`virtual_gateway_mac` as network-identifying-class.
+- **SECRET** — `SECRET_BEARING`: passphrase / hash / community / shared key /
+  auth token / engineID.
+- **WALKED** — does `_walk_canonical` currently emit this xpath? (`yes` /
+  `no` / `cond` = yes but only under a populated/condition guard).
+
+> A leaf is counted once. Where the same canonical sub-model is reused on
+> two parents (e.g. `CanonicalIPv4Address` on both `CanonicalInterface` and
+> `CanonicalVlan`), it is listed under **both** parents because they have
+> distinct xpaths and distinct codec handling — this is load-bearing for
+> both gaps (the VLAN-SVI L3 leak #175 was exactly this reuse).
+
+---
+
+## 1. Top-level `CanonicalIntent` scalars / lists (intent.py:790–930)
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/system/hostname` | `CanonicalIntent.hostname` | str | `""` | scalar | yes¹ | no | cond |
+| `/system/domain` | `CanonicalIntent.domain` | str | `""` | scalar | **yes** | no | cond |
+| `/system/dns-server` | `CanonicalIntent.dns_servers` | list[str] | `[]` | list[scalar] | **yes** | no | cond |
+| `/system/ntp-server` | `CanonicalIntent.ntp_servers` | list[str] | `[]` | list[scalar] | **yes** | no | cond |
+| `/system/timezone` | `CanonicalIntent.timezone` | str | `""` | scalar | no | no | cond |
+| `/system/syslog-server` | `CanonicalIntent.syslog_servers` | list[str] | `[]` | list[scalar] | **yes** | no | cond |
+| `/anycast-gateway-mac` | `CanonicalIntent.anycast_gateway_mac` | str | `""` | scalar | **yes (MAC)** | no | cond |
+| `raw_sections` | `CanonicalIntent.raw_sections` | dict[str,str] | `{}` | dict | **yes²** | **yes²** | no (Tier-3, not walked by design) |
+| `dropped_tier3_sections` | `CanonicalIntent.dropped_tier3_sections` | list[str] | `[]` | list[scalar] | maybe² | no | no (notify-only) |
+| `source_vendor` | `CanonicalIntent.source_vendor` | str | `""` | scalar (metadata) | no | no | no (metadata) |
+| `source_format` | `CanonicalIntent.source_format` | str | `""` | scalar (metadata) | no | no | no (metadata) |
+| `source_version` | `CanonicalIntent.source_version` | str | `""` | scalar (metadata) | no | no | no (metadata) |
+| `apply_groups` | `CanonicalIntent.apply_groups` | list[str] | `[]` | list[scalar] | maybe² | no | no (provenance) |
+| `group_content` | `CanonicalIntent.group_content` | dict[str,list[list[str]]] | `{}` | dict | **yes²** | **yes²** | no (provenance) |
+
+¹ `hostname` is a host identifier (operator-traceable PII per AGENTS.md Hard
+Rules) but the sanitizer does NOT redact it today — it is *passthrough*. I
+mark IP/HOST=yes¹ because it is host-identifying even though it is not an
+`ip_address()`-parseable string; a blanket `ip_address()` rule would NOT
+catch it, which is a finding for agent 12 (free-text host identity escapes
+an IP-only rule). It is not in this run's two named classes but is the same
+disease shape.
+
+² **Container/free-text leaves (`raw_sections`, `group_content`,
+`dropped_tier3_sections`, `apply_groups`):** these hold *raw vendor config
+text* / group set-line tails / stanza headers. They can contain ANYTHING —
+IPs, hostnames, hashes — embedded in free text. The sanitizer DOES handle
+the first three (`raw_sections`/`dropped_tier3_sections`/`group_content`/
+`apply_groups` are stripped wholesale, categories `tier3-stripped` /
+`apply-groups-stripped`, sanitize.py:683–787). They are **not** model
+*leaves* in the structured sense (no typed scalar field), so a
+type-driven/`ip_address()` enumeration (class-2 design C / blanket A) would
+NOT reach inside them — they need their existing wholesale-strip handling.
+**Census note for agents 20/22:** these are the leaves that defeat a
+"reflect over typed scalar fields" guard; they must be an explicit,
+self-justifying exemption (already strip-handled) in any completeness guard.
+
+---
+
+## 2. `CanonicalInterface` (intent.py:168–281) — element of `/interfaces/interface`
+
+Scalars + nested lists. Container leaf: `/interfaces/interface/name` is the
+list-element anchor.
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/interfaces/interface/name` | `.name` | str | (required) | scalar | no | no | cond |
+| `/interfaces/interface/default-name` | `.default_name` | str | `""` | scalar | no | no | **no** |
+| `/interfaces/interface/config/description` | `.description` | str | `""` | scalar | no³ | no | cond |
+| `/interfaces/interface/config/enabled` | `.enabled` | bool | `True` | scalar | no | no | cond (always, per-iface) |
+| `/interfaces/interface/config/type` | `.interface_type` | str | `""` | scalar | no | no | cond |
+| `/interfaces/interface/config/mtu` | `.mtu` | int \| None | `None` | scalar | no | no | cond |
+| `/interfaces/interface/switchport-mode` | `.switchport_mode` | str \| None | `None` | scalar | no | no | cond |
+| `/interfaces/interface/access-vlan` | `.access_vlan` | int \| None | `None` | scalar | no | no | cond |
+| `/interfaces/interface/trunk-allowed-vlans` | `.trunk_allowed_vlans` | list[int] | `[]` | list[scalar] | no | no | cond |
+| `/interfaces/interface/trunk-native-vlan` | `.trunk_native_vlan` | int \| None | `None` | scalar | no | no | cond |
+| `/interfaces/interface/voice-vlan` | `.voice_vlan` | int \| None | `None` | scalar | no | no | cond |
+| `/interfaces/interface/lag-member-of` | `.lag_member_of` | str \| None | `None` | scalar | no | no | cond |
+| `/interfaces/interface/dhcp-client` | `.dhcp_client` | bool | `False` | scalar | no | no | cond |
+| `/interfaces/interface/dhcp-client-v6` | `.dhcp_client_v6` | str | `""` | scalar | no | no | cond |
+| `/interfaces/interface/tunnel-type` | `.tunnel_type` | str | `""` | scalar | no | no | cond |
+| `/interfaces/interface/config/vrf` | `.vrf` | str | `""` | scalar | no | no | cond |
+| `/interfaces/interface/kind` | `.kind` | str | `""` | scalar | no | no | **no** |
+| (sub-models below) | `.ipv4_addresses` | list[`CanonicalIPv4Address`] | `[]` | list[model] | — | — | — |
+| (sub-models below) | `.ipv6_addresses` | list[`CanonicalIPv6Address`] | `[]` | list[model] | — | — | — |
+| (sub-models below) | `.vrrp_groups` | list[`CanonicalVRRPGroup`] | `[]` | list[model] | — | — | — |
+
+³ `description` is operator free text. Not IP-bearing as a class, BUT free
+text CAN contain an IP-like substring or hostname (the VLAN-name/description
+case #133 was exactly this). Flagged `no³` here because it is not a
+structurally IP-typed field — this is the precise category agent 12 must
+evaluate for the over-redaction risk of a blanket `ip_address()` rule (a
+description like `"link to 10.0.0.1 core"` would partial-match). The
+sanitizer does NOT touch interface `description` today.
+
+**Two un-walked interface scalars:** `default-name` and `kind`. Both are
+opaque vendor-mechanical strings (MikroTik factory port name; logical-role
+override). Neither is IP/secret-bearing. They are silent-loss *candidates*
+in the strict sense (a codec could drop them and `classify()` would say ok),
+but they are low-risk metadata. Agent 11 should confirm whether any codec
+populates them (e.g. mikrotik `default_name`); they are census rows here.
+
+### 2a. `CanonicalIPv4Address` (intent.py:83–124) — on interface AND vlan
+
+| xpath (interface) | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/interfaces/interface/ipv4/address/ip` | `.ip` | str | (required) | scalar | **yes** | no | cond |
+| `/interfaces/interface/ipv4/address/prefix-length` | `.prefix_length` | int (ge0 le32) | (required) | scalar | no | no | cond |
+| `/interfaces/interface/ipv4/address/secondary-ip` | `.is_secondary` | bool | `False` | scalar | no | no | cond (only when secondary) |
+| `/interfaces/interface/ipv4/address/virtual-gateway-address` | `.virtual_gateway_address` | str | `""` | scalar | **yes** | no | cond |
+| `/interfaces/interface/ipv4/address/virtual-gateway-mac` | `.virtual_gateway_mac` | str | `""` | scalar | **yes (MAC)** | no | cond |
+
+Same model reused on the VLAN record (distinct xpath, distinct handling — the
+#175 leak surface):
+
+| xpath (vlan SVI) | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/vlans/vlan/ipv4/address/ip` | `.ip` | str | (required) | scalar | **yes** | no | cond |
+| `/vlans/vlan/ipv4/address/prefix-length` | `.prefix_length` | int | (required) | scalar | no | no | **no** ⚠ |
+| `/vlans/vlan/ipv4/address/secondary-ip` | `.is_secondary` | bool | `False` | scalar | no | no | **no** |
+| `/vlans/vlan/ipv4/address/virtual-gateway-address` | `.virtual_gateway_address` | str | `""` | scalar | **yes** | no | **no** ⚠ |
+| `/vlans/vlan/ipv4/address/virtual-gateway-mac` | `.virtual_gateway_mac` | str | `""` | scalar | **yes (MAC)** | no | **no** |
+
+⚠ The walker yields only `/vlans/vlan/ipv4/address/ip` (xpath_walker.py:178–
+179) for the VLAN-SVI address. `prefix-length`, `secondary-ip`,
+`virtual-gateway-address`, `virtual-gateway-mac` on the **VLAN** copy are
+NOT walked — the walker walks `ip` only there (the #175 fix walked just the
+`ip` leaf). The interface copy walks the full set (xpath_walker.py:82–101).
+This is an asymmetry worth flagging to agents 11/20 (the VLAN-SVI VGA is a
+real anycast surface on Aruba/Junos IRB). The **sanitizer** DOES redact the
+VLAN copy's `ip` + `virtual_gateway_address` (sanitize.py:406–427), so the
+sanitizer is ahead of the walker here.
+
+### 2b. `CanonicalIPv6Address` (intent.py:127–165) — on interface only
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/interfaces/interface/ipv6/address/ip` | `.ip` | str | (required) | scalar | **yes** | no | cond |
+| `/interfaces/interface/ipv6/address/prefix-length` | `.prefix_length` | int (ge0 le128) | (required) | scalar | no | no | cond |
+| `/interfaces/interface/ipv6/address/scope` | `.scope` | str | `"global"` | scalar | no | no | **no** |
+| `/interfaces/interface/ipv6/address/secondary-ip` | `.is_secondary` | bool | `False` | scalar | no | no | cond (only when secondary) |
+| `/interfaces/interface/ipv6/address/virtual-gateway-address` | `.virtual_gateway_address` | str | `""` | scalar | **yes** | no | cond |
+| `/interfaces/interface/ipv6/address/virtual-gateway-mac` | `.virtual_gateway_mac` | str | `""` | scalar | **yes (MAC)** | no | cond |
+
+`scope` (`"global"`/`"link-local"`) is NOT walked — discriminator string,
+not IP/secret. Census row; low risk. (`CanonicalIPv6Address` is NOT reused on
+the VLAN record — only IPv4 is, per `CanonicalVlan.ipv4_addresses`.)
+
+### 2c. `CanonicalVRRPGroup` (intent.py:491–597) — on `/interfaces/interface/vrrp-groups/group`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/interfaces/interface/vrrp-groups/group` | `.group_id` | int (ge1 le255) | (required) | scalar (anchor) | no | no | cond |
+| `/interfaces/interface/vrrp-groups/group/mode` | `.mode` | str | `"vrrp"` | scalar | no | no | **no** |
+| `/interfaces/interface/vrrp-groups/group/virtual-ips` | `.virtual_ips` | list[str] | `[]` | list[scalar] | **yes** | no | cond (only when >1) ⚠ |
+| `/interfaces/interface/vrrp-groups/group/virtual-ipv6s` | `.virtual_ipv6s` | list[str] | `[]` | list[scalar] | **yes** | no | **no** ⚠ |
+| `/interfaces/interface/vrrp-groups/group/virtual-mac` | `.virtual_mac` | str | `""` | scalar | **yes (MAC)** | no | cond |
+| `/interfaces/interface/vrrp-groups/group/priority` | `.priority` | int (1-254) | `100` | scalar | no | no | **no** |
+| `/interfaces/interface/vrrp-groups/group/preempt` | `.preempt` | bool | `True` | scalar | no | no | **no** |
+| `/interfaces/interface/vrrp-groups/group/advertisement-interval` | `.advertisement_interval` | int | `1` | scalar | no | no | **no** |
+| `/interfaces/interface/vrrp-groups/group/authentication` | `.authentication` | str | `""` | scalar | no | **yes** | **no** ⚠SECRET |
+| `/interfaces/interface/vrrp-groups/group/track-interfaces` | `.track_interfaces` | list[str] | `[]` | list[scalar] | no | no | cond |
+| `/interfaces/interface/vrrp-groups/group/description` | `.description` | str | `""` | scalar | no | no | **no** |
+
+⚠ Walker subtlety (xpath_walker.py:146–158): the group anchor is walked
+unconditionally per group; `virtual-ips` walked ONLY when `len > 1`;
+`virtual-mac` + `track-interfaces` walked only when populated.
+`virtual-ipv6s`, `mode`, `priority`, `preempt`, `advertisement-interval`,
+`authentication`, `description` are **never** walked. The **sanitizer** DOES
+redact `virtual_ips`, `virtual_ipv6s`, `authentication`, and `description`
+(sanitize.py:309–368) — again the sanitizer is ahead of the walker on the
+secret-bearing `authentication` and on `virtual_ipv6s`. `authentication` is
+a **secret-bearing leaf the walker never yields** — a notable census row for
+agent 11 (a codec dropping VRRP auth-token would classify `ok`).
+
+---
+
+## 3. `CanonicalVlan` (intent.py:284–298) — element of `/vlans/vlan`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/vlans/vlan/id` | `.id` | int (ge1 le4094) | (required) | scalar (anchor) | no | no | cond |
+| `/vlans/vlan/name` | `.name` | str | `""` | scalar | no³ | no | cond |
+| `/vlans/vlan/description` | `.description` | str | `""` | scalar | no³ | no | cond |
+| `/vlans/vlan/tagged-ports` | `.tagged_ports` | list[str] | `[]` | list[scalar] | no | no | cond |
+| `/vlans/vlan/untagged-ports` | `.untagged_ports` | list[str] | `[]` | list[scalar] | no | no | cond |
+| (sub-model) | `.ipv4_addresses` | list[`CanonicalIPv4Address`] | `[]` | list[model] | — | — | see §2a (vlan SVI rows) |
+
+`name`/`description` are operator free text (the #133 / v0.4.0-self-audit
+surface). Sanitizer DOES redact VLAN `name` + `description` (sanitize.py:
+381–404 area) via a stable substitution table.
+
+---
+
+## 4. `CanonicalStaticRoute` (intent.py:301–331) — element of `/routing/static-route`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/routing/static-route` | `.destination` | str (CIDR) | (required) | scalar (anchor) | **yes** | no | cond |
+| `/routing/static-route/gateway`⁴ | `.gateway` | str | `""` | scalar | **yes** | no | **no** ⚠IP |
+| `/routing/static-route/interface` | `.interface` | str | `""` | scalar | no | no | cond |
+| `/routing/static-route/metric` | `.metric` | int | `0` | scalar | no | no | cond |
+| `/routing/static-route/description` | `.description` | str | `""` | scalar | no | no | cond |
+| `/routing/static-route/vrf` | `.vrf` | str | `""` | scalar | no | no | cond |
+
+⁴ The route **gateway** (next-hop IP) is NOT walked (the walker walks
+`/routing/static-route` anchor + `vrf` + `metric` + `description` +
+`interface`, xpath_walker.py:180–196, but not a `gateway` leaf). The
+**destination** CIDR is the anchor. So the IP-bearing `gateway` is an
+un-walked IP leaf — but the **sanitizer** DOES redact it (sanitize.py:660–
+669, category `ipv4-public`, private preserved). Projected xpath
+`/routing/static-route/gateway` is my best guess at the convention; no
+matrix declares it today, so agents 11/20 should treat the spelling as
+TBD. (Walking the anchor effectively covers destination+gateway as one
+record for loss-classification, which is why no codec has needed the split.)
+
+---
+
+## 5. `CanonicalDHCPPool` (intent.py:339–361) — element of `/dhcp-servers/pool`
+
+The walker yields ONLY the anchor `/dhcp-servers/pool` (xpath_walker.py:215–
+216) — every sub-field is unwalked. The sanitizer, however, redacts the IP
+sub-fields.
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/dhcp-servers/pool` | (record anchor) | — | — | scalar (anchor) | — | — | cond |
+| `/dhcp-servers/pool/interface` | `.interface` | str | `""` | scalar | no | no | **no** |
+| `/dhcp-servers/pool/network` | `.network` | str (CIDR) | `""` | scalar | **yes** | no | **no** ⚠IP |
+| `/dhcp-servers/pool/start-ip` | `.start_ip` | str | `""` | scalar | **yes** | no | **no** ⚠IP |
+| `/dhcp-servers/pool/end-ip` | `.end_ip` | str | `""` | scalar | **yes** | no | **no** ⚠IP |
+| `/dhcp-servers/pool/gateway` | `.gateway` | str | `""` | scalar | **yes** | no | **no** ⚠IP |
+| `/dhcp-servers/pool/dns-servers` | `.dns_servers` | list[str] | `[]` | list[scalar] | **yes** | no | **no** ⚠IP |
+| `/dhcp-servers/pool/lease-time` | `.lease_time` | int | `86400` | scalar | no | no | **no** |
+| `/dhcp-servers/pool/domain-name` | `.domain_name` | str | `""` | scalar | **yes (host)** | no | **no** ⚠HOST |
+
+Sanitizer coverage (sanitize.py:578–658): `network` (CIDR host-portion),
+`start_ip`, `end_ip`, `gateway`, `dns_servers` (public→docs, private
+preserved), `domain_name` (category `domain`). So **5 of the 6 IP/host-
+bearing DHCP sub-fields are sanitizer-covered but walker-blind** — a clean
+illustration of the two gaps' independence.
+
+---
+
+## 6. SNMP
+
+### 6a. `CanonicalSNMP` (intent.py:450–471) — singleton `/snmp` (nullable)
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/snmp/community` | `.community` | str | `""` | scalar | no | **yes** | cond |
+| `/snmp/location` | `.location` | str | `""` | scalar | no | no | cond |
+| `/snmp/contact` | `.contact` | str | `""` | scalar | no⁵ | no | cond |
+| `/snmp/trap-host` | `.trap_hosts` | list[str] | `[]` | list[scalar] | **yes** | no | cond |
+| (sub-model) | `.v3_users` | list[`CanonicalSNMPv3User`] | `[]` | list[model] | — | — | see §6b |
+
+⁵ `contact` is often an email/name (operator PII) — sanitizer redacts it
+(category `snmp-contact`, sanitize.py:~480) and `location` (`snmp-location`,
+~489). Not IP-bearing; not caught by an `ip_address()` rule. `community` is
+the v1/v2c shared secret → sanitizer redacts (`snmp-community`, ~461).
+
+### 6b. `CanonicalSNMPv3User` (intent.py:364–447) — element of `/snmp/v3-user`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/snmp/v3-user` | `.name` | str | (required) | scalar (anchor) | no | no | cond |
+| `/snmp/v3-user/group` | `.group` | str | `""` | scalar | no | no | **no** |
+| `/snmp/v3-user/auth-protocol` | `.auth_protocol` | str | `""` | scalar | no | no | **no** |
+| `/snmp/v3-user/auth-passphrase` | `.auth_passphrase` | str | `""` | scalar | no | **yes** | cond |
+| `/snmp/v3-user/priv-protocol` | `.priv_protocol` | str | `""` | scalar | no | no | **no** |
+| `/snmp/v3-user/priv-passphrase` | `.priv_passphrase` | str | `""` | scalar | no | **yes** | **no** ⚠SECRET |
+| `/snmp/v3-user/engine-id` | `.engine_id` | str | `""` | scalar | no | **yes** | cond |
+
+⚠ `priv_passphrase` is a **secret-bearing leaf the walker never yields**
+(walker walks `/snmp/v3-user` anchor + `auth-passphrase` + `engine-id` only,
+xpath_walker.py:209–214). The sanitizer DOES redact `auth_passphrase`,
+`priv_passphrase`, `engine_id`, and even the v3 user `name`
+(sanitize.py:519–551). So `priv_passphrase` joins VRRP `authentication` as a
+secret leaf that is walker-blind. Census row for agent 11.
+
+---
+
+## 7. `CanonicalLAG` (intent.py:474–488) — element of `/lags/lag`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/lags/lag/name` | `.name` | str | (required) | scalar | no | no | cond |
+| `/lags/lag/members` | `.members` | list[str] | `[]` | list[scalar] | no | no | cond |
+| `/lags/lag/mode` | `.mode` | str | `"active"` | scalar | no | no | cond |
+
+Fully walked (xpath_walker.py:217–220 — all three yielded per LAG). No
+IP/secret. No gap.
+
+---
+
+## 8. `CanonicalLocalUser` (intent.py:600–621) — element of `/local-users/user`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/local-users/user/name` | `.name` | str | (required) | scalar | no | no | cond |
+| `/local-users/user/privilege-level` | `.privilege_level` | int | `1` | scalar | no | no | cond |
+| `/local-users/user/hashed-password` | `.hashed_password` | str | `""` | scalar | no | **yes** | cond |
+| `/local-users/user/role` | `.role` | str | `""` | scalar | no | no | cond |
+
+Fully walked (xpath_walker.py:221–227). `hashed_password` is secret-bearing
+AND walked AND sanitized (sanitize.py:448–456, format-preserving fake hash).
+Clean example of a fully-handled secret leaf.
+
+---
+
+## 9. `CanonicalRADIUSServer` (intent.py:624–638) — element of `/radius-servers/server`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/radius-servers/server/host` | `.host` | str | (required) | scalar | **yes** | no | cond |
+| `/radius-servers/server/key` | `.key` | str | `""` | scalar | no | **yes** | cond |
+| `/radius-servers/server/auth-port` | `.auth_port` | int | `1812` | scalar | no | no | **no** |
+| `/radius-servers/server/acct-port` | `.acct_port` | int | `1813` | scalar | no | no | **no** |
+
+Walker yields `host` + `key` only (xpath_walker.py:228–230). `auth_port` /
+`acct_port` unwalked (defaulted ports, low risk). `host` (IP) and `key`
+(secret) both sanitized (sanitize.py:558–576).
+
+---
+
+## 10. `CanonicalVxlan` (intent.py:641–692) — element of `/vxlan-vnis`
+
+Note the unusual xpath shape: the matrices/walker spell this `/vxlan-vnis/<leaf>`
+(NOT `/vxlan-vnis/vni/<leaf>`), i.e. the record-element segment is implicit.
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/vxlan-vnis/vni` | `.vni` | int (1-16777215) | (required) | scalar (anchor) | no | no | cond |
+| `/vxlan-vnis/vlan-id` | `.vlan_id` | int (1-4094) | (required) | scalar | no | no | cond |
+| `/vxlan-vnis/mcast-group` | `.mcast_group` | str | `""` | scalar | **yes (mcast IP)** | no | cond |
+| `/vxlan-vnis/flood-list` | `.flood_list` | list[str] | `[]` | list[scalar] | **yes (VTEP IPs)** | no | cond |
+| `/vxlan-vnis/source-interface` | `.source_interface` | str | `""` | scalar | no | no | cond |
+| `/vxlan-vnis/udp-port` | `.udp_port` | int | `4789` | scalar | no | no | cond |
+
+Walker (xpath_walker.py:231–240): `vni`, `udp-port`, `vlan-id` always;
+`source-interface`, `mcast-group`, `flood-list` when populated. `mcast_group`
++ `flood_list` are network-identifying and sanitizer-redacted (sanitize.py:
+731–746, `redact_mcast_group` + `vtep-flood` — note redact_ipv4 PRESERVES
+multicast, so a dedicated `redact_mcast_group` exists). No secret. No gap.
+
+---
+
+## 11. `CanonicalRoutingInstance` (intent.py:695–742) — element of `/routing-instances/instance`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/routing-instances/instance` | (record anchor) | — | — | scalar (anchor) | no | no | cond |
+| `/routing-instances/instance/name` | `.name` | str | (required) | scalar | no | no | cond |
+| `/routing-instances/instance/instance-type` | `.instance_type` | str | `"vrf"` | scalar | no | no | **no** |
+| `/routing-instances/instance/route-distinguisher` | `.route_distinguisher` | str | `""` | scalar | **yes (RD has IP:nn form)** | no | cond |
+| `/routing-instances/instance/rt-imports` | `.rt_imports` | list[str] | `[]` | list[scalar] | **yes (RT)** | no | cond |
+| `/routing-instances/instance/rt-exports` | `.rt_exports` | list[str] | `[]` | list[scalar] | **yes (RT)** | no | cond |
+| `/routing-instances/instance/description` | `.description` | str | `""` | scalar | no | no | cond |
+| `/routing-instances/instance/l3-vni` | `.l3_vni` | int \| None | `None` | scalar | no | no | cond |
+
+Walker (xpath_walker.py:243–255): anchor + name always; description, RD,
+rt-imports, rt-exports, l3-vni when populated. `instance_type` unwalked
+(defaulted discriminator). RD + RTs are network-identifying (RD/RT can carry
+an `<ip>:<nn>` admin field) → sanitizer redacts via `redact_route_target` /
+`redact_overlay`-class (sanitize.py:709–728, categories `route-distinguisher`
+/ route-target list). No secret. The #162 overlay-ID work covered these.
+
+---
+
+## 12. `CanonicalEvpnType5Route` (intent.py:745–782) — element of `/evpn-type5-routes`
+
+| xpath | Class.field | type | default | kind | IP/HOST | SECRET | WALKED |
+|---|---|---|---|---|---|---|---|
+| `/evpn-type5-routes/route` | (record anchor) | — | — | scalar (anchor) | — | — | cond |
+| `/evpn-type5-routes/route/vrf` | `.vrf` | str | (required) | scalar | no | no | **no** |
+| `/evpn-type5-routes/route/prefix` | `.prefix` | str (CIDR) | (required) | scalar | **yes** | no | **no** ⚠IP |
+| `/evpn-type5-routes/route/rt-imports` | `.rt_imports` | list[str] | `[]` | list[scalar] | **yes (RT)** | no | **no** ⚠IP |
+| `/evpn-type5-routes/route/rt-exports` | `.rt_exports` | list[str] | `[]` | list[scalar] | **yes (RT)** | no | **no** ⚠IP |
+
+Walker yields ONLY the anchor `/evpn-type5-routes/route` (xpath_walker.py:241–
+242) — `prefix`, `rt_imports`, `rt_exports` are unwalked. The sanitizer DOES
+redact all three (`prefix` → `evpn-type5-prefix`; rt lists → route-target,
+sanitize.py:749–760). Note: NO codec populates `evpn_type5_routes` today
+(it's lossy-by-default everywhere — see iosxe_cli matrix:206–219), so the
+walker gap here is a *dead leaf* in practice. Agent 11 should confirm.
+
+---
+
+## 13. Counts (the denominator)
+
+### Leaf totals
+
+Counting every distinct scalar / list-of-scalar leaf as an xpath, treating
+the reused `CanonicalIPv4Address` as two surfaces (interface + vlan), and
+EXCLUDING the 4 metadata/provenance scalars (`source_vendor`,
+`source_format`, `source_version`) + the container-of-raw-text leaves
+(`raw_sections`, `group_content`, `dropped_tier3_sections`, `apply_groups`)
+which are not structured scalar leaves:
+
+| Category | Count |
+|---|---|
+| Top-level system scalars/lists (incl. anycast-gateway-mac) | 7 |
+| `CanonicalInterface` own scalars/lists | 18 |
+| `CanonicalIPv4Address` on interface | 5 |
+| `CanonicalIPv4Address` on vlan (SVI) | 5 |
+| `CanonicalIPv6Address` on interface | 6 |
+| `CanonicalVRRPGroup` | 11 |
+| `CanonicalVlan` own scalars/lists | 5 |
+| `CanonicalStaticRoute` | 6 |
+| `CanonicalDHCPPool` | 9 |
+| `CanonicalSNMP` own | 4 |
+| `CanonicalSNMPv3User` | 7 |
+| `CanonicalLAG` | 3 |
+| `CanonicalLocalUser` | 4 |
+| `CanonicalRADIUSServer` | 4 |
+| `CanonicalVxlan` | 6 |
+| `CanonicalRoutingInstance` | 8 |
+| `CanonicalEvpnType5Route` | 4 |
+| **TOTAL structured leaves** | **112** |
+| Excluded metadata/provenance/raw-container leaves | 7 |
+| **GRAND TOTAL model leaves** | **119** |
+
+(The 112 is the number both downstream gap analyses should treat as the
+denominator for "leaves a walk-everything / type-driven rule must reach";
+the 7 excluded are the explicit-exemption set discussed in §1 note ².)
+
+### IP-or-host-bearing leaves (IP_OR_HOST_BEARING = yes)
+
+26 structured leaves (+ `hostname` flagged yes¹ as host-identity-not-
+ip_address, + the 2 raw-text containers that can embed IPs). Enumerated:
+
+1. `/system/domain` (host)
+2. `/system/dns-server`
+3. `/system/ntp-server`
+4. `/system/syslog-server`
+5. `/anycast-gateway-mac` (MAC)
+6. `/interfaces/interface/ipv4/address/ip`
+7. `/interfaces/interface/ipv4/address/virtual-gateway-address`
+8. `/interfaces/interface/ipv4/address/virtual-gateway-mac` (MAC)
+9. `/interfaces/interface/ipv6/address/ip`
+10. `/interfaces/interface/ipv6/address/virtual-gateway-address`
+11. `/interfaces/interface/ipv6/address/virtual-gateway-mac` (MAC)
+12. `/vlans/vlan/ipv4/address/ip`
+13. `/vlans/vlan/ipv4/address/virtual-gateway-address`
+14. `/vlans/vlan/ipv4/address/virtual-gateway-mac` (MAC)
+15. `/interfaces/interface/vrrp-groups/group/virtual-ips`
+16. `/interfaces/interface/vrrp-groups/group/virtual-ipv6s`
+17. `/interfaces/interface/vrrp-groups/group/virtual-mac` (MAC)
+18. `/routing/static-route` (destination CIDR)
+19. `/routing/static-route/gateway`
+20. `/dhcp-servers/pool/network`, `/start-ip`, `/end-ip`, `/gateway`,
+    `/dns-servers`, `/domain-name` (host) — 6
+21. `/snmp/trap-host`
+22. `/radius-servers/server/host`
+23. `/vxlan-vnis/mcast-group`, `/vxlan-vnis/flood-list` — 2
+24. `/routing-instances/instance/route-distinguisher`, `/rt-imports`,
+    `/rt-exports` — 3
+25. `/evpn-type5-routes/route/prefix`, `/rt-imports`, `/rt-exports` — 3
+
+Total IP/host-bearing structured leaves ≈ **31** (count of bullets expanded).
+`hostname` is host-identifying but not `ip_address()`-parseable — the
+key over-redaction-rule edge case for agent 12.
+
+### Secret-bearing leaves (SECRET_BEARING = yes)
+
+6 structured leaves:
+
+1. `/snmp/community`
+2. `/snmp/v3-user/auth-passphrase`
+3. `/snmp/v3-user/priv-passphrase` ⚠ walker-blind
+4. `/local-users/user/hashed-password`
+5. `/radius-servers/server/key`
+6. `/interfaces/interface/vrrp-groups/group/authentication` ⚠ walker-blind
+   (+ `engine_id` is arguably secret-adjacent; sanitizer treats it as a
+   redaction category. If counted, total = 7.)
+
+(+ raw-text containers `raw_sections` / `group_content` can embed secrets —
+handled by wholesale strip.)
+
+---
+
+## 14. Cross-cutting findings for downstream agents
+
+1. **The two gaps are genuinely independent and the sanitizer is generally
+   AHEAD of the walker.** Many IP/secret leaves are sanitizer-redacted but
+   walker-blind: DHCP sub-fields (×6), static-route gateway, VRRP
+   `authentication`/`virtual_ipv6s`, SNMPv3 `priv_passphrase`, VLAN-SVI
+   `virtual_gateway_address`, EVPN Type-5 `prefix`/RTs. The walker gap is the
+   bigger silent-loss surface; the sanitizer gap is narrower (most known
+   IP/secret fields are already named). Agents 11 and 12 should not assume
+   symmetric blast radius.
+
+2. **Two secret-bearing leaves the walker never yields:** VRRP
+   `authentication` and SNMPv3 `priv_passphrase`. A codec that drops either
+   on render would classify `severity: ok`. These are concrete class-1
+   silent-loss candidates beyond the audit-named instances — hand them to
+   agent 11/20.
+
+3. **The walker walks anchors but not all sub-leaves** for DHCP, EVPN-Type5,
+   and (on the VLAN copy) IPv4-address sub-fields. A "walk EVERY leaf"
+   design (class-1 form A) would multiply yields substantially (DHCP alone
+   goes 1→9; EVPN-Type5 1→4). Agent 20 must quantify the phase4
+   reclassification blast radius of expanding these.
+
+4. **The raw-text containers (`raw_sections`, `group_content`,
+   `dropped_tier3_sections`, `apply_groups`) are the natural exemption set**
+   for any reflection-driven completeness guard: they are not typed scalar
+   leaves, they hold opaque vendor text, and they already have wholesale
+   strip handling in the sanitizer and are by-design-not-walked
+   (Tier-3 / provenance). Model the exemption on #149's
+   `_SYNTHETIC_NONWALKABLE` — each carries its reason. Likewise the 3
+   `source_*` metadata scalars.
+
+5. **Free-text fields are the over-redaction trap for class-2 design A**
+   (blanket `ip_address()`): `hostname`, interface `description`, VLAN
+   `name`/`description`, SNMP `contact`/`location`, DHCP `domain_name`,
+   route `description`, VRRP `description`, routing-instance `description`,
+   `instance_type`, `vxlan source_interface`, `tunnel_type`,
+   `dhcp_client_v6`, `kind`, `scope`, `mode`. None are `ip_address()`-
+   parseable as a whole, but several can CONTAIN an IP-like substring. A
+   value-level `ip_address()` rule (parse the whole field) would NOT mangle
+   these (they don't parse as a bare IP); a substring/regex rule WOULD. This
+   is the decisive over-redaction distinction for agent 12.
+
+6. **xpath spelling caveats** (so agents 11/20/12 reuse the right strings):
+   - VXLAN leaves are `/vxlan-vnis/<leaf>` (no `/vni/` element segment).
+   - Switchport leaves are `/interfaces/interface/<leaf>` (no `config/`
+     segment) — `switchport-mode`, `access-vlan`, etc.
+   - `description`/`enabled`/`type`/`mtu`/`vrf` on interface DO carry a
+     `config/` segment (`/interfaces/interface/config/...`).
+   - Several projected xpaths in this census (`/routing/static-route/
+     gateway`, `/dhcp-servers/pool/*`, `/evpn-type5-routes/route/*`,
+     vlan-SVI sub-fields, VRRP `mode`/`priority`/`preempt`/`auth`) are NOT
+     declared by any matrix today — treat the spelling as the proposed
+     convention, not an existing string.

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/11-walker-gap.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/11-walker-gap.md
@@ -1,0 +1,409 @@
+# 11 — Walker-gap census (silent capability-loss class, class 1)
+
+**Agent:** `11-walker-gap` · Phase 1 · read-only
+**Date:** 2026-06-24 · ultracode blackboard · netcanon
+**Scope:** Quantify the silent-loss gap: enumerate exactly what
+`_walk_canonical` yields, confirm the default-to-supported rule in
+`classify()`, build the leaf denominator from `intent.py`, compute the
+GAP (expressible-but-never-walked leaves), grep which codecs populate
+each gap leaf, catalogue what each of the 5 existing partial guards
+covers, and account for the #149 intentionally-non-walkable exemption.
+
+---
+
+## 0. TL;DR
+
+- **`classify()` default-to-supported is CONFIRMED.** `netcanon/models/migration.py:221-228`: any xpath not exact-matched in `unsupported` or `lossy` returns `"supported"`. An unwalked leaf is never passed to `classify()` at all, so it can never be lossy/unsupported in the **live** report — it is structurally invisible (`migration_validate.py:80-87` only iterates `_enumerate_xpaths` → `source.iter_xpaths` → `_walk_canonical`).
+- **The walker yields 64 distinct xpath strings** (counted from `xpath_walker.py:62-256`).
+- **The canonical model has ~95 data-bearing leaves.** The **silent-loss GAP = ~24 leaves that are expressible (a codec parses a non-default value into them) but the walker NEVER yields** → they default `supported` in the live report → silent loss.
+- **The highest-risk gap leaves** (multiple codecs populate them, real reachability/semantic loss): the **VRRP/FHRP group sub-fields** `mode` (hsrp/carp discriminator), `priority`, `preempt`, `advertisement_interval`, `authentication`, `virtual_ipv6s`; the **IPv6 `scope`** (link-local vs global); the **DHCP pool option leaves** (`network`, `start_ip`, `end_ip`, `gateway`, `dns_servers`, `lease_time`, `domain_name`); the **RADIUS port leaves** (`auth_port`, `acct_port`); and the **routing-instance `instance_type` / `l3_vni`** and **EVPN type-5 `prefix`/`rt_imports`/`rt_exports`**.
+- **A mitigating fact** (do not over-state the gap): the **offline cross-mesh audit** (`tools/run_full_mesh.py`) does NOT use the walker — it compares `model_dump()` field-by-field (`run_full_mesh.py:334-335`) — so several gap leaves ARE caught at audit time even though they are blind to the **live `validate_against` UI banner**. The two surfaces have different blind spots. The walker gap is specifically a **live-report** honesty hole.
+- **#149 lesson honoured:** Tier-3 routing-protocol paths (`/routing/bgp`, `/routing/ospf`, …) and the 6 `_SYNTHETIC_NONWALKABLE` per-vendor structural markers are **intentionally non-walkable**; any walk-everything rule (design-phase A) or completeness guard (design-phase B) MUST exempt them or it false-fails.
+
+---
+
+## 1. What `_walk_canonical` yields — exact enumeration
+
+Source: `netcanon/migration/canonical/xpath_walker.py`. Every yield is guarded on the field being populated (truthy / `is not None`). Below is the complete yield set with the file:line of each yield site and the guard condition.
+
+### 1.1 Tier 1 — system scalars + interfaces (lines 62-198)
+
+| xpath | line | guard / owning field |
+|---|---|---|
+| `/system/hostname` | 64 | `intent.hostname` |
+| `/system/domain` | 66 | `intent.domain` |
+| `/system/dns-server` | 68 | per `intent.dns_servers` |
+| `/system/ntp-server` | 70 | per `intent.ntp_servers` |
+| `/system/timezone` | 72 | `intent.timezone` |
+| `/system/syslog-server` | 74 | per `intent.syslog_servers` |
+| `/interfaces/interface/name` | 76 | per `intent.interfaces` (unconditional within loop) |
+| `/interfaces/interface/config/description` | 78 | `iface.description` |
+| `/interfaces/interface/config/enabled` | 79 | unconditional within loop |
+| `/interfaces/interface/config/type` | 81 | `iface.interface_type` |
+| `/interfaces/interface/ipv4/address/ip` | 83 | per `iface.ipv4_addresses` |
+| `/interfaces/interface/ipv4/address/prefix-length` | 84 | per ipv4 address |
+| `/interfaces/interface/ipv4/address/secondary-ip` | 91 | `addr.is_secondary` |
+| `/interfaces/interface/ipv4/address/virtual-gateway-address` | 93-95 | `addr.virtual_gateway_address` |
+| `/interfaces/interface/ipv4/address/virtual-gateway-mac` | 98-100 | `addr.virtual_gateway_mac` |
+| `/interfaces/interface/ipv6/address/ip` | 103 | per `iface.ipv6_addresses` |
+| `/interfaces/interface/ipv6/address/prefix-length` | 104 | per ipv6 address |
+| `/interfaces/interface/ipv6/address/secondary-ip` | 106 | `addr6.is_secondary` |
+| `/interfaces/interface/ipv6/address/virtual-gateway-address` | 108-110 | `addr6.virtual_gateway_address` |
+| `/interfaces/interface/ipv6/address/virtual-gateway-mac` | 113-115 | `addr6.virtual_gateway_mac` |
+| `/interfaces/interface/dhcp-client-v6` | 118 | `iface.dhcp_client_v6` |
+| `/interfaces/interface/tunnel-type` | 120 | `iface.tunnel_type` |
+| `/interfaces/interface/config/mtu` | 122 | `iface.mtu is not None` |
+| `/interfaces/interface/config/vrf` | 124 | `iface.vrf` |
+| `/interfaces/interface/lag-member-of` | 126 | `iface.lag_member_of` |
+| `/interfaces/interface/dhcp-client` | 128 | `iface.dhcp_client` |
+| `/interfaces/interface/switchport-mode` | 137 | `iface.switchport_mode` |
+| `/interfaces/interface/access-vlan` | 139 | `iface.access_vlan is not None` |
+| `/interfaces/interface/trunk-allowed-vlans` | 141 | `iface.trunk_allowed_vlans` |
+| `/interfaces/interface/trunk-native-vlan` | 143 | `iface.trunk_native_vlan is not None` |
+| `/interfaces/interface/voice-vlan` | 145 | `iface.voice_vlan is not None` |
+| `/interfaces/interface/vrrp-groups/group` | 147 | per `iface.vrrp_groups` |
+| `/interfaces/interface/vrrp-groups/group/virtual-ips` | 154 | `len(grp.virtual_ips) > 1` |
+| `/interfaces/interface/vrrp-groups/group/virtual-mac` | 156 | `grp.virtual_mac` |
+| `/interfaces/interface/vrrp-groups/group/track-interfaces` | 158 | `grp.track_interfaces` |
+| `/vlans/vlan/id` | 160 | per `intent.vlans` |
+| `/vlans/vlan/name` | 161 | unconditional within loop |
+| `/vlans/vlan/description` | 163 | `vlan.description` |
+| `/vlans/vlan/tagged-ports` | 165 | per `vlan.tagged_ports` |
+| `/vlans/vlan/untagged-ports` | 167 | per `vlan.untagged_ports` |
+| `/vlans/vlan/ipv4/address/ip` | 179 | per `vlan.ipv4_addresses` |
+| `/routing/static-route` | 181 | per `intent.static_routes` |
+| `/routing/static-route/vrf` | 183 | `route.vrf` |
+| `/routing/static-route/metric` | 192 | `route.metric` (truthy → 0 NOT walked) |
+| `/routing/static-route/description` | 194 | `route.description` |
+| `/routing/static-route/interface` | 196 | `route.interface` |
+| `/anycast-gateway-mac` | 198 | `intent.anycast_gateway_mac` |
+
+### 1.2 Tier 2 (lines 199-256)
+
+| xpath | line | guard / owning field |
+|---|---|---|
+| `/snmp/community` | 202 | `intent.snmp.community` |
+| `/snmp/location` | 204 | `intent.snmp.location` |
+| `/snmp/contact` | 206 | `intent.snmp.contact` |
+| `/snmp/trap-host` | 208 | per `intent.snmp.trap_hosts` |
+| `/snmp/v3-user` | 210 | per `intent.snmp.v3_users` |
+| `/snmp/v3-user/auth-passphrase` | 212 | `v3.auth_passphrase` |
+| `/snmp/v3-user/engine-id` | 214 | `v3.engine_id` |
+| `/dhcp-servers/pool` | 216 | per `intent.dhcp_servers` |
+| `/lags/lag/name` | 218 | per `intent.lags` |
+| `/lags/lag/members` | 219 | unconditional within loop |
+| `/lags/lag/mode` | 220 | unconditional within loop |
+| `/local-users/user/name` | 222 | per `intent.local_users` |
+| `/local-users/user/role` | 224 | `user.role` |
+| `/local-users/user/hashed-password` | 226 | `user.hashed_password` |
+| `/local-users/user/privilege-level` | 227 | unconditional within loop |
+| `/radius-servers/server/host` | 229 | per `intent.radius_servers` |
+| `/radius-servers/server/key` | 230 | unconditional within loop |
+| `/vxlan-vnis/vni` | 232 | per `intent.vxlan_vnis` |
+| `/vxlan-vnis/source-interface` | 234 | `vx.source_interface` |
+| `/vxlan-vnis/mcast-group` | 236 | `vx.mcast_group` |
+| `/vxlan-vnis/flood-list` | 238 | `vx.flood_list` |
+| `/vxlan-vnis/udp-port` | 239 | unconditional within loop |
+| `/vxlan-vnis/vlan-id` | 240 | unconditional within loop |
+| `/evpn-type5-routes/route` | 242 | per `intent.evpn_type5_routes` |
+| `/routing-instances/instance` | 244 | per `intent.routing_instances` |
+| `/routing-instances/instance/name` | 245 | unconditional within loop |
+| `/routing-instances/instance/description` | 247 | `inst.description` |
+| `/routing-instances/instance/route-distinguisher` | 249 | `inst.route_distinguisher` |
+| `/routing-instances/instance/rt-imports` | 251 | `inst.rt_imports` |
+| `/routing-instances/instance/rt-exports` | 253 | `inst.rt_exports` |
+| `/routing-instances/instance/l3-vni` | 255 | `inst.l3_vni is not None` |
+
+**Total distinct walker xpaths: 64.** (This matches `_WALKABLE = frozenset(_walk_canonical(_maximal_intent()))` in `test_registry_capability_honesty.py:225` — the maximal-intent kitchen-sink populates every conditional surface.)
+
+---
+
+## 2. The default-to-supported rule — CONFIRMED, quoted
+
+`netcanon/models/migration.py`, `CapabilityMatrix.classify` (lines 195-228):
+
+```python
+for up in self.unsupported:
+    if up.path == xpath:
+        return "unsupported"
+for lp in self.lossy:
+    if lp.path == xpath:
+        return "lossy"
+# Explicit supported list OR implicit default.
+return "supported"
+```
+
+The matching is **exact string equality** (docstring lines 210-219 makes this explicit). The consumer is `migration_validate.classify_tree` (`migration_validate.py:80-87`):
+
+```python
+for xpath in _enumerate_xpaths(tree, source):
+    kind = caps.classify(xpath)
+    ...
+```
+
+and `_enumerate_xpaths` (lines 28-45) yields **only** what `source.iter_xpaths(tree)` returns — which for every canonical codec is `_walk_canonical`. **Therefore: a leaf the walker never yields is never an argument to `classify()`.** It cannot be classified lossy/unsupported in the live report; it simply does not appear in `supported_paths`/`lossy_paths`/`unsupported_paths`. The migrate-page banner aggregates severity over the classified set (`validate_against` lines 118-153) — an unwalked dropped leaf contributes nothing and the banner stays green. **This is the silent-loss mechanism, and it is the literal "default-to-supported on an unwalked leaf" the seed describes.** Confirmed.
+
+> **Nuance the design phase must carry:** the default is not literally "the unwalked leaf is classified supported"; it is "the unwalked leaf is classified **nothing** — it never reaches `classify()`." The *effect* is identical to supported (no warn/block contribution), but a class-1 design that reasons about "leaves classified supported" will mis-model this: the leaf is **absent**, not present-and-supported. The completeness guard (design B) must therefore check *walker coverage*, not *classification output*.
+
+---
+
+## 3. The leaf denominator — independent census from `intent.py`
+
+Built independently from `netcanon/migration/canonical/intent.py` (per the brief — I run parallel to `10-model-leaf-census`; treat their table as authoritative if it differs, but this is my sufficient list to compute the gap). Leaves are scalar / list-of-scalar fields on each model. I exclude pure container references (e.g. `interfaces: list[CanonicalInterface]`) since those are walked at the child-leaf granularity.
+
+### 3.1 `CanonicalIntent` (root) — `intent.py:790-930`
+
+| field | type | default | walked? | IP/host | secret |
+|---|---|---|---|---|---|
+| hostname | str | "" | ✅ `/system/hostname` | — | — |
+| domain | str | "" | ✅ | maybe | — |
+| dns_servers | list[str] | [] | ✅ | ✅ | — |
+| ntp_servers | list[str] | [] | ✅ | ✅ | — |
+| timezone | str | "" | ✅ | — | — |
+| syslog_servers | list[str] | [] | ✅ | ✅ | — |
+| anycast_gateway_mac | str | "" | ✅ `/anycast-gateway-mac` | — | — |
+| raw_sections | dict | {} | ❌ (Tier-3, by design) | maybe | maybe |
+| dropped_tier3_sections | list[str] | [] | ❌ (notification, by design) | — | — |
+| source_vendor | str | "" | ❌ (metadata) | — | — |
+| source_format | str | "" | ❌ (metadata) | — | — |
+| source_version | str | "" | ❌ (metadata) | — | — |
+| apply_groups | list[str] | [] | ❌ **GAP** (provenance; Junos populates) | — | — |
+| group_content | dict | {} | ❌ **GAP** (provenance; Junos populates) | maybe | maybe |
+
+### 3.2 `CanonicalInterface` — `intent.py:168-281`
+
+| field | walked? | note |
+|---|---|---|
+| name | ✅ `/interfaces/interface/name` | |
+| default_name | ❌ **GAP** | MikroTik factory name; populated by `mikrotik_routeros` parse/render |
+| description | ✅ | |
+| enabled | ✅ | |
+| interface_type | ✅ `/interfaces/interface/config/type` | |
+| mtu | ✅ | |
+| ipv4_addresses | ✅ (child leaves) | |
+| ipv6_addresses | ✅ (child leaves) | |
+| switchport_mode | ✅ | |
+| access_vlan | ✅ | |
+| trunk_allowed_vlans | ✅ | |
+| trunk_native_vlan | ✅ | |
+| voice_vlan | ✅ | |
+| lag_member_of | ✅ | |
+| dhcp_client | ✅ | |
+| dhcp_client_v6 | ✅ | |
+| tunnel_type | ✅ | |
+| vrf | ✅ | |
+| kind | ❌ **GAP** | role override; `cisco_iosxe_cli`/`cisco_nxos` set `kind="mgmt"` |
+| vrrp_groups | partial (child leaves — see 3.4) | |
+
+### 3.3 `CanonicalIPv4Address` (`:83-124`) / `CanonicalIPv6Address` (`:127-165`)
+
+| field | walked? | note |
+|---|---|---|
+| ip | ✅ | |
+| prefix_length | ✅ | |
+| is_secondary | ✅ (`/…/secondary-ip`) | |
+| virtual_gateway_address | ✅ | |
+| virtual_gateway_mac | ✅ | |
+| scope (IPv6 only) | ❌ **GAP** | `arista_eos` parse sets `scope="link-local"` (`parse.py:1064`) |
+
+### 3.4 `CanonicalVRRPGroup` — `intent.py:491-597`  ← **the densest gap cluster**
+
+| field | type | walked? | note |
+|---|---|---|---|
+| group_id | int | partial — only `/interfaces/interface/vrrp-groups/group` (the whole-group marker, line 147) | identity leaf walked |
+| mode | str | ❌ **GAP (HIGH)** | "vrrp"/"hsrp"/"carp"; `cisco_nxos` sets `mode="hsrp"` (`parse.py:809`), `opnsense` sets `mode="carp"` (`parse.py:838`) |
+| virtual_ips | list[str] | ✅ ONLY when `len>1` (line 154) | a single-VIP drop is NOT walked |
+| virtual_ipv6s | list[str] | ❌ **GAP** | populated by junos/mikrotik/opnsense (`parse.py:2399`, `776`, `840`) |
+| virtual_mac | str | ✅ | |
+| priority | int | ❌ **GAP** | populated by every FHRP codec |
+| preempt | bool | ❌ **GAP** | populated by junos/mikrotik/opnsense |
+| advertisement_interval | int | ❌ **GAP** | populated by junos/mikrotik/opnsense (`parse.py:2383`, `779`, `842`) |
+| authentication | str | ❌ **GAP (secret-adjacent)** | opaque `<scheme>:<value>`; junos/mikrotik/opnsense (`parse.py:780`, `843`) |
+| track_interfaces | list[str] | ✅ | |
+| description | str | ❌ **GAP** | operator text |
+
+The whole-group identity (`/interfaces/interface/vrrp-groups/group`) IS walked, so a codec that drops VRRP wholesale surfaces the loss at that leaf. But a codec that **keeps the group yet drops `mode`/`priority`/`preempt`/`adv-interval`/`authentication`** silently changes the redundancy semantics with a green banner. This is exactly the silent-loss class, and it is the largest concentrated gap.
+
+### 3.5 `CanonicalVlan` — `intent.py:284-298`
+
+All four leaves walked (`id`, `name`, `description`, `tagged_ports`, `untagged_ports`, `ipv4_addresses/ip`). The VLAN SVI L3 prefix-length on `CanonicalVlan.ipv4_addresses[].prefix_length` is **NOT** walked (only `/vlans/vlan/ipv4/address/ip` at line 179, not `…/prefix-length`) — a minor gap.
+
+### 3.6 `CanonicalStaticRoute` — `intent.py:301-331`
+
+| field | walked? | note |
+|---|---|---|
+| destination | partial — only `/routing/static-route` (whole-route marker, line 181) | |
+| gateway | ❌ **GAP (minor)** | the next-hop IP itself is never its own leaf; a route that keeps destination but mangles the gateway is not surfaced |
+| interface | ✅ (when populated) | |
+| metric | ✅ (when truthy — `metric=0` NOT walked) | |
+| description | ✅ | |
+| vrf | ✅ | |
+
+### 3.7 `CanonicalDHCPPool` — `intent.py:339-361`  ← **second-densest gap cluster**
+
+The walker yields ONLY `/dhcp-servers/pool` (the whole-pool marker, line 216). **Every option leaf is unwalked:**
+
+| field | walked? | IP/host | note |
+|---|---|---|---|
+| interface | ❌ **GAP** | — | |
+| network | ❌ **GAP** | ✅ | populated by all DHCP codecs |
+| start_ip | ❌ **GAP** | ✅ | |
+| end_ip | ❌ **GAP** | ✅ | |
+| gateway | ❌ **GAP** | ✅ | |
+| dns_servers | ❌ **GAP** | ✅ | |
+| lease_time | ❌ **GAP** | — | opnsense/mikrotik populate (`parse.py:701`, `1007`) |
+| domain_name | ❌ **GAP** | maybe | opnsense/junos/mikrotik populate (`parse.py:702`, `788`, `1007`) |
+
+Because only `/dhcp-servers/pool` is walked, a codec that renders the pool envelope but drops the lease-time / domain / dns options reports `severity:ok`. (Mitigation: cross-mesh `model_dump()` audit catches these — see §6.)
+
+### 3.8 `CanonicalSNMP` (`:450-471`) + `CanonicalSNMPv3User` (`:364-447`)
+
+| field | walked? | note |
+|---|---|---|
+| snmp.community / location / contact / trap_hosts | ✅ | |
+| snmp.v3_users (identity) | ✅ `/snmp/v3-user` | |
+| v3.auth_passphrase | ✅ (secret) | |
+| v3.engine_id | ✅ | |
+| v3.group | ❌ **GAP** | VACM group; populated by arista/aoss/junos |
+| v3.auth_protocol | ❌ **GAP** | md5/sha/sha256… — a protocol downgrade is a security change |
+| v3.priv_protocol | ❌ **GAP** | des/aes/aes256 |
+| v3.priv_passphrase | ❌ **GAP (secret)** | walked twin `auth-passphrase` IS walked but `priv-passphrase` is NOT |
+
+The asymmetry (`auth-passphrase` walked, `priv-passphrase` not) is notable: a codec that drops the privacy key while keeping the auth key reports ok.
+
+### 3.9 `CanonicalLAG` (`:474-488`)
+
+`name`, `members`, `mode` all walked unconditionally. No gap.
+
+### 3.10 `CanonicalLocalUser` (`:600-621`)
+
+`name`, `role`, `hashed_password`, `privilege_level` all walked. No gap.
+
+### 3.11 `CanonicalRADIUSServer` (`:624-638`)
+
+| field | walked? | note |
+|---|---|---|
+| host | ✅ | |
+| key | ✅ (secret) | |
+| auth_port | ❌ **GAP** | opnsense/fortigate/mikrotik/iosxe/aoss populate non-default ports |
+| acct_port | ❌ **GAP** | same |
+
+### 3.12 `CanonicalVxlan` (`:641-692`)
+
+`vni`, `source-interface`, `mcast-group`, `flood-list`, `udp-port`, `vlan-id` all walked. **`vlan_id` walked but the model also has it as the binding** — no gap.
+
+### 3.13 `CanonicalRoutingInstance` (`:695-742`)
+
+| field | walked? | note |
+|---|---|---|
+| name / description / route_distinguisher / rt_imports / rt_exports / l3_vni | ✅ | |
+| instance_type | ❌ **GAP** | "vrf"/"virtual-router"/"l2vpn"/"mac-vrf"; arista sets `instance_type="mac-vrf"` (`parse.py:853`) — a mac-vrf rendered as a plain vrf is a real semantic loss |
+
+### 3.14 `CanonicalEvpnType5Route` (`:745-782`)
+
+The walker yields ONLY `/evpn-type5-routes/route` (whole-route marker, line 242). **`vrf`, `prefix`, `rt_imports`, `rt_exports` are all unwalked sub-leaves** → **GAP**. A codec that emits the route envelope but drops the prefix / RTs reports ok. (Like DHCP, caught by the model_dump cross-mesh audit but blind to the live report.)
+
+---
+
+## 4. THE GAP — expressible-but-never-walked leaves
+
+Consolidated list of leaves that (a) a codec can populate with a non-default value AND (b) the walker never yields. Ranked by **real risk** = (# codecs that populate it) × (severity of a silent drop).
+
+### 4.1 HIGH risk (multiple codecs populate; reachability/security/semantic loss)
+
+| # | gap leaf (proposed walker spelling) | owning `Class.field` | populating codecs (grep-confirmed) | why it matters |
+|---|---|---|---|---|
+| 1 | `/interfaces/interface/vrrp-groups/group/mode` | `CanonicalVRRPGroup.mode` | cisco_nxos (`hsrp` `parse.py:809`), opnsense (`carp` `parse.py:838`), arista (`parse.py:198`) | a hsrp→vrrp or carp→vrrp silent conversion changes the redundancy protocol; operator never warned |
+| 2 | `/interfaces/interface/vrrp-groups/group/priority` | `.priority` | all FHRP codecs | priority drop → master election flips silently |
+| 3 | `/interfaces/interface/vrrp-groups/group/preempt` | `.preempt` | junos (`parse.py:2411`), mikrotik (`663`), opnsense | preempt flip changes failover behaviour |
+| 4 | `/interfaces/interface/vrrp-groups/group/advertisement-interval` | `.advertisement_interval` | junos (`2383`), mikrotik (`779`), opnsense (`842`) | timer mismatch → flapping |
+| 5 | `/interfaces/interface/vrrp-groups/group/authentication` | `.authentication` | junos (`780` area), mikrotik (`780`), opnsense (`843`) | **secret-adjacent**; auth dropped → group won't form / forms unauthenticated |
+| 6 | `/interfaces/interface/vrrp-groups/group/virtual-ipv6s` | `.virtual_ipv6s` | junos (`2399`), mikrotik (`776`), opnsense (`840`) | a v6 VIP silently lost |
+| 7 | `/snmp/v3-user/priv-passphrase` | `CanonicalSNMPv3User.priv_passphrase` | arista/aoss/fortigate/mikrotik/junos | **secret**; privacy key dropped (auth twin IS walked — asymmetric) |
+| 8 | `/snmp/v3-user/auth-protocol` | `.auth_protocol` | same v3 codecs | algorithm downgrade is a security change |
+| 9 | `/snmp/v3-user/priv-protocol` | `.priv_protocol` | same v3 codecs | cipher downgrade |
+| 10 | `/interfaces/interface/ipv6/address/scope` | `CanonicalIPv6Address.scope` | arista (`parse.py:1064`) | link-local rendered as global (or dropped) breaks NDP/OSPFv3 adjacency |
+| 11 | `/routing-instances/instance/instance-type` | `CanonicalRoutingInstance.instance_type` | arista (`mac-vrf` `parse.py:853`) | mac-vrf↔vrf semantic loss |
+
+### 4.2 MEDIUM risk (single/few codecs; option-detail loss, caught by cross-mesh audit but not live report)
+
+| # | gap leaf | owning | populating | note |
+|---|---|---|---|---|
+| 12-19 | `/dhcp-servers/pool/{interface,network,start-ip,end-ip,gateway,dns-servers,lease-time,domain-name}` | `CanonicalDHCPPool.*` | opnsense/mikrotik/junos/iosxe etc. | only the `/dhcp-servers/pool` envelope is walked; every option detail blind to live report |
+| 20-23 | `/evpn-type5-routes/route/{vrf,prefix,rt-imports,rt-exports}` | `CanonicalEvpnType5Route.*` | arista/nxos/junos | only the `/evpn-type5-routes/route` envelope walked |
+| 24-25 | `/radius-servers/server/{auth-port,acct-port}` | `CanonicalRADIUSServer.*` | opnsense/fortigate/mikrotik/iosxe/aoss | non-default ports silently lost |
+| 26 | `/snmp/v3-user/group` | `.group` | arista/aoss/junos | VACM group dropped |
+
+### 4.3 LOW risk (dead-ish / provenance / structurally-covered)
+
+| # | gap leaf | owning | note |
+|---|---|---|---|
+| 27 | `/interfaces/interface/kind` | `CanonicalInterface.kind` | role override; it drives the *rename mesh*, not render fidelity — arguably correctly unwalked (it's a transform hint, not a config surface). Flag, don't necessarily walk. |
+| 28 | `/interfaces/interface/default-name` | `.default_name` | MikroTik factory name; a render mechanism, not an operator-visible surface. Same-vendor round-trip only. Correctly unwalked. |
+| 29 | `/routing/static-route/gateway` | `CanonicalStaticRoute.gateway` | the next-hop value; covered implicitly because a route with a wrong/dropped gateway usually drops the whole `/routing/static-route`. Minor. |
+| 30 | `/vlans/vlan/ipv4/address/prefix-length` | SVI prefix | `ip` is walked; prefix nearly always travels with it. Minor. |
+| 31 | `/interfaces/interface/vrrp-groups/group/description` | `.description` | operator text; low fidelity stakes |
+| 32 | `apply_groups` / `group_content` | root provenance | Junos-only provenance hints; explicitly "ship-before-wire for most codecs"; arguably metadata (already in `_NON_CAPABILITY_FIELDS` of the honesty guard) |
+| 33 | single-VIP `virtual_ips` drop | `CanonicalVRRPGroup.virtual_ips` | walked ONLY when `len>1`; a codec that drops the *sole* VIP keeps the group marker but the VIP is gone — a narrow hole |
+
+**Gap headline count: ~24 leaves of genuine concern** (HIGH 11 + MEDIUM 9, treating the DHCP/EVPN clusters as single concerns gives ~20; with the LOW/structural ones ~33 total expressible-unwalked). The **~24** figure for the design phase = the HIGH + MEDIUM rows, i.e. leaves where a codec populates a non-default value and a silent drop has real consequence.
+
+---
+
+## 5. Catalogue of the 5 existing partial guards — what each covers / leaves open
+
+| guard | file | what it covers | what it LEAVES OPEN |
+|---|---|---|---|
+| **G1** value-detail subfields | `tests/unit/migration/test_silent_loss_list_subfields.py` | A hand-curated `_CASES` list (10 cases): vxlan mcast/flood, vlan-description, snmp v3 engine-id, varp vga/vgm v4+v6, tunnel-type, vlan-svi-ipv4. For each: if a codec keeps the identity leaf but drops the sub-detail, the sub-detail MUST be declared lossy/unsupported. | **Hand-maintained `_CASES`** — a NEW sub-detail (e.g. vrrp `mode`, dhcp `lease-time`) is NOT in `_CASES` so it's uncovered. This is itself an instance of the covered-subset blind spot, one level up. |
+| **G2** naming-sensitive | `tests/unit/migration/test_silent_loss_naming_sensitive.py` | LAG members + `lag-member-of` + per-interface switchport + VLAN-centric port lists, using a per-codec `_NATIVE` name map so a drop is unambiguous. | Only the L2/LAG surfaces. Pins the opnsense/mikrotik/fortigate VLAN-port-list finding. Nothing about VRRP/DHCP/RADIUS/SNMP-v3 sub-fields. |
+| **G3** registry honesty (reverse-parity) | `tests/unit/migration/test_registry_capability_honesty.py` | (a) every declared `supported` xpath is walkable; (b) rendered field ⇒ not-unsupported; (c) no supported/unsupported overlap; (d) **#149** non-walkable lossy/unsupported must be documented-synthetic; (e) naming-independent total-drop must be declared; (f) static-route subfield + secondary drops declared; (g) `test_marker_dict_covers_every_data_bearing_field` — every top-level field has a marker. | These are **declaration-vs-render** and **declaration-vs-walker** consistency checks. **NONE of them assert that the walker COVERS every model leaf.** `test_marker_dict_covers_every_data_bearing_field` is the closest — but it only checks **top-level** `CanonicalIntent.model_fields`, NOT nested sub-leaves (it would never notice `CanonicalVRRPGroup.priority` going unwalked). **This is the precise hole class-1 design must fill.** |
+| **G4** #149 non-walkable allowlist | (within G3) `test_lossy_unsupported_nonwalkable_is_documented_synthetic` + `_SYNTHETIC_NONWALKABLE` + `_is_legitimate_nonwalkable` | Teaches the self-justifying-exemption precedent: 6 blessed structural markers + raw-sections + Tier-3-top-segment + whole-field-marker rules. | It's a *reverse* check (declared-but-not-walkable is OK if blessed). It does NOT enforce *walked-coverage* in the forward direction. |
+| **G5** per-codec walker coverage floor | `tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py` | The **forward** check, but only at **top-level** granularity: `_FIELD_TO_EXPECTED_XPATH` (18 top-level fields) must each yield ≥1 walker xpath; plus hand-listed per-interface sub-fields, vlan-svi-l3, snmp-v3 sub-fields. | **Hand-maintained `_FIELD_TO_EXPECTED_XPATH` + hand-listed sub-fields.** It proves the 18 top-level surfaces are walked, but a NEW nested leaf (vrrp `priority`, dhcp `lease-time`) added to a model is invisible to it. This is the existing closest-to-the-goal guard and the natural place to generalise — but today it relocates the blind spot into the hand-maintained dict. |
+
+**Synthesis for the design phase:** The forward-coverage direction (every model leaf is walked-or-justified) is **the missing guard**. G5 does it for 18 top-level fields via a hand-maintained dict; G3's `test_marker_dict_covers_every_data_bearing_field` does it for top-level fields via `model_fields` reflection but doesn't recurse into nested models. **Neither recurses into the nested `CanonicalVRRPGroup` / `CanonicalDHCPPool` / `CanonicalSNMPv3User` / `CanonicalEvpnType5Route` / `CanonicalRoutingInstance` sub-leaves — which is exactly where the gap concentrates (§4.1, §4.2).** A reflection-driven guard that recurses through `model_fields` of nested models and asserts each leaf is walked-or-exempt would catch the whole class.
+
+---
+
+## 6. The two-surface nuance (do NOT over-state the gap)
+
+There are **two** consumers that decide whether a dropped field is surfaced, and they have **different** blind spots:
+
+1. **Live `validate_against` report** (the migrate-page banner) — depends 100% on `_walk_canonical`. Blind to every gap leaf in §4.
+2. **Offline cross-mesh audit** `tools/run_full_mesh.py` — does **NOT** use the walker. It compares `source.model_dump()` vs `target.model_dump()` field-by-field (`run_full_mesh.py:334-335`) and reads each target's `CapabilityMatrix.unsupported` directly. The `_walk_canonical` docstring (lines 57-60) explicitly notes this. So a DHCP `lease-time` drop, an EVPN `prefix` drop, etc. **are** caught at audit/regen time as field-disposition drift — they are blind only to the *live UI banner*.
+
+**Consequence for the design:** the class-1 fix closes the **live-report** honesty hole specifically. The HIGH-risk VRRP/SNMP-v3/IPv6-scope leaves (§4.1) are the ones where the live report is the operator's only signal before they commit a migration — those are the leaves where walking matters most. The DHCP/EVPN envelope sub-leaves (§4.2) have a partial backstop in the cross-mesh audit, so they are lower urgency even though they are real walker gaps.
+
+---
+
+## 7. The #149 exemption — what MUST stay non-walkable
+
+Any "walk every leaf" rule (design A) or "every model leaf must be walked or justified" guard (design B) must NOT flag these as gaps — they are **intentionally** non-walkable:
+
+- **Tier-3 routing-protocol paths** — `/routing/bgp`, `/routing/ospf`, `/routing/isis`, etc. The canonical model does NOT have BGP/OSPF surfaces as walkable leaves; codecs declare them `unsupported` and they're modelled only as `dropped_tier3_sections`. The `_is_legitimate_nonwalkable` predicate (`test_registry_capability_honesty.py:333-346`) handles this via the `/routing/` + not-`static-route` rule and the `_WALKABLE_TOP_SEGMENTS` top-segment check.
+- **The 6 `_SYNTHETIC_NONWALKABLE` markers** (`test_registry_capability_honesty.py:323-330`): `/interfaces/interface/4th-port-segment` (IOS-XR), `/interfaces/interface/vrrp-groups/group/address-family` (IOS-XE-CLI), `/interfaces/interface/subinterfaces/subinterface` (Junos dot1q), `/interfaces/interface/subinterfaces/subinterface/ipv6` (IOS-XE-CLI), `/routing-instances/instance/table` (VyOS), `/vxlan-vnis/l2vni-route-target` (AOS-CX/VyOS). These are per-vendor structural quirks the canonical model deliberately does not represent as leaves.
+- **`raw_sections`, `dropped_tier3_sections`** (root) — Tier-3 carry-through / notification surfaces; never walked by design.
+- **Metadata** — `source_vendor`/`source_format`/`source_version` (already in `_NON_CAPABILITY_FIELDS`).
+
+**Crucial distinction the design phase must respect:** #149 is about *declared-but-not-walkable* (a matrix declares a path the walker never yields → OK if blessed). The class-1 gap is the **opposite direction**: *model-leaf-exists-but-not-walked-AND-not-declared*. The `_SYNTHETIC_NONWALKABLE` set is the *precedent for the exemption mechanism* (each entry self-justifies with a comment), but the new forward-coverage guard needs its OWN exemption set keyed by `Class.field` (or model xpath), e.g. exempting `CanonicalInterface.kind` (transform hint), `CanonicalInterface.default_name` (render mechanism), `apply_groups`/`group_content` (provenance metadata), and the routing-protocol Tier-3 absence.
+
+---
+
+## 8. Recommendation seeds for Phase 2 (`20-design-walker-guard`)
+
+(Phase-1 agent — I do not pick the design, but I flag what the census implies.)
+
+1. **The gap concentrates in NESTED model sub-leaves** (VRRP group, DHCP pool, SNMPv3 user, EVPN-type5, routing-instance). The two existing forward-coverage guards (G5's `_FIELD_TO_EXPECTED_XPATH`, G3's `test_marker_dict_covers_every_data_bearing_field`) BOTH stop at top-level `CanonicalIntent` fields. **The durable fix must recurse into nested `model_fields`.** A reflection-driven completeness guard (design B) that walks `CanonicalIntent` → child models → leaf fields and asserts each leaf maps to a walked xpath or a justified exemption would have caught all 11 HIGH-risk leaves.
+2. **A "walk everything" runtime change (design A) is risky here** because the walker is the input to the live report AND (indirectly via the matrices that must then declare the newly-walked leaves) would force a phase4 reclassification storm: every newly-walked leaf that a codec drops needs a per-codec lossy/unsupported declaration across up to 11 codecs, and `tests/unit/audit` reconciliation cells would move. The St3 demotion lesson in MEMORY (anycast VGA broke a `tests/unit/audit/` reconciliation test) is the precedent — quantify before shipping.
+3. **A guard that maps each model leaf to its expected walker xpath spelling is the lowest-risk option** — it FAILS at CI time the moment a new leaf is added without a walker yield+declaration, with zero runtime behaviour change, but does NOT itself force every existing gap leaf to be walked (it would need an initial exemption entry per current-gap leaf, each carrying a one-line reason — which makes the gap *visible and accounted-for* rather than silent). The open question (for `30-review-correctness`/`31-review-pragmatism`): does the exemption list just relocate the blind spot? Mitigation precedent = #149's self-justifying `_SYNTHETIC_NONWALKABLE` (each entry has a rationale comment + the guard fails loudly on un-blessed additions).
+4. **Prioritise walking the §4.1 HIGH leaves regardless of design choice** — the VRRP sub-fields and the SNMPv3 `priv-passphrase`/protocols are the ones where the live report is the operator's only pre-commit signal and the loss is a security/reachability change, not a cosmetic detail.
+
+---
+
+## 9. Citations index (file:line)
+
+- Default-to-supported: `netcanon/models/migration.py:221-228`.
+- Walker yields: `netcanon/migration/canonical/xpath_walker.py:62-256` (per-leaf lines in §1).
+- Walker-is-sole-input: `netcanon/services/migration_validate.py:28-45, 80-87`.
+- Cross-mesh uses model_dump not walker: `tools/run_full_mesh.py:334-335`; walker docstring `xpath_walker.py:57-60`.
+- Gap-leaf population (grep-confirmed): vrrp `mode=hsrp` `cisco_nxos/parse.py:809`, `mode=carp` `opnsense/parse.py:838`, arista `parse.py:198`; vrrp adv-interval/preempt/auth/virtual_ipv6s `juniper_junos/parse.py:2379-2413`, `mikrotik_routeros/parse.py:663-780`, `opnsense/parse.py:804-843`; ipv6 scope `arista_eos/parse.py:1064`; dhcp lease/domain `opnsense/parse.py:701-702`, `mikrotik_routeros/parse.py:1007`, `juniper_junos/parse.py:788`; radius ports `opnsense/parse.py:258-259`, `fortigate_cli/parse.py:767-768`, `mikrotik_routeros/parse.py:975-976`, `cisco_iosxe_cli/parse.py:1509-1510`, `aruba_aoss/parse.py:1012-1013`; instance_type=mac-vrf `arista_eos/parse.py:853`; l3_vni `arista_eos/parse.py:1346`; kind=mgmt `cisco_iosxe_cli/parse.py:1062`, `cisco_nxos/parse.py:848`.
+- Guards: G1 `tests/unit/migration/test_silent_loss_list_subfields.py`; G2 `tests/unit/migration/test_silent_loss_naming_sensitive.py`; G3+G4 `tests/unit/migration/test_registry_capability_honesty.py` (#149 allowlist lines 323-346, top-level-only marker check lines 527-541); G5 `tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py` (top-level `_FIELD_TO_EXPECTED_XPATH` lines 165-184).

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/12-sanitizer-gap.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/12-sanitizer-gap.md
@@ -1,0 +1,512 @@
+# 12 — Sanitizer-bypass gap (class 2) + over-redaction risk
+
+**Agent:** `12-sanitizer-gap` · Phase 1 census · read-only
+**Scope:** `netcanon/tools/sanitize.py` (`sanitize_intent`, ~1153 lines) measured
+against `netcanon/migration/canonical/intent.py` (the 17-class canonical model).
+**Question:** which IP/host/secret-bearing canonical leaves does the sanitizer
+**never touch** (leak candidates), and how risky is the user's proposed blanket
+`ip_address()`-redact-everything rule (over-redaction)?
+
+---
+
+## 0. TL;DR / verdict
+
+- **The current allow-list is, today, essentially complete.** Every
+  IP/host-bearing and every secret-bearing *modelled* leaf I can find in
+  `intent.py` is already walked and redacted by `sanitize_intent`. The class-2
+  blind spot is **latent, not currently-bleeding**: the gap is *the next field
+  someone adds*, not a field present-but-missed today. This matches the
+  meta-finding ("each round fixes the named instance; the next pass finds a new
+  surface of the same class") — five rounds of patching have actually closed the
+  *current* surface. (Caveat: two genuinely-uncovered leaves below — `ntp_servers`
+  / `syslog_servers` / `dns_servers` accept **hostnames** that pass through
+  verbatim; and `radius_servers[].host` / `snmp.trap_hosts[]` likewise. These are
+  *documented residuals*, not bugs — DNS-name hosts are deliberately preserved.)
+
+- **The user's blanket `ip_address()` rule is SAFER than it sounds, but is the
+  WRONG primitive.** Because the codebase already redacts via *whole-string*
+  `ipaddress.IPvNAddress(value)` parsing (NOT substring scanning), free-text
+  fields like `description = "Uplink to ISP-PRD"` or `"Topology control"` simply
+  **fail to parse** and pass through untouched — `ipaddress.IPv4Address("Topology
+  control")` raises `ValueError`. So the headline over-redaction fear (mangling
+  prose) is **largely unfounded for the parse-the-whole-string form**. The REAL
+  over-redaction risks are narrower and enumerable (§5). But a blanket "redact any
+  field that parses as an IP" *still* misses the point: it only finds **string
+  leaves whose value happens to be an IP**, and would (a) catch `timezone` if an
+  operator ever set it to an IP-shaped string, and (b) **completely miss the
+  cross-reference-stable / format-preserving categories** (RD/RT `64496:N`, mcast
+  `233.252.0.N`, hashes, communities, free-text PII) that are *not* IPs. The
+  blanket rule is neither sufficient (misses non-IP secrets) nor the right shape.
+
+- **Recommended class-2 form: a reflection-driven COMPLETENESS GUARD (form B),
+  extended from the existing `TestSecretRedactionCoverage` guard, NOT a runtime
+  blanket rule.** It already exists in skeleton form for secrets
+  (`_REGISTERED_SECRET_FIELDS` + `_SECRET_NAME_RE`, two-sided). The durable fix is
+  to **add a parallel IP/host coverage half** to the same test file, with a
+  self-justifying exemption set (modelled on #149's `_SYNTHETIC_NONWALKABLE`). This
+  converts "a new IP-bearing field leaks until a human notices" into "a new
+  IP-bearing field turns CI red until a human redacts-or-exempts it." Zero runtime
+  behavior change, zero fixture-corpus diff, ~0 over-redaction risk. Detail and
+  the head-on over-redaction analysis below; agent `21-design-sanitizer-guard`
+  should carry this into the concrete test shape. Agent `22-design-typed-marker`
+  should weigh whether a typed marker beats the naming heuristic (my read: marker
+  is nicer but probably over-engineering vs. a 40-line guard — §7).
+
+---
+
+## 1. The redaction primitives (what the sanitizer can do)
+
+All redaction flows through one `_SubstitutionTable` instance per call, which
+gives **cross-reference stability** (same input → same output across the config).
+The primitives, `sanitize.py:801–1105`:
+
+| Primitive | File:line | Behaviour | Preserves |
+|---|---|---|---|
+| `redact_hostname` | `839` | `device-N` (stable map) | — |
+| `redact_domain` | `844` | `example-N.test` (stable map) | — |
+| `redact_ipv4` | `849` | public → cycles `192.0.2/198.51.100/203.0.113` docs ranges | **private, loopback, link-local, multicast, reserved, unspecified, existing-docs-range, CGNAT `100.64/10`** (`857–871`) |
+| `redact_ipv6` | `883` | global → `2001:db8::N` | **ULA `fc00::/7`, link-local `fe80::/10`, `::1`, `::`, multicast `ff00::/8`, reserved, `2001:db8::/32`** (`904–913`) |
+| `redact_ip_string` | `921` | tries v4 then v6 whole-string; non-IP → returned verbatim | everything `redact_ipv4`/`redact_ipv6` preserve, **plus any non-IP string** (`932–933`) |
+| `redact_cidr` | `935` | splits on `/`, redacts addr, keeps prefix | prefix length; non-IP host verbatim |
+| `redact_route_target` | `943` | `<l>:<r>` → `64496:N` (stable map) | correlation structure |
+| `redact_mcast_group` | `960` | admin-scoped mcast → `233.252.0.N` (stable); non-mcast falls to `redact_ip_string` | non-multicast handled by IP path |
+| `redact_community` | `982` | `public_redacted_N` (stable) | — |
+| `redact_secret(cat)` | `987` | `REDACTED-<cat>-N` (per-category counter) | — |
+| `redact_vrrp_authentication` | `993` | preserves `<scheme>:` prefix, replaces value with `REDACTED-VRRP-AUTH-N` | scheme prefix (renderer slices it) |
+| `redact_vlan_name` | `1014` | `vlan-N` (stable) | — |
+| `redact_local_user_name` | `1028` | `localuserN` (stable) | — |
+| `redact_snmpv3_user_name` | `1048` | `snmpv3userN` (stable, separate counter) | — |
+| `redact_hash` | `1066` | format-preserving fake (`$9$`/`$5$`/`$6$`/`$2y$`/`ENC`/type-7/hex/generic) | hash prefix shape so render stays valid |
+
+### 1a. The private/documentation PRESERVATION logic (load-bearing — DO NOT break)
+
+The single most important behavioural property is that `redact_ipv4`/`redact_ipv6`
+**preserve RFC-1918 / ULA / loopback / link-local / multicast / docs / CGNAT
+addresses by design** (`sanitize.py:857–871`, `904–913`). The rationale stated in
+the module docstring (`sanitize.py:20–26`) and the seed: RFC-1918 LAN gear is the
+common case; redacting it would destroy a useful shared config. This predicate —
+"is this address public/routable?" — is the reusable guard ANY class-2 redesign
+**must** preserve. The good news for the user's blanket proposal: this predicate
+is already centralised inside `redact_ipv4`/`redact_ipv6`, so a blanket rule that
+routes through `redact_ip_string` automatically inherits private-preservation. The
+preservation is NOT lost by going blanket — that specific fear in the seed is
+unfounded *as long as* a blanket rule calls the existing primitives rather than a
+naive "any IP → docs."
+
+---
+
+## 2. The EXACT redaction allow-list (every field `sanitize_intent` touches)
+
+Enumerated from the `sanitize_intent` walk, `sanitize.py:216–793`. Grouped by
+owning model; each row cites the walk site.
+
+### Top-level scalars / lists
+| Canonical field | xpath-ish | walk site | primitive |
+|---|---|---|---|
+| `CanonicalIntent.hostname` | `/hostname` | `221–229` | `redact_hostname` |
+| `CanonicalIntent.domain` | `/domain` | `231–239` | `redact_domain` |
+| `CanonicalIntent.dns_servers[]` | `/dns-servers` | `242–243` | `redact_ip_string` (list) |
+| `CanonicalIntent.ntp_servers[]` | `/ntp-servers` | `244–245` | `redact_ip_string` (list) |
+| `CanonicalIntent.syslog_servers[]` | `/syslog-servers` | `246–247` | `redact_ip_string` (list) |
+| `CanonicalIntent.dropped_tier3_sections` | `/dropped-tier3-sections` | `680–688` | **stripped to `[]`** |
+| `CanonicalIntent.raw_sections` | `/raw-sections` | `695–703` | **stripped to `{}`** |
+| `CanonicalIntent.apply_groups` | `/apply-groups` | `784–791` | **stripped to `[]`** |
+| `CanonicalIntent.group_content` | `/group-content` | `776–783` | **stripped to `{}`** |
+
+### Interface (`CanonicalInterface`) + nested addresses
+| Field | walk site | primitive |
+|---|---|---|
+| `interfaces[].description` | `251–259` | `"description redacted"` |
+| `interfaces[].ipv4_addresses[].ip` | `261–270` | `redact_ipv4` |
+| `interfaces[].ipv4_addresses[].virtual_gateway_address` | `277–286` | `redact_ipv4` (#174 fix) |
+| `interfaces[].ipv6_addresses[].ip` | `288–297` | `redact_ipv6` |
+| `interfaces[].ipv6_addresses[].virtual_gateway_address` | `298–307` | `redact_ipv6` |
+| `interfaces[].vrrp_groups[].authentication` | `316–325` | `redact_vrrp_authentication` |
+| `interfaces[].vrrp_groups[].description` | `326–333` | `"description redacted"` |
+| `interfaces[].vrrp_groups[].virtual_ips[]` | `341–354` | `redact_ip_string` |
+| `interfaces[].vrrp_groups[].virtual_ipv6s[]` | `355–368` | `redact_ip_string` |
+
+### VLAN (`CanonicalVlan`)
+| Field | walk site | primitive |
+|---|---|---|
+| `vlans[].name` | `387–395` | `redact_vlan_name` |
+| `vlans[].description` | `396–403` | `"description redacted"` |
+| `vlans[].ipv4_addresses[].ip` | `405–414` | `redact_ipv4` |
+| `vlans[].ipv4_addresses[].virtual_gateway_address` | `418–427` | `redact_ipv4` |
+
+### Local users, SNMP, RADIUS, DHCP, static routes, routing-instances, VXLAN, EVPN
+| Field | walk site | primitive |
+|---|---|---|
+| `local_users[].name` | `438–447` | `redact_local_user_name` |
+| `local_users[].hashed_password` | `448–456` | `redact_hash` |
+| `snmp.community` | `460–468` | `redact_community` |
+| `snmp.contact` | `476–484` | `"<contact redacted>"` |
+| `snmp.location` | `486–494` | `"<location redacted>"` |
+| `snmp.trap_hosts[]` | `499–510` | `redact_ip_string` |
+| `snmp.v3_users[].name` | `516–524` | `redact_snmpv3_user_name` |
+| `snmp.v3_users[].auth_passphrase` | `525–533` | `redact_secret("AUTH")` |
+| `snmp.v3_users[].priv_passphrase` | `534–542` | `redact_secret("PRIV")` |
+| `snmp.v3_users[].engine_id` | `543–551` | `redact_secret("SNMPV3-ENGINE-ID")` |
+| `radius_servers[].host` | `558–567` | `redact_ip_string` |
+| `radius_servers[].key` | `568–576` | `redact_secret("RADIUS")` |
+| `dhcp_servers[].dns_servers[]` | `580–591` | `redact_ip_string` |
+| `dhcp_servers[].gateway` | `596–605` | `redact_ip_string` |
+| `dhcp_servers[].start_ip` | `613–622` | `redact_ip_string` |
+| `dhcp_servers[].end_ip` | `623–632` | `redact_ip_string` |
+| `dhcp_servers[].network` | `633–642` | `redact_cidr` |
+| `dhcp_servers[].domain_name` | `648–656` | `redact_domain` |
+| `static_routes[].gateway` | `659–669` | `redact_ip_string` |
+| `static_routes[].description` | `670–677` | `"description redacted"` |
+| `routing_instances[].description` | `706–714` | `"description redacted"` |
+| `routing_instances[].route_distinguisher` | `715–723` | `redact_route_target` |
+| `routing_instances[].rt_imports[]` | `724–726` | `redact_route_target` (list) |
+| `routing_instances[].rt_exports[]` | `727–729` | `redact_route_target` (list) |
+| `vxlan_vnis[].mcast_group` | `734–744` | `redact_mcast_group` |
+| `vxlan_vnis[].flood_list[]` | `745–747` | `redact_ip_string` (list) |
+| `evpn_type5_routes[].rt_imports[]` | `749–751` | `redact_route_target` (list) |
+| `evpn_type5_routes[].rt_exports[]` | `752–754` | `redact_route_target` (list) |
+| `evpn_type5_routes[].prefix` | `755–764` | `redact_cidr` |
+
+**Total: 41 distinct field sites redacted (or 4 stripped-entirely surfaces +
+37 field-typed).**
+
+---
+
+## 3. The complete IP/host-bearing + secret-bearing leaf list (my own census)
+
+Built independently from `intent.py`, flagging each leaf as IP/host-bearing (`IP`)
+and/or secret-bearing (`SEC`). This is the *denominator* — every leaf that *should*
+be considered by class-2. (Agent `10-model-leaf-census` produces the full leaf
+table; here I list only the IP/secret-relevant ones.)
+
+### IP / host-bearing leaves (`IP`)
+| Leaf | intent.py | Sanitized? | Notes |
+|---|---|---|---|
+| `dns_servers[]` | `896` | ✅ `redact_ip_string` | **but hostnames pass through** |
+| `ntp_servers[]` | `897` | ✅ `redact_ip_string` | **hostnames pass through** (docstring `81–84`) |
+| `syslog_servers[]` | `899` | ✅ `redact_ip_string` | **hostnames pass through** |
+| `CanonicalIPv4Address.ip` | `120` | ✅ | interface + VLAN SVI sites |
+| `CanonicalIPv4Address.virtual_gateway_address` | `123` | ✅ | #174 |
+| `CanonicalIPv6Address.ip` | `160` | ✅ | |
+| `CanonicalIPv6Address.virtual_gateway_address` | `164` | ✅ | |
+| `CanonicalStaticRoute.destination` | `326` | ⚠️ **NO** | CIDR; see §4 (private-mostly, low-risk) |
+| `CanonicalStaticRoute.gateway` | `327` | ✅ | |
+| `CanonicalStaticRoute.interface` | `328` | n/a | interface name, not an IP |
+| `CanonicalDHCPPool.network/start_ip/end_ip/gateway/dns_servers[]` | `355–359` | ✅ | all five |
+| `CanonicalSNMP.trap_hosts[]` | `463` | ✅ | hostnames pass through |
+| `CanonicalRADIUSServer.host` | `635` | ✅ | hostnames pass through |
+| `CanonicalVRRPGroup.virtual_ips[] / virtual_ipv6s[]` | `589–590` | ✅ | |
+| `CanonicalVxlan.mcast_group / flood_list[] / source_interface` | `689–691` | ✅ mcast+flood; `source_interface` n/a (iface name) | |
+| `CanonicalRoutingInstance.route_distinguisher / rt_*[]` | `733–735` | ✅ | RD/RT (may be `<ip>:nn` form) |
+| `CanonicalEvpnType5Route.prefix / rt_*[]` | `780–782` | ✅ | |
+
+### Secret-bearing leaves (`SEC`)
+| Leaf | intent.py | Sanitized? | In `_REGISTERED_SECRET_FIELDS`? |
+|---|---|---|---|
+| `CanonicalLocalUser.hashed_password` | `620` | ✅ | ✅ |
+| `CanonicalSNMP.community` | `460` | ✅ | ✅ |
+| `CanonicalSNMPv3User.auth_passphrase` | `444` | ✅ | ✅ |
+| `CanonicalSNMPv3User.priv_passphrase` | `446` | ✅ | ✅ |
+| `CanonicalSNMPv3User.engine_id` | `447` | ✅ (redacted; NOT in registry — see §6) | ❌ (not secret-*named*) |
+| `CanonicalRADIUSServer.key` | `636` | ✅ | ✅ |
+| `CanonicalVRRPGroup.authentication` | `595` | ✅ | ✅ |
+
+### Free-text / org-PII leaves (`PII`, neither pure-IP nor secret)
+| Leaf | intent.py | Sanitized? |
+|---|---|---|
+| `CanonicalInterface.description` | `264` | ✅ |
+| `CanonicalVlan.name / description` | `292–293` | ✅ |
+| `CanonicalSNMP.contact / location` | `461–462` | ✅ |
+| `CanonicalStaticRoute.description` | `309` | ✅ |
+| `CanonicalRoutingInstance.description` | `727` | ✅ |
+| `CanonicalVRRPGroup.description` | `597` | ✅ |
+| `CanonicalDHCPPool.domain_name` | `361` | ✅ |
+| `hostname` / `domain` | `894–895` | ✅ |
+| `local_users[].name` / `snmp.v3_users[].name` | — | ✅ |
+
+---
+
+## 4. THE GAP — IP/secret/PII-bearing leaves the sanitizer NEVER touches
+
+After the five rounds of fixes, the gap is **small and mostly justified**. The
+leaks fall into two tiers:
+
+### 4a. True residuals (documented, deliberate, low-risk)
+1. **Hostname-form host fields pass through verbatim.** `dns_servers[]`,
+   `ntp_servers[]`, `syslog_servers[]`, `snmp.trap_hosts[]`, `radius_servers[].host`
+   all run through `redact_ip_string`, which returns non-IP strings **unchanged**
+   (`sanitize.py:932–933`). So `ntp_servers=["nms.corp.example"]` survives. This is
+   **documented** in `sanitize.py:81–84` and asserted as expected behaviour in
+   `test_sanitize.py:837–843` (`test_hostname_trap_target_preserved`). Realistic
+   leak class: an internal-DNS hostname reveals the org. **Classified: (a)
+   realistically-identifying true leak**, but *intentional* — the project chose
+   not to guess which non-IP strings are sensitive hostnames vs. legitimate labels.
+
+### 4b. Genuinely-unredacted modelled IP leaves (small)
+2. **`CanonicalStaticRoute.destination`** (`intent.py:326`) — the route's CIDR
+   *prefix* is never redacted (only `.gateway` is, `sanitize.py:659–669`). A static
+   route to a **public** destination (`ip route 8.8.8.0/24 ...`) leaks that
+   destination prefix. **Classified: (a) realistically public-bearing true leak**,
+   though in practice static-route destinations are overwhelmingly RFC-1918 (LAN
+   subnets, default-route `0.0.0.0/0`). Low real risk but it is the cleanest
+   example of a *modelled IP leaf the allow-list omits* — a good probe case for the
+   guard in §6. (`redact_cidr` already exists and would handle it identically to
+   `dhcp.network` / `evpn.prefix`.)
+3. **`CanonicalVxlan.source_interface`** and `CanonicalInterface` name/`default_name`
+   — interface names, not IPs; structurally non-sensitive (opaque vendor labels).
+   **Classified: (b) structurally non-sensitive.** No action.
+
+### 4c. Structurally always-private / non-sensitive (no action)
+- All the integer/enum/bool fields (`prefix_length`, `vlan_id`, `vni`, `mode`,
+  `priority`, `switchport_mode`, `interface_type`, `tunnel_type`, `dhcp_client_v6`,
+  `scope`, `instance_type`, `auth_protocol`, `priv_protocol`, `kind`, …) —
+  **cannot carry an IP or secret**. The user's blanket `ip_address()` rule would
+  correctly skip these (a number/enum won't parse as IP), but a *naming*-based or
+  *typed-marker* guard must also skip them — they should NOT be flagged as
+  "uncovered" by any guard. This is the bulk of the model and the main source of
+  exemption-list noise the guard design (§6) must handle cleanly.
+
+**Bottom line on the gap:** the only *modelled* leak worth wiring is
+`static_routes[].destination` (and arguably it's marginal). The dangerous part is
+**field N+1** — the field nobody has added yet. That is precisely why the durable
+fix is a *guard*, not another hand-added redaction.
+
+---
+
+## 5. OVER-REDACTION analysis of the user's blanket rule (critical)
+
+The user proposed: *"the sanitizer redacts on `ip_address()` of ANY IP-typed
+string field, not an allow-list."* I evaluated this head-on against the model and
+read-only fixture sampling.
+
+### 5a. The good news: whole-string parsing makes prose-mangling a non-issue
+The existing primitive `redact_ip_string` (`sanitize.py:921–933`) parses the
+**entire field value** as `IPv4Address`/`IPv6Address`. It does **not** scan for
+IP-like substrings. Therefore:
+
+- `description = "Uplink to ISP-PRD"` → `IPv4Address("Uplink to ISP-PRD")` raises
+  `ValueError` → **untouched.** Confirmed against fixture descriptions like
+  `"Topology control"`, `"EWLC Data, Inter FED Traffic"`,
+  `"TRUNK - FORTIGATE"` (cisco_iosxe `user_contrib_cat9300_iosxe1712.txt:163–233`)
+  and MikroTik comments `"contains all interfaces"`, `"AWS PROPOSAL"`,
+  `"The quinta teltonika router has OSPF enabled"`
+  (`routeros_diff_verbose_export.rsc:46–416`). None parse as an IP. **A blanket
+  whole-string `ip_address()` rule would leave every one of these alone.** The
+  seed's headline fear ("description/name/banner mangled") is **largely
+  unfounded** for the whole-string form.
+- A free-text field would only be redacted if its *entire* value is exactly an IP
+  string (e.g. someone literally typed `description "8.8.8.8"`). That's a
+  vanishingly rare and arguably-correct redaction anyway.
+
+So the over-redaction surface is FAR smaller than the seed feared — **provided**
+the blanket rule keeps the whole-string semantics and routes through
+`redact_ipv4/6` (which preserves private/docs). A substring-scanning rule (regex
+for `\d+\.\d+\.\d+\.\d+` inside prose) WOULD be dangerous — but that is not what
+the existing primitive does, and a redesign should not introduce it.
+
+### 5b. The residual over-redaction risks (enumerable, small)
+Even a whole-string blanket rule has three sharp edges:
+
+1. **Enum/keyword string fields whose value can be IP-shaped.** None today. But
+   `timezone` (`intent.py:898`) is free text (`"PST -8"`, `"Europe/London"`) — an
+   operator *could* in principle store something IP-shaped, and a blanket "every
+   str field → try IP" would then redact it. Risk is theoretical, cost is a wrong
+   substitution in a metadata field. Acceptable but it argues against truly-blanket
+   (every `str`) over **typed/targeted** (only fields *declared* host-bearing).
+2. **CIDR vs bare-address ambiguity.** `redact_cidr` must be used (not
+   `redact_ip_string`) for `host/prefix` fields, else the `/24` is lost or the
+   parse fails. A blanket rule that applied `redact_ip_string` uniformly would
+   **fail to redact** `network`/`prefix`/`destination` (they don't parse as a bare
+   address) — i.e. it *under*-redacts those, not over-redacts. The current code
+   already distinguishes (`redact_cidr` at `633`,`755`). A blanket rule must
+   preserve that distinction → another argument that "blanket" is too blunt.
+3. **The MAC / hex-string fields.** `anycast_gateway_mac` (`intent.py:917`),
+   `virtual_gateway_mac` (`123`,`164`), `engine_id`. A MAC `00:1c:73:00:dc:01` is
+   not a valid `IPv4Address`/`IPv6Address` (it has colons but wrong group count) so
+   `ip_address()` rejects it — **a blanket IP rule misses MACs entirely.** MACs are
+   network-identifying. (Today MACs are NOT redacted at all — another latent gap a
+   *guard* would surface and a blanket-IP rule would not.) This is the strongest
+   evidence the blanket-IP rule is the wrong primitive: it is blind to MACs, RD/RT,
+   communities, hashes, and hostnames.
+
+### 5c. Fixture-corpus impact of a blanket rule (reasoned estimate)
+The corpus is ~60 real fixtures across 11 codecs (`tests/fixtures/real/`). Because
+the *current* allow-list already covers every IP-valued modelled leaf, a blanket
+`ip_address()` rule routed through the existing private-preserving primitives would
+produce **almost no diff vs. today** on the corpus — the only new redactions would
+be `static_routes[].destination` public prefixes (rare in the corpus; most are
+RFC-1918 or default routes per the MikroTik/Cisco samples I read) and any
+free-text field that happens to be exactly an IP (I found none in sampled
+fixtures). **Estimated corpus diff: < 1% of redaction sites, near-zero risk of
+mangling prose.** This is the empirical reassurance the user asked for. (The main
+thread should confirm by prototyping `sanitize_text` over the corpus, but the
+reasoned answer is "negligible change.")
+
+### 5d. Does blanket break private/docs preservation? No — if it reuses the predicate
+The preservation logic lives *inside* `redact_ipv4`/`redact_ipv6`
+(`sanitize.py:857–871`,`904–913`). Any blanket rule that calls `redact_ip_string`
+(which delegates to those) **inherits private-preservation for free.** The seed's
+concern ("does blanket break the deliberate private/docs-IP preservation?") is
+answered: **no, as long as it reuses the same primitive** rather than a fresh
+"any-IP → docs" implementation. This is a hard must-fix if blanket were chosen.
+
+---
+
+## 6. Recommendation — which class-2 form is SAFEST
+
+**Recommended: form B — a reflection-driven COMPLETENESS GUARD, built by adding an
+IP/host coverage half to the existing `TestSecretRedactionCoverage`
+(`test_sanitize.py:646–767`).** NOT the runtime blanket rule (form A).
+
+### Why not blanket (A)
+- It is **not sufficient**: blind to MACs, RD/RT (`64496:N`), mcast (`233.252.0.N`),
+  communities, hashes, hostnames, and free-text PII — i.e. ~half the categories the
+  sanitizer already handles are *not* IPs (§5b.3). "Redact any `ip_address()`" only
+  covers the IP slice and would *regress* the carefully-tuned non-IP categories.
+- It is **the wrong altitude**: the leak class is "a new field is forgotten," which
+  is a *coverage* problem, best caught at test time, not a runtime *behaviour*
+  problem. The seed itself prefers "convert the blind spot into a CI failure over a
+  risky runtime behavior change."
+- It introduces real (if small) over-redaction edges (`timezone`, CIDR ambiguity)
+  for negligible benefit, since the current allow-list is already complete.
+
+### Why guard (B) — and how it kills the class
+The existing secret guard `test_reverse_no_unregistered_secret_field`
+(`test_sanitize.py:743–767`) already does exactly the right thing for secrets:
+
+```python
+# existing, secret half
+_REGISTERED_SECRET_FIELDS = {("CanonicalLocalUser","hashed_password"), ...}
+_SECRET_NAME_RE = re.compile(r"passphrase|password|secret|community|^authentication$|(^|_)key$", re.I)
+# reverse test: any secret-NAMED str field on the model not in the registry → FAIL
+```
+
+The durable class-2 fix is a **parallel IP/host half** in the same file:
+
+```python
+# proposed IP/host half (sketch — agent 21 to finalize)
+_REGISTERED_IP_FIELDS = {        # leaf -> reason it's covered
+    ("CanonicalIPv4Address", "ip"),
+    ("CanonicalIPv4Address", "virtual_gateway_address"),
+    ("CanonicalDHCPPool", "gateway"), ("CanonicalDHCPPool", "network"),
+    ("CanonicalDHCPPool", "start_ip"), ("CanonicalDHCPPool", "end_ip"),
+    ("CanonicalStaticRoute", "gateway"),
+    ("CanonicalRADIUSServer", "host"), ...
+}
+_IP_HOST_NAME_RE = re.compile(
+    r"(^|_)(ip|host|gateway|network|destination|prefix|address|"
+    r"dns_servers|ntp_servers|syslog_servers|trap_hosts|flood_list|"
+    r"start_ip|end_ip|virtual_ips|virtual_ipv6s|virtual_gateway_address)$",
+    re.I,
+)
+# Self-justifying exemptions (modelled on #149 _SYNTHETIC_NONWALKABLE):
+_IP_NAME_EXEMPT = {
+    # field -> reason it is NOT an IP despite an IP-ish name
+    ("CanonicalVxlan", "source_interface"): "opaque vendor iface name, not an IP",
+    ("CanonicalStaticRoute", "interface"): "outgoing iface name, not an IP",
+    # ... each carries a human-readable reason string
+}
+
+def test_reverse_no_unregistered_ip_field():
+    found = {(m.__name__, f) for m in _reachable_canonical_models(CanonicalIntent)
+             for f, fld in m.model_fields.items()
+             if _IP_HOST_NAME_RE.search(f) and str in _flatten_annotation(fld.annotation)}
+    unregistered = found - set(_REGISTERED_IP_FIELDS) - set(_IP_NAME_EXEMPT)
+    assert not unregistered, (
+        "IP/host-bearing canonical field(s) with no redaction rule — "
+        "redact in sanitize_intent + register, or add a justified exemption: "
+        f"{sorted(unregistered)}")
+```
+
+**The decisive property (would it catch the next leak?):** if a future dev adds
+`CanonicalThing.management_ip: str = ""` and forgets to redact it, the name `…_ip`
+matches `_IP_HOST_NAME_RE`, the leaf is neither registered nor exempt → **CI fails
+with an actionable message naming the exact `Class.field`.** That is the class-kill.
+And `test_forward_*` (populate-sentinel-then-assert-gone) gives the complementary
+"the redaction actually works" side.
+
+**Would the guard have failed before #174 (the VGA leak)?** Yes, *if* the
+`_IP_HOST_NAME_RE` included `virtual_gateway_address` (it would — name ends in
+`_address`). Before #174, `virtual_gateway_address` was a model field with NO
+redaction → the reverse test would have flagged it `unregistered` → red CI. This is
+the proof the guard kills the historical instance prospectively. (Agent
+`21-design-sanitizer-guard` should include this as the headline regression
+argument.)
+
+### The exemption-relocates-the-blind-spot concern (real, but mitigable)
+The honest weakness of any guard is that the exemption set can become a dumping
+ground that *re-creates* the blind spot. Mitigations (each cheap):
+1. **Every exemption carries a free-text reason string** (the `_IP_NAME_EXEMPT`
+   value), exactly like #149's structural-rule precedent. A reviewer reading a PR
+   that adds `("X","management_ip"): "internal-only, never public"` can challenge a
+   bogus reason.
+2. **The forward (`test_forward_*`) half is NOT exemptable** — it sentinel-tests
+   that *registered* fields are actually redacted, so you cannot "exempt" your way
+   out of redacting a registered field.
+3. The exemption set is for *naming false-positives* (`source_interface`,
+   `interface`) — structurally NOT IPs — which is a closed, small, reviewable set,
+   not an open escape hatch for "I didn't want to redact this IP."
+
+### Typed-marker (C) — defer to agent 22, but my read
+A typed marker (`Annotated[str, IPField()]`) would let the guard enumerate covered
+leaves *from the model itself* with zero naming heuristic and zero exemption list
+for false-positives. It is the most intrinsic ("fail-surfaced by construction").
+**But for class-2 specifically it is probably over-engineering vs. the ~40-line
+guard:** the naming heuristic already works (every IP/host field in the model has an
+IP-ish name; every secret field has a secret-ish name — the existing secret guard
+proves the heuristic is reliable here), and the exemption set for false-positives is
+tiny (2 entries). The marker's payoff is higher for class-1 (the walker) where
+there is no naming convention to lean on. **My verdict: guard (B) for class-2 now;
+typed-marker only if agent 22 shows it cheaply subsumes BOTH the walker and the
+sanitizer guard.** Keep the existing secret guard; add the IP/host half; done.
+
+---
+
+## 7. Catalogue of the existing partial guard (what it covers / leaves open)
+
+`tests/unit/tools/test_sanitize.py` — `TestSecretRedactionCoverage`
+(`646–767`), the only structural class-2 guard today:
+
+| Mechanism | Covers | Leaves open |
+|---|---|---|
+| `_REGISTERED_SECRET_FIELDS` (6 entries) + `test_reverse_no_unregistered_secret_field` | **secret-NAMED** str fields (`password`/`secret`/`community`/`authentication`/`key`/`passphrase`) — a new secret field FAILS CI | **IP/host fields entirely** (no name match); **PII free-text fields** (description/contact/location — no secret name); `engine_id` (redacted but not secret-named, so not in registry) |
+| `test_forward_no_registered_secret_survives` | sentinel round-trip for the 6 registered secrets | only the registered set |
+| `_reachable_canonical_models` + `_flatten_annotation` (`662–685`) | **reusable model-reflection machinery** — already handles `list[...]`, nested models, unions, `from __future__ annotations` string types | — (this is the reusable engine the IP/host half plugs into) |
+| Per-category forward blocks (`TestFreeTextPiiRedaction`, `TestOverlayFieldRedaction`, `TestIPv6Redaction`, `TestVRRPVirtualIPRedaction`, `TestDHCPRangeRedaction`, `TestVirtualGatewayAddressRedaction`) | hand-written "this specific field's value doesn't survive" | each is per-instance; none is a *reverse* completeness check for IP/PII |
+
+**Key finding for the design phase:** the reflection engine
+(`_reachable_canonical_models` + `_flatten_annotation`, already proven to handle
+pydantic v2 + `from __future__ import annotations`) **already exists** in this exact
+test file. The IP/host guard is a ~40-line addition that reuses it — NOT a new
+subsystem. This is the cheapest possible durable fix and it is the recommendation.
+
+---
+
+## 8. Coordination notes for downstream agents
+
+- **`21-design-sanitizer-guard`**: adopt form B; the concrete shape is in §6. Lead
+  with the "would have failed before #174" regression argument. Decide the exact
+  `_IP_HOST_NAME_RE` token list (I sketched it; tune against the real model field
+  names) and whether `static_routes[].destination` should be *wired* (add
+  `redact_cidr` at `sanitize.py:659` block) before the guard goes green, or
+  registered-as-known-gap. My rec: wire it (1-line, `redact_cidr`, identical to
+  `dhcp.network`) so the guard is honest, then the guard is green from day one.
+- **`22-design-typed-marker`**: my honest read is the marker is over-engineering for
+  class-2 alone (§6). Only pursue if it *cheaply* serves the walker (class-1) too.
+- **`20-design-walker-guard`**: note that the class-2 reflection engine
+  (`_reachable_canonical_models`) is reusable for the walker completeness guard.
+- **Over-redaction headline for synthesis**: the blanket-`ip_address()` fear is
+  **mostly unfounded** because redaction parses whole strings (not substrings) and
+  reuses the private-preserving predicate; the real argument against blanket is that
+  it is *insufficient* (blind to MAC/RD/RT/community/hash/hostname), not that it
+  over-fires.
+
+## 9. Citations index
+- `netcanon/tools/sanitize.py:200–793` — `sanitize_intent` walk (the allow-list).
+- `netcanon/tools/sanitize.py:849–933` — `redact_ipv4/ipv6/ip_string` + private-preservation.
+- `netcanon/migration/canonical/intent.py:83–931` — the model (leaf denominator).
+- `netcanon/migration/canonical/intent.py:326` — `CanonicalStaticRoute.destination` (the one modelled IP leak).
+- `tests/unit/tools/test_sanitize.py:646–767` — `TestSecretRedactionCoverage` (the reusable guard skeleton).
+- `tests/unit/tools/test_sanitize.py:837–843` — documented hostname-passthrough residual.
+- `tests/fixtures/real/cisco_iosxe/user_contrib_cat9300_iosxe1712.txt:163–233` — free-text descriptions (over-redaction sample, none parse as IP).
+- `tests/fixtures/real/mikrotik/routeros_diff_verbose_export.rsc:46–416` — free-text comments (over-redaction sample, none parse as IP).

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/20-design-walker-guard.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/20-design-walker-guard.md
@@ -1,0 +1,711 @@
+# 20 — Design: the durable class-1 (silent capability-loss) fix
+
+**Agent:** `20-design-walker-guard` · Phase 2 (Design) · read-only
+**Run:** 2026-06-24 · fail-surfaced-defaults · netcanon
+**Scope:** Design the durable structural fix for **class 1** — the
+silent-loss-on-an-unwalked-leaf blind spot. Compare **(A)** "walker
+auto-yields every leaf" vs **(B)** a reflection-driven **completeness
+GUARD** that FAILS at CI time when a model leaf is neither
+walked-and-declared nor in a documented exemption set. Recommend one (or
+hybrid), give the EXACT test/code shape, the self-justifying exemption
+design, and a **quantified blast radius**.
+
+Built on the Phase-1 census (`10-model-leaf-census.md`), the walker-gap
+quantification (`11-walker-gap.md`), and the sanitizer-gap report
+(`12-sanitizer-gap.md`, whose reflection-engine finding I reuse).
+
+---
+
+## 0. TL;DR / recommendation
+
+- **Recommend a HYBRID, staged: (B) a reflection-driven completeness
+  guard as the durable spine + a SMALL, surgical slice of (A)** — walk
+  the handful of HIGH-risk nested sub-leaves the census found
+  (§4.1 of `11-walker-gap.md`: the VRRP group sub-fields, SNMPv3
+  `priv-passphrase`/protocols, IPv6 `scope`, routing-instance
+  `instance_type`) **only where doing so is pure-declaration / low
+  phase4 risk**. The guard is the thing that kills the *class*; the
+  small walk-expansion converts the worst *currently-silent* instances
+  into surfaced ones. Reject the full "walk EVERY leaf" form (A) — it is
+  a phase4 reclassification storm for marginal benefit on the
+  envelope-covered DHCP/EVPN clusters that the offline cross-mesh audit
+  already backstops (`11-walker-gap.md` §6).
+
+- **The guard is the literal answer to the user's "fail-surfaced
+  *defaults*" goal at the right altitude.** The disease is "a new model
+  leaf defaults to silently-fine." The guard flips that default: a new
+  leaf defaults to **CI-red** until the author either (a) walks it AND
+  declares it per-codec, or (b) adds a one-line self-justifying
+  exemption. That IS a fail-surfaced default — surfaced at *test time*,
+  which the seed explicitly prefers over a risky runtime behavior
+  change.
+
+- **The decisive structural finding** (from `11-walker-gap.md` §5, which
+  I re-verified): the gap concentrates in **NESTED model sub-leaves**
+  (`CanonicalVRRPGroup`, `CanonicalDHCPPool`, `CanonicalSNMPv3User`,
+  `CanonicalEvpnType5Route`, `CanonicalRoutingInstance`). The TWO
+  existing forward-coverage guards both stop at **top-level
+  `CanonicalIntent` fields** and never recurse:
+  - `test_marker_dict_covers_every_data_bearing_field`
+    (`test_registry_capability_honesty.py:527-541`) checks
+    `set(CanonicalIntent.model_fields)` — top-level only.
+  - G5 `_FIELD_TO_EXPECTED_XPATH`
+    (`test_walk_canonical_coverage.py:165-184`) — 18 hand-listed
+    top-level fields only.
+  **The durable guard must recurse through `model_fields` of the nested
+  models.** That single change (recurse, not just top-level) is what
+  closes the class.
+
+- **The reflection engine already exists and is pydantic-v2 +
+  `from __future__ import annotations` proven**:
+  `_reachable_canonical_models` + `_flatten_annotation`
+  (`tests/unit/tools/test_sanitize.py:662-685`), used by the secret
+  coverage guard. The class-1 guard reuses the same machinery — this is
+  a ~60-line addition, not a new subsystem. (Promote the two helpers to
+  a shared test util so both the sanitizer guard and the walker guard
+  import one copy — see §6.)
+
+- **Blast radius to make the guard GREEN today**: with the guard set to
+  the *current* walker + an exemption row per current gap leaf, **zero
+  code change, zero phase4 reclassification** — the guard ships green
+  and every gap is now *accounted-for in writing*. The optional surgical
+  walk-expansion of the §4.1 HIGH leaves is a SEPARATE, later PR whose
+  phase4 cost I quantify in §5 (it is per-codec-declaration work, not a
+  storm — phase4 reads matrices, not the walker).
+
+---
+
+## 1. The two designs, precisely
+
+### Design A — runtime: walker auto-yields every leaf
+
+Make `_walk_canonical` (`xpath_walker.py`) emit an xpath for **every**
+populated model leaf, by reflection rather than the current hand-written
+`yield` ladder. Maximally durable: a new leaf is walked the instant it is
+added, with no human action.
+
+**Why it is the wrong primary tool here** (each point load-bearing):
+
+1. **It forces a phase4 / matrix reclassification storm.** The walker is
+   the input to the *live report* only (`xpath_walker.py:57-60`,
+   `migration_validate.py:80-87`), BUT the moment a newly-walked leaf is
+   one a codec drops, the codec MUST gain a `lossy`/`unsupported`
+   declaration or `test_dropped_naming_independent_field_is_declared` /
+   `test_static_route_subfield_and_secondary_drops_are_declared`
+   (`test_registry_capability_honesty.py:471-505, 601-646`) go red. Each
+   newly-walked dropped leaf = up to 11 per-codec declarations. The
+   census (`11-walker-gap.md` §4.2) shows DHCP alone expands 1→8 yields,
+   EVPN-Type5 1→4. That is dozens of new declarations across the fleet.
+2. **The benefit is uneven.** The DHCP/EVPN envelope sub-leaves have a
+   backstop: the offline cross-mesh `model_dump()` audit already catches
+   them (`11-walker-gap.md` §6; `tools/run_full_mesh.py:334-335`). Only
+   the live report is blind to them, and they are option-detail losses,
+   not reachability/security losses.
+3. **Reflection-walk changes ordering / duplication semantics.** The
+   live report counts duplicate xpaths "one leaf per occurrence"
+   (`migration_validate.py:80-87` docstring). A reflection walker that
+   emits a fixed leaf-order per record would subtly shift the report's
+   per-surface counts — a behavior change to verify across every codec
+   pair. The current hand-written ladder's emit-order is load-bearing
+   for the report and (indirectly) the round-trip tree-order trap noted
+   in MEMORY (`_compare` doesn't normalize `routing_instances` order).
+
+A **bounded, surgical** slice of A is still worth doing for the §4.1
+HIGH leaves (see §3 recommendation + §5 cost) — but "walk literally
+everything by reflection" is over-reach.
+
+### Design B — CI: reflection-driven completeness GUARD
+
+A new test that:
+
+1. **Reflects** every data-bearing leaf reachable from `CanonicalIntent`
+   (recursing into nested models, unwrapping `list[...]` / `X | None`).
+2. **Computes** the walker's actual yield universe by running
+   `_walk_canonical` on the kitchen-sink (reusing the existing
+   `_WALKABLE` frozenset = `frozenset(_walk_canonical(_maximal_intent()))`,
+   `test_registry_capability_honesty.py:225`).
+3. **Maps** each reflected leaf to its expected walker-xpath spelling.
+4. **FAILS** if a leaf is neither walked NOR in a self-justifying
+   exemption set — with an actionable message naming the exact
+   `Class.field`.
+
+Zero runtime change. Converts "a new leaf silently defaults to
+supported" into "a new leaf turns CI red until handled-or-exempted." The
+open question — *does the exemption set just relocate the blind spot?* —
+is answered by the #149 precedent (§4): each exemption carries a written
+reason, and adding one is a reviewable, costly-on-purpose act.
+
+---
+
+## 2. Recommendation and rationale
+
+**HYBRID, in two PRs:**
+
+- **PR-1 (the durable spine — guard, GREEN day one, zero behavior
+  change):** ship Design B as a recursive completeness guard, seeded
+  with the *current* walker coverage + an exemption entry **for every
+  current gap leaf**, each carrying a one-line reason (the §4.1 HIGH
+  leaves get reason `"KNOWN-GAP: scheduled to walk in PR-2"`; the
+  genuinely-non-config leaves get their structural reason). This makes
+  the entire class **visible and accounted-for in writing** without
+  changing a single yield or matrix. The guard now fails if anyone adds
+  a *new* leaf without handling it.
+
+- **PR-2 (surgical walk-expansion of the worst instances — behavior
+  change, staged, phase4-quantified):** walk the §4.1 HIGH leaves
+  (VRRP `mode`/`priority`/`preempt`/`advertisement-interval`/
+  `authentication`/`virtual-ipv6s`; SNMPv3 `priv-passphrase`/
+  `auth-protocol`/`priv-protocol`; IPv6 `scope`; routing-instance
+  `instance-type`), add the matching per-codec `lossy`/`unsupported`
+  declarations, remove those leaves from the guard exemption set, and
+  regen the cross-mesh + phase4 artefacts. This converts the
+  highest-consequence silent losses into surfaced ones. Each leaf moved
+  out of the exemption set is gated by the guard, so PR-2 cannot
+  "forget" a declaration.
+
+Rationale for hybrid over pure-B:
+- Pure-B leaves every current HIGH gap leaf *documented-but-still-
+  silent* in the live report. The user's named instances (switchport →
+  static-route → VXLAN → VLAN-ports → VLAN-SVI) were all closed by
+  *walking + declaring*, not merely by documenting. Honoring the user's
+  intent for the worst surfaces (a dropped HSRP→VRRP conversion, a
+  dropped SNMPv3 privacy key) means actually walking them.
+- The guard alone is the *class* kill; the walk-expansion is the
+  *instance* cleanup of the worst current offenders. Doing both, in that
+  order, is the minimal honest answer.
+
+Rationale for B (not A) as the spine: the seed's stated preference
+("favor the option that converts the blind spot into a CI failure over a
+risky runtime behavior change") plus the asymmetry that the live report
+is blind but the cross-mesh audit is not for the bulk
+(`11-walker-gap.md` §6).
+
+---
+
+## 3. Exact shape of the guard (Design B, PR-1)
+
+### 3.1 Where it lives
+
+A new module: `tests/unit/migration/test_walker_completeness.py`
+(sibling of the silent-loss guards `test_silent_loss_list_subfields.py`
+/ `test_silent_loss_naming_sensitive.py`; the seed lists those as the
+guards to build *on*, not duplicate). It is a **model-level structural
+guard**, not per-codec, so it lives at `tests/unit/migration/` root, not
+under `codecs/<vendor>/`. It supersedes the top-level-only
+`test_marker_dict_covers_every_data_bearing_field` reflection by
+recursing — but keep that test (it guards a *different* dict, the
+unsupported-markers); the new test guards *walker coverage*.
+
+### 3.2 The reflection machinery (reuse, don't reinvent)
+
+Promote the two proven helpers from `test_sanitize.py:662-685` to a
+shared test-support module (e.g.
+`tests/unit/migration/_model_reflection.py` or
+`tests/support/canonical_reflection.py`) and import them in BOTH the
+sanitizer guard and the new walker guard:
+
+```python
+# already proven against pydantic v2 + `from __future__ import annotations`
+def _flatten_annotation(ann):
+    """Yield ann + every nested type arg (unwraps list[...] / X|None / dict)."""
+    args = typing.get_args(ann)
+    if not args:
+        yield ann
+        return
+    for a in args:
+        yield from _flatten_annotation(a)
+
+def _reachable_canonical_models(root_cls, acc=None):
+    """All BaseModel subclasses reachable from root_cls via field annotations."""
+    if acc is None:
+        acc = set()
+    if root_cls in acc:
+        return acc
+    acc.add(root_cls)
+    for fld in root_cls.model_fields.values():
+        for t in _flatten_annotation(fld.annotation):
+            if isinstance(t, type) and issubclass(t, BaseModel):
+                _reachable_canonical_models(t, acc)
+    return acc
+```
+
+**Critical correctness note on `from __future__ import annotations`:**
+`intent.py` uses it (`intent.py:1` region — all type hints are strings).
+The helper works **because** pydantic v2 *resolves* `model_fields[...]
+.annotation` to the real type object at class-build time (not the raw
+string). I confirmed this is the exact path the secret guard already
+relies on (`test_sanitize.py:754` does `str in _flatten_annotation(fld
+.annotation)` and passes in CI). So `fld.annotation` is the resolved
+`list[CanonicalVRRPGroup]`, not the string `"list[CanonicalVRRPGroup]"`
+— the recursion finds the nested `BaseModel`s reliably. **Do NOT** use
+`typing.get_type_hints` on the raw class (it can choke on forward refs /
+needs the module globals); use pydantic's already-resolved
+`model_fields[...].annotation`. This is the single most important
+implementation gotcha and it is already de-risked by the secret guard.
+
+### 3.3 Enumerating the model's leaves
+
+A "leaf" = a field on a reachable model whose flattened annotation
+contains a **scalar** type (`str` / `int` / `bool` / `float`) — i.e. it
+is a scalar or a `list[scalar]`, NOT a pure nested-model container.
+Nested-model containers (`interfaces: list[CanonicalInterface]`) are
+*not* leaves; their child fields are (recursion handles them).
+
+```python
+_SCALAR = (str, int, bool, float)
+
+def _model_leaves():
+    """Yield (ModelName, field_name) for every data-bearing scalar /
+    list-of-scalar leaf reachable from CanonicalIntent."""
+    for model in _reachable_canonical_models(CanonicalIntent):
+        for fname, fld in model.model_fields.items():
+            flat = set(_flatten_annotation(fld.annotation))
+            has_scalar = any(t in _SCALAR for t in flat)
+            has_nested_model = any(
+                isinstance(t, type) and issubclass(t, BaseModel) for t in flat
+            )
+            # A pure nested-model container is not a leaf (its children are).
+            # A scalar / list[scalar] field IS a leaf.
+            if has_scalar and not has_nested_model:
+                yield (model.__name__, fname)
+            # dict fields (raw_sections/group_content) handled via exemption.
+            elif not has_scalar and not has_nested_model:
+                yield (model.__name__, fname)  # e.g. dict — exemption catches it
+```
+
+This yields the full leaf set the census enumerates (`10-model-leaf-
+census.md` §13: ~112 structured leaves). Counting by `(Class, field)`
+de-duplicates the `CanonicalIPv4Address` reuse (it appears once as a
+model, but the walker emits it under two xpaths — the guard handles that
+in the mapping, §3.4).
+
+### 3.4 Mapping a `(Class, field)` leaf to its walker xpath(s)
+
+The walker uses kebab-case xpaths with a `container/element` shape, and
+some leaves carry a `config/` segment while others don't
+(`10-model-leaf-census.md` §14.6 spelling caveats). A **declared
+mapping dict** `_LEAF_TO_WALKER_XPATHS: dict[tuple[str,str], tuple[str,
+...]]` makes the spelling explicit and reviewable, e.g.:
+
+```python
+_LEAF_TO_WALKER_XPATHS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("CanonicalIntent", "hostname"):       ("/system/hostname",),
+    ("CanonicalIntent", "anycast_gateway_mac"): ("/anycast-gateway-mac",),
+    ("CanonicalInterface", "mtu"):         ("/interfaces/interface/config/mtu",),
+    ("CanonicalInterface", "switchport_mode"): ("/interfaces/interface/switchport-mode",),
+    ("CanonicalIPv4Address", "ip"): (
+        "/interfaces/interface/ipv4/address/ip",
+        "/vlans/vlan/ipv4/address/ip",          # the reused-on-VLAN xpath (#175)
+    ),
+    ("CanonicalVRRPGroup", "virtual_ips"): (
+        "/interfaces/interface/vrrp-groups/group/virtual-ips",),
+    # ... one row per leaf
+}
+```
+
+The reused `CanonicalIPv4Address` (interface + VLAN-SVI) is the reason
+the value is a **tuple** of xpaths: a leaf "is walked" if **ANY** of its
+mapped xpaths is in `_WALKABLE`. This faithfully models the asymmetry
+the census flagged (`10-model-leaf-census.md` §2a: interface copy walks
+the full set, VLAN copy walks only `ip`).
+
+> Design choice — declared map vs. derived spelling. I deliberately use
+> a **declared** `_LEAF_TO_WALKER_XPATHS` rather than algorithmically
+> deriving the xpath from the field name. Derivation is brittle: the
+> `config/` segment is present for `mtu`/`vrf`/`type`/`description`/
+> `enabled` but absent for `switchport-mode`/`access-vlan`; VXLAN is
+> `/vxlan-vnis/<leaf>` with no `/vni/` element; the VLAN-SVI reuse needs
+> two strings. A declared map is honest about these and is itself
+> guarded (a leaf with no map entry and no exemption → fail). **The map
+> is NOT a second blind spot** because the guard fails on any leaf
+> *missing from both* the map and the exemption set — you cannot add a
+> leaf and forget both. (Contrast `30-review`'s concern: the map is a
+> *spelling* table, not a *coverage decision* table; the coverage
+> decision is "walked-or-exempt," enforced separately.)
+
+### 3.5 The self-justifying exemption set (modelled on #149)
+
+```python
+#: Leaves the completeness guard does NOT require to be walked, each with
+#: a written reason — modelled on #149's _SYNTHETIC_NONWALKABLE
+#: (test_registry_capability_honesty.py:323-330). Adding an entry here is a
+#: conscious, reviewable act: a bogus reason is challengeable in PR review.
+_WALK_EXEMPT: dict[tuple[str, str], str] = {
+    # ── Metadata / provenance (never a translatable capability surface;
+    #    mirrors _NON_CAPABILITY_FIELDS at test_registry_capability_honesty.py:520) ──
+    ("CanonicalIntent", "source_vendor"):   "metadata: codec that produced the tree",
+    ("CanonicalIntent", "source_format"):   "metadata: source input_format",
+    ("CanonicalIntent", "source_version"):  "metadata: OS version hint",
+    ("CanonicalIntent", "raw_sections"):    "Tier-3 verbatim blob; never auto-rendered (dict, not a scalar leaf)",
+    ("CanonicalIntent", "dropped_tier3_sections"): "notification-only surface; surfaced via its own banner",
+    ("CanonicalIntent", "apply_groups"):    "Junos provenance hint (dict/list, not a config leaf)",
+    ("CanonicalIntent", "group_content"):   "Junos provenance hint paired with apply_groups",
+    # ── Transform hints / render mechanics (not an operator-visible surface) ──
+    ("CanonicalInterface", "kind"):         "rename-mesh transform hint, not a render fidelity surface (11-walker-gap.md §4.3 #27)",
+    ("CanonicalInterface", "default_name"): "MikroTik factory-name render mechanism; same-vendor round-trip only (#28)",
+    # ── Discriminators that always travel with their walked identity leaf ──
+    ("CanonicalIPv6Address", "scope"):      "KNOWN-GAP: link-local discriminator — scheduled to walk in PR-2",
+    ("CanonicalIPv4Address", "prefix_length"): "always travels with /…/ip; lost-prefix-without-IP not observed",
+    ("CanonicalIPv4Address", "is_secondary"): "walked conditionally as /…/secondary-ip when secondary",
+    # ── KNOWN-GAP: the §4.1 HIGH leaves PR-2 will walk (each removed there) ──
+    ("CanonicalVRRPGroup", "mode"):         "KNOWN-GAP: FHRP discriminator — PR-2",
+    ("CanonicalVRRPGroup", "priority"):     "KNOWN-GAP: master-election — PR-2",
+    ("CanonicalVRRPGroup", "preempt"):      "KNOWN-GAP: failover behavior — PR-2",
+    ("CanonicalVRRPGroup", "advertisement_interval"): "KNOWN-GAP: timer — PR-2",
+    ("CanonicalVRRPGroup", "authentication"): "KNOWN-GAP: secret-adjacent — PR-2",
+    ("CanonicalVRRPGroup", "virtual_ipv6s"): "KNOWN-GAP: v6 VIP — PR-2",
+    ("CanonicalVRRPGroup", "description"):  "operator free text; low fidelity stakes",
+    ("CanonicalSNMPv3User", "priv_passphrase"): "KNOWN-GAP: privacy key (auth twin IS walked) — PR-2",
+    ("CanonicalSNMPv3User", "auth_protocol"):   "KNOWN-GAP: algorithm downgrade — PR-2",
+    ("CanonicalSNMPv3User", "priv_protocol"):   "KNOWN-GAP: cipher downgrade — PR-2",
+    ("CanonicalSNMPv3User", "group"):           "KNOWN-GAP: VACM group — PR-2 (lower)",
+    ("CanonicalRoutingInstance", "instance_type"): "KNOWN-GAP: mac-vrf↔vrf — PR-2",
+    # ── Envelope-covered clusters (cross-mesh audit backstops these;
+    #    live-report-only gap, lower urgency — 11-walker-gap.md §6) ──
+    ("CanonicalDHCPPool", "interface"):     "envelope /dhcp-servers/pool walked; option detail backstopped by cross-mesh audit",
+    ("CanonicalDHCPPool", "network"):       "same; redact_cidr-class IP, audit-backstopped",
+    ("CanonicalDHCPPool", "start_ip"):      "same",
+    ("CanonicalDHCPPool", "end_ip"):        "same",
+    ("CanonicalDHCPPool", "gateway"):       "same",
+    ("CanonicalDHCPPool", "dns_servers"):   "same",
+    ("CanonicalDHCPPool", "lease_time"):    "same",
+    ("CanonicalDHCPPool", "domain_name"):   "same",
+    ("CanonicalEvpnType5Route", "vrf"):     "envelope /evpn-type5-routes/route walked; no codec populates today (dead leaf)",
+    ("CanonicalEvpnType5Route", "prefix"):  "same (dead leaf; audit-backstopped)",
+    ("CanonicalEvpnType5Route", "rt_imports"): "same",
+    ("CanonicalEvpnType5Route", "rt_exports"): "same",
+    ("CanonicalRADIUSServer", "auth_port"): "defaulted port (1812); non-default audit-backstopped",
+    ("CanonicalRADIUSServer", "acct_port"): "defaulted port (1813); audit-backstopped",
+    ("CanonicalStaticRoute", "destination"): "the route anchor /routing/static-route IS the destination record",
+    ("CanonicalStaticRoute", "gateway"):    "covered implicitly: a dropped gateway usually drops the whole route (11-walker-gap.md §4.3 #29)",
+}
+```
+
+Each entry is a `(Class, field) -> reason`. The **`KNOWN-GAP:` prefix
+convention** makes the PR-2 worklist greppable and makes the
+"documented-but-still-silent" leaves visually distinct from the
+structurally-correct exemptions. (A reviewer can `grep KNOWN-GAP` to see
+the entire deferred backlog at a glance — and a stretch guard, §3.7,
+can even assert the count only ever *decreases*.)
+
+### 3.6 The test body
+
+```python
+def test_every_model_leaf_is_walked_or_exempt():
+    """Every data-bearing CanonicalIntent leaf (recursing into nested
+    models) must either be emitted by _walk_canonical (so the live
+    validation report can classify it) OR carry a written exemption.
+
+    This is the FORWARD completeness guard the project lacked: the two
+    prior coverage checks (test_marker_dict_covers_every_data_bearing_field,
+    G5's _FIELD_TO_EXPECTED_XPATH) stop at top-level CanonicalIntent
+    fields and never recurse into CanonicalVRRPGroup / CanonicalDHCPPool /
+    CanonicalSNMPv3User — exactly where the silent-loss gap concentrates
+    (run3 walker-gap §4). A NEW nested leaf added without a walker yield
+    + per-codec declaration now turns this red instead of defaulting to
+    'supported' (the class kill)."""
+    walkable = _WALKABLE  # frozenset(_walk_canonical(_maximal_intent()))
+    unhandled = []
+    for (cls, field) in _model_leaves():
+        if (cls, field) in _WALK_EXEMPT:
+            continue
+        xpaths = _LEAF_TO_WALKER_XPATHS.get((cls, field))
+        if xpaths is None:
+            unhandled.append(f"{cls}.{field} (no walker-xpath mapping)")
+            continue
+        if not any(xp in walkable for xp in xpaths):
+            unhandled.append(
+                f"{cls}.{field} -> {xpaths} (mapped but walker never emits it)"
+            )
+    assert not unhandled, (
+        "Canonical model leaf/leaves are neither walked by _walk_canonical "
+        "nor exempt — they would silently classify 'supported' and any codec "
+        "dropping them reports severity:ok (the silent-loss class).  For each: "
+        "(1) add a yield in _walk_canonical + per-codec lossy/unsupported "
+        "declaration + a _LEAF_TO_WALKER_XPATHS row, OR (2) add a "
+        "self-justifying _WALK_EXEMPT entry with a written reason "
+        f"(see #149 _SYNTHETIC_NONWALKABLE precedent): {unhandled}"
+    )
+```
+
+Plus three **"guard the guard"** companions (mirroring the existing
+`test_maximal_intent_exercises_every_top_level_field` /
+`test_marker_dict_covers_every_data_bearing_field` discipline at
+`test_registry_capability_honesty.py:527-557`):
+
+```python
+def test_no_stale_walk_exemptions():
+    """Every _WALK_EXEMPT key must still be a real model leaf — a leaf
+    removed/renamed from the model must drop out of the exemption set,
+    else the exemption rots into a lie."""
+    real = set(_model_leaves())
+    stale = sorted(k for k in _WALK_EXEMPT if k not in real)
+    assert not stale, f"_WALK_EXEMPT references non-existent leaves: {stale}"
+
+def test_no_stale_xpath_mappings():
+    """Every _LEAF_TO_WALKER_XPATHS key must still be a real model leaf."""
+    real = set(_model_leaves())
+    stale = sorted(k for k in _LEAF_TO_WALKER_XPATHS if k not in real)
+    assert not stale, f"_LEAF_TO_WALKER_XPATHS references dead leaves: {stale}"
+
+def test_exempt_and_mapped_are_disjoint():
+    """A leaf is EITHER walked-and-mapped OR exempt, never both — an
+    exemption on a walked leaf is dead weight that hides intent."""
+    both = sorted(set(_WALK_EXEMPT) & set(_LEAF_TO_WALKER_XPATHS))
+    assert not both, f"leaves both mapped AND exempt (pick one): {both}"
+```
+
+`test_no_stale_walk_exemptions` is the antidote to the "exemption set
+rots" failure mode — it forces the exemption list to track the model.
+
+### 3.7 Optional stretch guard: the backlog only shrinks
+
+```python
+def test_known_gap_backlog_does_not_grow():
+    """Soft ratchet: the count of KNOWN-GAP exemptions (deferred silent
+    losses) must never EXCEED the recorded baseline.  A new KNOWN-GAP
+    deferral requires bumping this number in a PR — a visible, reviewable
+    act — so the deferred backlog can only be paid down, not quietly
+    grown."""
+    known_gaps = [k for k, r in _WALK_EXEMPT.items() if r.startswith("KNOWN-GAP")]
+    assert len(known_gaps) <= _KNOWN_GAP_BASELINE  # PR-2 lowers this as it walks each
+```
+
+This directly answers the seed's "does the exemption list just relocate
+the blind spot?" — the `KNOWN-GAP` sub-class is ratcheted-down-only, so
+it is a *paydown queue*, not a dumping ground. (Pragmatism review may
+judge this gold-plating; I flag it as optional, not load-bearing.)
+
+---
+
+## 4. Why the exemption set does NOT merely relocate the blind spot
+
+This is the crux the reviewers will probe. The #149 precedent
+(`test_registry_capability_honesty.py:323-346`,
+`_SYNTHETIC_NONWALKABLE` + `_is_legitimate_nonwalkable`) is the proof
+that a self-justifying exemption mechanism works in this codebase:
+
+1. **Adding an exemption is a code change in a guarded file**, visible in
+   the PR diff, requiring a written reason string. Contrast the status
+   quo: adding a leaf and *forgetting* it is **invisible** — no diff in
+   the guard, no red CI, silent loss. The guard converts an invisible
+   omission into a visible, reviewable decision. That asymmetry IS the
+   class kill, even though exemptions exist.
+2. **The reason string is challengeable.** A reviewer reading
+   `("X","mgmt_ip"): "internal-only, never lost"` can reject a bogus
+   justification. #149's entries each carry a `# comment` rationale; the
+   project already runs this discipline.
+3. **`test_no_stale_walk_exemptions` keeps the set honest** — a leaf
+   removed from the model can't leave a zombie exemption behind.
+4. **The `KNOWN-GAP:` sub-class is ratcheted** (§3.7) so deferred losses
+   are a shrinking queue, not a permanent hiding place.
+5. **The exemption set is SMALL and CLOSED in shape**: metadata (7),
+   transform-hints (2), discriminators-that-travel (3), envelope-covered
+   clusters (audit-backstopped, ~14), and the KNOWN-GAP paydown queue
+   (~12). None is an open "I didn't feel like walking this IP" hatch —
+   each is a *category* with a structural reason.
+
+The honest residual weakness (for the review agents): a contributor
+*could* write a plausible-but-wrong reason and a reviewer *could* miss
+it. That is a social-process risk, not a structural one, and it is
+strictly better than today (no signal at all). The mitigation is reason
+strings + ratchet + the `KNOWN-GAP` paydown queue.
+
+---
+
+## 5. Quantified blast radius
+
+### 5.1 PR-1 (the guard) — to make it GREEN today
+
+- **Code changes to `_walk_canonical`:** ZERO.
+- **Matrix changes:** ZERO.
+- **phase4 (`tests/unit/audit/`) reclassifications:** ZERO. This is the
+  load-bearing quantification, and it is *certain*, not estimated:
+  phase4 `reconcile_cell` reads (a) the codec `unsupported`/`lossy`
+  declarations and (b) the per-pair `cross_vendor_expectations` YAMLs
+  (`test_run_phase4_reconciliation.py:288-308`, the runner at
+  `run_phase4_reconciliation.py`). **It never consumes `_walk_canonical`**
+  (confirmed: `11-walker-gap.md` §6; `xpath_walker.py:57-60`;
+  `run_full_mesh.py:334-335`). PR-1 changes neither matrices nor YAMLs,
+  so not a single phase4 cell moves.
+- **New test cost:** one new module (~150 lines incl. the two declared
+  dicts), the two reflection helpers promoted to a shared util (moved,
+  not duplicated). Runs in milliseconds (reflection + one `_walk_canonical`
+  call already cached as `_WALKABLE`).
+- **Leaves to enumerate in the dicts to go green:** ~112 leaves total
+  (`10-model-leaf-census.md` §13). Of these:
+  - ~64 are already-walked → `_LEAF_TO_WALKER_XPATHS` rows
+    (`11-walker-gap.md` §1: 64 walker xpaths, mapping to ~52 distinct
+    `(Class,field)` leaves after de-duping the multi-xpath/reused ones).
+  - ~38 go into `_WALK_EXEMPT` (the §3.5 set: metadata 7 + transform 2 +
+    discriminators 3 + envelope-clusters ~14 + KNOWN-GAP ~12).
+  This is one-time data entry, mechanically derivable from the census +
+  walker. **Behavior-change classification: PURE-DECLARATION.** No code
+  path changes; no operator-visible output changes.
+
+### 5.2 PR-2 (surgical walk-expansion of §4.1 HIGH leaves) — staged later
+
+Walking each HIGH leaf is the only *behavior-changing* work, and its
+phase4 cost is bounded and per-leaf, NOT a storm — because phase4 only
+moves when a **matrix declaration** changes, and the walk-expansion adds
+declarations deliberately:
+
+| HIGH leaf to walk | populating codecs (from `11-walker-gap.md` §9) | new declarations needed | phase4 effect |
+|---|---|---|---|
+| VRRP `mode` | nxos(hsrp), opnsense(carp), arista | codecs that flatten mode→vrrp declare `lossy` on `/…/vrrp-groups/group/mode` | the affected pair cells reclassify drifted→EXPECTED_LOSSY (ok), not CODEC_BUG — same pattern as the St3 anycast demotion in MEMORY |
+| VRRP `priority`/`preempt`/`advertisement-interval` | junos, mikrotik, opnsense | per-codec `lossy` where dropped | bounded to FHRP-bearing pairs |
+| VRRP `authentication` | junos, mikrotik, opnsense | `lossy`/`unsupported` (secret-adjacent → arguably `unsupported`) | bounded |
+| VRRP `virtual_ipv6s` | junos, mikrotik, opnsense | `lossy` where dropped | bounded |
+| SNMPv3 `priv-passphrase` | arista/aoss/fortigate/mikrotik/junos | the auth twin is ALREADY walked+declared; mirror its declarations | reuses existing per-codec SNMPv3 dispositions; near-zero new |
+| SNMPv3 `auth-protocol`/`priv-protocol` | same v3 codecs | `lossy` where downgraded/dropped | bounded |
+| IPv6 `scope` | arista | `lossy`/`unsupported` on droppers | single-codec-narrow |
+| routing-instance `instance-type` | arista(mac-vrf) | `lossy` where mac-vrf→vrf | single-codec-narrow |
+
+**phase4 reclassification character:** every one of these, when walked +
+declared, produces *drifted-against-lossy = EXPECTED_LOSSY (severity ok)*
+cells — NOT new CODEC_BUGs — because the declaration is added in the same
+PR as the walk. The dangerous direction (CODEC_BUG inflation) only
+happens if you walk a leaf WITHOUT declaring it, which the new guard
+*prevents* (the leaf can't leave `_WALK_EXEMPT` until it's both walked
+and the per-codec declarations exist, or
+`test_dropped_naming_independent_field_is_declared` /
+`test_static_route_subfield_and_secondary_drops_are_declared` already
+fail). **MEMORY precedent:** the St3 anycast `supported→lossy` demotion
+broke ONE `tests/unit/audit/` reconciliation test (reconciler reads
+matrix anycast decl → drift reclassifies CODEC_BUG→EXPECTED_LOSSY) — so
+each HIGH leaf walked in PR-2 needs a regen of `CROSS_MESH_RESULTS.md` +
+`PHASE4_RECONCILIATION.md` and a re-run of the FULL `tests/unit` (incl.
+`tests/unit/audit`), not just `…/migration`. **LESSON (from MEMORY):
+run FULL `tests/unit`, not just `…/migration`.**
+
+**Recommendation: split PR-2 by surface** (one PR for the VRRP cluster,
+one for SNMPv3, one for the two single-codec leaves) so each regen diff
+is small and narrates one capability delta cleanly (per AGENTS.md
+doc-sync row: "a capability-matrix change … regen `CROSS_MESH_RESULTS.md`
++ `PHASE4_RECONCILIATION.md`").
+
+### 5.3 Doc-sync obligations (AGENTS.md)
+
+- PR-1: a new pytest module — `tests/README.md` only if it introduces a
+  new marker (it doesn't; it's `pytestmark = pytest.mark.unit`). No
+  capability/matrix/operator-doc change. Minimal.
+- PR-2: each capability-matrix flip triggers the AGENTS.md rows for
+  cross-vendor expectation YAMLs + `CROSS_MESH_RESULTS.md` +
+  `PHASE4_RECONCILIATION.md` regen, plus `docs/CAPABILITIES.md` /
+  per-vendor `docs/vendors/<vendor>.md` for the surfaced caveat, plus
+  `docs/adding-a-canonical-field.md` is unaffected (no new field).
+
+---
+
+## 6. PR sequencing + regen-tool needs
+
+1. **PR-1 — completeness guard (no behavior change, green day one).**
+   - Promote `_flatten_annotation` + `_reachable_canonical_models` from
+     `test_sanitize.py:662-685` into a shared test-support module; update
+     the sanitizer guard import (1-line). (Coordinate with agent 21 —
+     the sanitizer IP/host guard wants the SAME helpers; ship the shared
+     util in whichever PR lands first, or a tiny precursor PR.)
+   - Add `tests/unit/migration/test_walker_completeness.py` with
+     `_model_leaves`, `_LEAF_TO_WALKER_XPATHS`, `_WALK_EXEMPT`, the main
+     test + the three guard-the-guard tests (+ optional ratchet).
+   - **Regen:** none. No matrix/YAML/walker change.
+   - **Verify:** `pytest tests/unit/migration/test_walker_completeness.py`
+     + the full `tests/unit/migration` (the guard must not perturb peers).
+2. **PR-2a — VRRP sub-field walk + declarations.** Walk the 6 VRRP HIGH
+   leaves, add per-codec `lossy`/`unsupported`, remove them from
+   `_WALK_EXEMPT` + add `_LEAF_TO_WALKER_XPATHS` rows. **Regen:**
+   `python tools/run_full_mesh.py --matrix` then
+   `python tools/run_phase4_reconciliation.py` (a separate "matrix delta"
+   commit per AGENTS.md). **Verify:** FULL `tests/unit` (incl.
+   `tests/unit/audit`).
+3. **PR-2b — SNMPv3 `priv-passphrase`/protocols.** Same recipe; lower
+   phase4 churn (auth twin already declared).
+4. **PR-2c — IPv6 `scope` + routing-instance `instance-type`.** Two
+   single-codec-narrow walks; smallest regen.
+
+The main thread (not agents) runs the regen tools and commits — per the
+seed's hard constraints. Agents propose; the main thread actuates +
+verifies against the fixture corpus + full `tests/unit`.
+
+---
+
+## 7. How the recommended fix would have caught the audit-named instances
+
+Decisive scenario test (for `30-review-correctness`): a dev adds
+`CanonicalThing.mgmt_ip: str = ""` to a nested model and forgets to walk
+it. `_model_leaves()` yields `("CanonicalThing","mgmt_ip")`; it is not in
+`_LEAF_TO_WALKER_XPATHS` and not in `_WALK_EXEMPT` →
+`test_every_model_leaf_is_walked_or_exempt` FAILS with
+`"CanonicalThing.mgmt_ip (no walker-xpath mapping)"`. **Class killed.**
+
+Retrospective: every audit-named instance was a leaf that existed on the
+model but wasn't walked — switchport, static-route sub-fields, VXLAN
+mcast/flood, VLAN port-membership (#172), VLAN-SVI L3 (#175). For each,
+the recursive guard would have flagged the `(Class, field)` the moment it
+was added without a yield, *before* the blind audit found it — because it
+recurses into nested models, which the two existing top-level-only guards
+never did. (The VLAN-SVI #175 case is the cleanest proof: the leaf is
+`CanonicalIPv4Address.ip` reused on the VLAN — the guard's tuple-mapping
+`("CanonicalIPv4Address","ip") -> ("/interfaces/.../ip", "/vlans/.../ip")`
+makes "is the VLAN copy walked?" an explicit, guarded question.)
+
+---
+
+## 8. Coordination notes
+
+- **Agent 21 (sanitizer guard):** we both reuse
+  `_reachable_canonical_models` + `_flatten_annotation`. Recommend ONE
+  shared test-support module (`tests/support/canonical_reflection.py` or
+  `tests/unit/migration/_model_reflection.py`); pick the home in
+  synthesis. The class-1 leaf-enumeration (`_model_leaves`,
+  scalar-vs-nested) is identical machinery to your IP/host field
+  enumeration — only the *predicate* differs (walked-or-exempt vs
+  redacted-or-exempt). Consider a single `_model_leaves()` consumed by
+  both guards.
+- **Agent 22 (typed-marker):** if a typed marker (`Annotated[str,
+  IPField()]`) is adopted, the class-1 guard does NOT need it — the
+  walker-coverage question is "is the leaf walked," which is
+  field-name-independent, so the marker buys class-1 nothing the
+  `(Class,field)` map doesn't already give. Class-1's case for a marker
+  is weak; the `_LEAF_TO_WALKER_XPATHS` declared map is the natural shape
+  because xpath spelling is irregular (config/ segment, VXLAN element
+  collapse, VLAN reuse) and no marker encodes spelling. Recommend the
+  marker (if any) be scoped to class-2 (sanitizer) where the predicate is
+  "is this IP/secret-bearing," which a marker answers cleanly.
+- **`30-review-correctness`:** the decisive synthetic-new-leaf test is
+  §7. Probe whether `_LEAF_TO_WALKER_XPATHS` is a second blind spot —
+  my answer: no, because a leaf missing from BOTH map and exemption
+  fails (§3.4 design note).
+- **`31-review-pragmatism`:** the minimal version is PR-1 alone (~150
+  lines, zero behavior change, zero phase4). PR-2 is the
+  honor-the-user-intent cleanup of the worst instances and is
+  *stageable/deferrable* — the guard documents every deferral as a
+  `KNOWN-GAP` exemption, so deferring PR-2 is honest, not a hidden gap.
+  The optional `KNOWN-GAP` ratchet (§3.7) is the one piece I flag as
+  possibly gold-plating.
+
+---
+
+## 9. Citations index (file:line)
+
+- Walker yields + the gap: `netcanon/migration/canonical/xpath_walker.py:62-256`.
+- Default-to-supported: `netcanon/models/migration.py:221-228`;
+  unwalked-leaf-never-classified: `netcanon/services/migration_validate.py:28-45, 80-87`.
+- Reflection engine (reuse): `tests/unit/tools/test_sanitize.py:662-685`
+  (`_flatten_annotation`, `_reachable_canonical_models`), proven against
+  pydantic v2 + `from __future__ import annotations` by the passing
+  `test_reverse_no_unregistered_secret_field` (`:743-767`).
+- `_WALKABLE` kitchen-sink universe: `tests/unit/migration/test_registry_capability_honesty.py:132-225`.
+- The #149 self-justifying-exemption precedent: same file `:323-346`
+  (`_SYNTHETIC_NONWALKABLE`, `_is_legitimate_nonwalkable`).
+- The two existing TOP-LEVEL-ONLY forward checks (the hole this fills):
+  `test_marker_dict_covers_every_data_bearing_field` (same file `:527-541`,
+  reflects `set(CanonicalIntent.model_fields)` — no recursion);
+  G5 `_FIELD_TO_EXPECTED_XPATH` (`tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py:165-208`).
+- phase4 reads matrices+YAMLs, NOT the walker (PR-1 = zero phase4 churn):
+  `tests/unit/audit/test_run_phase4_reconciliation.py:288-308`;
+  `tools/run_full_mesh.py:334-335`.
+- The HIGH gap-leaf population (grep-confirmed): see `11-walker-gap.md`
+  §9 (VRRP/SNMPv3/IPv6-scope/instance-type populating codecs + parse.py
+  line cites).
+- The full leaf census denominator (~112 leaves): `10-model-leaf-census.md` §13.

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/21-design-sanitizer-guard.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/21-design-sanitizer-guard.md
@@ -1,0 +1,693 @@
+# 21 — Durable class-2 fix design: sanitizer completeness guard
+
+**Agent:** `21-design-sanitizer-guard` · Phase 2 (Design) · read-only
+**Run:** 2026-06-24 · ultracode blackboard · netcanon
+**Scope:** the durable structural fix for the **sanitizer-bypass class** (class 2):
+any new IP/host/secret-bearing canonical field leaks verbatim until a human names
+it in `sanitize_intent`'s allow-list. Compare (A) blanket `ip_address()` redaction,
+(B) reflection-driven completeness GUARD, (C) typed-marker enumeration; recommend
+one; give the EXACT test/code shape, exemption mechanism, over-redaction handling,
+the would-have-failed-before-#174 proof, and quantified blast radius.
+
+**Peers read first:** `10-model-leaf-census.md`, `11-walker-gap.md`,
+`12-sanitizer-gap.md`. I build directly on agent 12's §6 recommendation and §7
+catalogue; I do NOT re-derive the leaf census (I cite agent 10/12 as authoritative).
+
+---
+
+## 0. TL;DR / recommendation
+
+**Recommend form (B): extend the existing two-sided reflection guard
+`TestSecretRedactionCoverage` (`tests/unit/tools/test_sanitize.py:688-767`) with a
+parallel IP/host coverage half + a MAC coverage half.** NOT the runtime blanket
+`ip_address()` rule (A). Defer the typed-marker (C) to agent 22's verdict — my read
+matches agent 12's: marker is over-engineering *for class-2 alone* because the model
+already obeys a reliable naming convention (every IP/host/secret leaf has an IP/host/
+secret-shaped name), and the only marker payoff is cross-class reuse with the walker.
+
+The fix is **three commits**, all low-risk:
+
+1. **PR-S1 (runtime, tiny):** wire the *two genuine current leaks* the guard would
+   otherwise have to register-as-known-gap: `CanonicalStaticRoute.destination` (1-line
+   `redact_cidr`, identical to `dhcp.network`/`evpn.prefix`) and the **four MAC fields**
+   (`virtual_gateway_mac` ×2, `virtual_mac`, `anycast_gateway_mac`) via a new
+   `redact_mac` primitive. This makes the guard GREEN from day one and is itself the
+   first instance of "the guard works" (agent 12 §4b/§5b.3 + this report §3).
+2. **PR-S2 (the guard, zero runtime change):** add `_REGISTERED_IP_FIELDS`,
+   `_REGISTERED_MAC_FIELDS`, `_IP_HOST_NAME_RE`, `_MAC_NAME_RE`, the self-justifying
+   `_IP_NAME_EXEMPT` set, and `test_reverse_no_unregistered_ip_field` /
+   `test_reverse_no_unregistered_mac_field` + the forward sentinel halves. ~70 lines,
+   reuses the existing `_reachable_canonical_models` + `_flatten_annotation` engine.
+3. **PR-S3 (docs, mandatory under AGENTS.md):** SECURITY.md sanitiser table +
+   BUG_REPORTING.md "what gets sanitised" + the sanitize.py module docstring get the
+   new `mac` / static-route-destination categories (the AGENTS.md doc-sync row for "a
+   new redaction category lands in sanitize.py" — §7).
+
+**Blast radius:** fixture-corpus diff is **near-zero** (agent 12 §5c: only public
+static-route destinations newly redact, vanishingly rare in the corpus; MAC redaction
+adds substitutions only where a MAC is present — cosmetic, not breaking). Zero phase4
+reconciliation impact (the sanitizer is NOT in the migration-validate / cross-mesh
+path). Test cost: ~70 new lines in one existing file + 2 forward sentinel tests.
+
+---
+
+## 1. Why not (A) the runtime blanket `ip_address()` rule — settled by agent 12
+
+Agent 12 §5 did the over-redaction homework and the verdict is decisive; I restate
+the load-bearing points because they directly drive my recommendation, then add two
+the census surfaced that sharpen the case against (A):
+
+1. **It is the WRONG ALTITUDE.** The leak class is "a new field is forgotten" — a
+   *coverage* defect, best caught at **test time**, not a runtime *behaviour* defect.
+   The seed itself says: favour "convert the blind spot into a CI failure over a risky
+   runtime behavior change." A guard does exactly that; a blanket rule does not (a
+   blanket rule still silently does *something* for the new field — possibly the wrong
+   something — but never tells a human a decision was skipped).
+
+2. **It is INSUFFICIENT.** `ip_address()` only matches string leaves whose *entire*
+   value parses as a bare IPv4/IPv6 literal. It is structurally **blind** to every
+   non-bare-IP category the sanitizer already handles (agent 12 §5b.3, §6):
+   - **MACs** — `00:1c:73:00:dc:01` is not a valid `IPv4Address`/`IPv6Address`
+     (wrong group count) → a blanket IP rule **misses all four MAC fields entirely**
+     (and MACs are currently un-redacted — §3 — so a blanket-IP rule would NOT close
+     that real gap, while it would *masquerade* as a complete fix).
+   - **CIDR fields** (`network`, `prefix`, `destination`) — `IPv4Address("10.0.0.0/24")`
+     raises `ValueError`; they need `redact_cidr`. A uniform `redact_ip_string` blanket
+     would *under*-redact these (agent 12 §5b.2).
+   - **RD/RT** `64496:N`, **mcast** `233.252.0.N` (preserved by `redact_ipv4`),
+     **communities**, **hashes**, **hostnames**, **free-text PII** — none are bare IPs.
+   So a blanket-IP rule would have to be *bolted onto* the existing 41 hand-written
+   redaction sites anyway, not replace them — gaining a partial redundant cover for the
+   IP slice while leaving the actual "field N+1" class only half-closed.
+
+3. **It introduces real (small) over-redaction edges for negligible benefit** —
+   `timezone` could in principle hold an IP-shaped string and get mangled; the current
+   allow-list is already empirically complete (agent 12 §0). The benefit/cost of (A)
+   is poor when the allow-list has no *current* leak to plug.
+
+**One nuance against the seed's framing.** The seed states the durable fix the user
+described as: "the sanitizer redacts on `ip_address()` of ANY IP-typed field, not an
+allow-list." Agent 12 §5a shows the *over-redaction fear* behind that caution is
+largely unfounded (whole-string parsing, not substring) — but the deeper finding is
+that `ip_address()`-blanket is **not the right primitive at all** because it cannot see
+MACs/RD/RT/secrets. The faithful reading of the user's GOAL ("fail-surfaced defaults")
+is better served by a guard that fails-RED on *any* unhandled IP/host/MAC/secret-named
+field than by a runtime rule that silently handles only the bare-IP subset. I take a
+position on goal-fidelity in §8.
+
+---
+
+## 2. Recommended design (B) — the exact shape
+
+The recommendation extends the **existing, proven** two-sided guard rather than
+inventing a subsystem. The reusable engine (`_reachable_canonical_models` +
+`_flatten_annotation`, `test_sanitize.py:662-685`) is already battle-tested against
+pydantic v2 + `from __future__ import annotations` string annotations (it powers the
+secret half today, and `_flatten_annotation` already unwraps `list[...]` / `Optional` /
+`dict` / unions). The IP/host and MAC halves are *peers* of `test_reverse_no_
+unregistered_secret_field`, dropped into the same file (`TestSecretRedactionCoverage`
+becomes the umbrella for all three categories, or a sibling `TestSanitizerFieldCoverage`
+class — naming is a synthesis-thread call; the mechanism is identical).
+
+### 2.1 The registries (lockstep with the sanitizer allow-list)
+
+```python
+# IP/host-bearing canonical fields that MUST be redacted by sanitize_intent.
+# (ClassName, field_name). Keep in lockstep with the sanitiser walk — both
+# directions enforced below. Source of truth: agent-12 §2 allow-list table.
+_REGISTERED_IP_FIELDS = {
+    ("CanonicalIntent", "dns_servers"),
+    ("CanonicalIntent", "ntp_servers"),
+    ("CanonicalIntent", "syslog_servers"),
+    ("CanonicalIPv4Address", "ip"),
+    ("CanonicalIPv4Address", "virtual_gateway_address"),
+    ("CanonicalIPv6Address", "ip"),
+    ("CanonicalIPv6Address", "virtual_gateway_address"),
+    ("CanonicalVRRPGroup", "virtual_ips"),
+    ("CanonicalVRRPGroup", "virtual_ipv6s"),
+    ("CanonicalVlan", "ipv4_addresses"),       # nested IPv4Address.ip covered above
+    ("CanonicalStaticRoute", "destination"),   # wired in PR-S1
+    ("CanonicalStaticRoute", "gateway"),
+    ("CanonicalDHCPPool", "network"),
+    ("CanonicalDHCPPool", "start_ip"),
+    ("CanonicalDHCPPool", "end_ip"),
+    ("CanonicalDHCPPool", "gateway"),
+    ("CanonicalDHCPPool", "dns_servers"),
+    ("CanonicalSNMP", "trap_hosts"),
+    ("CanonicalRADIUSServer", "host"),
+    ("CanonicalVxlan", "mcast_group"),
+    ("CanonicalVxlan", "flood_list"),
+    ("CanonicalRoutingInstance", "route_distinguisher"),
+    ("CanonicalRoutingInstance", "rt_imports"),
+    ("CanonicalRoutingInstance", "rt_exports"),
+    ("CanonicalEvpnType5Route", "prefix"),
+    ("CanonicalEvpnType5Route", "rt_imports"),
+    ("CanonicalEvpnType5Route", "rt_exports"),
+}
+
+# MAC-bearing canonical fields (network-identifying; class twin of IP).
+# Wired in PR-S1 (currently UN-redacted — see §3).
+_REGISTERED_MAC_FIELDS = {
+    ("CanonicalIPv4Address", "virtual_gateway_mac"),
+    ("CanonicalIPv6Address", "virtual_gateway_mac"),
+    ("CanonicalVRRPGroup", "virtual_mac"),
+    ("CanonicalIntent", "anycast_gateway_mac"),
+}
+```
+
+### 2.2 The name heuristics (what the reverse test *scans for*)
+
+The reverse test must find *candidate* IP/host/MAC fields by name, then assert each is
+registered-or-exempt. The regex is the trigger; the registry+exemption is the bless.
+
+```python
+# A field name that looks like it holds an IP, a CIDR, a host, or an
+# IP-bearing list. Tuned against the live model field names (agent-10 census).
+_IP_HOST_NAME_RE = re.compile(
+    r"(^|_)("
+    r"ip|ips|ipv4|ipv6|"
+    r"host|hosts|"
+    r"gateway|"
+    r"network|destination|prefix|"
+    r"address|addresses|"
+    r"dns_servers|ntp_servers|syslog_servers|trap_hosts|flood_list|"
+    r"start_ip|end_ip|"
+    r"route_distinguisher|rt_imports|rt_exports|mcast_group"
+    r")$",
+    re.IGNORECASE,
+)
+
+# A field name that looks like it holds a MAC address.
+_MAC_NAME_RE = re.compile(r"(^|_)mac$", re.IGNORECASE)
+```
+
+> **Heuristic-reliability evidence (this is the crux of why (B) beats (C) for class-2).**
+> Walk agent-10's full leaf table: *every* IP/host-bearing leaf has an IP/host-shaped
+> name (`ip`, `*_address`, `*_addresses`, `gateway`, `network`, `prefix`,
+> `destination`, `*_servers`, `host`, `trap_hosts`, `flood_list`, `mcast_group`,
+> `route_distinguisher`, `rt_*`, `start_ip`/`end_ip`, `virtual_ips`/`virtual_ipv6s`).
+> *Every* MAC leaf ends in `_mac`. *Every* secret leaf already matches the proven
+> `_SECRET_NAME_RE`. There is **no IP/MAC/secret leaf in the model that hides behind a
+> non-indicative name**, and there is **no non-IP leaf whose name falsely matches**
+> except the two structural-name false-positives in §2.3. The naming convention is a
+> de-facto invariant of this codebase — which is exactly the condition under which a
+> naming-heuristic guard is *sufficient* and a typed marker is *redundant ceremony*.
+
+### 2.3 The self-justifying exemption set (modelled on #149 `_SYNTHETIC_NONWALKABLE`)
+
+The exemption set exists ONLY to silence *naming false-positives* — fields whose name
+matches `_IP_HOST_NAME_RE` but which structurally cannot carry an IP. It is NOT an
+escape hatch for "this is an IP I chose not to redact" (those must go through the
+forward sentinel, which is non-exemptable — §2.5). Each entry carries a human-readable
+reason string, exactly like #149's precedent (`test_registry_capability_honesty.py:
+317-330`):
+
+```python
+# Fields whose NAME matches _IP_HOST_NAME_RE but which are NOT IP-bearing.
+# Each carries the reason it is exempt — a reviewer reading a PR that adds an
+# entry can challenge a bogus reason (the #149 self-justifying-exemption pattern).
+_IP_NAME_EXEMPT = {
+    ("CanonicalStaticRoute", "interface"): "outgoing iface name, not an IP",
+    ("CanonicalVxlan", "source_interface"): "loopback/SVI iface NAME, not an IP literal",
+    # NOTE: `prefix_length` (int) does not match the regex; no exemption needed.
+    # NOTE: `interface` on DHCP pool — same iface-name rationale if regex ever widens.
+}
+```
+
+Today this set is **2 entries** (agent 12 §4b/§5b: `source_interface` and route
+`interface` are the only IP-named-but-not-IP leaves). The exemption set is therefore a
+*closed, small, reviewable* surface — not the open dumping-ground that would re-create
+the blind spot (the §30/§31 reviewers must stress this; I argue its boundedness in §6).
+
+MAC has **zero** false-positives (`_MAC_NAME_RE` = exactly `*_mac`; all four matches
+are real MAC fields), so `_MAC_NAME_EXEMPT` starts empty — but I still declare it (as
+an empty set with a comment) so the mechanism is symmetric and the next `*_mac` field
+that is somehow not a MAC has an obvious home.
+
+### 2.4 The reverse (coverage) tests — the class-kill
+
+```python
+def _scan_named_fields(name_re):
+    """All (ClassName, field) reachable from CanonicalIntent whose name
+    matches name_re AND whose annotation contains `str` (scalar or list[str])."""
+    found = set()
+    for model in _reachable_canonical_models(CanonicalIntent):
+        for fname, fld in model.model_fields.items():
+            if not name_re.search(fname):
+                continue
+            flat = list(_flatten_annotation(fld.annotation))
+            # str scalar, list[str], Optional[str] all flatten to include `str`;
+            # nested-model fields (list[CanonicalIPv4Address]) include the model
+            # class, which the registry covers via the child leaves, so we also
+            # accept a field whose annotation reaches a registered child model.
+            if str in flat or any(
+                isinstance(t, type) and issubclass(t, BaseModel) for t in flat
+            ):
+                found.add((model.__name__, fname))
+    return found
+
+
+def test_reverse_no_unregistered_ip_field():
+    found = _scan_named_fields(_IP_HOST_NAME_RE)
+    unregistered = found - _REGISTERED_IP_FIELDS - set(_IP_NAME_EXEMPT)
+    stale = _REGISTERED_IP_FIELDS - found
+    assert not unregistered, (
+        "IP/host-bearing canonical field(s) with no known redaction rule — "
+        "add a redaction in sanitize_intent AND register in _REGISTERED_IP_FIELDS, "
+        "or add a justified exemption to _IP_NAME_EXEMPT: " + repr(sorted(unregistered))
+    )
+    assert not stale, (
+        "Registered IP field(s) no longer on the model — remove from "
+        "_REGISTERED_IP_FIELDS: " + repr(sorted(stale))
+    )
+
+
+def test_reverse_no_unregistered_mac_field():
+    found = _scan_named_fields(_MAC_NAME_RE)
+    unregistered = found - _REGISTERED_MAC_FIELDS  # _MAC_NAME_EXEMPT empty today
+    stale = _REGISTERED_MAC_FIELDS - found
+    assert not unregistered, (
+        "MAC-bearing canonical field(s) with no redaction rule — redact in "
+        "sanitize_intent AND register in _REGISTERED_MAC_FIELDS: "
+        + repr(sorted(unregistered))
+    )
+    assert not stale, ("Stale _REGISTERED_MAC_FIELDS: " + repr(sorted(stale)))
+```
+
+> **Annotation-reach subtlety (important for correctness).** Container fields like
+> `CanonicalInterface.ipv4_addresses: list[CanonicalIPv4Address]` and
+> `CanonicalVlan.ipv4_addresses` match `_IP_HOST_NAME_RE` (`addresses$`) but their
+> *value* is a nested model, not a string — the actual IP lives on the child's `.ip`.
+> The `_scan_named_fields` helper above accepts a name-matching field if its annotation
+> reaches *either* a `str` *or* a registered child `BaseModel`. I register
+> `("CanonicalVlan", "ipv4_addresses")` (the container) because the SVI-L3 leak (#175)
+> was precisely this container's nested `.ip`; the child `CanonicalIPv4Address.ip` is
+> *also* registered, so the nested address is doubly accounted. The reviewers should
+> confirm this dual-accounting reads cleanly (alternative: scan only `str`-typed leaves
+> and rely on the child registration — simpler, drops the two `ipv4_addresses`
+> container rows from `_REGISTERED_IP_FIELDS`. I lean toward the str-only scan for
+> minimality; documented as an option for synthesis in §9.)
+
+### 2.5 The forward (sentinel) tests — proves the registered redaction actually fires
+
+Mirrors `test_forward_no_registered_secret_survives`: populate every registered IP/MAC
+field with a *public, unique sentinel* (public so the private-preservation predicate
+does not legitimately keep it), sanitize, assert the sentinel does not survive into the
+output JSON. This half is **non-exemptable** — you cannot "exempt" your way out of
+redacting a *registered* field, closing the "register-and-forget-to-actually-wire"
+hole.
+
+```python
+def test_forward_no_registered_ip_survives():
+    # Public sentinels (so private-preservation doesn't legitimately keep them).
+    intent = CanonicalIntent(
+        dns_servers=["8.8.8.8"], ntp_servers=["9.9.9.9"], syslog_servers=["1.1.1.1"],
+        interfaces=[CanonicalInterface(
+            name="Vlan10",
+            ipv4_addresses=[CanonicalIPv4Address(
+                ip="203.0.0.7", prefix_length=24,
+                virtual_gateway_address="203.0.0.8",
+            )],
+            vrrp_groups=[CanonicalVRRPGroup(
+                group_id=1, virtual_ips=["203.0.0.9", "203.0.0.10"],
+            )],
+        )],
+        static_routes=[CanonicalStaticRoute(
+            destination="203.0.0.0/24", gateway="9.9.9.1",
+        )],
+        dhcp_servers=[CanonicalDHCPPool(
+            network="203.0.0.0/24", start_ip="203.0.0.20", end_ip="203.0.0.40",
+            gateway="203.0.0.1", dns_servers=["8.8.4.4"],
+        )],
+        radius_servers=[CanonicalRADIUSServer(host="9.9.9.2", key="k")],
+        snmp=CanonicalSNMP(community="", trap_hosts=["9.9.9.3"]),
+    )
+    sanitized, _ = sanitize_intent(intent)
+    blob = sanitized.model_dump_json()
+    # No public sentinel octet-string should survive (allowing docs-range output).
+    for leak in ("8.8.8.8", "9.9.9.9", "1.1.1.1", "203.0.0.7", "203.0.0.8",
+                 "9.9.9.1", "203.0.0.20", "9.9.9.2", "9.9.9.3"):
+        assert leak not in blob, f"public IP sentinel survived: {leak}"
+```
+
+> Caveat the author of this test must heed: pick sentinels that are unambiguously
+> *public* but do NOT collide with the docs ranges the redactor *emits* (`192.0.2.x`,
+> `198.51.100.x`, `203.0.113.x`, `2001:db8::`). I used `203.0.0.x`/`8.8.x`/`9.9.x`/
+> `1.1.1.1` above precisely to avoid the `203.0.113.x` docs block. The MAC forward test
+> populates each MAC field with a recognizable OUI sentinel and asserts it is gone.
+
+---
+
+## 3. The two genuine current leaks PR-S1 must wire (so the guard is green day one)
+
+The guard is only honest if it is GREEN against the *current* model. Two registrations
+in §2.1 are **not redacted today** and must be wired in PR-S1 before the guard lands:
+
+### 3.1 `CanonicalStaticRoute.destination` (agent 12 §4b.2)
+
+The route's destination CIDR is never redacted — only `.gateway` is
+(`sanitize.py:659-669`). A static route to a public destination leaks that prefix. The
+fix is a 1-line `redact_cidr` in the existing static-route loop, identical to
+`dhcp.network` (`sanitize.py:633`) and `evpn.prefix` (`sanitize.py:755`):
+
+```python
+# inside the `for i, route in enumerate(sanitized.static_routes):` loop
+if route.destination:
+    new_dest = table.redact_cidr(route.destination)
+    if new_dest != route.destination:
+        subs.append(Substitution(
+            category="ipv4-public",   # or a dedicated "static-route-destination"
+            field=f"static_routes[{i}].destination",
+            original=route.destination, redacted=new_dest,
+        ))
+        route.destination = new_dest
+```
+
+`redact_cidr` preserves the prefix length and (via `redact_ip_string` → `redact_ipv4`)
+**preserves RFC-1918 / default-route `0.0.0.0/0`** — so the overwhelmingly-common LAN
+and default routes are untouched (agent 12 §4b.2). Corpus impact: only *public*
+static-route destinations change, which agent 12's read-only fixture sampling found to
+be near-absent (< 1% of redaction sites, §5c).
+
+### 3.2 The four MAC fields (agent 12 §5b.3 — currently un-redacted)
+
+Confirmed by grep: `sanitize.py` has **no** MAC handling, and the model has four
+MAC-bearing leaves (`CanonicalIPv4Address.virtual_gateway_mac`,
+`CanonicalIPv6Address.virtual_gateway_mac`, `CanonicalVRRPGroup.virtual_mac`,
+`CanonicalIntent.anycast_gateway_mac` — `intent.py:124,165,591,917`). A MAC is
+operator-traceable network-identifying data (AGENTS.md Hard Rules class it with
+"real MAC addresses" under the never-push-PII review) and several codecs render it
+verbatim (Arista VARP `mac-address`, NX-OS `fabric forwarding anycast-gateway-mac`,
+Aruba/Junos virtual-MAC). This is the **single most defensible new redaction** the run
+surfaces — it is a real (if narrow) class-2 leak that NONE of the five prior audits
+named, exactly the "field N+1" the guard is meant to catch *prospectively*.
+
+A new stable primitive on `_SubstitutionTable`:
+
+```python
+def redact_mac(self, value: str) -> str:
+    """Cross-reference-stable MAC redaction. Maps each distinct MAC to a
+    stable address in the IANA documentation OUI 00:00:5E (RFC 7042 /
+    locally-administered space), preserving the separator style so the
+    renderer still emits valid syntax. Non-MAC strings returned verbatim."""
+    # parse-validate as 6 hex groups (`:`/`-`/`.`-separated); if not a MAC,
+    # return verbatim (don't mangle). Stable map -> `00:00:5e:00:53:NN`
+    ...
+```
+
+> **Design choice — which docs MAC range.** RFC 7042 §2.1.2 reserves
+> `00:00:5E:00:53:00–FF` as a *documentation* unicast MAC block (the IPv6-doc-MAC
+> twin), the cleanest analogue to RFC-5737 docs-IP redaction. Note `00:00:5E` is also
+> the IANA VRRP virtual-MAC OUI (`00:00:5E:00:01:VRID`) and the doc block `…:53:NN`
+> avoids the `…:01:` VRRP and `…:02:` IPv6-anycast sub-blocks, so a redacted MAC is
+> visibly a documentation MAC and won't be mistaken for a live VRRP vMAC. Synthesis can
+> pick a different placeholder; the *guard* doesn't care which, only that the field is
+> redacted-and-registered.
+
+Wire it at all four sites (the two address loops, the VRRP loop, and the top-level
+scalar). New `Substitution.category = "mac"`.
+
+> **Open micro-decision (for synthesis, not blocking):** VRRP `virtual_mac` for a
+> *standard* VRID is the well-known deterministic `00:00:5E:00:01:VRID` and is NOT
+> operator-identifying (it's derivable from the group id, which is itself walked). One
+> could argue to *preserve* a well-known VRRP vMAC the way `redact_ipv4` preserves
+> well-known multicast. I lean toward redacting all four uniformly for simplicity and
+> because `virtual_mac` is frequently an *override* (operator-chosen) on Junos/Aruba;
+> the well-known-vMAC-preservation is a possible later refinement, not a launch
+> requirement. Either way the field stays *registered* (redacted), so the guard is
+> satisfied — this decision lives entirely in the primitive, not the guard.
+
+---
+
+## 4. Would the guard have FAILED before #174 (the VGA leak)? — the regression proof
+
+**Yes.** This is the headline argument that the guard kills the historical instance
+*prospectively*, and it generalises to the whole class.
+
+Before #174, `CanonicalIPv4Address.virtual_gateway_address` (and the IPv6 twin) was a
+model field with **no redaction rule** in `sanitize_intent`. Trace the reverse test
+against the *pre-#174* model:
+
+1. `_reachable_canonical_models(CanonicalIntent)` reaches `CanonicalIPv4Address`.
+2. Its field `virtual_gateway_address` matches `_IP_HOST_NAME_RE` (the name ends in
+   `_address` → matches the `address$` alternative). Its annotation is `str`.
+3. So `("CanonicalIPv4Address", "virtual_gateway_address") ∈ found`.
+4. Pre-#174, it is **not** in `_REGISTERED_IP_FIELDS` (no redaction existed to register)
+   and **not** in `_IP_NAME_EXEMPT` (it IS an IP).
+5. ⇒ `unregistered` is non-empty ⇒ **`test_reverse_no_unregistered_ip_field` FAILS**
+   with: *"IP/host-bearing canonical field(s) with no known redaction rule … :
+   [('CanonicalIPv4Address', 'virtual_gateway_address'), ('CanonicalIPv6Address',
+   'virtual_gateway_address')]"*.
+
+The PR that *added* `virtual_gateway_address` to the model (well before the audit found
+it) would have turned CI red the moment it landed, forcing the author to either wire the
+redaction (which is what #174 eventually did, reactively) or consciously exempt it with
+a reason a reviewer could challenge. **The five-rounds-of-whack-a-mole pattern is
+exactly the absence of this guard.** The same trace works for the *next* unforeseen
+field: any `*_ip`, `*_address`, `*_gateway`, `*_mac`, `*_host`, `…_servers` leaf added
+without a redaction → red CI naming the exact `Class.field`.
+
+(Symmetric proof for the secret half already exists and ships today — this run only
+adds the IP/host + MAC halves the secret guard's author deliberately scoped out, see
+the comment at `test_sanitize.py:778-782`.)
+
+---
+
+## 5. Over-redaction — addressed head-on (the user's explicit caution)
+
+The user's caution was about *over-redaction risk*. The guard form (B) has **essentially
+zero over-redaction risk** because **it changes no runtime behaviour** — it is a test.
+The only runtime change is PR-S1's two narrow redactions, whose over-redaction surface
+is:
+
+| Runtime change | Over-redaction risk | Mitigation already in the primitive |
+|---|---|---|
+| static-route `destination` via `redact_cidr` | Only *public* destinations redact; RFC-1918 + `0.0.0.0/0` preserved | `redact_cidr` → `redact_ip_string` → `redact_ipv4` inherits private/docs preservation (`sanitize.py:857-871`) |
+| four MAC fields via `redact_mac` | A non-MAC string in a `*_mac` field would be left verbatim (parse-validate-first); well-known VRRP vMAC arguably over-redacted (cosmetic) | `redact_mac` validates 6-hex-group shape before substituting; §3.2 open-decision on vMAC preservation |
+
+Crucially, the guard does **not** push the project toward the blanket `ip_address()`
+rule the user worried about — it does the opposite: it lets the sanitizer keep its
+carefully-tuned per-field primitives (CIDR vs bare-address, mcast-preservation,
+RD/RT-correlation, format-preserving hashes, private/docs preservation) and simply
+*proves the set is complete*. Agent 12's §5d hard-must-fix ("a blanket rule must reuse
+the private-preserving predicate") is **moot** under (B) because there is no blanket
+rule. The deliberate private/docs-IP preservation is untouched.
+
+The one residual the guard deliberately does **not** force-close is the **hostname-form
+passthrough** (`ntp_servers=["nms.corp.example"]` etc., agent 12 §4a) — those fields
+ARE registered (they go through `redact_ip_string`, which returns non-IP strings
+verbatim by design, asserted at `test_sanitize.py:837-843`). The guard treats
+"registered" as "has a redaction rule," and the rule for these is "redact IP form,
+preserve name form" — a *conscious* documented decision, not a silent gap. If the
+project later decides to redact DNS-name hosts, that is a new redaction primitive, not a
+guard change. (I flag this so §30/§31 don't read the passthrough as a guard false-pass.)
+
+---
+
+## 6. Does the exemption set relocate the blind spot? — the honest weakness, bounded
+
+This is the central adversarial question (the seed flags it; §30/§31 will press it). My
+position: the exemption set does NOT meaningfully relocate the blind spot for class-2,
+because of four structural properties:
+
+1. **It is for naming false-positives only, not redaction opt-outs.** The only way into
+   `_IP_NAME_EXEMPT` is "this field's NAME looks IP-ish but it structurally is not an
+   IP." You cannot use it to say "this IS an IP but I don't want to redact it" —
+   because the *forward sentinel* (§2.5) is non-exemptable and would fail if a registered
+   field isn't actually redacted, and the *only* alternative to registering is exempting,
+   which a reviewer can reject on the reason string. The two escape routes (register =
+   must-actually-redact; exempt = must-not-be-an-IP) are both costly to abuse.
+
+2. **It is tiny and closed.** Today 2 entries (`interface`, `source_interface`). The set
+   grows only when a *new* IP-named-but-not-IP field is added — a rare event, and each
+   addition is a reviewable PR line with a reason string. Contrast the *original* blind
+   spot (the entire 41-site allow-list, hand-maintained, with no forcing function): the
+   exemption set is two orders of magnitude smaller and self-documenting.
+
+3. **The reason string makes abuse visible.** `("X", "management_ip"): "internal-only,
+   never public"` is a *claim a reviewer can challenge* — internal IPs are still
+   operator-traceable, so that reason is bogus and a reviewer rejects it. The #149
+   precedent (each `_SYNTHETIC_NONWALKABLE` entry self-justifies) is the proven pattern;
+   it has held since PR #149 without the set ballooning.
+
+4. **Belt-and-suspenders for class-2 specifically:** because every IP/host/MAC leaf in
+   *this* model truly does have an indicative name (§2.2 evidence), the regex catches
+   the real field and the exemption only ever needs to silence the handful of
+   iface-name fields. The blind spot would only "relocate" if a future dev added an
+   IP-bearing field with a deceptive name (e.g. `peer_endpoint` holding an IP) — that is
+   the *one* residual, and it is addressable by (a) the secret/IP naming-convention being
+   a documented contributor expectation (it already is, de-facto), and (b) the
+   typed-marker (C) as a belt for the deceptive-name case — see §8 / agent 22.
+
+**Residual honest gap (state it plainly):** a name-heuristic guard cannot catch an
+IP-bearing field given a *non-indicative* name. That residual is the strongest argument
+for the typed marker (C), and the only place (C) buys something (B) cannot. I judge it a
+low-probability event for class-2 (the codebase's naming discipline is strong and
+contributor-visible) and recommend (B) now, with (C) reserved as a documented escalation
+if a deceptive-name field ever ships — see agent 22's verdict.
+
+---
+
+## 7. Doc-sync obligations (AGENTS.md — mandatory, not optional)
+
+PR-S1 lands new redaction behaviour, so the AGENTS.md doc-sync table fires. Two rows
+apply directly (the main thread MUST honour these in the *same commit* as the runtime
+change, per the Hard Rule "Never land a code change without updating the docs it
+renders stale"):
+
+- **Row "A new redaction category lands in `netcanon/tools/sanitize.py`"** →
+  (1) `SECURITY.md` § "Sanitiser (Bug-Reporting Workflow)" redaction-rule table — add
+  `mac` and (if a dedicated category) `static-route-destination`;
+  (2) `BUG_REPORTING.md` § "What gets sanitised" — operator-facing rule list + the
+  per-category counter scheme;
+  (3) `docs/CAPABILITIES.md` only if the new category surfaces in a migrate-page banner
+  (the sanitizer categories do not, so this sub-item is likely N/A — confirm).
+- **The `sanitize.py` module docstring** (`sanitize.py:16-72` field-typed-rules list) —
+  add the `virtual_gateway_mac`/`virtual_mac`/`anycast_gateway_mac` → docs-MAC line and
+  the `static_routes[].destination` → docs-range line. (Module-docstring-inventory row.)
+- **`docs/METHODOLOGY.md`** is a *candidate* but optional — the "completeness guard"
+  pattern is already exemplified by the secret half; adding the IP/MAC halves is more of
+  the same, not a new pattern. Synthesis can add a one-line pointer if it wants the
+  pattern discoverable, but it's not a Hard-Rule obligation.
+
+PR-S2 (the guard test itself) is test-only and triggers no doc-sync row (it adds no
+marker to `pyproject.toml` and changes no operator-facing surface).
+
+---
+
+## 8. Reconciling with the user's literal goal ("fail-surfaced *defaults*")
+
+The seed asks each design agent to take a position on whether a CI guard is *faithful*
+to "fail-surfaced defaults," or whether the goal demands the behaviour-change /
+by-construction form.
+
+**My position: the guard (B) IS faithful to the goal for class-2, and is the *better*
+realization of it than the runtime blanket.** Parse the goal: "a new field should
+DEFAULT to surfaced/flagged, not to silently fine." Under (B), the literal default for a
+newly-added IP/host/MAC-named field is **CI-red** — the developer is *forced* to make a
+conscious redact-or-exempt decision before the field can merge. That is precisely
+"defaults to flagged." The runtime blanket (A), by contrast, makes a new bare-IP field
+default to *silently redacted* (and a new MAC/RD/RT/secret field default to *silently
+leaked*) — which is *less* surfaced, not more: no human is told a decision was made.
+"Fail-surfaced" means a human is *surfaced the failure*; a guard does that, a silent
+runtime transform does not.
+
+The one place the guard is *less* than the by-construction ideal is the deceptive-name
+residual (§6). That is real, and it is the honest seam where the typed marker (C) would
+make the default truly *intrinsic* (the field carries `Annotated[str, IPField()]` so no
+name guessing is needed). My recommendation is therefore: **(B) now as the faithful,
+minimal, zero-risk realization of the goal; (C) as a documented escalation** if agent 22
+shows it cheaply subsumes both classes — see §8.1.
+
+### 8.1 Coordination with agent 22 (typed marker)
+
+If agent 22 recommends the typed marker for class-1 (the walker, where there is *no*
+naming convention to lean on and the heuristic is unreliable), then class-2 should
+**reuse the same marker** rather than maintain a parallel naming heuristic — at that
+point the marginal cost of marking the ~31 IP + 4 MAC + 6 secret leaves is small and the
+deceptive-name residual disappears for free. The decision rule for synthesis:
+
+- If agent 22 = "marker worth it for class-1" → adopt the marker for class-2 too
+  (the guard then enumerates from `model_fields[...].metadata`, not the regex; the
+  `_REGISTERED_*` sets collapse into the annotations). The guard *test* survives —
+  it just reflects markers instead of names.
+- If agent 22 = "marker is over-engineering for both" → ship (B) exactly as in §2.
+
+Either way the **guard test is the durable artifact**; the only question is whether it
+reflects *names* (B) or *markers* (C). That decoupling is deliberate — it means the
+class-1/class-2 marker decision can change later without touching the guard's contract.
+
+---
+
+## 9. Blast radius (quantified) + PR sequencing
+
+### 9.1 Fields to add now
+
+| Category | New runtime redactions (PR-S1) | New registry entries (PR-S2) |
+|---|---|---|
+| IP/host | 1 (`static_routes[].destination`) | 0 new fields *leaking* beyond that — the other 26 IP rows are already redacted; they are merely *registered* (documentation of existing coverage) |
+| MAC | 4 (the two vMAC, VRRP vMAC, anycast-gateway-mac) + 1 new `redact_mac` primitive | 4 |
+| **Total new redaction sites** | **5** | 30 IP-registry + 4 MAC-registry rows (mostly documenting existing coverage) |
+
+### 9.2 Fixture-corpus diff (reasoned, from agent 12 §5c + this report)
+
+- **Static-route destination:** only public destinations change. Agent 12's read-only
+  sampling of the MikroTik/Cisco fixtures found destinations are overwhelmingly RFC-1918
+  / default-route → **< 1% of redaction sites**, likely zero in most fixtures.
+- **MAC:** adds substitutions only where a fixture carries a virtual/anycast MAC (Arista
+  VARP, NX-OS anycast-gateway, Junos/Aruba). Cosmetic (new `mac` substitutions in the
+  audit log); not a *breaking* diff for any existing assertion unless a test pins a MAC
+  value verbatim — the main thread must grep `tests/` for a MAC literal in a
+  sanitizer-output assertion before landing (low probability; the existing sanitizer
+  never touched MACs so no test should pin a *redacted* MAC).
+- **Net:** near-zero corpus diff, no prose mangling (the runtime changes are CIDR + MAC,
+  neither touches free-text). The main thread should still run the end-to-end
+  `sanitize_text` over the corpus as a confirmation (agent 12 §5c rec), but the reasoned
+  answer is "negligible."
+
+### 9.3 Phase4 / cross-mesh reconciliation impact: **ZERO**
+
+The sanitizer is NOT in the migration-validate / `_walk_canonical` / `classify()` path
+(it has its own walk in `sanitize_intent`). It is NOT consumed by `tools/run_full_mesh.py`
+or `tools/run_phase4_reconciliation.py`. So unlike the class-1 walker fix (agent 20,
+which CAN reclassify `tests/unit/audit` cells), the class-2 fix touches **no** matrix,
+**no** cross-mesh artifact, and **no** phase4 cell. This is a major reason class-2 is the
+*safer, ship-first* half of this run. (Contrast MEMORY's St3 lesson where a walker/matrix
+change broke a `tests/unit/audit/` reconciliation test — that hazard does not exist
+here.)
+
+### 9.4 Test cost
+
+~70 lines added to one existing file (`tests/unit/tools/test_sanitize.py`): two registry
+sets, two name regexes, two exemption sets, `_scan_named_fields` helper (~12 lines), and
+4 tests (2 reverse + 2 forward). Reuses the existing `_reachable_canonical_models` +
+`_flatten_annotation` (no new reflection engine). Runs in the existing `tests/unit` tier;
+no new marker, no conftest change, no CI job change.
+
+### 9.5 PR sequencing
+
+1. **PR-S1** — runtime: `redact_mac` primitive + 4 MAC sites + 1 static-route-destination
+   site + the 5 new `Substitution` rows + the 3 doc-sync targets (§7). Self-contained,
+   behaviour-additive, near-zero corpus diff. *Land first* so the model is fully covered.
+2. **PR-S2** — the guard: the IP/host + MAC reverse+forward tests. Green from day one
+   *because* PR-S1 closed the two real gaps. Pure test addition, zero runtime change.
+3. **PR-S3** — (optional, only if agent 22 wins) migrate the registries to typed-marker
+   reflection. Defer until the agent-22 verdict + §30/§31 review.
+
+PR-S1 and PR-S2 *could* be one PR (the doc-sync rules want the redaction + its docs in
+one commit anyway, and the guard naturally accompanies the redaction); I split them only
+to keep the "runtime change" and "the guard" reviewable separately. Synthesis decides.
+
+---
+
+## 10. Decision summary
+
+| Question | Answer |
+|---|---|
+| Recommended form | **(B) reflection-driven completeness guard**, extending `TestSecretRedactionCoverage` with IP/host + MAC halves |
+| Differs from walker rec? | Possibly — class-2's naming convention is reliable so (B) suffices without a marker; class-1 (agent 20) may need more because nested sub-leaves lack a naming convention. Coordinate via §8.1. |
+| Runtime behaviour change? | Only PR-S1's 5 narrow redactions (static-route dest + 4 MACs). The guard itself is test-only. |
+| Over-redaction risk | Essentially zero (no blanket rule; CIDR + MAC reuse private/docs preservation). |
+| Would catch #174 prospectively? | **Yes** (§4 trace). |
+| Exemption relocates blind spot? | Bounded — naming-false-positives only, non-exemptable forward half, reason strings, 2 entries today (§6). |
+| phase4 / cross-mesh impact | **Zero** (sanitizer is off that path — §9.3). |
+| Fixture-corpus diff | Near-zero (< 1% sites; no prose mangling — §9.2). |
+| Doc-sync obligations | SECURITY.md + BUG_REPORTING.md + module docstring for the new `mac` / static-route-dest categories (§7). |
+| Faithful to "fail-surfaced defaults"? | **Yes** — a new IP/host/MAC-named field defaults to CI-red, the truest "default-to-flagged" (§8). |
+
+---
+
+## 11. Citations index (file:line)
+
+- Existing secret guard skeleton (the thing I extend): `tests/unit/tools/test_sanitize.py:646-767` (`_REGISTERED_SECRET_FIELDS`, `_SECRET_NAME_RE`, `_flatten_annotation`, `_reachable_canonical_models`, `test_forward_no_registered_secret_survives`, `test_reverse_no_unregistered_secret_field`).
+- Secret guard deliberately scopes out IP/PII: `tests/unit/tools/test_sanitize.py:770-782` (the R-16/CF-04 comment).
+- Documented hostname-passthrough residual: `tests/unit/tools/test_sanitize.py:837-843`.
+- Sanitizer allow-list walk: `netcanon/tools/sanitize.py:200-793`.
+- Static-route loop (where `destination` wiring lands, next to existing `gateway`): `netcanon/tools/sanitize.py:658-677`.
+- `redact_cidr` / `redact_ip_string` primitives + private/docs preservation: `netcanon/tools/sanitize.py:849-941` (preservation logic 857-871, 904-913).
+- No MAC handling in sanitizer (grep confirmed empty): `netcanon/tools/sanitize.py` (no `mac`/`MAC` token).
+- MAC-bearing model fields: `netcanon/migration/canonical/intent.py:124` (IPv4 vMAC), `:165` (IPv6 vMAC), `:591` (VRRP virtual_mac), `:917` (anycast_gateway_mac).
+- `CanonicalStaticRoute.destination` (the un-redacted CIDR leaf): `netcanon/migration/canonical/intent.py:326`.
+- #149 self-justifying-exemption precedent: `tests/unit/migration/test_registry_capability_honesty.py:317-346` (`_SYNTHETIC_NONWALKABLE` + `_is_legitimate_nonwalkable`).
+- AGENTS.md doc-sync row for new redaction category: `AGENTS.md` "A new redaction category lands in `netcanon/tools/sanitize.py`" row (SECURITY.md + BUG_REPORTING.md + CAPABILITIES.md targets).
+- Peer reports: `docs/reviews/2026-06-24-fail-surfaced-defaults/12-sanitizer-gap.md` §2 (allow-list), §4 (gap), §5 (over-redaction), §6 (form-B rec + #174 proof sketch), §7 (guard catalogue); `…/10-model-leaf-census.md` §13 (IP/host=31, secret=6 counts, +4 MAC); `…/11-walker-gap.md` §5 (reusable reflection engine note).

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/22-design-typed-marker.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/22-design-typed-marker.md
@@ -1,0 +1,602 @@
+# 22 — Fail-surfaced BY CONSTRUCTION: the typed-marker design
+
+**Agent:** `22-design-typed-marker` · Phase 2 (Design) · read-only
+**Run:** 2026-06-24 · fail-surfaced-defaults · netcanon
+**Question I own:** annotate IP/host-bearing + secret-bearing canonical fields
+with a *typed marker* so the walker, the sanitizer, AND the guards can
+**mechanically enumerate** the relevant leaves from the model itself — no
+hand-maintained list. Show the exact annotation mechanism that survives
+pydantic v2 + `from __future__ import annotations`; assess churn; decide whether
+it SUBSUMES or merely complements the guard tests (`20`/`21`); and give an
+HONEST over-engineering verdict vs. the lighter reflection guard (form B).
+
+---
+
+## 0. TL;DR / verdict
+
+- **The mechanism works and is reliable.** I prototyped it against the installed
+  pydantic (2.13.0) under `from __future__ import annotations`: a frozen
+  dataclass placed inside `Annotated[...]` is retrievable at runtime via
+  `Model.model_fields[name].metadata` (filter by `isinstance`). It coexists
+  cleanly with `Field(ge=, le=, default_factory=)` constraints, with `str | None`
+  unions, and with `list[str]` containers; it does **not** alter
+  `model_dump`, `model_dump_json`, or `model_json_schema`. So "introspect the
+  marker reliably" — the load-bearing risk in my brief — is **confirmed, not
+  hypothetical** (§2, with the prototype transcript).
+
+- **For class-2 (sanitizer): the marker is a real improvement but NOT
+  required.** Agent `12` is right that the naming heuristic (`_IP_HOST_NAME_RE` /
+  `_SECRET_NAME_RE`) already works because every IP/secret field in *this* model
+  happens to have an IP-ish / secret-ish name. The marker's payoff over the
+  heuristic is narrow: it removes the false-positive exemption list
+  (`source_interface`, `interface`) and the false-negative risk (a future field
+  named e.g. `peer` or `endpoint` that the regex misses). That risk is the SAME
+  covered-subset disease one level up — **the regex is itself a hand-maintained
+  pattern that the next blind audit could find a hole in.** That is the honest
+  case FOR the marker. But it is a *medium*-strength case, not decisive.
+
+- **For class-1 (walker): the marker does NOT solve the actual problem and is
+  the wrong tool.** The walker gap (agents `10`/`11`) is about *structural
+  coverage* of EVERY data-bearing leaf — VRRP `priority`/`preempt`, DHCP
+  `lease-time`, SNMPv3 `auth-protocol`, routing-instance `instance-type` — most
+  of which are **neither IP nor secret**. An IP/secret marker enumerates the
+  wrong subset. A walker completeness guard (agent `20`'s form B) needs to reflect
+  over *all* leaves and check each is walked-or-exempt; a marker keyed to
+  IP/secret semantics is orthogonal to that. (A *different* marker — "walkable /
+  declared / exempt" — would just be a more verbose spelling of the exemption
+  list the guard already needs. §6.)
+
+- **RECOMMENDED minimal version (the "most value, least churn" cut):** introduce
+  **ONE** marker family, `Sensitive(...)`, with a `kind` discriminator
+  (`"ipv4"` / `"ipv6"` / `"cidr"` / `"host"` / `"mac"` / `"secret"`), annotate
+  the **~31 IP/host + ~7 secret leaves** the census found, and let BOTH
+  sanitizer-side guards (agent `21`) enumerate covered leaves from the marker
+  set instead of from a `_REGISTERED_*` literal + a naming regex. This **subsumes
+  the existing secret guard** (`TestSecretRedactionCoverage`) and the proposed IP
+  half into one model-derived source of truth, and it makes the sanitizer's
+  *redaction-primitive dispatch* derivable from the `kind` too (a bonus the
+  heuristic can't give). It is ~38 one-line annotation edits + a ~25-line
+  `markers.py` module + a rewrite of the two coverage guards to read the marker
+  set. **It does NOT touch the walker** — class-1 stays with agent `20`'s
+  completeness guard.
+
+- **Net verdict: WORTH IT for class-2 (sanitizer) in the minimal form above;
+  NOT worth it for class-1 (walker); so "both" is wrong and "neither" is wrong —
+  the answer is class-2 only.** Whether even class-2 should adopt the marker vs.
+  the lighter agent-`21` guard is a genuine judgement call that I lay out
+  explicitly in §7 with the decisive tie-breaker: **the marker eliminates the
+  naming-regex blind spot (the disease itself), the guard does not.** I lean
+  marker, but flag it as the kind of decision the main thread / reviewers
+  (`30`/`31`) should ratify, not something to ram through.
+
+---
+
+## 1. What "by construction" means here, and the bar it must clear
+
+The user's literal goal: *"the sanitizer redacts on `ip_address()` of ANY
+IP-typed field, not an allow-list."* The marker design is the principled
+realisation of "IP-**typed** field": instead of inferring IP-ness from the
+*value* at runtime (`ip_address()`, which agent `12` shows is both insufficient —
+blind to MAC/RD/RT/community/hash — and the wrong altitude) or from the *name* at
+test time (the regex, which is a hand-maintained pattern), we declare IP-ness /
+secret-ness **on the field, in the model**, once. Every consumer that needs "the
+set of sensitive leaves" then derives it mechanically.
+
+For this to count as a genuine *fail-surfaced default* (and not just a
+prettier allow-list), it must clear three bars:
+
+1. **Enumerable at runtime/test-time** from the model with no parallel list to
+   keep in sync. ✅ confirmed §2.
+2. **A new sensitive field is RED by default** — i.e. forgetting the marker, OR
+   adding the marker but forgetting the redaction, FAILS CI. This is where the
+   marker *needs a companion guard* — the marker alone does not fail anything;
+   it is the guard reading the marker that fails. So the marker does not
+   *replace* the guard, it *re-bases* the guard onto a sounder source of truth.
+   (This is the single most important nuance and the reason "marker subsumes the
+   guard" is half-true — §4.)
+3. **The exemption set must not relocate the blind spot.** The marker's headline
+   advantage is that for class-2 it *shrinks the exemption set to near-zero*
+   (§4.3), which is a real answer to the `30`/`31` "does the exemption list just
+   move the problem" critique.
+
+---
+
+## 2. The exact mechanism (pydantic v2 + `from __future__ import annotations`)
+
+### 2.1 The marker class
+
+A frozen dataclass is the right carrier: it is hashable (usable in sets), cheap,
+introspectable by `isinstance`, and (unlike a pydantic `Field(json_schema_extra=)`
+hack) does not leak into the JSON schema or serialization. Proposed
+`netcanon/migration/canonical/markers.py`:
+
+```python
+"""Typed field markers — make IP/secret-bearing canonical leaves
+mechanically enumerable from the model itself (fail-surfaced by
+construction).  A marker placed inside ``Annotated[...]`` is invisible
+to pydantic validation/serialisation/JSON-schema and is read back at
+test time via ``Model.model_fields[name].metadata``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+SensitiveKind = Literal["ipv4", "ipv6", "cidr", "host", "mac", "secret"]
+
+
+@dataclass(frozen=True)
+class Sensitive:
+    """Marks a canonical leaf as carrying network-identifying or secret
+    data, so the sanitiser-coverage guards can enumerate the complete
+    set from the model (no hand-maintained allow-list) and — optionally —
+    the sanitiser can dispatch the right redaction primitive from ``kind``.
+
+    kind:
+      "ipv4"   – bare IPv4 literal           → redact_ipv4 / redact_ip_string
+      "ipv6"   – bare IPv6 literal           → redact_ipv6 / redact_ip_string
+      "cidr"   – addr/prefix                 → redact_cidr
+      "host"   – IP **or** DNS host/domain   → redact_ip_string (host passes through, by design)
+      "mac"    – MAC / network id            → (future) redact_mac
+      "secret" – passphrase/hash/community/key → redact_secret / redact_hash / ...
+    """
+    kind: SensitiveKind
+```
+
+I deliberately use **one** marker class with a `kind` discriminator rather than
+six marker classes (`IPField`, `SecretField`, …). Reasons: (a) the guards do a
+single `isinstance(x, Sensitive)` filter; (b) the `kind` carries the
+redaction-primitive choice, which is information the naming regex can NEVER give
+(the regex can't tell `network` should use `redact_cidr` while `gateway` uses
+`redact_ip_string`); (c) it is one import, one symbol, one doc paragraph.
+
+### 2.2 Proof it is introspectable (prototype transcript)
+
+I ran this against the repo's pydantic (2.13.0) with `from __future__ import
+annotations` active — the exact conditions the real model runs under:
+
+```
+Root.gateway:     annotation=str        metadata=[IPField(kind='ip')]      markers=[IPField...]
+Root.dns_servers: annotation=list[str]  metadata=[IPField(kind='ip')]      markers=[IPField...]
+Root.community:   annotation=str        metadata=[SecretField(kind='...')] markers=[SecretField...]
+Root.subs:        annotation=list[Sub]  metadata=[]                        markers=[]
+Root.name:        annotation=str        metadata=[]                        markers=[]
+Sub.ip:           annotation=str        metadata=[IPField(kind='ip')]      markers=[IPField...]
+```
+
+Key confirmations from the four prototype runs I executed:
+
+- **`metadata` is populated even under `from __future__ import annotations`.**
+  Pydantic resolves the `Annotated[...]` form at class-build time and stashes the
+  non-type args in `FieldInfo.metadata`. The string-ised annotation does NOT
+  defeat this (pydantic resolves it; we never call `get_type_hints` ourselves).
+- **`list[str]` carries the marker at the FIELD level** while `.annotation`
+  resolves to `list[str]`. So `dns_servers: Annotated[list[str], Sensitive("host")]`
+  is enumerable as a host-bearing leaf with one annotation — no need to descend
+  into the list arg.
+- **Coexists with pydantic constraints**: `Annotated[int, Field(ge=1, le=255)]`
+  shows `metadata=[Ge(1), Le(255)]`; adding `Sensitive(...)` alongside leaves
+  both present and **the `ge/le` validation is still enforced** (I confirmed a
+  `ValidationError` on out-of-range). So markers and constraints compose.
+- **Unions work**: `Annotated[str | None, Sensitive("host")]` keeps the marker
+  and `.annotation == str | None`.
+- **Reused models collapse correctly**: `CanonicalIPv4Address.ip` marked once is
+  enumerated as ONE `(Class, field)` pair even though it appears on both
+  `CanonicalInterface` and `CanonicalVlan`. This is *exactly right* — the marker
+  rides the model, so it covers every xpath the model is mounted at with a
+  single edit. (Contrast the per-xpath naming regex, which is xpath-agnostic and
+  also gets this right, but contrast the per-xpath `_REGISTERED_*` literals which
+  must list both surfaces.)
+- **Zero serialization/schema impact**: `model_json_schema()` properties
+  unchanged; `model_dump_json()` byte-identical. So **no existing serialization
+  test, API contract, or fixture can break from adding markers** — a critical
+  property for a low-risk change.
+
+### 2.3 The enumeration helper (reuses the existing reflection engine)
+
+The reflection machinery already exists in `tests/unit/tools/test_sanitize.py`
+(`_reachable_canonical_models` + `_flatten_annotation`,
+`test_sanitize.py:662–685`) and is *already proven* to handle pydantic v2 +
+future-annotations + `list[...]` + unions + nested models. The marker enumerator
+is a ~10-line addition on top of it (test-side, or promoted to a small shared
+helper so the sanitiser can reuse it too):
+
+```python
+from netcanon.migration.canonical.markers import Sensitive
+
+def iter_sensitive_leaves(root_cls):
+    """Yield (Class.__name__, field_name, kind) for every Sensitive-marked
+    leaf reachable from root_cls."""
+    for model in _reachable_canonical_models(root_cls):
+        for fname, fld in model.model_fields.items():
+            for m in fld.metadata:
+                if isinstance(m, Sensitive):
+                    yield (model.__name__, fname, m.kind)
+```
+
+That is the entire "enumerate every IP-typed leaf from the model itself"
+capability the seed asked for, in 10 lines, with a build-time-proven engine.
+
+---
+
+## 3. What gets annotated (the churn, exactly)
+
+Grounded in agent `10`'s census (≈31 IP/host leaves, ≈7 secret leaves) and
+`12`'s allow-list. The annotation is a one-token edit per field. Below is the
+complete annotation roster — this IS the churn estimate (38 field edits across
+12 model classes in one file, `intent.py`).
+
+### 3.1 Secret leaves (kind="secret") — 7 edits
+
+| `Class.field` | current | becomes |
+|---|---|---|
+| `CanonicalLocalUser.hashed_password` | `str = ""` | `Annotated[str, Sensitive("secret")] = ""` |
+| `CanonicalSNMP.community` | `str = ""` | `Annotated[str, Sensitive("secret")] = ""` |
+| `CanonicalSNMPv3User.auth_passphrase` | `str = ""` | `Annotated[str, Sensitive("secret")] = ""` |
+| `CanonicalSNMPv3User.priv_passphrase` | `str = ""` | `Annotated[str, Sensitive("secret")] = ""` |
+| `CanonicalSNMPv3User.engine_id` | `str = ""` | `Annotated[str, Sensitive("secret")] = ""` |
+| `CanonicalRADIUSServer.key` | `str = ""` | `Annotated[str, Sensitive("secret")] = ""` |
+| `CanonicalVRRPGroup.authentication` | `str = ""` | `Annotated[str, Sensitive("secret")] = ""` |
+
+Note `engine_id` is marked `secret` here even though the existing secret guard
+does NOT register it (it isn't *named* like a secret — agent `12` §6). **This is
+the marker's first concrete win: it captures `engine_id` that the naming regex
+structurally cannot**, because IP/secret-ness is now declared, not inferred from
+the name.
+
+### 3.2 IP / host / cidr / mac leaves — ~31 edits
+
+| `Class.field` | kind | redaction primitive (today) |
+|---|---|---|
+| `CanonicalIntent.domain` | `host` | `redact_domain` |
+| `CanonicalIntent.dns_servers[]` | `host` | `redact_ip_string` |
+| `CanonicalIntent.ntp_servers[]` | `host` | `redact_ip_string` |
+| `CanonicalIntent.syslog_servers[]` | `host` | `redact_ip_string` |
+| `CanonicalIntent.anycast_gateway_mac` | `mac` | (not redacted today — latent) |
+| `CanonicalIPv4Address.ip` | `ipv4` | `redact_ipv4` |
+| `CanonicalIPv4Address.virtual_gateway_address` | `ipv4` | `redact_ipv4` |
+| `CanonicalIPv4Address.virtual_gateway_mac` | `mac` | (not redacted today — latent) |
+| `CanonicalIPv6Address.ip` | `ipv6` | `redact_ipv6` |
+| `CanonicalIPv6Address.virtual_gateway_address` | `ipv6` | `redact_ipv6` |
+| `CanonicalIPv6Address.virtual_gateway_mac` | `mac` | (not redacted today — latent) |
+| `CanonicalStaticRoute.destination` | `cidr` | (NOT redacted today — the one real modelled leak, `12` §4b) |
+| `CanonicalStaticRoute.gateway` | `host` | `redact_ip_string` |
+| `CanonicalDHCPPool.network` | `cidr` | `redact_cidr` |
+| `CanonicalDHCPPool.start_ip` | `ipv4` | `redact_ip_string` |
+| `CanonicalDHCPPool.end_ip` | `ipv4` | `redact_ip_string` |
+| `CanonicalDHCPPool.gateway` | `host` | `redact_ip_string` |
+| `CanonicalDHCPPool.dns_servers[]` | `host` | `redact_ip_string` |
+| `CanonicalDHCPPool.domain_name` | `host` | `redact_domain` |
+| `CanonicalSNMP.trap_hosts[]` | `host` | `redact_ip_string` |
+| `CanonicalRADIUSServer.host` | `host` | `redact_ip_string` |
+| `CanonicalVRRPGroup.virtual_ips[]` | `ipv4` | `redact_ip_string` |
+| `CanonicalVRRPGroup.virtual_ipv6s[]` | `ipv6` | `redact_ip_string` |
+| `CanonicalVRRPGroup.virtual_mac` | `mac` | (not redacted today — latent) |
+| `CanonicalVxlan.mcast_group` | `ipv4` | `redact_mcast_group` |
+| `CanonicalVxlan.flood_list[]` | `ipv4` | `redact_ip_string` |
+| `CanonicalRoutingInstance.route_distinguisher` | `host` | `redact_route_target` |
+| `CanonicalRoutingInstance.rt_imports[]` | `host` | `redact_route_target` |
+| `CanonicalRoutingInstance.rt_exports[]` | `host` | `redact_route_target` |
+| `CanonicalEvpnType5Route.prefix` | `cidr` | `redact_cidr` |
+| `CanonicalEvpnType5Route.rt_imports[]` / `.rt_exports[]` | `host` | `redact_route_target` |
+
+The roster surfaces **three latent gaps the naming regex would also have to
+hand-handle, but the marker handles for free** by forcing a decision at
+annotation time:
+
+1. **MAC fields** (`anycast_gateway_mac`, `virtual_gateway_mac` ×3,
+   `virtual_mac`) are network-identifying and **not redacted today** (agent `12`
+   §5b.3). The marker forces them into the covered set with `kind="mac"`; the
+   blanket `ip_address()` rule is structurally blind to them.
+2. **`static_routes[].destination`** — the one genuinely-unredacted modelled IP
+   leaf (`12` §4b). Marking it `cidr` makes the guard demand a redaction, which
+   is a 1-line `redact_cidr` wire-up (identical to `dhcp.network`).
+3. **`engine_id`** — secret-redacted but not secret-*named* (§3.1).
+
+The `kind` for RD/RT is `host` (not `cidr`/`ipv4`) because RD/RT have their own
+stable-correlation primitive `redact_route_target`; the marker's `kind` is a
+*hint*, and the guard's dispatch table maps `("CanonicalRoutingInstance",
+"route_distinguisher")` to `redact_route_target` explicitly where the kind is
+insufficient. (See §4.2 — the marker does NOT try to fully encode the primitive;
+it encodes the *category* and the guard owns the dispatch.)
+
+**Total churn: ~38 one-line field annotations in one file + one ~25-line
+`markers.py` + import line. Zero behaviour change at the model layer.**
+
+---
+
+## 4. Does it SUBSUME the guards, or only complement them?
+
+This is the crux of my brief. Honest answer: **it re-bases (improves the source
+of truth of) the class-2 guards and lets one guard family replace two; it does
+NOT eliminate the need for a guard.**
+
+### 4.1 The marker alone fails nothing
+
+Adding `Sensitive("secret")` to a field does not, by itself, make CI red if the
+sanitiser forgets to redact it. *A guard reading the marker* is what fails. So
+the marker is necessary-but-not-sufficient; it must be paired with:
+
+- **Forward guard** (sentinel round-trip): populate every marked leaf with a
+  unique sentinel, sanitise, assert no sentinel survives. This is the existing
+  `test_forward_no_registered_secret_survives` (`test_sanitize.py:691`)
+  generalised to iterate the marker set instead of the literal
+  `_REGISTERED_SECRET_FIELDS`.
+- **Reverse guard** (coverage): every marked leaf must have a redaction
+  dispatch entry. With markers this becomes "every `Sensitive`-marked leaf is in
+  the sanitiser's dispatch map," which is mechanical and exemption-free.
+
+### 4.2 How the marker re-bases agent `21`'s guard (the win)
+
+Agent `12`/`21`'s form-B guard has THREE hand-maintained artefacts:
+`_REGISTERED_SECRET_FIELDS` (literal set), `_SECRET_NAME_RE` + the proposed
+`_IP_HOST_NAME_RE` (naming regexes), and `_IP_NAME_EXEMPT` (false-positive
+exemptions for IP-ish names that aren't IPs). The marker design **collapses all
+three into one**: the marker set on the model. The guard becomes:
+
+```python
+def test_every_sensitive_leaf_is_redacted_and_no_unmarked_leaf_leaks():
+    # 1. coverage: every marked leaf must have a dispatch entry (no exemption list)
+    marked = {(c, f) for c, f, _ in iter_sensitive_leaves(CanonicalIntent)}
+    undispatched = marked - set(_REDACTION_DISPATCH)
+    assert not undispatched, (
+        f"Sensitive-marked canonical leaf with no redaction primitive — "
+        f"wire it into sanitize_intent + add to _REDACTION_DISPATCH: {undispatched}")
+    # 2. forward: sentinel round-trip over the marked set (unchanged in spirit)
+    ...
+```
+
+This is strictly better than the regex form on the dimension the WHOLE RUN is
+about: **the regex is itself a covered-subset (a hand-maintained pattern), so a
+future field named in a way the regex doesn't anticipate (`peer_address`?
+`endpoint`? `vtep`? `nexthop`?) re-opens the exact blind spot.** The marker
+cannot have that failure mode because IP/secret-ness is *declared on the field*,
+not *guessed from the field name*.
+
+### 4.3 The exemption-relocation answer (decisive for `30`/`31`)
+
+The single sharpest critique reviewers `30`/`31` will raise about ANY guard is
+"the exemption list just relocates the blind spot." The marker's answer is the
+strongest available:
+
+- **Naming-heuristic guard (agent `21` form B):** needs `_IP_NAME_EXEMPT`
+  (`source_interface`, `interface`, … — fields that *look* IP-ish but aren't).
+  This exemption set GROWS as the model grows and is an open escape hatch ("I
+  didn't want to redact this").
+- **Marker guard:** the only "exemption" is *not putting a marker on a field*,
+  which is the default. There is no exemption LIST. The reverse direction is
+  inverted: instead of "this IP-named field is exempt because it's not really an
+  IP," the dangerous direction would be "someone forgot to mark a real IP
+  field." That residual risk is real (§5) but it is the SAME residual the regex
+  has (a regex also misses an un-anticipated name), and the marker at least makes
+  the omission a *reviewable single-line decision at the field* ("why is this
+  `str` field unmarked?") rather than buried in a regex token list.
+
+So: **the marker shrinks class-2's hand-maintained surface from {literal set +
+regex + exemption list} to {markers on the model}.** That is a genuine reduction
+of the covered-subset disease for class-2, not a relocation. This is the
+strongest single argument in the marker's favour and the one the synthesis should
+weigh.
+
+### 4.4 It does NOT subsume the walker guard (class-1)
+
+The walker completeness guard (agent `20`) must check *every data-bearing leaf*
+is walked-or-exempt — `priority`, `preempt`, `lease_time`, `instance_type`,
+`auth_protocol`, etc., which are not IP/secret. The `Sensitive` marker
+enumerates a *different, smaller* subset. So the marker contributes **nothing**
+to closing the walker gap. (You could imagine a second marker `Walkable`/
+`NonWalkable`, but that just re-spells the exemption list agent `20`'s guard
+needs anyway — and would mean marking ~100+ leaves, most as "yes walk me," which
+is pure noise. §6.)
+
+---
+
+## 5. Honest assessment: over-engineering vs. agent `21`'s lighter guard
+
+I was asked to be honest about whether this is gold-plating. Here is the
+two-sided ledger.
+
+### Arguments it IS over-engineering (the `12`/`21` position)
+- The naming heuristic **already works** for every field in the current model;
+  agent `12` verified every IP/secret leaf has an IP-ish/secret-ish name.
+- The exemption set for naming false-positives is **tiny** (2 entries).
+- A ~40-line guard reusing the existing reflection engine is the cheapest
+  durable fix and ships with zero model churn.
+- Markers add a new concept (`markers.py`, the `Annotated` idiom) that every
+  future contributor adding a field must learn and remember — a *new* discipline
+  to keep honest, which is itself a maintenance tax.
+- The `from __future__ import annotations` + `Annotated` interaction, while
+  proven to work, is subtle; a contributor who writes `gateway: str = ""` and
+  forgets the `Annotated` wrapper gets NO error from pydantic (the field just
+  isn't marked) — so the marker can be silently *omitted*, which is the very
+  failure mode we're trying to kill.
+
+### Arguments it is NOT over-engineering (the case FOR)
+- **The naming regex is itself an instance of the disease.** This run exists
+  because hand-maintained subsets keep springing leaks. `_IP_HOST_NAME_RE` is a
+  hand-maintained subset of *name patterns*. The marker is the only form that
+  removes the heuristic entirely. If the synthesis takes the meta-finding
+  seriously ("durable fix = fail-surfaced defaults, NOT a covered subset"), the
+  regex guard is philosophically the *same shape* as the bug.
+- **The marker carries the redaction-primitive category** (`kind`), enabling the
+  sanitiser dispatch to be model-derived too — the regex cannot do this. (This
+  is optional but it means `static_routes[].destination` and any future `cidr`
+  field auto-route to `redact_cidr` instead of needing a hand-coded branch.)
+- **It captures `engine_id`, the MACs, and `destination`** — three things the
+  naming regex / blanket rule structurally miss — *for free*, by forcing the
+  decision at the field.
+- **Zero serialization/schema/fixture risk** (proven §2.2), so the change is
+  low-blast-radius despite touching the model file.
+
+### The tie-breaker
+The decisive question is **whether the contributor-forgets-the-marker failure
+mode is worse than the regex-doesn't-match-the-name failure mode.** They are
+symmetric in one sense (both rely on the author doing the right thing), but they
+differ in *catchability*:
+
+- **Marker omitted:** caught ONLY if a *separate* "every `str` field is either
+  marked or in a tiny structurally-non-sensitive exemption set" meta-guard
+  exists. That meta-guard would itself need an exemption list (for genuinely
+  non-sensitive strings like `name`, `description`, `mode`, `interface_type`) —
+  re-introducing exactly the exemption-list relocation problem the marker was
+  supposed to solve. **This is the marker's Achilles heel and I will not
+  pretend otherwise.**
+- **Regex misses a name:** caught never, until the next blind audit.
+
+So neither is strictly self-enforcing. **My honest read: the marker is modestly
+better than the regex (removes the heuristic, captures 3 extra latent leaks,
+enables dispatch-by-kind, shrinks the exemption surface) but it is NOT the
+qualitative leap to "self-enforcing" that the framing might suggest** — because
+the "did you remember to mark it" gap is real and closing IT requires a
+meta-guard with its own exemption list. The marker moves the blind spot from
+"the regex token list" to "the unmarked-string meta-exemption list," which is a
+*smaller and more reviewable* surface but not a vanished one.
+
+---
+
+## 6. Why a "walkable" marker for class-1 is the wrong idea (explicit)
+
+For completeness, the symmetric idea — annotate every leaf with whether the
+walker should yield it — fails on three counts:
+
+1. **Inverted density.** ~100+ leaves should be walked and only a handful are
+   legitimately non-walkable (Tier-3, `kind`, `default_name`, provenance). You'd
+   annotate the overwhelming majority "yes walk me," which is noise; the
+   *exceptions* are the information, and they are exactly agent `20`'s exemption
+   set. A marker would just relocate that exemption set onto the model with no
+   gain.
+2. **The walker is hand-written and ordered.** A marker says "this leaf is
+   walkable" but not *what xpath string to yield* — and the xpath spelling
+   (`/interfaces/interface/config/mtu` vs `/interfaces/interface/switchport-mode`,
+   the `config/` inconsistency agent `10` §6 flagged) is irregular and
+   hand-mapped. A marker can't generate the right string; agent `20`'s guard
+   reflects-and-maps, which is the right tool.
+3. **phase4 sensitivity.** Walking a new leaf forces per-codec matrix
+   declarations and reclassifies `tests/unit/audit` cells (agent `11` §6, the
+   St3-demotion lesson in MEMORY). A marker that *implies* walking would couple
+   model edits to phase4 churn — exactly the runtime-behaviour-change risk the
+   seed wants to avoid. Agent `20`'s pure-declaration guard keeps the model edit
+   and the walk decision separable.
+
+**Conclusion: class-1 is agent `20`'s completeness guard, full stop. The marker
+adds nothing there.**
+
+---
+
+## 7. Recommendation + minimal version
+
+### Verdict
+- **Class-2 (sanitizer): adopt the `Sensitive` marker in the minimal form
+  (§2–§3), re-basing agent `21`'s guard onto the marker set.** WORTH IT — it is
+  the only form that removes the naming heuristic (the in-class disease), it
+  captures three latent leaks for free, and it enables model-derived primitive
+  dispatch. Net cost is low (~38 one-line annotations + 25-line module + guard
+  rewrite, zero behaviour/serialization risk).
+- **Class-1 (walker): do NOT use a marker.** Use agent `20`'s reflection-driven
+  completeness guard. (§6.)
+- **So the answer to "both / class-1 / class-2 / neither" is: class-2 only.**
+
+### The honest hedge for the synthesis
+This is a *close* call against agent `12`/`21`'s lighter regex guard, and the
+marker's Achilles heel (a contributor can silently omit the marker, §5) means it
+is not a clean "self-enforcing by construction" win. If the main thread wants the
+**absolute lowest-risk** ship, agent `21`'s ~40-line guard is defensible and I
+would not block it. If the main thread takes the meta-finding's spirit literally
+(*stop hand-maintaining subsets*), the marker is the philosophically-correct
+class-2 form and the extra cost is genuinely small. **I lean marker, but flag
+this as a decision for `30`/`31` to ratify, not a slam-dunk.**
+
+### The minimal version that captures most of the value
+If even the full marker roster feels like too much for one PR, the
+**value-maximising minimal cut** is:
+
+1. Ship `markers.py` with the single `Sensitive` class.
+2. Annotate ONLY the **7 secret leaves + the 3 latent-gap leaves** (`engine_id`
+   already covered, `static_routes[].destination`, and the 5 MAC fields) — the
+   ones where the marker captures something the regex/blanket CANNOT. Leave the
+   already-covered IP leaves on the existing naming guard for now.
+3. Re-base ONLY the *secret* guard (`TestSecretRedactionCoverage`) onto the
+   marker set, deleting `_REGISTERED_SECRET_FIELDS` + `_SECRET_NAME_RE`.
+
+That proves the mechanism, kills the `engine_id`-not-named-like-a-secret gap and
+the MAC/`destination` latent leaks, and defers the larger IP-leaf annotation
+sweep — while leaving a clean path to complete it later. ~12 annotations + module
++ one guard rewrite.
+
+### Coordination with peers
+- **Agent `21`** (sanitizer guard) is the consumer that decides regex-vs-marker.
+  My input: if you adopt the marker, your guard loses the regex and the
+  `_IP_NAME_EXEMPT` list entirely and gains a `_REDACTION_DISPATCH` table keyed
+  by `(Class, field)`; the "would have failed before #174" regression argument
+  still holds (an unmarked `virtual_gateway_address` → not in dispatch → RED).
+- **Agent `20`** (walker guard): the marker does NOT help you; keep the
+  completeness-guard design. But note the *reflection engine*
+  (`_reachable_canonical_models`) is shared infrastructure — if it gets promoted
+  out of the test file into a small `canonical/_reflect.py`, both your guard and
+  the marker enumerator can import it (one engine, two consumers).
+
+---
+
+## 8. Risks / must-watch for the main thread (if marker is chosen)
+
+1. **The silent-omission failure mode (§5).** Adding a sensitive field WITHOUT
+   the marker is not caught unless an "unmarked-string meta-guard" exists, and
+   that guard needs its own non-sensitive-string exemption list. Decide
+   explicitly whether to ship that meta-guard (and accept its small exemption
+   list) or accept the residual. My rec: ship a *lightweight* version — every
+   `str`/`list[str]` leaf is either `Sensitive`-marked OR in a small, reviewed
+   `_NON_SENSITIVE_TEXT` set (`name`, `description`, `mode`, `interface_type`,
+   `timezone`, `tunnel_type`, `dhcp_client_v6`, `scope`, `kind`, `default_name`,
+   `instance_type`, `source_interface`, `interface`, …). This makes "new string
+   field" a forced binary decision (sensitive or not) — which is the actual
+   fail-surfaced default. It DOES re-introduce a small exemption list, but for
+   *non-sensitive free text*, which is a closed, low-churn, reviewable set
+   (these are the §5 free-text fields agent `10` and `12` both enumerated).
+2. **`AGENTS.md` doc-sync.** Adding a redaction category / changing the
+   sanitiser's coverage mechanism trips the doc-sync rows for
+   `SECURITY.md` § Sanitiser, `BUG_REPORTING.md`, and
+   `docs/adding-a-canonical-field.md` (the marker becomes part of "how to add a
+   field"). The marker also wants a row in `netcanon/migration/codecs/README.md`
+   or `ARCHITECTURE.md` cross-cutting section. Budget those edits into the PR.
+3. **`get_args` vs `.metadata` for list element kinds.** I mark the *field*
+   (`Annotated[list[str], Sensitive(...)]`), NOT the element
+   (`list[Annotated[str, Sensitive(...)]]`). Both work, but field-level is
+   simpler to enumerate (no descent into list args) and is what my prototype
+   validated. Keep it field-level; do not mix the two conventions.
+4. **No CI floor surprise.** The repo's CI floor is py3.11 (MEMORY). `Annotated`,
+   frozen dataclasses, and `FieldInfo.metadata` are all 3.9+/pydantic-2.x stable;
+   nothing here is 3.12+-only. Low risk, but the main thread should run the guard
+   under the 3.11 matrix leg, not just local 3.14.
+
+---
+
+## 9. Citations index (file:line)
+
+- Model (annotation targets): `netcanon/migration/canonical/intent.py` — IP/host
+  leaves and secret leaves enumerated in §3 with their line homes
+  (`CanonicalIPv4Address` :120–124, `CanonicalIPv6Address` :160–165,
+  `CanonicalSNMPv3User` :441–447, `CanonicalVRRPGroup` :587–597,
+  `CanonicalDHCPPool` :354–361, `CanonicalRADIUSServer` :635–638,
+  `CanonicalStaticRoute` :326–331, `CanonicalVxlan` :687–692,
+  `CanonicalRoutingInstance` :731–742, `CanonicalEvpnType5Route` :779–782, root
+  scalars :894–917).
+- Reusable reflection engine (the marker enumerator builds on it):
+  `tests/unit/tools/test_sanitize.py:662–685` (`_flatten_annotation`,
+  `_reachable_canonical_models`).
+- Existing secret guard the marker re-bases: `tests/unit/tools/test_sanitize.py:646–767`
+  (`_REGISTERED_SECRET_FIELDS`, `_SECRET_NAME_RE`, `TestSecretRedactionCoverage`).
+- Self-justifying-exemption precedent (#149): `tests/unit/migration/test_registry_capability_honesty.py:317–346`
+  (`_SYNTHETIC_NONWALKABLE`, `_is_legitimate_nonwalkable`) and the top-level
+  marker-coverage guard `:527–541` (`test_marker_dict_covers_every_data_bearing_field`)
+  — the pattern the §8.1 meta-guard mirrors.
+- Walker (why class-1 needs structural coverage, not an IP marker):
+  `netcanon/migration/canonical/xpath_walker.py:23–256`.
+- pydantic version + no existing `Annotated`-metadata usage: verified
+  `pydantic 2.13.0`; repo grep for `Annotated|json_schema_extra|FieldInfo|.metadata`
+  hits only `importlib.metadata` imports (none in the canonical model).
+- Mechanism proof: four prototype runs (this session) confirming
+  `Annotated[...]` metadata is readable via `model_fields[...].metadata` under
+  `from __future__ import annotations`, coexists with `Field(ge/le)` +
+  unions + `list[str]`, collapses reused models to one `(Class, field)`, and
+  leaves `model_dump`/`model_json_schema` byte-unchanged (§2.2).
+```

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/30-review-correctness.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/30-review-correctness.md
@@ -1,0 +1,565 @@
+# 30 — Adversarial CORRECTNESS review: does the fix kill the CLASS?
+
+**Agent:** `30-review-correctness` · Phase 3 (Review) · read-only
+**Run:** 2026-06-24 · fail-surfaced-defaults · netcanon
+**Scope:** Adversarially test the Phase-2 recommendations (`20-design-walker-guard`,
+`21-design-sanitizer-guard`, `22-design-typed-marker`) on ONE question: **does the
+recommended fix kill the recurring CLASS, or only today's named instances?** The
+decisive tests are concrete synthetic-new-leaf scenarios. If a recommended guard
+PASSES (i.e. fails to catch) a synthetic new unhandled field → NO-GO must-fix.
+I independently re-verified every load-bearing source claim (citations in §8).
+
+---
+
+## 0. Verdict
+
+**GO-WITH-FIXES.**
+
+The recommended designs are structurally sound and DO kill the class for the
+*common* failure mode (a new field added with an indicative shape, forgotten by
+its author). I reproduced the decisive synthetic-new-leaf scenarios and the
+recommended guards go RED in every one of the cases the five blind audits
+actually hit. But the review surfaces **four correctness gaps**, two of them
+blockers, where a recommended guard would silently PASS a synthetic new leaf —
+i.e. the blind spot is *relocated*, not closed. They are all fixable with small,
+additive changes, hence GO-WITH-FIXES rather than NO-GO.
+
+Headline findings (detail + decisive traces below):
+
+- **Class-1 walker guard (agent 20, design B): KILLS the class — with one
+  blocker.** The recursive `_model_leaves()` correctly catches a new *scalar*
+  leaf added to any nested model (the audit-named pattern). BUT a dev who adds a
+  whole **new nested model** (e.g. `CanonicalQoSPolicy`) and hangs it off
+  `CanonicalIntent` via a `list[...]` field is NOT caught: the new container
+  field is a nested-model field (not a scalar leaf), `_reachable_canonical_models`
+  finds the new model, its scalar leaves get enumerated and *would* fail —
+  **good** — UNLESS the new model is unreachable because the container field
+  itself escapes enumeration. The actual blocker is narrower and concrete (MF-1,
+  §2.3): the `_LEAF_TO_WALKER_XPATHS` *spelling map* is a SECOND hand-maintained
+  subset, and agent 20's "you can't forget both" claim has a hole when a leaf is
+  added to the **exemption** set by a copy-paste author. I show the exact hole and
+  the fix.
+
+- **Class-2 sanitizer guard (agent 21, design B, naming-regex form): DOES NOT
+  kill the class.** The decisive synthetic-new-leaf test — a dev adds
+  `CanonicalBGPNeighbor.peer: str = ""` holding a neighbor IP — **PASSES the
+  guard** (the name `peer` matches neither `_IP_HOST_NAME_RE` nor `_MAC_NAME_RE`,
+  so it is never even a candidate, so it is never flagged). This is the literal
+  covered-subset disease one level up, exactly as agent 22 §4.2 warned and agent
+  21 §6 conceded as its "residual honest gap." **For the class-2 goal as stated by
+  the user ("a NEW IP-bearing field… forgets to redact it → must fail"), the
+  naming-regex guard is NOT faithful.** This is MF-2, a blocker — but the fix is
+  agent 22's marker + a cheap *unmarked-string meta-guard*, which I show closes it.
+
+- **The typed marker (agent 22) is the only form that is faithful to the user's
+  literal goal for class-2** — but ONLY if paired with the meta-guard agent 22
+  itself flagged as its "Achilles heel" (§22.5/§22.8). The marker alone has the
+  identical blind spot as the regex (a forgotten marker on a deceptively-named
+  field). My position (§4): adopt the marker for class-2 AND ship the
+  `_NON_SENSITIVE_TEXT` meta-guard; that combination is the *only* recommended
+  configuration that actually fails-red on the `peer:str` scenario. Without the
+  meta-guard, neither the regex nor the marker kills the class.
+
+- **The exemption mechanism does NOT merely relocate the blind spot — for the
+  walker guard.** The #149 self-justifying precedent + `test_no_stale_walk_exemptions`
+  + reason strings make exemption a *visible, reviewable, diff-bearing* act, which
+  is strictly better than today's invisible omission. **For the sanitizer regex
+  guard the exemption set IS a near-non-issue (2 entries) — but the regex itself
+  is the relocation** (the blind spot moved from "the allow-list" to "the regex
+  token list"). That distinction is the crux of MF-2.
+
+- **Reconciling with the user's literal goal ("fail-surfaced *defaults*"):** a CI
+  guard IS a faithful realization of "defaults to flagged" — *provided* the guard's
+  trigger is the field's mere existence (every leaf / every string field), NOT a
+  name pattern. Agent 20's walker guard triggers on existence (every `_model_leaves()`
+  entry) → faithful. Agent 21's regex guard triggers on a name match → NOT faithful
+  (a leaf with a non-matching name never triggers). The marker+meta-guard triggers
+  on existence (every string field is marked-or-exempt) → faithful. **Take-away: the
+  faithful designs are the ones whose default branch is "unknown field → RED," and
+  the regex form fails that test.** §5.
+
+---
+
+## 1. The bar I held each design to
+
+The seed's decisive test (Phase-3 brief): *"Would the recommended class-1 guard
+FAIL if a dev adds a NEW unwalked leaf and forgets to walk/declare it? Would the
+class-2 design FAIL if a dev adds a NEW IP-bearing field and forgets to redact
+it? Walk both synthetic scenarios concretely; if either PASSES (misses the new
+field) → NO-GO must-fix."*
+
+I operationalised this as four synthetic scenarios — the same *shapes* the five
+blind audits actually exploited (switchport / static-route subfield / VXLAN /
+VLAN-port / VLAN-SVI for class-1; IPv4→IPv6→RD/RT→VGA for class-2) plus the
+*next* shape an adversary would reach for:
+
+| # | Scenario | Class | The shape the audits exploited |
+|---|---|---|---|
+| S1 | New **scalar** leaf on an existing nested model: `CanonicalVRRPGroup.tracking_weight: int = 0` | 1 | exactly the VRRP/DHCP-subfield pattern (#172/#175 shape) |
+| S2 | New **whole nested model**: `CanonicalQoSPolicy` hung off `CanonicalIntent.qos_policies: list[...]` | 1 | the "new feature surface" pattern (the way VXLAN/EVPN first landed) |
+| S3 | New **indicatively-named** IP field: `CanonicalThing.mgmt_ip: str = ""` | 2 | the VGA #174 shape (name ends `_address`/`_ip`) |
+| S4 | New **deceptively-named** IP field: `CanonicalBGPNeighbor.peer: str = ""` (a neighbor IP) | 2 | the *next* audit's shape — a real IP behind a non-IP-looking name |
+
+A design that goes RED on S1–S4 kills the class. A design that PASSES (stays
+green) on any of them relocates the blind spot. The results:
+
+| Design | S1 | S2 | S3 | S4 |
+|---|---|---|---|---|
+| 20 walker guard (B, recursive) | **RED** ✓ | **RED** ✓ (with MF-3 caveat) | n/a | n/a |
+| 21 sanitizer guard (B, naming-regex) | n/a | n/a | **RED** ✓ | **GREEN** ✗ (MF-2 blocker) |
+| 22 marker (alone) | n/a | n/a | **GREEN** ✗ (forgot marker) | **GREEN** ✗ |
+| 22 marker + `_NON_SENSITIVE_TEXT` meta-guard | n/a | n/a | **RED** ✓ | **RED** ✓ |
+
+The decisive rows: **S4 is GREEN (a miss) for the recommended sanitizer regex
+guard AND for the marker-alone** — that is the relocation. Only the
+marker+meta-guard combination catches S4. Detail below.
+
+---
+
+## 2. Class-1 (walker guard, agent 20) — does it kill the class?
+
+### 2.1 S1 (new scalar leaf on a nested model) — RED ✓ (the class kill works)
+
+Trace, against the *actual* mechanism I verified:
+
+1. A dev adds `CanonicalVRRPGroup.tracking_weight: int = 0` and forgets the walker
+   yield + the per-codec declaration + the `_LEAF_TO_WALKER_XPATHS` row + the
+   `_WALK_EXEMPT` row.
+2. `_reachable_canonical_models(CanonicalIntent)` reaches `CanonicalVRRPGroup`
+   (it is mounted via `CanonicalInterface.vrrp_groups: list[CanonicalVRRPGroup]`;
+   the engine descends through `list[...]` — verified at
+   `test_sanitize.py:662-685`, the recursion is real and pydantic resolves the
+   future-annotation string to the live class).
+3. `_model_leaves()` yields `("CanonicalVRRPGroup", "tracking_weight")` because
+   `int ∈ _SCALAR` and the field has no nested model.
+4. It is in neither `_LEAF_TO_WALKER_XPATHS` nor `_WALK_EXEMPT` →
+   `test_every_model_leaf_is_walked_or_exempt` appends
+   `"CanonicalVRRPGroup.tracking_weight (no walker-xpath mapping)"` and **FAILS**.
+
+**This is the precise hole the two existing guards leave open and that agent 20's
+recursion fills.** I confirmed both existing guards stop at top level:
+`test_marker_dict_covers_every_data_bearing_field` reflects
+`set(CanonicalIntent.model_fields)` (`test_registry_capability_honesty.py:534`) —
+top level only, no recursion; G5's `_FIELD_TO_EXPECTED_XPATH`
+(`test_walk_canonical_coverage.py:165-184`) is a hand-listed 18-entry top-level
+dict. **Neither would notice `CanonicalVRRPGroup.tracking_weight`.** Agent 20's
+recursive `_model_leaves()` is the genuine fix. **S1 = class killed.** ✓
+
+### 2.2 S2 (new whole nested model) — RED ✓ but with a real caveat (MF-3)
+
+A dev adds a brand-new `CanonicalQoSPolicy(BaseModel)` with scalar fields
+(`name`, `dscp`, `rate_limit`) and hangs it off
+`CanonicalIntent.qos_policies: list[CanonicalQoSPolicy] = Field(default_factory=list)`.
+
+Trace:
+1. `_reachable_canonical_models(CanonicalIntent)` iterates `CanonicalIntent`'s
+   fields; for `qos_policies`, `_flatten_annotation(list[CanonicalQoSPolicy])`
+   yields `CanonicalQoSPolicy` (a `BaseModel` subclass) → it is added to the
+   reachable set and recursed. **Confirmed**: the engine descends into new nested
+   models automatically (`test_sanitize.py:681-684`).
+2. `_model_leaves()` yields `("CanonicalQoSPolicy", "name")`, `(…, "dscp")`,
+   `(…, "rate_limit")` — none mapped, none exempt → **FAILS** naming all three.
+
+**So S2 is caught.** ✓ — *provided* the new field's annotation is a form
+`_flatten_annotation` can see through. **MF-3 (major, not a blocker):** the
+recursion's coverage of the *container field itself* depends on
+`_flatten_annotation`/`get_args` handling the annotation. For `list[X]`,
+`dict[str, X]`, `X | None` it does (verified). But three real shapes in this
+codebase would be missed by the *leaf* enumerator (not the model-reachability):
+- a `dict[str, list[list[str]]]` field (`group_content` is exactly this) — the
+  `_model_leaves()` `has_scalar`/`has_nested_model` branches both go false for a
+  pure-dict, and agent 20 routes it to the `elif not has_scalar and not
+  has_nested_model: yield` arm → it becomes a leaf that must be exempted. Good,
+  but agent 20 must verify the dict branch actually yields (the sketch's `elif`
+  is correct but the `_SCALAR` membership test on a `dict` type needs care — a
+  bare `dict` annotation has no args, so `_flatten_annotation` yields `dict`
+  itself, which is not in `_SCALAR` and not a `BaseModel` → the `elif` fires →
+  yielded → exemption catches it. OK, but this is subtle enough to need a unit
+  test of `_model_leaves()` itself, see MF-3 fix.)
+- a `Literal["a","b"]` field (the codebase uses `Literal` for codec metadata) —
+  `typing.get_args(Literal["a","b"])` returns `("a","b")` (the *values*, not
+  types), so `_flatten_annotation` yields the strings `"a"`,`"b"`, neither in
+  `_SCALAR` nor a `BaseModel` → the leaf is routed to the `elif` "dict-like" arm
+  and yielded-for-exemption. That is *accidentally* correct (it gets flagged) but
+  for the *wrong reason*, and a `Literal[1,2]` int-enum would behave differently.
+  The intent model today has no `Literal` field on a walked surface, but the
+  guard's `_model_leaves()` MUST be unit-tested against a `Literal` to avoid a
+  silent mis-classification when one is added.
+
+**MF-3 fix:** agent 20's `_model_leaves()` needs its own ≥3-case unit test
+(scalar / list[scalar] / nested-model / dict / Literal) asserting the exact
+`(Class,field)` set it yields on a tiny synthetic model, so the enumerator's
+own correctness is guarded. Without it, the guard could silently *under-enumerate*
+(miss a leaf) and the whole class-1 fix would have a hole at its foundation. This
+is the "guard the guard's enumerator" test, distinct from agent 20's three
+"guard the guard" tests (which check staleness/disjointness, not enumeration
+correctness).
+
+### 2.3 MF-1 (blocker): the `_LEAF_TO_WALKER_XPATHS` map is a second hand-maintained subset — and agent 20's "can't forget both" claim has a hole
+
+Agent 20 §3.4 design-note asserts: *"The map is NOT a second blind spot because
+the guard fails on any leaf missing from BOTH the map and the exemption set."*
+That is true for a leaf missing from both. **But it does not cover the case where
+a copy-paste author adds the leaf to `_WALK_EXEMPT` with a plausible-but-wrong
+reason instead of walking it.** Concretely the S1 author, faced with a red
+`test_every_model_leaf_is_walked_or_exempt`, has TWO ways to green it:
+(a) walk it + declare it + map it (correct), or (b) drop one line into
+`_WALK_EXEMPT`: `("CanonicalVRRPGroup","tracking_weight"): "minor, low stakes"`.
+Path (b) is *easier* and turns the guard green while the field silently classifies
+`supported` forever. **The guard does not distinguish a legitimate exemption from
+a lazy one — it relies entirely on PR review catching the bogus reason string.**
+
+This is the honest residual agent 20 acknowledged (§4 "social-process risk"), but
+I rate it a **blocker for the class-kill claim** because the whole run exists to
+stop relying on a human noticing. The mitigations as designed are insufficient on
+their own:
+- `test_no_stale_walk_exemptions` only checks the leaf still *exists* — a lazy
+  exemption on a real field passes it.
+- The `KNOWN-GAP:` ratchet (§3.7) only constrains the `KNOWN-GAP`-prefixed
+  subset; a lazy exemption with reason `"minor"` is not `KNOWN-GAP`-prefixed so
+  the ratchet never sees it.
+
+**MF-1 fix (cheap, structural — makes the exemption costly to abuse):** require
+every `_WALK_EXEMPT` entry to match one of a small set of **structured reason
+codes**, not free text, e.g. `reason: Literal["METADATA","TRANSFORM_HINT",
+"DISCRIMINATOR_TRAVELS","ENVELOPE_AUDIT_BACKSTOPPED","KNOWN_GAP_PR2"]` plus a
+free-text note. A test asserts (i) every reason is one of the codes and (ii) the
+*count per code* is ratcheted (not just `KNOWN_GAP`). Then "I'll just exempt it"
+forces the author to pick a category that *visibly does not fit* a real
+config-bearing leaf — a reviewer challenging `DISCRIMINATOR_TRAVELS` on
+`tracking_weight` is a far sharper signal than challenging free-text `"minor"`.
+This converts the social-process risk into a structural one: there is no honest
+reason-code for "I didn't feel like walking this," so the lazy path has no green
+door. (This is the same move that makes #149's `_is_legitimate_nonwalkable`
+robust — it is *predicates*, not free text. Agent 20's free-text reason strings
+are weaker than the #149 precedent it cites.)
+
+### 2.4 Does the walker exemption set relocate the blind spot? — NO (net positive)
+
+Setting MF-1 aside (which hardens it further), the walker exemption is genuinely
+better than the status quo, for the reason agent 20 §4 gives and I verified:
+**today, forgetting a leaf is invisible — no diff, no red CI, silent loss. With
+the guard, forgetting a leaf is a red CI naming the exact `(Class,field)`; the
+ONLY way to green it is a *diff-bearing* decision (walk-or-exempt) that appears in
+PR review.** That asymmetry (invisible omission → visible decision) is the class
+kill even before MF-1 hardening. The #149 precedent
+(`test_registry_capability_honesty.py:323-346`, `_SYNTHETIC_NONWALKABLE` +
+`_is_legitimate_nonwalkable`) is a real, shipped, self-justifying-exemption
+mechanism in this exact codebase, so the pattern is proven. **Verdict for
+class-1: the guard kills the class; MF-1 + MF-3 harden it from "kills it modulo a
+lazy reviewer" to "kills it structurally."**
+
+---
+
+## 3. Class-2 (sanitizer) — the regex guard does NOT kill the class
+
+### 3.1 S3 (indicatively-named new IP field) — RED ✓
+
+Agent 21 §4's #174-regression trace is correct and I re-verified the mechanism. A
+new `CanonicalThing.mgmt_ip: str = ""` matches `_IP_HOST_NAME_RE` (ends `_ip`),
+is neither registered nor exempt → `test_reverse_no_unregistered_ip_field` FAILS.
+The pre-#174 `virtual_gateway_address` trace is sound (name ends `_address`). **S3
+= caught.** ✓ The regex guard does kill the *named-instance* class — every audit
+instance so far (ip, virtual_gateway_address, RD/RT, …) had an indicative name.
+
+### 3.2 S4 (deceptively-named new IP field) — GREEN ✗ — MF-2, the blocker
+
+This is the decisive test and the recommended class-2 design **fails it.**
+
+Trace against agent 21's `test_reverse_no_unregistered_ip_field`
+(`21-design-sanitizer-guard.md` §2.4):
+1. A dev adds `CanonicalBGPNeighbor.peer: str = ""` (holds the neighbor's IP) and
+   forgets to redact it.
+2. `_scan_named_fields(_IP_HOST_NAME_RE)` iterates the model. For field `peer`:
+   `_IP_HOST_NAME_RE.search("peer")` → **no match** (`peer` is not in the token
+   list `ip|host|gateway|network|destination|prefix|address|…`).
+3. So `("CanonicalBGPNeighbor","peer")` is **never added to `found`.**
+4. `found - _REGISTERED_IP_FIELDS - _IP_NAME_EXEMPT` does not contain it (it was
+   never a candidate). `unregistered` is empty for it. **Test PASSES.** The IP
+   leaks verbatim into every shared config / bug report.
+
+**The guard is structurally blind to any IP-bearing field whose name the regex
+does not anticipate.** This is the literal covered-subset disease — the blind spot
+moved from "the 41-site allow-list" to "the `_IP_HOST_NAME_RE` token list," which
+is *also* a hand-maintained subset. The next blind audit finds `peer` /
+`endpoint` / `nexthop` / `vtep` / `bfd_source` and we are back to whack-a-mole.
+Agent 21 §6.4 concedes this exactly ("the blind spot would only relocate if a
+future dev added an IP-bearing field with a deceptive name… that is the one
+residual"); agent 22 §4.2 names the same hole as the marker's core argument. **I
+escalate it from "residual" to BLOCKER** because the seed's decisive test is
+literally "a NEW IP-bearing field … forgets to redact it → must FAIL," and S4 is
+the cleanest instance of it. A design that passes S4 has not killed the class; it
+has renamed the subset.
+
+> **Why this matters more for class-2 than class-1.** Class-1's `_model_leaves()`
+> triggers on a leaf's *existence* (every scalar leaf is enumerated, regardless of
+> name) — so a deceptively-named scalar leaf is still enumerated and still must be
+> walked-or-exempt. Class-2's regex triggers on a leaf's *name* — so a
+> deceptively-named leaf is never even a candidate. **The two recommended guards
+> are not symmetric in faithfulness: the walker guard's default branch is
+> "unknown leaf → RED"; the sanitizer regex guard's default branch is "unknown
+> name → IGNORED."** That asymmetry is the whole finding.
+
+### 3.3 MF-2 fix: the marker (agent 22) + an unmarked-string meta-guard is the only S4-faithful form
+
+Agent 22 already did the work and reached the right shape, then under-sold it.
+The fix for MF-2 is exactly agent 22 §8.1 "Risk 1" — but it must be promoted from
+"risk to watch" to **required component**:
+
+1. Adopt the `Sensitive(kind=...)` marker (agent 22 §2) on the IP/host/mac/secret
+   leaves. The marker rides the field, so it is name-independent.
+2. Ship the **unmarked-string meta-guard** (agent 22 §8 rec): *every* `str` /
+   `list[str]` leaf reachable from `CanonicalIntent` is EITHER `Sensitive`-marked
+   OR in a small, reviewed `_NON_SENSITIVE_TEXT` exemption set. Trace S4 against
+   it: `CanonicalBGPNeighbor.peer: str` is unmarked AND not in `_NON_SENSITIVE_TEXT`
+   → **meta-guard FAILS** naming `("CanonicalBGPNeighbor","peer")`, forcing the
+   author to make a binary decision (mark sensitive, or justify non-sensitive). **S4
+   = caught.** ✓
+
+This is the ONLY recommended configuration that goes RED on S4. The marker *alone*
+(without the meta-guard) PASSES S4 (a forgotten marker is invisible — agent 22
+§5's own "Achilles heel"). The regex guard PASSES S4. So:
+
+> **MF-2 (blocker): the class-2 fix MUST be marker + unmarked-string meta-guard,
+> NOT the naming-regex guard (agent 21 form B as written) and NOT the marker
+> alone.** Only the combination triggers on field *existence* (the faithful
+> default), which is what "fail-surfaced default" means.
+
+### 3.4 Does the meta-guard just relocate the blind spot again?
+
+This is the fair counter-question (agent 22 §5 raises it honestly): the
+`_NON_SENSITIVE_TEXT` set is itself a hand-maintained subset, so haven't we just
+moved the blind spot to *it*? **No — and the asymmetry is decisive:**
+
+- The dangerous direction is *under-redaction* (a sensitive field leaks). For the
+  meta-guard, leaking requires a sensitive field to be (a) unmarked AND (b)
+  wrongly placed in `_NON_SENSITIVE_TEXT`. That is a *diff-bearing, reviewable*
+  act with a name attached — `("CanonicalBGPNeighbor","peer"): "non-sensitive"`
+  is a claim a reviewer rejects (a BGP peer IP is obviously sensitive). Contrast
+  the regex: a leak requires only *forgetting* — no diff, no entry, invisible.
+- The meta-guard's failure mode is *over-flagging* (a genuinely non-sensitive new
+  string field turns CI red until someone adds it to `_NON_SENSITIVE_TEXT`). That
+  is a safe failure: it annoys a contributor, it does not leak. **Over-flag-safe
+  beats under-redact-unsafe.** The user's own framing ("fail-surfaced") explicitly
+  prefers the noisy-but-safe default.
+- The `_NON_SENSITIVE_TEXT` set is *closed and enumerable today* (agent 10/12
+  listed them: `name`, `description`, `mode`, `interface_type`, `timezone`,
+  `tunnel_type`, `dhcp_client_v6`, `scope`, `kind`, `default_name`,
+  `instance_type`, `source_interface`, `interface`, …). New free-text fields are
+  rare; each is one reviewed line.
+
+So the meta-guard relocates the blind spot from "invisible omission of a redaction"
+(unsafe, silent) to "visible mis-classification of a string field" (safe, noisy,
+reviewable). That is the relocation we *want* — it is the same move that makes the
+walker guard faithful (trigger on existence, fail safe).
+
+### 3.5 The marker's own residual (honest) — and why it's acceptable
+
+Agent 22 §5 is right that the marker+meta-guard is not *perfectly* self-enforcing:
+a dev could add `peer: str`, see the meta-guard go red, and *lazily* drop it into
+`_NON_SENSITIVE_TEXT` with reason "internal." This is the class-2 twin of MF-1.
+**Same fix applies: structured reason codes on `_NON_SENSITIVE_TEXT`** (e.g.
+`Literal["ENUM_KEYWORD","OPERATOR_FREE_TEXT","IFACE_NAME","METADATA"]`) so there
+is no honest code for "an IP I didn't want to redact." A BGP peer IP fits none of
+those codes, so the lazy path again has no green door. With that, the class-2 fix
+is structurally faithful to S4, not merely socially.
+
+---
+
+## 4. The two reviewers' designs disagree on class-2 — I take a position
+
+Agent 21 recommends the regex guard and treats the marker as deferrable; agent 22
+recommends the marker and concedes it is a "close call." **My adversarial finding
+forces the tie-break: the regex guard fails the seed's decisive test (S4), so it
+cannot be the recommended class-2 form.** The position:
+
+- **Class-2: adopt the typed marker (agent 22) + the unmarked-string meta-guard +
+  structured exemption reason codes.** This is the only form that goes RED on a
+  deceptively-named new IP field. Agent 21's guard *test infrastructure* survives
+  (the forward sentinel half, the reflection engine, the would-have-caught-#174
+  argument) — it just reflects *markers* instead of *names*, exactly as agent 21
+  §8.1 itself offers as the alternative branch. So this is not "reject agent 21";
+  it is "take agent 21's guard machinery and re-base it onto agent 22's marker,
+  and add the meta-guard." The two designs *compose*.
+
+- **Class-1: keep agent 20's walker guard (do NOT use a marker).** Agent 22 §6 is
+  correct that a "walkable" marker is the wrong tool (inverted density, no xpath
+  spelling, phase4 coupling). Agent 20's `_model_leaves()` already triggers on
+  existence, so it is already faithful to S1/S2 — it does NOT have the regex's S4
+  problem, because it never used names. Apply MF-1 (structured reason codes) +
+  MF-3 (enumerator unit test) to harden it.
+
+This split (marker for class-2, structural-leaf-enumeration for class-1) is
+*more* than each Phase-2 agent individually recommended, but it is the minimal
+configuration that survives all four synthetic scenarios. Agent 22's own verdict
+("class-2 only" for the marker) plus agent 20's walker guard plus the two
+meta-guards = the coherent whole.
+
+---
+
+## 5. Reconciling with the user's literal goal: is a CI guard faithful?
+
+The user's goal, verbatim from the seed: *"fail-surfaced defaults — the walker
+yields EVERY leaf (or the codec must declare it); the sanitizer redacts on
+`ip_address()` of ANY IP-typed field, not an allow-list."*
+
+**My position: a CI guard IS a faithful realization of "fail-surfaced defaults" —
+but ONLY when the guard's trigger is field existence, not a heuristic.** The
+parse of "fail-surfaced default": *the default state of a newly-added field is
+"flagged/surfaced," not "silently fine."* A guard delivers that iff adding the
+field (with no other action) flips CI red. Test each design against that literal
+criterion:
+
+| Design | Adding a new field, no other action → ? | Faithful? |
+|---|---|---|
+| Walker guard (20) | new leaf ∉ map ∉ exempt → **RED** | **Yes** — triggers on existence |
+| Sanitizer regex (21) | new field, name not in regex → **GREEN** | **No** — triggers on name |
+| Marker alone (22) | new field, no marker → **GREEN** (meta-guard absent) | **No** — triggers on marker-presence |
+| Marker + meta-guard (22 §8) | new string field, unmarked, ∉ `_NON_SENSITIVE_TEXT` → **RED** | **Yes** — triggers on existence |
+| Runtime blanket `ip_address()` (A) | new IP field → silently redacted; new MAC/secret → silently leaked | **No** — no human surfaced |
+
+So the user's literal goal is satisfiable by a CI guard, and the seed's stated
+preference ("convert the blind spot into a CI failure over a risky runtime
+behavior change") is honored — **but the faithful CI forms are specifically the
+existence-triggered ones (walker `_model_leaves`, marker+meta-guard), and the
+recommended-by-agent-21 name-triggered form is NOT faithful.** The user's
+intuition that pushed toward "ANY IP-typed field, not an allow-list" was
+*correct*: the allow-list (and its regex cousin) is the disease; the
+existence-triggered guard is the cure. The runtime `ip_address()` form the user
+literally proposed is the wrong mechanism (agent 12/21/22 all show it is
+insufficient + unsafe), but the *instinct* — "ANY field, not a curated subset" —
+is exactly what the marker+meta-guard delivers at test time. **The goal does NOT
+demand the runtime behavior-change form; it demands the existence-triggered
+default, which the guard provides.** So: faithful, with the MF-2 correction.
+
+---
+
+## 6. Secondary correctness checks (non-blocking but worth landing)
+
+- **C-1 (minor): the walker guard's `_WALKABLE` is built from `_maximal_intent()`,
+  which does NOT populate the HIGH gap leaves it claims to detect.** I verified
+  `_maximal_intent` (`test_registry_capability_honesty.py:132-221`) sets VRRP
+  `group_id` + `virtual_ips`/`virtual_mac`/`track_interfaces` but NOT `mode`/
+  `priority`/`preempt`/`advertisement_interval`/`authentication`; sets SNMPv3
+  `group`/`auth_protocol`/`priv_protocol`/`priv_passphrase` but the walker yields
+  none of them; sets `routing_instances.instance_type="vrf"` (the *default*).
+  **This is actually fine for agent 20's guard** — the guard computes "is this
+  leaf's xpath in `_WALKABLE`," and these leaves' xpaths are correctly *absent*
+  from `_WALKABLE` (the walker never emits them), so the guard correctly flags
+  them as un-walked. But it means PR-2's walk-expansion MUST also extend
+  `_maximal_intent()` to populate the newly-walked sub-fields with NON-DEFAULT
+  values, or the new yields fire vacuously and the reverse-parity guards
+  (`test_declared_supported_is_walkable`) could pass without exercising the new
+  paths. Flag for the main thread; it's a regen-time detail agent 20 §5.2 gestures
+  at but doesn't make explicit.
+
+- **C-2 (minor): `instance_type` default-value trap.** `instance_type="vrf"` is
+  the default; if PR-2 walks `/routing-instances/instance/instance-type` only
+  `when populated` (truthy), it is ALWAYS truthy (`"vrf"` is truthy) so it always
+  walks — unlike `mode="vrrp"` default which is also truthy. Contrast `metric=0`
+  which is falsy and correctly skipped. Agent 20 should confirm each HIGH leaf's
+  walk-guard truthiness matches the intended "walk only on loss" semantics, or the
+  live report gains noise (a `vrf` instance_type that every codec round-trips
+  cleanly would still be walked and classified — harmless but not the lossy-only
+  intent of the existing VRRP/static-route conditional yields at
+  `xpath_walker.py:153-196`).
+
+- **C-3 (confirm): the marker's `from __future__ import annotations` survival.**
+  Agent 22 §2.2 claims a prototype confirmed `model_fields[name].metadata` is
+  readable under future-annotations. I could not re-run the prototype (read-only),
+  but I confirmed the *adjacent* claim it rests on: the existing secret guard does
+  `str in _flatten_annotation(fld.annotation)` (`test_sanitize.py:754`) and passes
+  in CI, which proves `fld.annotation` is the *resolved* type object (not the raw
+  string) under this repo's future-annotations + pydantic 2.x. Marker `.metadata`
+  retrieval is the same resolution path. **Low risk, but the main thread must run
+  the marker guard under the py3.11 CI leg** (agent 22 §8.4) — `model_fields[...]
+  .metadata` semantics are pydantic-version-sensitive and local is py3.14.
+
+- **C-4 (no-op, just confirming agent 21/20's phase4 claim): a pure guard PR is
+  zero phase4 churn.** I confirmed `classify()` is the only consumer of walker
+  output for the live report (`migration.py:221-228` default-to-supported;
+  `migration_validate.py:80-87` walker-is-sole-input) and that phase4 reads
+  matrices+YAMLs not the walker. So PR-1 (walker guard, no new yields) and the
+  marker/meta-guard PRs (sanitizer side, off the migration-validate path entirely)
+  are genuinely zero-phase4. The phase4 risk is real ONLY for agent 20's PR-2
+  walk-expansion, which agent 20 correctly stages separately. **No correctness
+  issue; the staging is right.**
+
+---
+
+## 7. Summary of must-fixes
+
+| id | severity | target | issue | fix |
+|---|---|---|---|---|
+| MF-2 | **blocker** | class-2 design (agents 21/22 synthesis) | The recommended naming-regex sanitizer guard PASSES (misses) a deceptively-named new IP field (`peer: str`) — S4. It relocates the blind spot from the allow-list to the regex token list; it does not kill the class. | Adopt the typed marker (agent 22) AND ship the unmarked-string meta-guard (`every str/list[str] leaf is Sensitive-marked OR in `_NON_SENSITIVE_TEXT``). This is the only form that triggers on field existence (the faithful default). Re-base agent 21's guard machinery (forward sentinel, #174 regression argument) onto the marker. |
+| MF-1 | **blocker** | class-1 walker guard (agent 20) | The `_WALK_EXEMPT` free-text reason strings let a lazy author green a forgotten leaf by exempting it with a plausible-but-wrong reason; relies on a reviewer catching free text. Same hole in class-2's `_NON_SENSITIVE_TEXT`. | Replace free-text reasons with a small `Literal[...]` set of structured reason codes (METADATA / TRANSFORM_HINT / DISCRIMINATOR_TRAVELS / ENVELOPE_AUDIT_BACKSTOPPED / KNOWN_GAP_PR2), ratchet the count per code, and apply the same to the class-2 meta-guard exemptions. No honest code fits "an IP/leaf I didn't want to handle" → the lazy path has no green door. |
+| MF-3 | major | class-1 walker guard (agent 20) | `_model_leaves()` (the enumerator the whole class-1 fix rests on) is itself untested; its dict/`Literal`/union branches could silently UNDER-enumerate (miss a leaf), reopening the gap at the foundation. | Add a unit test of `_model_leaves()` against a tiny synthetic model covering scalar / list[scalar] / nested-model / dict / `Literal`, asserting the exact `(Class,field)` set. Guards the enumerator's own correctness. |
+| MF-4 | minor | class-1 PR-2 (agent 20) | If PR-2 walks the HIGH sub-leaves but `_maximal_intent()` leaves them at default/empty, the new yields fire vacuously and reverse-parity passes without exercising them (C-1); and default-truthy leaves like `instance_type="vrf"` would walk-always rather than walk-on-loss (C-2). | PR-2 must extend `_maximal_intent()` to populate each newly-walked sub-field with a non-default value, and confirm each new walk-guard's truthiness matches walk-only-on-loss intent. |
+
+(MF-1 and MF-2 are both blockers for the *class-kill claim*; the underlying
+guards are still net-positive and shippable, so the overall verdict is
+GO-WITH-FIXES, not NO-GO. The fixes are additive and small.)
+
+---
+
+## 8. Independent verification log (claims I re-checked at source)
+
+- **Default-to-supported CONFIRMED** — `netcanon/models/migration.py:221-228`:
+  `for up in self.unsupported … for lp in self.lossy … return "supported"`. Exact
+  string match per docstring `:209-219`. (Agents 11/20's central premise.) ✓
+- **Walker is sole live-report input** — `migration_validate.py:80-87` iterates
+  `_enumerate_xpaths` → `source.iter_xpaths` → `_walk_canonical`; an unwalked leaf
+  never reaches `classify()`. ✓
+- **Both existing forward-coverage guards are TOP-LEVEL ONLY** —
+  `test_marker_dict_covers_every_data_bearing_field` reflects
+  `set(CanonicalIntent.model_fields)` (`test_registry_capability_honesty.py:534`),
+  no recursion; G5 `_FIELD_TO_EXPECTED_XPATH` is an 18-entry hand-list
+  (`test_walk_canonical_coverage.py:165-184`). Agent 20's "must recurse" claim is
+  correct — the gap is real. ✓
+- **Reflection engine exists + is future-annotations-proven** —
+  `_flatten_annotation` + `_reachable_canonical_models` at `test_sanitize.py:662-685`;
+  consumed by the passing `test_reverse_no_unregistered_secret_field` (`:743-767`)
+  which does `str in _flatten_annotation(fld.annotation)` — proving `.annotation`
+  resolves to the live type under this repo's `from __future__ import annotations`
+  + pydantic 2.x. ✓ (de-risks both the walker guard recursion and the marker
+  retrieval.)
+- **#149 self-justifying-exemption precedent is real + predicate-based** —
+  `_SYNTHETIC_NONWALKABLE` (`test_registry_capability_honesty.py:323-330`) +
+  `_is_legitimate_nonwalkable` (`:333-346`) uses structural *predicates*
+  (top-segment, `/routing/` not-static-route, whole-field markers), NOT free text.
+  This is why MF-1 (agent 20's free-text reasons are *weaker* than the precedent
+  it cites) is well-founded. ✓
+- **`_maximal_intent()` does NOT populate the HIGH gap sub-leaves** (VRRP
+  mode/priority/preempt/adv-int/auth; SNMPv3 group/auth-proto/priv-proto/
+  priv-passphrase) — `test_registry_capability_honesty.py:167-204`. Confirms C-1
+  and that `_WALKABLE` correctly lacks those xpaths (the guard's gap-detection is
+  sound). ✓
+- **VRRP walker conditional yields** — `xpath_walker.py:146-158`: group anchor
+  unconditional; `virtual-ips` only `len>1`; `virtual-mac`/`track` only when
+  populated; mode/priority/preempt/adv-int/auth NEVER. ✓ (the densest class-1
+  gap, agent 11 §3.4.) ✓
+- **Existing secret registry** — `_REGISTERED_SECRET_FIELDS` (6 entries) +
+  `_SECRET_NAME_RE` (`test_sanitize.py:646-659`): the regex-form guard the marker
+  would re-base. Confirms agent 21/22's "extend this" is accurate and that
+  `engine_id` is redacted-but-not-secret-NAMED (so the regex misses it — the same
+  S4-class hole inside the *existing* guard, reinforcing MF-2). ✓
+
+---
+
+## 9. Bottom line for synthesis
+
+- **Class-1:** agent 20's recursive completeness guard KILLS the class for the
+  audit-named pattern (new scalar leaf, new nested model). Land PR-1 as designed,
+  PLUS MF-1 (structured reason codes) + MF-3 (enumerator unit test). PR-2
+  walk-expansion is correctly staged; add MF-4. Zero phase4 for PR-1 confirmed.
+- **Class-2:** the recommended naming-regex guard (agent 21 form B as written)
+  does NOT kill the class — it fails S4 (deceptively-named IP field). The fix is
+  MF-2: adopt agent 22's marker + an unmarked-string meta-guard + structured
+  exemption reason codes (MF-1's twin). This is the only S4-faithful form and the
+  truest realization of the user's "fail-surfaced default" goal. Zero phase4
+  (sanitizer is off the migration-validate path) confirmed.
+- **Faithfulness to the user's literal goal:** a CI guard is faithful iff it
+  triggers on field *existence*, not a name heuristic. The walker `_model_leaves`
+  guard and the marker+meta-guard both qualify; the regex guard does not. The
+  user's "ANY field, not an allow-list" instinct was right — implement it at test
+  time via existence-triggered guards, not at runtime via blanket `ip_address()`.

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/31-review-pragmatism.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/31-review-pragmatism.md
@@ -1,0 +1,616 @@
+# 31 — Adversarial PRAGMATISM / over-engineering / maintenance review
+
+**Agent:** `31-review-pragmatism` · Phase 3 (Review) · read-only
+**Run:** 2026-06-24 · fail-surfaced-defaults · netcanon
+**Scope:** Is the recommended design the MINIMAL thing that closes the class, or
+gold-plated? Over-fire / false-positive risk on legitimate model evolution and the
+intentional exemptions (#149 Tier-3, sanitizer private-IP preservation). Maintenance
+burden: who keeps the exemption list honest, friction on ordinary model changes, is
+the failure message actionable. Blast-radius sanity-check: are the phase-2 churn
+estimates realistic? One PR or several? What to stage/defer.
+
+I verified the load-bearing structural claims against the live tree (not just the
+peer reports): `test_registry_capability_honesty.py:323-346` (#149 exemption),
+`:527-541` (the top-level-only marker check), `:225` (`_WALKABLE` frozenset),
+`tests/unit/tools/test_sanitize.py:646-767` (the secret guard + reflection engine),
+`tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py:165-208`
+(the per-codec G5 floor). All six peer reports are internally consistent with the
+code. My critique is therefore about *proportion and maintenance*, not factual error.
+
+---
+
+## 0. Verdict + headline
+
+**GO-WITH-FIXES.** The recommended spine is sound and genuinely minimal *if trimmed*:
+
+- **Class-1 (walker):** agent 20's **PR-1 completeness guard is the right minimal
+  fix** — but the proposed shape is **moderately over-built** in two places: the
+  declared `_LEAF_TO_WALKER_XPATHS` spelling map (~52 hand-typed rows) and the
+  `test_known_gap_backlog_does_not_grow` ratchet (§3.7). Both add maintenance
+  surface without proportional class-kill value. Trim them (MF-1, MF-2).
+- **Class-1 PR-2 (surgical walk-expansion):** correctly staged and deferrable. **My
+  recommendation: defer the whole of PR-2 out of this run** — the guard already makes
+  every HIGH gap *visible and accounted-for in writing*, which is the class-kill the
+  user asked for; the per-instance walk + per-codec declaration + phase4 regen is a
+  separate, riskier, behavior-changing exercise that should not ride the same wave
+  (MF-3).
+- **Class-2 (sanitizer):** agent 21's **regex-driven guard (form B) is the right
+  minimal fix**; agent 22's **typed marker is over-engineering for the scope of this
+  run** and should be explicitly declined-for-now, not deferred-ambiguously (MF-4).
+  The one genuinely valuable nugget in the marker report — the `engine_id`
+  not-named-like-a-secret gap and the four un-redacted MAC fields — is capturable
+  *without* the marker (MF-5).
+- **The single biggest pragmatism risk across both designs is the MAC redaction
+  (PR-S1).** It is the only proposal that changes runtime behavior on class-2, it
+  invents a new primitive (`redact_mac`) and picks a docs-MAC range, and it is being
+  smuggled in as "make the guard green day one." It deserves its own scrutiny and
+  arguably its own PR or deferral (MF-6).
+
+Net: the durable fix is **two small CI guards** (one recursive walker-coverage guard,
+one IP/MAC sanitizer-coverage half), both reusing the *already-proven* reflection
+engine, both zero-runtime-change, both phase4-neutral. Everything beyond that —
+the spelling map's full population, the ratchet, the marker, the walk-expansion, the
+MAC primitive — is either trimmable or stageable-out. Strip to the spine and this is
+~100 net lines of test code that kills the class.
+
+---
+
+## 1. Is each recommended design the MINIMAL thing that closes the class?
+
+### 1.1 Class-1 walker guard — minimal in concept, over-built in artifacts
+
+The *concept* is minimal and correct: the existing forward-coverage checks
+(`test_marker_dict_covers_every_data_bearing_field` reflects only
+`set(CanonicalIntent.model_fields)` — confirmed top-level-only at
+`test_registry_capability_honesty.py:534`; G5's `_FIELD_TO_EXPECTED_XPATH` is 18
+hand-listed top-level fields, confirmed at `test_walk_canonical_coverage.py:165-184`)
+**both stop at the top level and never recurse into the nested models where the gap
+concentrates** (VRRP group, DHCP pool, SNMPv3 user). A recursive reflection guard is
+the smallest change that closes that hole. Agreed. This is the spine and it is right.
+
+But agent 20's PR-1 carries **two artifacts that are bigger than the class-kill
+needs**:
+
+**(a) The declared `_LEAF_TO_WALKER_XPATHS` spelling map (~52 rows).** Agent 20
+argues (§3.4) the map is necessary because xpath spelling is irregular
+(`config/` segment present for `mtu`/`vrf` but absent for `switchport-mode`; VXLAN is
+`/vxlan-vnis/<leaf>` with no `/vni/`; the VLAN-SVI reuse needs two strings). That
+irregularity is real — I confirmed it in the census (`10-model-leaf-census.md` §14.6)
+and in the walker. **But the guard does not need the exact xpath spelling to kill the
+class.** The class-kill question is binary: *"is this leaf reachable by the live
+validator at all?"* — i.e. *"does the walker emit ANY xpath that this `(Class, field)`
+contributes to?"* That can be answered without a per-leaf spelling table, by a far
+cheaper construction (§2.1 below): partition leaves into "walked" vs "not walked" by
+asking whether the field is *touched* during a walk of the kitchen-sink, not by
+hand-asserting which string it maps to. The spelling map is a **second
+hand-maintained list** — exactly the artifact shape this whole run exists to
+eliminate — and it is ~52 rows that a contributor must edit every time they add a
+walked leaf. Agent 20's own defense ("the map is itself guarded; a leaf missing from
+both map and exemption fails") is true but misses the pragmatism point: *the map's
+existence is itself the maintenance tax*, and a leaf that IS walked still forces a map
+edit. **MF-1: drop the spelling map; derive walked-ness structurally (§2.1).**
+
+**(b) The `test_known_gap_backlog_does_not_grow` ratchet (§3.7).** Agent 20 flags
+this as "possibly gold-plating" — it is. A `_KNOWN_GAP_BASELINE` integer that a PR
+must manually decrement is itself a hard-coded count that rots (it directly violates
+the AGENTS.md "never hard-code a count unless a guard keeps it honest" rule — here the
+count IS the guard, which is circular and brittle). The `KNOWN-GAP:` reason-prefix
+convention already makes the backlog `grep`-able; that is sufficient visibility.
+**MF-2: drop the ratchet.** (Severity minor — it is opt-in and agent 20 already
+flagged it.)
+
+### 1.2 Class-2 sanitizer guard — minimal and correct
+
+Agent 21's form B (extend `TestSecretRedactionCoverage` with an IP/host + MAC half,
+reusing `_reachable_canonical_models` / `_flatten_annotation`) is genuinely the
+cheapest durable fix. The reflection engine already exists and ships green today
+(confirmed `test_sanitize.py:662-685`, used by the passing
+`test_reverse_no_unregistered_secret_field`). ~70 lines, one file. No notes on the
+guard *shape* — it is the right altitude and the right size. My only class-2 concerns
+are (a) the typed marker that agent 22 layers on top (§1.3), and (b) the MAC runtime
+change bundled into PR-S1 (§4).
+
+### 1.3 The typed marker (agent 22) — over-engineering for THIS run
+
+Agent 22 is admirably honest: it self-describes the marker as "a *close* call," "not
+a clean self-enforcing win," with an "Achilles heel" (a contributor can silently omit
+the marker), and concludes the synthesis should *ratify, not ram through*. I will take
+the position agent 22 invites: **for the scope of this run, the marker is
+over-engineering and should be explicitly declined, not left as an ambiguous
+"PR-S3 (optional, only if agent 22 wins)."**
+
+The case against, on pragmatism grounds specifically:
+
+1. **It re-introduces the exact disease it claims to cure.** Agent 22 §5 + §8.1
+   admit the marker only becomes self-enforcing if paired with a *meta-guard* that
+   asserts "every `str`/`list[str]` leaf is either marked OR in a
+   `_NON_SENSITIVE_TEXT` exemption set." That exemption set (agent 22 §8.1 lists
+   `name`, `description`, `mode`, `interface_type`, `timezone`, `tunnel_type`,
+   `dhcp_client_v6`, `scope`, `kind`, `default_name`, `instance_type`,
+   `source_interface`, `interface`, …) is a **hand-maintained subset with a permissive
+   default** — the literal definition of the class this run is killing. The regex
+   guard's exemption set is *2 entries* (`interface`, `source_interface`); the
+   marker's meta-guard exemption set is *~14 and growing with every non-sensitive
+   string field added*. The marker makes the exemption surface **larger**, not
+   smaller, once you account for the meta-guard it requires to be self-enforcing.
+   Without the meta-guard, the marker is strictly *worse* than the regex (silent
+   omission, caught by nothing).
+
+2. **It is a new contributor-facing discipline for marginal gain.** Every future
+   field author must learn the `Annotated[str, Sensitive("...")]` idiom and remember
+   it; forgetting produces *no error* (agent 22 §5 concedes this). The regex requires
+   contributors to do nothing — it scans names they already write. The net new
+   maintenance burden of the marker (learn idiom + remember + meta-guard + its
+   exemption list + doc-sync into `adding-a-canonical-field.md`) exceeds the ~70-line
+   regex guard's burden by a wide margin.
+
+3. **The "real" wins agent 22 cites are achievable without the marker.** The three
+   nuggets — `engine_id` (redacted but not secret-*named*), the four un-redacted MAC
+   fields, and `static_routes[].destination` — are all capturable in the regex guard
+   by (a) adding `engine_id` to `_REGISTERED_SECRET_FIELDS` explicitly (it is already
+   redacted, just not registered — a one-line registry add), and (b) the MAC half /
+   destination wire-up agent 21 already proposes. None require the marker. **MF-5.**
+
+The marker's *one* irreducible advantage is the deceptive-name residual (a future
+`peer_endpoint: str` holding an IP that the regex misses). That is a real but
+low-probability event, and the honest mitigation is the one agent 21 §6.4 and agent 22
+itself land on: the codebase's naming convention is a documented, de-facto-enforced
+contributor expectation. **Reserve the marker as a documented escalation IF a
+deceptive-name field ever actually ships** — do not pay its cost speculatively now.
+**MF-4: decline the marker for this run; record it as a deferred option in
+`99-synthesis.md` with the trigger condition "a real IP/secret field ships with a
+non-indicative name."**
+
+---
+
+## 2. A cheaper class-1 guard construction (the MF-1 alternative)
+
+To make MF-1 actionable rather than a complaint, here is the minimal construction
+that kills the class *without* the spelling map. It answers "is this leaf walked?"
+structurally instead of by a hand-asserted string.
+
+### 2.1 Walked-ness by sentinel-difference, not by spelling
+
+The walker yields xpaths conditionally on a field being populated. So "this leaf is
+walkable" ≡ "populating this field (and nothing else) on a maximal intent causes
+`_walk_canonical` to emit at least one xpath it would not emit on the empty intent."
+That is mechanically derivable:
+
+```python
+_WALKABLE = frozenset(_walk_canonical(_maximal_intent()))   # reuse the existing one
+_EMPTY    = frozenset(_walk_canonical(CanonicalIntent()))
+
+# A leaf is "covered by the walker" if the maximal-intent walk is STRICTLY larger
+# than the empty walk *because of* that field's surface. In practice the simpler
+# and sufficient check is: every (Class, field) leaf must correspond to at least
+# one walked xpath segment, OR be exempt. We do NOT need the exact string — only
+# the yes/no.
+```
+
+The honest simplification: rather than per-leaf sentinel diffing (which is fiddly for
+shared sub-models), keep agent 20's `_model_leaves()` enumerator and the
+`_WALK_EXEMPT` set, but **replace the `_LEAF_TO_WALKER_XPATHS` map with a derived
+membership test**: a leaf `(Class, field)` is "walked" iff the walker emits an xpath
+whose final segment matches the field's kebab spelling *or* whose path contains the
+field — using a tolerant `field_name → kebab` transform and substring/suffix match
+against `_WALKABLE`, not an exact hand-typed string. The guard then only needs the
+**exemption set** (the genuinely-not-walked leaves), which is the information that
+actually carries meaning — exactly mirroring how #149's `_is_legitimate_nonwalkable`
+works (it is a *predicate*, not a per-path lookup table; confirmed
+`test_registry_capability_honesty.py:333-346`).
+
+This is strictly less code (no ~52-row map), and it removes the second
+hand-maintained list. The residual risk — a tolerant match could *false-positively*
+decide a leaf is walked when a same-named-but-different xpath is what's actually
+emitted — is real but narrow, and is itself caught by the existing per-codec
+render-reparse survival guards (`test_static_route_subfield_and_secondary_drops_are_declared`,
+confirmed `:601-629`) which assert *value* survival independent of spelling. So the
+tolerant guard's only job is the *forward coverage* binary, and a rare false-"walked"
+is backstopped.
+
+**If the synthesis judges the tolerant match too loose**, the fallback is *not* the
+full spelling map but a hybrid: derive walked-ness by tolerant match, and keep a
+**small `_SPELLING_OVERRIDE` dict ONLY for the handful of irregular cases** (the
+`config/` interface fields, the VXLAN element collapse, the VLAN-SVI reuse) — ~8 rows,
+not ~52. The 90% regular cases derive; only the irregulars are declared. That is the
+genuinely minimal version and I'd accept it as the GO bar.
+
+### 2.2 The exemption set is the only list worth hand-maintaining
+
+Agent 20's `_WALK_EXEMPT` (§3.5) is correct in spirit — it carries reasons, mirrors
+#149, and is guarded by `test_no_stale_walk_exemptions` (a good guard-the-guard). My
+only trims:
+
+- The **envelope-covered cluster entries** (DHCP ×8, EVPN-Type5 ×4, RADIUS ports ×2)
+  are correctly exempt (cross-mesh audit backstops them — `11-walker-gap.md` §6) but
+  their reason strings should *cite the backstop test by name* so a reader can verify
+  the claim, not just assert "audit-backstopped."
+- The **`KNOWN-GAP:` entries** are fine as exemptions but should NOT carry the ratchet
+  (MF-2). The prefix convention alone is the visibility mechanism.
+
+---
+
+## 3. Over-fire / false-positive risk on legitimate evolution + the intentional exemptions
+
+This is the core pragmatism question: *would these guards cry wolf on a normal,
+correct change?* I walked the likely evolution scenarios.
+
+### 3.1 Class-1 guard vs #149 Tier-3 non-walkable paths — SAFE, but one trap
+
+The #149 lesson (Tier-3 routing-protocol paths and the 6 `_SYNTHETIC_NONWALKABLE`
+markers are *intentionally* non-walkable) is about **declared-but-not-walkable**
+matrix paths (`/routing/bgp` etc.) — the *reverse* direction from the class-1 gap. The
+new walker-coverage guard reflects over **model leaves**, and the canonical model has
+*no BGP/OSPF leaf* (Tier-3 lives only as `raw_sections`/`dropped_tier3_sections`).
+**So the new guard never even sees a Tier-3 path** — there is no model field to
+enumerate. Confirmed: the model classes are the 17 in the census; none is a routing
+protocol. **No false-fire risk from #149's Tier-3 paths.** Agent 20 and 11 both got
+this right (`11-walker-gap.md` §7).
+
+**The trap (minor):** agent 20's guard reuses `_WALKABLE` which is built from
+`_maximal_intent()` in `test_registry_capability_honesty.py:132-225`. The per-codec G5
+floor uses a *different* kitchen-sink `_kitchen_sink()` in
+`test_walk_canonical_coverage.py`. If a future leaf is populated in one fixture but
+not the other, the guard reading `_WALKABLE` could disagree with G5. This is a
+cross-file coupling that will rot silently. **MF-7 (minor): the new guard's
+`_maximal_intent` dependency must be asserted to populate every non-exempt leaf**
+(agent 20's `test_no_stale_walk_exemptions` checks the exemption set tracks the model,
+but nothing checks `_maximal_intent` actually exercises every *walked* leaf — there is
+already a `test_maximal_intent_exercises_every_top_level_field` at `:544-556` but it,
+too, is top-level-only). Add the recursive sibling, or the guard can pass vacuously if
+`_maximal_intent` leaves a nested sub-field empty.
+
+### 3.2 Class-1 guard vs ordinary model evolution — actionable, low friction
+
+Scenario: a contributor adds `CanonicalInterface.poe_enabled: bool = False` and wires
+it through two codecs but forgets the walker yield. The guard fails with (agent 20
+§3.6 message): *"CanonicalInterface.poe_enabled (no walker-xpath mapping) … add a
+yield in `_walk_canonical` + per-codec declaration, OR add a self-justifying
+`_WALK_EXEMPT` entry."* **That message is actionable** — it names the exact field and
+the two valid resolutions. Friction is one of: (a) one yield line + the field travels
+as a walked surface, or (b) one exemption row with a reason. Both are proportionate to
+"you added a config surface." This is the *intended* friction and it is correctly
+sized. Good.
+
+The friction edge case: a contributor adding a **purely-internal/transform field**
+(like the existing `kind`/`default_name`) must now add an exemption row. That is a tiny
+tax (one line + reason) and is arguably *correct* — it forces the author to declare
+"this is not a config surface," which is exactly the fail-surfaced default. Accept.
+
+### 3.3 Class-2 regex guard vs the private-IP preservation — SAFE (it's a test)
+
+The seed's load-bearing constraint — *the sanitizer PRESERVES private/docs IPs by
+design; do not over-redact* — is **untouched by the recommended form B** because form B
+changes no runtime redaction behavior; it is a coverage *test*. Confirmed by agent 21
+§5: the only runtime changes are PR-S1's destination + MAC wires, which route through
+the existing private-preserving primitives. The blanket `ip_address()` rule (form A) —
+which *would* have risked the preservation logic — is correctly rejected by both agent
+12 and agent 21. **No private-IP over-redaction risk in the recommended path.** The
+seed's central fear is fully addressed by *not doing* the thing the user worried
+about.
+
+### 3.4 Class-2 regex guard vs legitimate field naming — one real false-fire vector
+
+The regex `_IP_HOST_NAME_RE` (agent 21 §2.2) will match ANY future field whose name
+contains `ip`/`host`/`gateway`/`network`/`address`/`prefix`/`destination`/etc. as a
+token. Two false-fire vectors:
+
+1. **A non-IP field with an IP-ish name token.** Today there are exactly 2
+   (`interface`, `source_interface` — and note `interface` matches via… actually it
+   does *not* match `_IP_HOST_NAME_RE` as written; agent 21's exemption comment is
+   slightly inconsistent here — `interface` contains no listed token). The real
+   matches are `source_interface` (matches nothing in the regex either — it has no
+   `ip`/`host`/`address` token) — **so agent 21's `_IP_NAME_EXEMPT` may be solving a
+   non-problem.** *This needs the synthesis to actually run the regex against the live
+   model field list before trusting the "2 entries" claim.* **MF-8 (minor): verify the
+   exemption set empirically — run `_scan_named_fields(_IP_HOST_NAME_RE)` against the
+   current model and confirm the false-positive set is exactly what's claimed; the
+   peer reports asserted "2 entries" without showing the scan output.**
+
+2. **`prefix_length` (int).** Named with `prefix` but it's an `int`, so it fails the
+   `str in _flatten_annotation` filter — correctly NOT flagged. Good, but it shows the
+   regex+type-filter interaction is load-bearing and must be tested.
+
+The friction when the regex DOES correctly fire on a new IP field is the right
+friction (wire redaction + register, or exempt-with-reason). Actionable message
+(agent 21 §2.4). Fine.
+
+### 3.5 Would a blanket sanitizer rule mangle real fixtures? — moot, but confirm the rejection sticks
+
+Agent 12 §5 did the over-redaction homework: whole-string `ip_address()` parsing means
+free-text descriptions don't mangle (they `ValueError`), and the corpus diff is <1%.
+That analysis is sound and I have no quarrel with it. **But the recommended design
+does not adopt the blanket rule at all**, so this is moot — *provided the synthesis
+does not quietly resurrect it.* The user's verbatim phrasing ("redacts on
+`ip_address()` of ANY IP-typed field") could tempt the main thread to implement form A
+to "honor the user's words." **MF-9 (the framing fix): the synthesis must explicitly
+tell the user that form A (blanket) is being declined in favor of the guard, with the
+one-line reason "blanket is both insufficient (blind to MAC/RD/RT/community/hash) and
+the wrong altitude (a coverage problem, not a runtime problem)" — and that this better
+serves the stated goal.** This is a communication must-fix, not a code one, but it is
+the place a well-meaning actuation could go wrong.
+
+---
+
+## 4. The MAC redaction (PR-S1) — the one runtime change that needs real scrutiny
+
+This is my single largest pragmatism flag, because it is being introduced almost
+incidentally ("to make the guard green day one") while being the *only* behavior-change
+in the class-2 path and the *only* new redaction primitive in the whole run.
+
+Concerns:
+
+1. **It is a NEW redaction category, which trips a heavy doc-sync chain.** Agent 21 §7
+   correctly identifies it: SECURITY.md sanitiser table + BUG_REPORTING.md "what gets
+   sanitised" + module docstring, all in the *same commit* (AGENTS.md Hard Rule). That
+   is real work and real review surface for what is, today, a *latent* gap (no audit
+   ever found a MAC leak; agent 12 §5b.3 classifies MACs as "currently un-redacted"
+   but did not show a fixture where a real operator MAC leaks). **Is the MAC gap
+   urgent enough to ride this run?** I think not — it is exactly the kind of
+   "field N+1" the *guard* is designed to surface, so the principled move is to let
+   the guard flag it and fix it deliberately, not pre-empt it.
+
+2. **`redact_mac` makes a non-trivial design choice** (the RFC 7042 `00:00:5E:00:53:NN`
+   docs range, avoiding the VRRP `:01:` sub-block — agent 21 §3.2). That is a
+   thoughtful choice but it is *a choice*, with a follow-on open question agent 21
+   itself flags (should the well-known VRRP vMAC `00:00:5E:00:01:VRID` be *preserved*
+   like multicast is?). Unresolved design questions do not belong in a "make the guard
+   green" precursor PR.
+
+3. **The "green day one" framing creates a coupling that shouldn't exist.** Agent 21
+   structures it as "PR-S1 wires destination + MAC so PR-S2's guard is green." But the
+   guard does not *need* MAC to be green — the MAC fields can simply be **registered as
+   a documented KNOWN-GAP exemption** in the IP/MAC guard (with reason "MAC redaction
+   not yet wired — tracked"), exactly as agent 20 does for the class-1 KNOWN-GAP
+   leaves. Then the guard ships green with zero runtime change, and MAC redaction
+   becomes a clean, separately-reviewable follow-up with its own doc-sync.
+
+**MF-6: split MAC redaction (and its `redact_mac` primitive + docs-range choice + vMAC
+open question) out of the guard PR entirely.** Ship the class-2 guard with the four
+MAC fields registered as a documented gap; do MAC redaction as a deliberate follow-up
+(or defer it — it is latent, not bleeding). The `static_routes[].destination` wire-up
+is genuinely tiny (1-line `redact_cidr`, identical to existing `dhcp.network`) and can
+stay in the guard PR or also be deferred-as-documented-gap; I lean keep-it (it is a
+real, if marginal, modelled leak and the fix is trivial and uses an existing
+primitive).
+
+This trim makes the *entire class-2 fix zero-runtime-change* — which is the safest
+possible posture and matches the seed's stated preference.
+
+---
+
+## 5. Maintenance burden — who keeps the exemption lists honest?
+
+The durable-fix story lives or dies on whether the exemption sets stay honest. My
+assessment, per list:
+
+| Exemption surface | Size today | Growth rate | Honesty mechanism | Verdict |
+|---|---|---|---|---|
+| Class-1 `_WALK_EXEMPT` | ~38 (if PR-2 deferred, incl. ~12 KNOWN-GAP) | one row per new non-config field | reason strings + `test_no_stale_walk_exemptions` | **Acceptable** — guarded, reason-carrying, mirrors #149 |
+| Class-1 `_LEAF_TO_WALKER_XPATHS` | ~52 | one row per new *walked* leaf | guard-the-guard `test_no_stale_xpath_mappings` | **Too heavy — MF-1 removes it** |
+| Class-2 `_REGISTERED_IP_FIELDS` | ~26-30 | one per new IP field | forward sentinel + `stale` check | **Acceptable** (mostly documents existing coverage) |
+| Class-2 `_IP_NAME_EXEMPT` | claimed 2 | rare | reason strings | **Acceptable if MF-8 confirms the count** |
+| Marker `_NON_SENSITIVE_TEXT` (if marker adopted) | ~14 | one per new non-sensitive *string* field — **frequent** | reason strings | **Unacceptable — this is the disease; MF-4 declines it** |
+
+The decisive maintenance observation: **the marker's required meta-guard exemption set
+grows with the most common kind of field change (adding a descriptive string field),
+whereas the regex/walker exemption sets grow only on the rare addition of a
+non-indicatively-named or non-config field.** Growth-on-common-change is the
+maintenance anti-pattern; growth-on-rare-change is acceptable. This is the clearest
+pragmatic discriminator and it points away from the marker.
+
+**Who keeps them honest:** PR review, backed by (a) the reason-string requirement
+(a reviewer can challenge a bogus reason — the #149 social process, which agent 20 §4
+and agent 21 §6 both lean on and which *has held since #149* per MEMORY), and (b) the
+`stale`/`no_stale` guard-the-guard tests that force the lists to track the model. This
+is the same discipline the project already runs successfully. I am satisfied it
+scales for the regex/walker exemption sets; I am NOT satisfied it scales for the
+marker meta-guard's free-text exemption set.
+
+**Failure-message actionability:** all three proposed guards name the exact
+`Class.field` and give the two valid resolutions (handle-it / exempt-with-reason).
+Confirmed in agent 20 §3.6 and agent 21 §2.4. Good — these are not cryptic assertion
+failures.
+
+---
+
+## 6. Blast-radius sanity check — are the phase-2 churn estimates realistic?
+
+### 6.1 Class-1 PR-1 (guard) — estimate is realistic, slightly understated on data-entry
+
+- "Zero phase4 reclassification" — **CORRECT and certain.** I confirmed phase4 reads
+  matrices + cross-vendor YAMLs, never the walker (`run_full_mesh.py:334-335`,
+  `xpath_walker.py:57-60` docstring, and the new guard touches neither). A pure test
+  addition cannot move a phase4 cell.
+- "~112 leaves to enumerate, ~64 walked + ~38 exempt" — realistic *as a count*, but
+  the "mechanically derivable, one-time data entry" framing **understates the
+  judgement cost**: deciding the *reason string* for each of ~38 exemptions, and the
+  *xpath spelling* for ~52 map rows, is not pure mechanics — it is ~90 small
+  decisions. With MF-1 (drop the spelling map) and MF-3 (defer PR-2, shrinking the
+  KNOWN-GAP exemptions to documented-deferrals), the real data-entry drops to ~38
+  exemption reasons, which is honest one-evening work. **The estimate is realistic
+  only after the MF-1/MF-3 trims; as written it's ~1.5× understated.**
+
+### 6.2 Class-1 PR-2 (walk-expansion) — estimate plausible but this is where the risk lives
+
+Agent 20 §5.2 claims each walked HIGH leaf produces "drifted-against-lossy =
+EXPECTED_LOSSY (ok), not CODEC_BUG" cells because the declaration lands in the same PR
+as the walk. **That is the correct theory and matches the MEMORY St3-anycast
+precedent** (which broke exactly one `tests/unit/audit/` reconciliation test when
+matrix decl drove a CODEC_BUG→EXPECTED_LOSSY reclass). But:
+
+- The estimate "bounded, per-leaf, not a storm" is **plausible but unverified** — it
+  depends on every populating codec correctly declaring lossy/unsupported for every
+  newly-walked leaf, across up to 11 codecs and the FHRP-bearing pairs. The St3 lesson
+  in MEMORY is precisely that this kind of change *broke a test the author didn't
+  expect* and required running FULL `tests/unit` (not just `…/migration`). Agent 20
+  flags this (§5.2 "run FULL `tests/unit`") — good — but it means PR-2 is the genuinely
+  risky, regen-requiring, behavior-changing part of the run.
+- **This is the strongest argument for MF-3 (defer PR-2 out of this run).** The guard
+  (PR-1) already converts every HIGH gap into a *written, visible* KNOWN-GAP. The
+  user's goal ("fail-surfaced defaults — stop the silent recurrence") is met by the
+  guard alone: a new such leaf can no longer be added silently. Actually *walking* the
+  existing HIGH leaves is instance-cleanup, not class-kill, and it carries the only
+  real phase4 risk in the run. Stage it as a separate, later, per-surface wave (agent
+  20 §6 already proposes PR-2a/2b/2c) — but do not make it part of the "land the
+  durable fix" deliverable.
+
+### 6.3 Class-2 — estimate realistic and reassuring
+
+- "Phase4 impact: ZERO" — **CORRECT.** The sanitizer is off the migration-validate /
+  cross-mesh path entirely (it has its own walk). Confirmed. This is genuinely the
+  safer half.
+- "Fixture-corpus diff near-zero (<1%)" — sound, *for the guard + destination wire*.
+  The MAC redaction's corpus impact is "cosmetic, where a MAC is present" — agent 21
+  §9.2 correctly flags the one real risk (a test pinning a MAC literal in a
+  sanitizer-output assertion) and says grep `tests/` first. With MF-6 (MAC split out),
+  the guard PR's corpus diff is *truly* near-zero.
+
+### 6.4 Reflection-engine relocation — one shared-util coupling to get right
+
+Both agent 20 and 21 want `_reachable_canonical_models` + `_flatten_annotation`
+promoted from `test_sanitize.py:662-685` to a shared test-support module. That is the
+right DRY move, but it is a **cross-test-file refactor** that both new guards then
+depend on. Pragmatism note: do the promotion as a **tiny precursor PR (PR-0)** that
+moves the two helpers + updates the one existing import, verified green, *before*
+either guard PR — so a bug in the move can't be conflated with a guard bug. **MF-10
+(minor): sequence the shared-util extraction as its own precursor commit.** Agent 20
+§6.1 gestures at this ("ship the shared util in whichever PR lands first, or a tiny
+precursor PR") — make it explicitly the precursor.
+
+---
+
+## 7. One PR or several? Staging recommendation
+
+The peer designs propose, in aggregate, up to **8 PRs** (PR-0 shared util, PR-1 walker
+guard, PR-2a/b/c walk-expansion, PR-S1 MAC+dest, PR-S2 sanitizer guard, PR-S3 marker).
+That is too many for the class-kill, and several are the riskier instance-cleanup. My
+staging, trimmed to the durable spine:
+
+**Ship in this run (the durable fix — all zero-runtime-change, all phase4-neutral):**
+
+1. **PR-0** — promote `_reachable_canonical_models` + `_flatten_annotation` to a shared
+   test-support module; update the one secret-guard import. Green, mechanical. (MF-10)
+2. **PR-1** — the recursive **walker-coverage guard** + `_WALK_EXEMPT` (with reasons) +
+   the guard-the-guard tests (`no_stale_*`, recursive `_maximal_intent` exerciser —
+   MF-7). **Without** the spelling map (MF-1, derive walked-ness or use the ~8-row
+   override) and **without** the ratchet (MF-2). Every current HIGH gap is a documented
+   KNOWN-GAP exemption.
+3. **PR-2** — the **sanitizer IP/host + MAC coverage guard** (form B). The four MAC
+   fields **registered as a documented gap** (MF-6), the `static_routes[].destination`
+   1-line `redact_cidr` wire (its only runtime change; uses existing primitive). Green
+   day one. **No marker** (MF-4).
+
+That is **3 small PRs** (+ the trivial PR-0), ~150 net lines of test code total, zero
+behavior change beyond one trivial existing-primitive redaction, zero phase4 movement.
+That kills both classes (a new unwalked leaf → red CI; a new IP/secret/MAC field → red
+CI).
+
+**Defer out of this run (instance-cleanup + speculative, each its own later wave):**
+
+- **The class-1 walk-expansion (PR-2a/b/c)** — behavior-changing, regen-requiring,
+  carries the only real phase4 risk. The guard documents every deferral honestly as a
+  KNOWN-GAP. (MF-3)
+- **MAC redaction** (`redact_mac` primitive + 4 sites + docs-range choice + vMAC
+  open question + 3 doc-sync targets) — latent gap, deliberate follow-up. (MF-6)
+- **The typed marker** — declined-for-now, with a recorded trigger condition. (MF-4)
+
+---
+
+## 8. Does the recommended design relocate the blind spot? (pragmatism angle)
+
+The correctness review (agent 30) owns the rigorous version of this. My pragmatism
+read: **the guards relocate the blind spot from "an invisible silent loss" to "a
+visible, reason-carrying exemption line in a guarded test file" — which is a genuine
+improvement, not a wash**, for three pragmatic reasons:
+
+1. The exemption is a **diff-visible code change requiring a written reason** — a
+   reviewer sees it; the status quo (forgetting a leaf) produces *no diff at all*.
+   That asymmetry is the whole value, and it is real.
+2. The exemption sets that matter (walker `_WALK_EXEMPT`, sanitizer `_IP_NAME_EXEMPT`)
+   grow on *rare* changes (non-config field; non-indicatively-named IP field), not
+   common ones — so they don't bloat in practice. (Contrast the marker meta-guard,
+   which bloats on common changes — §5.)
+3. The reason-string + `no_stale` discipline is **already proven in this codebase**
+   (#149 has held). I am not asking the project to invent a new social process; the
+   guards reuse one that works.
+
+The honest residual (both reviews should state it): a guard cannot stop a determined
+contributor from writing a *plausible-but-wrong* reason string that a reviewer misses.
+That is a social-process risk, strictly better than today's no-signal state, and not
+fixable by more machinery without diminishing returns. Accept it; do not gold-plate
+against it (this is the second reason to drop the ratchet, MF-2 — it is machinery
+fighting a social risk).
+
+---
+
+## 9. Must-fixes (consolidated)
+
+| ID | Issue | Fix | Severity | Target |
+|---|---|---|---|---|
+| MF-1 | Class-1 `_LEAF_TO_WALKER_XPATHS` (~52 hand-typed rows) is a *second hand-maintained list* — the exact artifact this run exists to kill — and forces a map edit even for correctly-walked leaves | Derive walked-ness structurally (sentinel-diff / tolerant kebab-suffix match against `_WALKABLE`); keep at most a ~8-row `_SPELLING_OVERRIDE` for the irregular cases (`config/` iface fields, VXLAN element collapse, VLAN-SVI reuse). The only hand-maintained list should be the *exemption* set | major | `20-design-walker-guard` §3.4 |
+| MF-2 | The `test_known_gap_backlog_does_not_grow` ratchet hard-codes a baseline count (rots; circular guard) and is machinery against a social risk | Drop the ratchet; the `KNOWN-GAP:` reason-prefix grep is sufficient visibility | minor | `20-design-walker-guard` §3.7 |
+| MF-3 | Class-1 PR-2 (walk-expansion) is behavior-changing, regen-requiring, and carries the run's only real phase4 risk (the St3 precedent broke a `tests/unit/audit` test) — it is instance-cleanup, not class-kill | Defer ALL of PR-2 out of this run; the PR-1 guard already makes every HIGH gap a documented KNOWN-GAP, which satisfies the user's "stop silent recurrence" goal. Stage walk-expansion as a separate later per-surface wave | major | `20-design-walker-guard` §5.2/§6 |
+| MF-4 | The typed marker (agent 22) is over-engineering for this run: its self-enforcing form REQUIRES a meta-guard whose `_NON_SENSITIVE_TEXT` exemption set grows on the *common* change (adding a string field) — re-introducing the disease — and it adds a contributor discipline that fails silently when forgotten | Decline the marker for this run; record it in `99-synthesis.md` as a deferred escalation with the explicit trigger "a real IP/secret field ships with a non-indicative name." Ship agent 21's regex guard instead | major | `22-design-typed-marker` §5/§7 |
+| MF-5 | The marker's three cited "wins" (`engine_id`, MACs, destination) are used to justify the marker but are all capturable without it | Register `engine_id` explicitly in `_REGISTERED_SECRET_FIELDS` (it is already redacted — one-line add); handle MACs + destination via agent 21's guard. No marker needed to capture them | minor | `21`/`22` |
+| MF-6 | MAC redaction is smuggled into PR-S1 as "make the guard green" but is the run's only class-2 runtime change, invents a primitive + docs-range, has an unresolved vMAC-preservation question, and trips a 3-target doc-sync chain — for a *latent* (never-observed) leak | Split MAC redaction entirely out of the guard PR; register the 4 MAC fields as a documented gap so the guard is green with zero runtime change. Do `redact_mac` as a deliberate follow-up (or defer — it's latent) | major | `21-design-sanitizer-guard` §3.2 |
+| MF-7 | The class-1 guard reads `_WALKABLE` (built from `_maximal_intent`) but nothing asserts `_maximal_intent` populates every *nested* walked leaf — the existing exerciser `test_maximal_intent_exercises_every_top_level_field` is top-level-only, so the new guard can pass VACUOUSLY if a nested sub-field is left empty in the fixture | Add a recursive sibling that asserts the kitchen-sink populates every non-exempt nested leaf | minor | `20-design-walker-guard` §3.6 |
+| MF-8 | Agent 21 asserts `_IP_NAME_EXEMPT` is "2 entries" but the regex as written may not actually match `interface`/`source_interface` (no `ip`/`host`/`address` token) — the false-positive set is unverified | Run `_scan_named_fields(_IP_HOST_NAME_RE)` against the live model and confirm the exemption set empirically before trusting the count; tune the regex/exemptions to the real result | minor | `21-design-sanitizer-guard` §2.3 |
+| MF-9 | The user's verbatim goal names the blanket `ip_address()` rule (form A); a well-meaning actuation could resurrect it. The synthesis must close that door explicitly | In `99-synthesis.md`, state plainly that form A is declined (insufficient: blind to MAC/RD/RT/community/hash; wrong altitude: coverage not runtime) and that the guard better serves the stated goal | minor (communication) | synthesis |
+| MF-10 | Both guards depend on a shared reflection engine extracted from `test_sanitize.py` — a cross-file refactor that, if bundled into a guard PR, conflates a move-bug with a guard-bug | Do the `_reachable_canonical_models`/`_flatten_annotation` extraction as a tiny green precursor PR-0 before either guard | minor | `20` §6.1 / `21` |
+
+---
+
+## 10. Over-engineering flags (the short list for synthesis)
+
+1. **`_LEAF_TO_WALKER_XPATHS` spelling map** — a second hand-maintained list; the
+   class-kill needs only the exemption set. (MF-1)
+2. **`test_known_gap_backlog_does_not_grow` ratchet** — hard-coded count + machinery
+   vs a social risk. (MF-2)
+3. **The typed `Sensitive` marker** — a new contributor discipline + a meta-guard with
+   a growing free-text exemption list, to fix a low-probability deceptive-name residual
+   that doesn't exist in the current model. (MF-4)
+4. **The marker meta-guard's `_NON_SENSITIVE_TEXT` set** — the clearest "relocates the
+   blind spot" artifact in the whole design space; grows on the most common field
+   change. (folds into MF-4)
+5. **Bundling MAC redaction + a new primitive + a docs-range decision into a "green
+   the guard" precursor** — scope creep on a latent gap. (MF-6)
+
+## 11. What is correctly minimal (do NOT trim further)
+
+- The recursive **reflection over `model_fields`** to reach nested leaves — this is
+  the irreducible core that closes the top-level-only hole; both existing guards stop
+  at the top level (confirmed `:534`, `:165-184`). Keep.
+- The **`_WALK_EXEMPT` set with reason strings + `test_no_stale_walk_exemptions`** —
+  this IS the #149 pattern, proven; it is the right and necessary hand-maintained list.
+- Agent 21's **regex IP/host coverage half + forward sentinel** — ~70 lines reusing the
+  proven engine; the minimal class-2 fix.
+- Reusing **`_WALKABLE`** and the **existing render-reparse survival guards** as
+  backstops rather than re-deriving them.
+
+---
+
+## 12. Citations index (independently verified)
+
+- #149 self-justifying exemption (the precedent both designs lean on):
+  `tests/unit/migration/test_registry_capability_honesty.py:323-346`
+  (`_SYNTHETIC_NONWALKABLE` + `_is_legitimate_nonwalkable` — note it is a *predicate*,
+  not a per-path lookup table; the model for MF-1).
+- Top-level-only forward coverage (the hole the walker guard fills):
+  `:527-541` (`test_marker_dict_covers_every_data_bearing_field` reflects
+  `set(CanonicalIntent.model_fields)` — no recursion); top-level-only exerciser
+  `:544-556`.
+- `_WALKABLE = frozenset(_walk_canonical(_maximal_intent()))`: `:225`.
+- Reflection engine (to be promoted, MF-10): `tests/unit/tools/test_sanitize.py:662-685`.
+- Secret guard the class-2 fix extends: `test_sanitize.py:646-767`; the explicit
+  "IP/PII deliberately scoped out of the secret guard" comment: `:770-782`.
+- Render-reparse value-survival backstops (why a tolerant walked-ness match is safe,
+  MF-1): `test_registry_capability_honesty.py:601-629`
+  (`test_static_route_subfield_and_secondary_drops_are_declared`).
+- Per-codec G5 floor (top-level + hand-listed sub-fields; the different kitchen-sink,
+  MF-7 coupling): `tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py:165-208`.
+- Peer reports: `10-model-leaf-census.md` (~112 leaves), `11-walker-gap.md` (§4 gap,
+  §6 two-surface backstop, §7 #149), `12-sanitizer-gap.md` (§5 over-redaction, §6 form
+  B), `20-design-walker-guard.md` (§3 guard shape, §5 blast radius), `21-design-
+  sanitizer-guard.md` (§2 guard, §3 MAC/dest, §9 blast radius), `22-design-typed-marker.md`
+  (§5 over-engineering ledger, §8 meta-guard Achilles heel).

--- a/docs/reviews/2026-06-24-fail-surfaced-defaults/99-synthesis.md
+++ b/docs/reviews/2026-06-24-fail-surfaced-defaults/99-synthesis.md
@@ -1,0 +1,146 @@
+# 99 — Synthesis + decision (main thread)
+
+**Run:** 2026-06-24 · fail-surfaced-defaults · netcanon
+**Author:** main thread (Claude), after reading all 8 agent reports.
+**Both reviews:** GO-WITH-FIXES. No NO-GO.
+
+---
+
+## The decision in one paragraph
+
+Kill both recurring classes with **two reflection-driven completeness GUARDS**
+(CI tests, **zero runtime change, zero phase4 movement**), plus a tiny shared
+reflection module. Each guard triggers on **field existence** — the only
+mechanism faithful to "fail-surfaced *defaults*" (a newly-added field defaults
+to CI-red until consciously handled-or-exempted). **Decline** the runtime
+blanket `ip_address()` rule (form A) and the typed marker (form C). **Defer**
+all instance-cleanup (walking the HIGH gap leaves; wiring MAC + static-route
+redaction) — the guards make every current gap a *visible, tracked* exemption,
+which is the class-kill the user asked for; the cleanups are safe follow-ups the
+guards now force.
+
+## Why not form A (runtime blanket `ip_address()`) — MF-9, stated for the user
+
+The user's verbatim goal named "redact on `ip_address()` of ANY IP-typed field,
+not an allow-list." We are **declining the literal runtime form** because both
+the sanitizer-gap analysis (12) and both designs (21/22) show it is
+(a) **insufficient** — `ip_address()` is blind to MACs, RD/RT (`64496:N`),
+multicast, communities, hashes, hostnames, and CIDR fields (which raise on bare
+`ip_address()`); it would have to be bolted onto the existing 41 redaction sites,
+not replace them; and (b) **the wrong altitude** — the leak class is "a new field
+is forgotten" (a *coverage* defect caught best at test time), not a runtime
+behavior defect. The user's *instinct* — "ANY field, not a curated subset" — is
+exactly right and is delivered by the existence-triggered guard, which fails-RED
+on any unhandled field rather than silently redacting only the bare-IP subset.
+
+## Class-1 (silent capability-loss) — walker completeness guard
+
+Adopt agent 20's **design B** (recursive reflection guard). The gap concentrates
+in *nested* model sub-leaves (VRRP group, DHCP pool, SNMPv3 user, EVPN-Type5);
+the two existing forward-coverage checks both stop at top-level `CanonicalIntent`
+fields and never recurse — that is the precise hole. The guard recurses through
+`model_fields` into nested models and FAILS when a scalar leaf is neither walked
+(emits an xpath in `_WALKABLE`) nor in a self-justifying exemption set.
+
+Applied fixes from review:
+- **MF-1 (pragmatism): drop the ~52-row `_LEAF_TO_WALKER_XPATHS` spelling map.**
+  Derive walked-ness by a tolerant kebab/suffix match of the field name against
+  `_WALKABLE`, keeping only a *small* `_SPELLING_OVERRIDE` for the genuine
+  irregulars (the reused VLAN-SVI `ip`, VXLAN element collapse). The only
+  hand-maintained list is the *exemption* set (the meaningful one). Tolerant
+  false-"walked" is backstopped by the existing render-reparse value-survival
+  guards.
+- **MF-1 (correctness): structured exemption reason CODES**, not free text — a
+  small `Literal[...]` (`METADATA`, `TRANSFORM_HINT`, `DISCRIMINATOR_TRAVELS`,
+  `ENVELOPE_AUDIT_BACKSTOPPED`, `KNOWN_GAP`) + a free-text note. No honest code
+  fits "a leaf I didn't want to walk," so the lazy-exempt path has no green door.
+- **MF-3 (correctness): unit-test the leaf enumerator itself** against a tiny
+  synthetic model (scalar / list[scalar] / nested-model / dict / `Literal`).
+- **MF-2 (pragmatism): drop the KNOWN-GAP ratchet** (hard-coded count; machinery
+  vs a social risk). The `KNOWN_GAP` reason code is greppable; that suffices.
+- **MF-3 (pragmatism) / PR-2 deferral:** do **not** walk the HIGH gap leaves in
+  this run — that is behavior-changing + phase4-sensitive (the St3 precedent). The
+  ~11 HIGH leaves ship as `KNOWN_GAP` exemptions (visible, tracked). Walk-expansion
+  is a separate later per-surface wave.
+
+## Class-2 (sanitizer-bypass) — existence-partition guard (the fork, resolved)
+
+The reviewers split: correctness (30) showed agent 21's **name-regex** guard
+PASSES a deceptively-named new IP field (`peer: str`) — it relocates the blind
+spot to the regex token list, so it does **not** kill the class; it demanded
+agent 22's **typed marker + unmarked-string meta-guard**. Pragmatism (31) showed
+the typed marker is over-engineering — a new contributor discipline that fails
+silently when forgotten, whose required meta-guard exemption set grows on the
+*common* change (adding a descriptive string field).
+
+**Resolution (a HYBRID neither stated outright):** adopt correctness's
+*existence trigger* without pragmatism's-objected *typed marker*. The guard
+partitions **every `str`/`list[str]` leaf** reachable from `CanonicalIntent` into
+exactly one of three reason-coded sets:
+
+1. `_SENSITIVE_REDACTED` — redacted by `sanitize_intent` today (verified by the
+   forward sentinel; reuses the existing `_REGISTERED_SECRET_FIELDS` + an IP set).
+2. `_SENSITIVE_GAP` — sensitive but redaction not yet wired (the 4 MAC fields +
+   `static_routes[].destination`); reason `KNOWN_GAP`, tracked.
+3. `_NON_SENSITIVE` — genuinely non-sensitive free-text/enum/identifier
+   (`description`, `mode`, `interface_type`, …); structured reason code.
+
+The class-killer: a NEW `str` leaf (e.g. `peer: str` holding an IP) is in **none**
+of the three → guard FAILS naming `(Class, field)`. This triggers on *existence*
+(faithful; catches the S4 deceptive-name case the regex misses) and needs **no
+typed marker** (no `Annotated[str, Sensitive(...)]`, no new contributor idiom — a
+field is classified by adding it to one of three reviewed sets, the binary
+decision the goal demands). The registries double as documentation of what the
+sanitizer covers.
+
+Why this beats both standalone recommendations:
+- vs regex (21): regex triggers on *name* → blind to `peer: str`. Existence
+  partition triggers on *name-independent existence* → catches it. (correctness)
+- vs marker (22): no per-field annotation discipline; the "is this sensitive?"
+  decision lives in three small reviewed sets, not a marker a contributor forgets
+  silently. The `_NON_SENSITIVE` set growth is the *accepted, safe* cost of
+  existence-triggering (over-flag-safe ≫ under-redact-unsafe) — and it is the
+  unavoidable price of catching S4, which the user's goal demands. (pragmatism's
+  marker objection addressed; its growth objection accepted as the cost of
+  faithfulness.)
+- **MF-1 (correctness): structured reason codes** on the exemption/gap sets, so a
+  sensitive field cannot be lazily dumped into `_NON_SENSITIVE`.
+- Keep the existing secret guard untouched (it ships green); the new partition
+  guard subsumes its coverage as a superset and is additive.
+
+Deferred (MF-4/MF-6): the typed marker (declined; reserved escalation **if** a
+real IP/secret field ever ships with a non-indicative name); `redact_mac` +
+docs-MAC-range + the vMAC-preservation question; the `static_routes[].destination`
+`redact_cidr` wire. All three are documented `KNOWN_GAP`s the guard now surfaces.
+
+## Shared util (MF-10)
+
+Extract `_flatten_annotation` + `_reachable_canonical_models` from
+`test_sanitize.py` to `tests/support/canonical_reflection.py` (+ the leaf
+enumerators + the MF-3 enumerator unit test). Both guards + the existing secret
+guard import it. Folded into the class-1 PR (the full suite verifies the move did
+not break the secret guard — the move is two functions).
+
+## What ships this run (PRs)
+
+- **PR-A (class-1 + shared util):** `tests/support/canonical_reflection.py`
+  (reflection + leaf enumerators + enumerator unit test) + update
+  `test_sanitize.py` imports + `tests/unit/migration/test_walker_completeness.py`
+  (the walker completeness guard + guard-the-guard tests + KNOWN_GAP exemptions).
+  Zero runtime change, zero phase4.
+- **PR-B (class-2):** the existence-partition sanitizer guard added to
+  `test_sanitize.py`. Zero runtime change, zero phase4.
+
+Both are test-only ⇒ merge-on-green autonomous (not release-pipeline). Each is
+verified by (1) full `tests/unit` green and (2) a **synthetic-leaf-injection
+proof** — temporarily add an unhandled leaf and confirm the guard goes RED — to
+demonstrate the class-kill (not just that it is green today).
+
+## Deferred follow-ups (the guards now force/track these)
+
+| Item | Why deferred | Tracked as |
+|---|---|---|
+| Walk the ~11 HIGH gap leaves (VRRP mode/priority/preempt/adv-int/auth/v6-VIP; SNMPv3 priv-passphrase/protocols; IPv6 scope; routing-instance instance-type) | behavior-changing + phase4 regen (St3 precedent) | class-1 `KNOWN_GAP` exemptions |
+| `redact_mac` + 4 MAC sites | new primitive + docs-range + vMAC-preservation design Q + 3-target doc-sync; latent (never-observed) leak | class-2 `_SENSITIVE_GAP` |
+| `static_routes[].destination` `redact_cidr` wire | trivial but a runtime change; keep the guard PRs zero-runtime | class-2 `_SENSITIVE_GAP` |
+| Typed marker | over-engineering for the current model's naming discipline | reserved escalation |

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared, non-fixture test-support helpers importable as ``tests.support.*``."""

--- a/tests/support/canonical_reflection.py
+++ b/tests/support/canonical_reflection.py
@@ -58,12 +58,28 @@ def flatten_annotation(ann) -> typing.Iterator:
 def reachable_models(root_cls: type[BaseModel], acc: set | None = None) -> set:
     """Return every ``BaseModel`` subclass reachable from *root_cls* via its
     (possibly nested / list-wrapped / optional) field annotations, including
-    *root_cls* itself."""
+    *root_cls* itself.
+
+    Forces forward-reference resolution first. With ``from __future__ import
+    annotations``, a field annotating a class defined LATER in the same module
+    (e.g. ``CanonicalInterface.vrrp_groups: list[CanonicalVRRPGroup]`` —
+    ``CanonicalVRRPGroup`` is defined further down) stays an unresolved
+    ``ForwardRef`` whose ``get_args()`` is empty until the owning model is
+    rebuilt — so the nested class would be INVISIBLE to this walk (and the
+    completeness guards would silently miss every leaf under it). ``model_rebuild
+    (force=True)`` resolves the annotations in place, deterministically, whether
+    or not an instance has been constructed first (relying on instance
+    construction to resolve refs is an import-order accident, not a guarantee).
+    """
     if acc is None:
         acc = set()
     if root_cls in acc:
         return acc
     acc.add(root_cls)
+    try:
+        root_cls.model_rebuild(force=True)
+    except Exception:  # pragma: no cover - rebuild is best-effort; a model with
+        pass           # a genuinely unresolvable ref will simply not recurse.
     for fld in root_cls.model_fields.values():
         for t in flatten_annotation(fld.annotation):
             if isinstance(t, type) and issubclass(t, BaseModel):

--- a/tests/support/canonical_reflection.py
+++ b/tests/support/canonical_reflection.py
@@ -1,0 +1,120 @@
+"""Reflection over the canonical model — the shared spine of the
+fail-surfaced-defaults completeness guards.
+
+Two recurring blind-spot classes (see
+``docs/reviews/2026-06-24-fail-surfaced-defaults/``) both stem from a
+hand-maintained *subset* of the canonical model's leaves with a permissive
+default:
+
+* the migration walker (`_walk_canonical`) yields a subset of leaves and
+  ``classify()`` defaults any *unwalked* leaf to ``supported`` — so a silently
+  dropped field reports ``severity: ok`` (the silent capability-loss class), and
+* the sanitizer (`sanitize_intent`) redacts a subset of fields — so a new
+  IP/secret-bearing field leaks verbatim (the sanitizer-bypass class).
+
+The durable fix in both cases is a CI **completeness guard** that enumerates the
+*full* leaf universe by reflection and FAILS when a leaf is neither handled nor
+in a self-justifying exemption set. Both guards enumerate the SAME universe, so
+the enumerators live here, in one place, rather than being re-derived per guard.
+
+These helpers were first proven in the secret-coverage guard
+(``tests/unit/tools/test_sanitize.py``) against pydantic v2 +
+``from __future__ import annotations``: pydantic resolves
+``model_fields[name].annotation`` to the *live type object* at class-build time,
+so we introspect that — NOT ``typing.get_type_hints`` on the raw class, which can
+choke on forward refs and needs the defining module's globals.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from pydantic import BaseModel
+
+#: Scalar leaf types. A field whose flattened annotation contains one of these
+#: is data-bearing (a scalar or a list/optional of a scalar), as opposed to a
+#: pure nested-model container (whose *children* are the leaves).
+SCALAR_TYPES: tuple[type, ...] = (str, int, bool, float)
+
+
+def flatten_annotation(ann) -> typing.Iterator:
+    """Yield *ann* and every nested type argument.
+
+    Unwraps ``list[...]`` / ``Optional[...]`` / ``dict[...]`` / unions by
+    recursing through ``typing.get_args``. A leaf annotation (no args) yields
+    itself. NB: ``Literal["a", "b"]`` yields the *values* ``"a"``, ``"b"`` (string
+    instances, not the ``str`` type) — callers that care must detect ``Literal``
+    via :func:`typing.get_origin`; the current canonical model has no ``Literal``
+    field (pinned by ``test_canonical_reflection``).
+    """
+    args = typing.get_args(ann)
+    if not args:
+        yield ann
+        return
+    for a in args:
+        yield from flatten_annotation(a)
+
+
+def reachable_models(root_cls: type[BaseModel], acc: set | None = None) -> set:
+    """Return every ``BaseModel`` subclass reachable from *root_cls* via its
+    (possibly nested / list-wrapped / optional) field annotations, including
+    *root_cls* itself."""
+    if acc is None:
+        acc = set()
+    if root_cls in acc:
+        return acc
+    acc.add(root_cls)
+    for fld in root_cls.model_fields.values():
+        for t in flatten_annotation(fld.annotation):
+            if isinstance(t, type) and issubclass(t, BaseModel):
+                reachable_models(t, acc)
+    return acc
+
+
+def _is_scalar(t) -> bool:
+    return isinstance(t, type) and issubclass(t, SCALAR_TYPES)
+
+
+def _is_model(t) -> bool:
+    return isinstance(t, type) and issubclass(t, BaseModel)
+
+
+def scalar_leaves(root_cls: type[BaseModel]) -> set[tuple[str, str]]:
+    """``(ModelName, field)`` for every data-bearing *scalar / list-of-scalar*
+    leaf reachable from *root_cls*.
+
+    A pure nested-model container (``interfaces: list[CanonicalInterface]``) is
+    NOT a leaf — its child fields are (recursion via :func:`reachable_models`
+    covers them). A field whose flattened annotation has neither a scalar nor a
+    ``BaseModel`` (e.g. a bare ``dict``) IS yielded, so the caller's exemption set
+    must consciously account for it (fail-surfaced: an unclassifiable field is
+    surfaced, not silently skipped).
+    """
+    out: set[tuple[str, str]] = set()
+    for model in reachable_models(root_cls):
+        for fname, fld in model.model_fields.items():
+            flat = set(flatten_annotation(fld.annotation))
+            has_scalar = any(_is_scalar(t) for t in flat)
+            has_model = any(_is_model(t) for t in flat)
+            if has_model and not has_scalar:
+                continue  # pure nested-model container — children are the leaves
+            out.add((model.__name__, fname))
+    return out
+
+
+def str_leaves(root_cls: type[BaseModel]) -> set[tuple[str, str]]:
+    """``(ModelName, field)`` for every leaf whose flattened annotation contains
+    ``str`` (a ``str`` scalar, ``list[str]``, ``Optional[str]``, or a
+    ``dict[..., str]``) reachable from *root_cls*.
+
+    This is the universe the sanitizer partition guard classifies: only ``str``
+    leaves can carry a free-form IP / host / secret. Pure nested-model containers
+    and non-``str`` scalars (``int`` ports, ``bool`` flags) are excluded — they
+    cannot hold an operator-supplied IP/secret literal.
+    """
+    out: set[tuple[str, str]] = set()
+    for model in reachable_models(root_cls):
+        for fname, fld in model.model_fields.items():
+            if str in set(flatten_annotation(fld.annotation)):
+                out.add((model.__name__, fname))
+    return out

--- a/tests/unit/migration/test_walker_completeness.py
+++ b/tests/unit/migration/test_walker_completeness.py
@@ -1,0 +1,322 @@
+"""Forward completeness guard for the migration walker (silent capability-loss
+class — blind-audit meta-finding, ``docs/reviews/2026-06-24-fail-surfaced-defaults``).
+
+THE CLASS (not an instance): ``_walk_canonical`` yields a *subset* of the
+canonical model's leaves, and ``classify()`` defaults any *unwalked* leaf to
+``supported`` — so a codec that silently drops that field on render reports
+``severity: ok``. Five blind-audit rounds each found a NEW instance of this same
+class (switchport -> static-route -> VXLAN -> VLAN port-membership #172 ->
+VLAN-SVI L3 #175). Point-fixes don't converge.
+
+THE DURABLE FIX (fail-surfaced default): this guard enumerates EVERY scalar leaf
+reachable from ``CanonicalIntent`` (recursing into nested models — the two prior
+forward-coverage checks stop at top-level ``CanonicalIntent`` fields and never
+recurse, which is exactly the hole) and FAILS when a leaf is neither walked nor
+in a self-justifying exemption set. A NEW leaf added without a walker yield now
+turns CI **red** instead of silently classifying ``supported`` — the default
+flips from "silently fine" to "surfaced." This is a CI test: **zero runtime
+change, zero phase4 movement** (``classify()``/phase4 do not consume this guard).
+
+WALKED-NESS is derived, not hand-listed per leaf: a leaf ``(Class, field)`` is
+"walked" iff the walker emits an xpath equal to one of the leaf's *expected*
+xpaths — its class container prefix(es) + the field's segment spelling. This is
+robust against a same-named NEW field (e.g. a new ``CanonicalInterface.ip`` does
+NOT match the nested ``/interfaces/interface/ipv4/address/ip``, because the
+expected ``/interfaces/interface/ip`` is not emitted) — a plain suffix match
+would have that class-kill hole. The container map (~16 rows) + segment overrides
+(~7 rows) are guarded against typos/staleness below, and the derivation is
+verified exhaustively against the live walker by ``_walked_leaves``.
+
+DEFERRED (tracked here as ``KNOWN_GAP`` exemptions, NOT fixed in this run): the
+~11 HIGH-value currently-unwalked leaves (VRRP mode/priority/preempt/adv-int/
+auth/v6-VIP, SNMPv3 priv-passphrase/protocols/group, IPv6 scope,
+routing-instance instance-type). Actually *walking* them is behaviour-changing +
+phase4-regen work (the St3-anycast precedent broke a ``tests/unit/audit`` test),
+so it is a separate per-surface follow-up. The guard makes every deferral a
+visible, greppable ``KNOWN_GAP`` line rather than an invisible silent loss.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import CanonicalIntent
+from netcanon.migration.canonical.xpath_walker import _walk_canonical
+from tests.support.canonical_reflection import scalar_leaves
+
+# Reuse the established kitchen-sink that populates every conditionally-walked
+# surface (the same one that builds the reverse-parity _WALKABLE universe), so
+# "what xpaths CAN the walker emit" is computed from one source of truth.
+from tests.unit.migration.test_registry_capability_honesty import _maximal_intent
+
+pytestmark = pytest.mark.unit
+
+
+#: Every xpath the shared walker emits when every surface is populated.
+_WALKABLE = frozenset(_walk_canonical(_maximal_intent()))
+
+#: Per-class xpath container prefix(es). A leaf's expected xpath is
+#: ``container + segment``; a leaf is "walked" iff any expected xpath is in
+#: ``_WALKABLE``. Two prefixes where a class is mounted under two trees
+#: (CanonicalIPv4Address: interface + VLAN-SVI) or where some fields sit under a
+#: ``config/`` sub-segment (CanonicalInterface). An EMPTY tuple means only the
+#: container *anchor* is walked, not its sub-leaves (DHCP pool / EVPN-Type5
+#: route) — so all that class's sub-leaves resolve to not-walked and must be
+#: exempt. Guarded against typos by ``test_class_containers_have_no_dead_prefixes``.
+_CLASS_CONTAINERS: dict[str, tuple[str, ...]] = {
+    "CanonicalIntent": ("/system/", "/"),
+    "CanonicalInterface": (
+        "/interfaces/interface/",
+        "/interfaces/interface/config/",
+    ),
+    "CanonicalIPv4Address": (
+        "/interfaces/interface/ipv4/address/",
+        "/vlans/vlan/ipv4/address/",
+    ),
+    "CanonicalIPv6Address": ("/interfaces/interface/ipv6/address/",),
+    "CanonicalVlan": ("/vlans/vlan/",),
+    "CanonicalVRRPGroup": ("/interfaces/interface/vrrp-groups/group/",),
+    "CanonicalStaticRoute": ("/routing/static-route/",),
+    "CanonicalSNMP": ("/snmp/",),
+    "CanonicalSNMPv3User": ("/snmp/v3-user/",),
+    "CanonicalLAG": ("/lags/lag/",),
+    "CanonicalLocalUser": ("/local-users/user/",),
+    "CanonicalRADIUSServer": ("/radius-servers/server/",),
+    "CanonicalVxlan": ("/vxlan-vnis/",),
+    "CanonicalRoutingInstance": ("/routing-instances/instance/",),
+    # Anchor-only (sub-leaves not walked -> all exempt below):
+    "CanonicalDHCPPool": (),
+    "CanonicalEvpnType5Route": (),
+}
+
+#: Field-name -> xpath-segment overrides where the walker's spelling diverges
+#: from ``field.replace("_", "-")`` (singularised list fields; two renames).
+#: Guarded against staleness by ``test_segment_overrides_reference_real_leaves``.
+_SEGMENT_OVERRIDE: dict[tuple[str, str], str] = {
+    ("CanonicalIntent", "dns_servers"): "dns-server",
+    ("CanonicalIntent", "ntp_servers"): "ntp-server",
+    ("CanonicalIntent", "syslog_servers"): "syslog-server",
+    ("CanonicalSNMP", "trap_hosts"): "trap-host",
+    ("CanonicalInterface", "interface_type"): "type",
+    ("CanonicalIPv4Address", "is_secondary"): "secondary-ip",
+    ("CanonicalIPv6Address", "is_secondary"): "secondary-ip",
+}
+
+#: Structured reason codes (no free text "I didn't want to walk this" door).
+#: METADATA               provenance / notification surface, never a config leaf
+#: TRANSFORM_HINT         render mechanism, not an operator fidelity surface
+#: DISCRIMINATOR_TRAVELS  identity that travels with its walked container anchor
+#: ENVELOPE_AUDIT_BACKSTOPPED  sub-leaf of a walked envelope; the offline
+#:                        cross-mesh model_dump audit catches its loss (the live
+#:                        migrate-report is blind, but the audit is not)
+#: KNOWN_GAP              a REAL currently-silent loss this guard surfaces;
+#:                        deferred to a per-surface walk-expansion follow-up
+_REASON_CODES = frozenset({
+    "METADATA",
+    "TRANSFORM_HINT",
+    "DISCRIMINATOR_TRAVELS",
+    "ENVELOPE_AUDIT_BACKSTOPPED",
+    "KNOWN_GAP",
+})
+
+#: Leaves the guard does NOT require to be walked, each (code, note). Adding an
+#: entry is a visible, reviewable act with a code a reviewer can challenge — a
+#: BGP-peer-IP-class leaf has no honest code here (modelled on #149's
+#: predicate-based self-justifying exemptions).
+_WALK_EXEMPT: dict[tuple[str, str], tuple[str, str]] = {
+    # ── Provenance / notification metadata (never a translatable surface) ──
+    ("CanonicalIntent", "source_vendor"): ("METADATA", "codec that produced the tree"),
+    ("CanonicalIntent", "source_format"): ("METADATA", "source input_format hint"),
+    ("CanonicalIntent", "source_version"): ("METADATA", "source OS-version hint"),
+    ("CanonicalIntent", "raw_sections"): ("METADATA", "Tier-3 verbatim blob; own banner, never auto-rendered"),
+    ("CanonicalIntent", "dropped_tier3_sections"): ("METADATA", "notification-only; own migrate banner"),
+    ("CanonicalIntent", "apply_groups"): ("METADATA", "Junos apply-groups provenance hint"),
+    ("CanonicalIntent", "group_content"): ("METADATA", "Junos group-body provenance"),
+    # ── Transform hints / render mechanics (not operator-visible fidelity) ──
+    ("CanonicalInterface", "kind"): ("TRANSFORM_HINT", "rename-mesh hint, not a render surface"),
+    ("CanonicalInterface", "default_name"): ("TRANSFORM_HINT", "MikroTik factory-name render mechanism"),
+    # ── Identity discriminators that travel with their walked anchor ──
+    ("CanonicalVRRPGroup", "group_id"): ("DISCRIMINATOR_TRAVELS", "/vrrp-groups/group anchor keyed by it"),
+    ("CanonicalSNMPv3User", "name"): ("DISCRIMINATOR_TRAVELS", "/snmp/v3-user anchor keyed by it"),
+    ("CanonicalStaticRoute", "destination"): ("DISCRIMINATOR_TRAVELS", "/routing/static-route anchor is the dest"),
+    # ── Envelope-covered sub-leaves: anchor walked; loss caught by the offline
+    #    cross-mesh model_dump audit (live migrate-report blind, audit is not) ──
+    ("CanonicalDHCPPool", "network"): ("ENVELOPE_AUDIT_BACKSTOPPED", "/dhcp-servers/pool envelope walked"),
+    ("CanonicalDHCPPool", "start_ip"): ("ENVELOPE_AUDIT_BACKSTOPPED", "DHCP pool option; audit-backstopped"),
+    ("CanonicalDHCPPool", "end_ip"): ("ENVELOPE_AUDIT_BACKSTOPPED", "DHCP pool option; audit-backstopped"),
+    ("CanonicalDHCPPool", "gateway"): ("ENVELOPE_AUDIT_BACKSTOPPED", "DHCP pool option; audit-backstopped"),
+    ("CanonicalDHCPPool", "dns_servers"): ("ENVELOPE_AUDIT_BACKSTOPPED", "DHCP pool option; audit-backstopped"),
+    ("CanonicalDHCPPool", "lease_time"): ("ENVELOPE_AUDIT_BACKSTOPPED", "DHCP pool option; audit-backstopped"),
+    ("CanonicalDHCPPool", "domain_name"): ("ENVELOPE_AUDIT_BACKSTOPPED", "DHCP pool option; audit-backstopped"),
+    ("CanonicalDHCPPool", "interface"): ("ENVELOPE_AUDIT_BACKSTOPPED", "DHCP pool bind-iface; audit-backstopped"),
+    ("CanonicalEvpnType5Route", "vrf"): ("ENVELOPE_AUDIT_BACKSTOPPED", "/evpn-type5-routes/route envelope walked"),
+    ("CanonicalEvpnType5Route", "prefix"): ("ENVELOPE_AUDIT_BACKSTOPPED", "EVPN-Type5 sub-leaf; audit-backstopped"),
+    ("CanonicalEvpnType5Route", "rt_imports"): ("ENVELOPE_AUDIT_BACKSTOPPED", "EVPN-Type5 sub-leaf; audit-backstopped"),
+    ("CanonicalEvpnType5Route", "rt_exports"): ("ENVELOPE_AUDIT_BACKSTOPPED", "EVPN-Type5 sub-leaf; audit-backstopped"),
+    ("CanonicalRADIUSServer", "auth_port"): ("ENVELOPE_AUDIT_BACKSTOPPED", "defaulted 1812; non-default backstopped"),
+    ("CanonicalRADIUSServer", "acct_port"): ("ENVELOPE_AUDIT_BACKSTOPPED", "defaulted 1813; non-default backstopped"),
+    # ── KNOWN_GAP: real currently-silent losses, deferred to walk-expansion ──
+    ("CanonicalIPv6Address", "scope"): ("KNOWN_GAP", "link-local discriminator not walked; PR-2"),
+    ("CanonicalRoutingInstance", "instance_type"): ("KNOWN_GAP", "mac-vrf vs vrf not walked; PR-2"),
+    ("CanonicalSNMPv3User", "auth_protocol"): ("KNOWN_GAP", "auth algorithm downgrade not walked; PR-2"),
+    ("CanonicalSNMPv3User", "priv_protocol"): ("KNOWN_GAP", "priv cipher downgrade not walked; PR-2"),
+    ("CanonicalSNMPv3User", "priv_passphrase"): ("KNOWN_GAP", "privacy key unwalked; sanitizer redacts it; PR-2"),
+    ("CanonicalSNMPv3User", "group"): ("KNOWN_GAP", "VACM group not walked; PR-2 (lower)"),
+    ("CanonicalVRRPGroup", "mode"): ("KNOWN_GAP", "FHRP family (hsrp/carp/vrrp) not walked; PR-2"),
+    ("CanonicalVRRPGroup", "priority"): ("KNOWN_GAP", "master-election priority not walked; PR-2"),
+    ("CanonicalVRRPGroup", "preempt"): ("KNOWN_GAP", "failover preempt not walked; PR-2"),
+    ("CanonicalVRRPGroup", "advertisement_interval"): ("KNOWN_GAP", "advert timer not walked; PR-2"),
+    ("CanonicalVRRPGroup", "authentication"): ("KNOWN_GAP", "FHRP auth unwalked; sanitizer redacts it; PR-2"),
+    ("CanonicalVRRPGroup", "virtual_ipv6s"): ("KNOWN_GAP", "IPv6 VIP list not walked; PR-2"),
+    ("CanonicalVRRPGroup", "description"): ("KNOWN_GAP", "group free-text not walked; PR-2 (low stakes)"),
+    ("CanonicalStaticRoute", "gateway"): ("KNOWN_GAP", "next-hop not walked; PR-2"),
+}
+
+
+def _expected_xpaths(cls: str, field: str) -> tuple[str, ...]:
+    """The xpath(s) the walker is expected to emit for leaf ``(cls, field)``,
+    or ``()`` if the leaf's class is anchor-only / unknown (-> not walked)."""
+    containers = _CLASS_CONTAINERS.get(cls)
+    if not containers:
+        return ()
+    seg = _SEGMENT_OVERRIDE.get((cls, field), field.replace("_", "-"))
+    return tuple(c + seg for c in containers)
+
+
+def _walked_leaves() -> set[tuple[str, str]]:
+    """Every scalar leaf whose expected xpath the walker actually emits."""
+    return {
+        leaf
+        for leaf in scalar_leaves(CanonicalIntent)
+        if any(xp in _WALKABLE for xp in _expected_xpaths(*leaf))
+    }
+
+
+# ---------------------------------------------------------------------------
+# The class-kill: every model leaf is walked OR self-justifyingly exempt
+# ---------------------------------------------------------------------------
+
+
+def test_every_model_leaf_is_walked_or_exempt():
+    """Every data-bearing scalar leaf reachable from CanonicalIntent (recursing
+    into nested models) is either emitted by ``_walk_canonical`` (so the live
+    validation report can classify it) OR carries a written, reason-coded
+    exemption. A NEW leaf added without a walker yield + per-codec declaration
+    turns this RED instead of silently classifying ``supported`` (the class kill).
+    """
+    walked = _walked_leaves()
+    unhandled = sorted(
+        leaf
+        for leaf in scalar_leaves(CanonicalIntent)
+        if leaf not in walked and leaf not in _WALK_EXEMPT
+    )
+    assert not unhandled, (
+        "Canonical model leaf/leaves are neither walked by _walk_canonical nor "
+        "exempt — they would silently classify 'supported' and any codec dropping "
+        "them reports severity:ok (the silent capability-loss class). For each: "
+        "(1) add a yield in _walk_canonical + the per-codec lossy/unsupported "
+        "declaration (and, if its xpath spelling is irregular, a _CLASS_CONTAINERS "
+        "/ _SEGMENT_OVERRIDE row), OR (2) add a self-justifying _WALK_EXEMPT entry "
+        f"with a structured reason code: {unhandled}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard-the-guard: keep the derivation + exemption set honest
+# ---------------------------------------------------------------------------
+
+
+def test_no_stale_walk_exemptions():
+    """Every _WALK_EXEMPT key is still a real model leaf — a removed/renamed
+    leaf must drop out of the exemption set, else the exemption rots into a lie."""
+    real = scalar_leaves(CanonicalIntent)
+    stale = sorted(k for k in _WALK_EXEMPT if k not in real)
+    assert not stale, f"_WALK_EXEMPT references non-existent leaves: {stale}"
+
+
+def test_walk_exempt_is_not_actually_walked():
+    """A leaf that IS walked must NOT also be exempt — a stale exemption on a
+    now-walked leaf hides intent and would mask a future un-walking regression."""
+    both = sorted(set(_WALK_EXEMPT) & _walked_leaves())
+    assert not both, f"leaves both walked AND exempt (drop the exemption): {both}"
+
+
+def test_exemption_reasons_are_structured_codes():
+    """Every exemption carries one of the closed reason codes — no free-text
+    'I didn't want to walk this' door (the lazy-exempt path has no green code)."""
+    bad = sorted(
+        f"{c}.{f} -> {code!r}"
+        for (c, f), (code, _note) in _WALK_EXEMPT.items()
+        if code not in _REASON_CODES
+    )
+    assert not bad, f"exemption(s) with an unknown reason code: {bad}"
+
+
+def test_class_containers_have_no_dead_prefixes():
+    """Every non-empty container prefix is a real prefix of some walkable xpath
+    — a typo'd prefix would silently mark its class's leaves not-walked."""
+    dead = sorted(
+        f"{cls}: {c!r}"
+        for cls, cs in _CLASS_CONTAINERS.items()
+        for c in cs
+        if not any(xp.startswith(c) for xp in _WALKABLE)
+    )
+    assert not dead, f"_CLASS_CONTAINERS prefix(es) match no walkable xpath: {dead}"
+
+
+def test_segment_overrides_reference_real_leaves():
+    """Every _SEGMENT_OVERRIDE key is a real leaf AND resolves to a walked xpath
+    (else the override is stale/wrong)."""
+    real = scalar_leaves(CanonicalIntent)
+    stale = sorted(k for k in _SEGMENT_OVERRIDE if k not in real)
+    assert not stale, f"_SEGMENT_OVERRIDE references non-existent leaves: {stale}"
+    unwalked = sorted(
+        k for k in _SEGMENT_OVERRIDE
+        if not any(xp in _WALKABLE for xp in _expected_xpaths(*k))
+    )
+    assert not unwalked, (
+        f"_SEGMENT_OVERRIDE entries that don't resolve to a walked xpath "
+        f"(wrong segment spelling?): {unwalked}"
+    )
+
+
+def test_guard_catches_a_synthetic_new_leaf():
+    """Prove the class-kill (not just green-today): a synthetic leaf that is
+    neither walked nor exempt IS flagged by the guard's logic. This pins that a
+    future refactor can't make the main guard pass vacuously."""
+    synthetic = ("CanonicalInterface", "synthetic_unwalked_field")
+    walked = _walked_leaves()
+    assert synthetic not in walked
+    assert synthetic not in _WALK_EXEMPT
+    leaves = scalar_leaves(CanonicalIntent) | {synthetic}
+    unhandled = [lf for lf in leaves if lf not in walked and lf not in _WALK_EXEMPT]
+    assert synthetic in unhandled, (
+        "the guard would NOT flag a new unwalked leaf — the class-kill is broken"
+    )
+
+
+def test_guard_is_robust_to_a_same_named_new_leaf():
+    """A NEW field whose name collides with a walked segment elsewhere (e.g. a
+    bare ``ip`` on CanonicalInterface, colliding with the nested address ``ip``)
+    must NOT be falsely classified walked — the container-scoped derivation
+    prevents the suffix-match class-kill hole."""
+    collision = ("CanonicalInterface", "ip")  # expects /interfaces/interface/ip
+    assert not any(xp in _WALKABLE for xp in _expected_xpaths(*collision)), (
+        "a same-named new leaf falsely matched a walked xpath — class-kill hole "
+        "(the nested /interfaces/interface/ipv4/address/ip must NOT count as "
+        "/interfaces/interface/ip)"
+    )
+
+
+def test_every_class_with_leaves_is_known():
+    """Every model class that owns a scalar leaf is in _CLASS_CONTAINERS (even
+    if anchor-only with an empty tuple) — a NEW model class hung off the tree
+    without a container entry would otherwise silently resolve all its leaves to
+    not-walked-but-also-unmapped; this makes adding a class a conscious act."""
+    classes = {cls for cls, _ in scalar_leaves(CanonicalIntent)}
+    missing = sorted(classes - set(_CLASS_CONTAINERS))
+    assert not missing, (
+        "model class(es) own canonical leaves but have no _CLASS_CONTAINERS entry "
+        "— add one (use an empty tuple () if only the container anchor is walked): "
+        f"{missing}"
+    )

--- a/tests/unit/test_canonical_reflection.py
+++ b/tests/unit/test_canonical_reflection.py
@@ -49,6 +49,23 @@ class TestReachableModels:
     def test_descends_through_optional_and_list(self):
         assert reachable_models(_Root) == {_Root, _Child}
 
+    def test_resolves_forward_ref_to_a_later_defined_model(self):
+        """A field annotating a model defined LATER in its module is a
+        ``ForwardRef`` (``get_args() == ()``) until the owner is rebuilt — it
+        must NOT be invisible to the walk. The real model hits this:
+        ``CanonicalInterface.vrrp_groups: list[CanonicalVRRPGroup]`` (VRRPGroup
+        is defined further down ``intent.py``). ``reachable_models`` must reach
+        it WITHOUT relying on an instance having been constructed first."""
+        from netcanon.migration.canonical.intent import (
+            CanonicalIntent,
+            CanonicalVRRPGroup,
+        )
+
+        assert CanonicalVRRPGroup in reachable_models(CanonicalIntent), (
+            "reachable_models missed a forward-referenced nested model — the "
+            "completeness guards would silently skip every leaf under it"
+        )
+
 
 class TestScalarLeaves:
     def test_exact_leaf_set(self):

--- a/tests/unit/test_canonical_reflection.py
+++ b/tests/unit/test_canonical_reflection.py
@@ -1,0 +1,92 @@
+"""Unit test for the shared canonical-model reflection enumerators
+(`tests/support/canonical_reflection.py`).
+
+The fail-surfaced-defaults completeness guards (walker coverage + sanitizer
+coverage) both rest on ``scalar_leaves`` / ``str_leaves``. If the enumerator
+silently *under*-counts (misses a leaf), both guards develop a hole at their
+foundation — the exact failure mode review finding MF-3 flagged. So pin the
+enumerators' behaviour against a tiny synthetic model that exercises every
+annotation shape the real model uses (scalar, list-of-scalar, optional, dict,
+nested model, list-of-nested) plus the ``Literal`` edge the real model does NOT
+yet use (so a future ``Literal`` field's handling is predictable, not a surprise).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from tests.support.canonical_reflection import (
+    reachable_models,
+    scalar_leaves,
+    str_leaves,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _Child(BaseModel):
+    cstr: str = ""
+    cint: int = 0
+
+
+class _Root(BaseModel):
+    s: str = ""
+    n: int = 0
+    b: bool = False
+    ls: list[str] = []
+    li: list[int] = []
+    opt: str | None = None
+    d: dict[str, str] = {}
+    lit: Literal["a", "b"] = "a"
+    child: _Child | None = None          # nested model (optional) — NOT a leaf
+    children: list[_Child] = []          # list of nested models — NOT a leaf
+
+
+class TestReachableModels:
+    def test_descends_through_optional_and_list(self):
+        assert reachable_models(_Root) == {_Root, _Child}
+
+
+class TestScalarLeaves:
+    def test_exact_leaf_set(self):
+        # Every scalar / list-of-scalar / dict / Literal field is a leaf; the
+        # two nested-model containers (child, children) are NOT (their child
+        # fields cstr/cint are the leaves, reached by recursion).
+        assert scalar_leaves(_Root) == {
+            ("_Root", "s"),
+            ("_Root", "n"),
+            ("_Root", "b"),
+            ("_Root", "ls"),
+            ("_Root", "li"),
+            ("_Root", "opt"),
+            ("_Root", "d"),       # dict[str,str] — yielded (caller must classify)
+            ("_Root", "lit"),     # Literal — yielded (neither scalar-type nor model)
+            ("_Child", "cstr"),
+            ("_Child", "cint"),
+        }
+
+    def test_nested_model_containers_are_not_leaves(self):
+        leaves = scalar_leaves(_Root)
+        assert ("_Root", "child") not in leaves
+        assert ("_Root", "children") not in leaves
+
+
+class TestStrLeaves:
+    def test_only_str_bearing_leaves(self):
+        # str scalar, list[str], Optional[str], dict[..,str] qualify.
+        # int/bool/list[int] do NOT. A Literal-of-strings does NOT (its args are
+        # string *values*, not the `str` type) — correct: a fixed enum can't hold
+        # an arbitrary operator IP/secret literal.
+        assert str_leaves(_Root) == {
+            ("_Root", "s"),
+            ("_Root", "ls"),
+            ("_Root", "opt"),
+            ("_Root", "d"),
+            ("_Child", "cstr"),
+        }
+
+    def test_literal_is_not_a_str_leaf(self):
+        assert ("_Root", "lit") not in str_leaves(_Root)

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -21,11 +21,9 @@ Covers:
 from __future__ import annotations
 
 import re
-import typing
 from pathlib import Path
 
 import pytest
-from pydantic import BaseModel
 
 from netcanon.migration.canonical.intent import (
     CanonicalDHCPPool,
@@ -50,6 +48,12 @@ from netcanon.tools.sanitize import (
     _SubstitutionTable,
     sanitize_intent,
     sanitize_text,
+)
+from tests.support.canonical_reflection import (
+    flatten_annotation as _flatten_annotation,
+)
+from tests.support.canonical_reflection import (
+    reachable_models as _reachable_canonical_models,
 )
 
 pytestmark = pytest.mark.unit
@@ -657,32 +661,6 @@ _SECRET_NAME_RE = re.compile(
     r"passphrase|password|secret|community|^authentication$|(^|_)key$",
     re.IGNORECASE,
 )
-
-
-def _flatten_annotation(ann):
-    """Yield ``ann`` and every nested type argument (unwraps
-    ``list[...]`` / ``Optional[...]`` / ``dict[...]`` / unions)."""
-    args = typing.get_args(ann)
-    if not args:
-        yield ann
-        return
-    for a in args:
-        yield from _flatten_annotation(a)
-
-
-def _reachable_canonical_models(root_cls, acc=None):
-    """All ``BaseModel`` subclasses reachable from ``root_cls`` via its
-    (possibly nested) field annotations."""
-    if acc is None:
-        acc = set()
-    if root_cls in acc:
-        return acc
-    acc.add(root_cls)
-    for fld in root_cls.model_fields.values():
-        for t in _flatten_annotation(fld.annotation):
-            if isinstance(t, type) and issubclass(t, BaseModel):
-                _reachable_canonical_models(t, acc)
-    return acc
 
 
 class TestSecretRedactionCoverage:

--- a/tests/unit/tools/test_sanitize_completeness.py
+++ b/tests/unit/tools/test_sanitize_completeness.py
@@ -1,0 +1,210 @@
+"""Sanitizer completeness PARTITION guard (sanitizer-bypass CLASS — blind-audit
+meta-finding, ``docs/reviews/2026-06-24-fail-surfaced-defaults``).
+
+THE CLASS (not an instance): ``sanitize_intent`` redacts a *subset* of fields,
+so a new IP/host/secret-bearing field leaks verbatim until a human names it
+(IPv4 -> IPv6 -> RD/RT -> anycast-VGA #174 — each a fresh blind-audit round).
+The existing ``TestSecretRedactionCoverage`` reverse guard triggers on a field's
+NAME (``_SECRET_NAME_RE``), so a deceptively-named sensitive field (e.g. a future
+``CanonicalBGPNeighbor.peer: str`` holding a neighbour IP) is never even a
+candidate — the blind spot just relocates to the name list (review finding MF-2).
+
+THE DURABLE FIX (fail-surfaced default): partition EVERY ``str`` / ``list[str]``
+leaf reachable from ``CanonicalIntent`` into exactly one of three reason-coded
+sets — redacted / sensitive-gap / non-sensitive. The guard triggers on a leaf's
+EXISTENCE, not its name: a NEW str leaf in none of the three turns CI red,
+forcing the author to make the binary "is this sensitive?" decision before it
+can merge. This is the existence-trigger a typed marker would give, WITHOUT the
+marker (no per-field ``Annotated[...]`` discipline that fails silently when
+forgotten) — the registries double as documentation of sanitizer coverage.
+
+ZERO runtime change: the existing redaction behaviour + its forward tests
+(``TestSecretRedactionCoverage``, the R-16 PII block, the overlay-ID block in
+``test_sanitize.py``) are untouched; this is a coverage test. A comprehensive
+forward sentinel over the whole IP set (crafting per-field public sentinels for
+CIDR / multicast / RD-RT / MAC) is a deliberate follow-up — the existing
+per-category forward tests already pin actual redaction for the known fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import CanonicalIntent
+from tests.support.canonical_reflection import str_leaves
+
+pytestmark = pytest.mark.unit
+
+
+_GAP_CODES = frozenset({"REDACTION_NOT_WIRED", "TIER3_OPAQUE"})
+_NON_SENSITIVE_CODES = frozenset(
+    {"ENUM", "IDENTIFIER", "FREE_TEXT", "METADATA", "IFACE_REF"}
+)
+
+#: str / list[str] leaves the sanitiser HANDLES today (redacted, or — for
+#: multicast / RD-RT / hostname-form — deliberately format-preserved). Actual
+#: redaction behaviour is verified by the existing forward tests in
+#: test_sanitize.py; this set documents coverage and anchors the partition.
+_SENSITIVE_REDACTED = frozenset({
+    ("CanonicalDHCPPool", "dns_servers"),
+    ("CanonicalDHCPPool", "end_ip"),
+    ("CanonicalDHCPPool", "gateway"),
+    ("CanonicalDHCPPool", "network"),
+    ("CanonicalDHCPPool", "start_ip"),
+    ("CanonicalEvpnType5Route", "prefix"),
+    ("CanonicalEvpnType5Route", "rt_exports"),
+    ("CanonicalEvpnType5Route", "rt_imports"),
+    ("CanonicalIPv4Address", "ip"),
+    ("CanonicalIPv4Address", "virtual_gateway_address"),
+    ("CanonicalIPv6Address", "ip"),
+    ("CanonicalIPv6Address", "virtual_gateway_address"),
+    ("CanonicalIntent", "dns_servers"),
+    ("CanonicalIntent", "ntp_servers"),
+    ("CanonicalIntent", "syslog_servers"),
+    ("CanonicalRADIUSServer", "host"),
+    ("CanonicalRADIUSServer", "key"),
+    ("CanonicalRoutingInstance", "route_distinguisher"),
+    ("CanonicalRoutingInstance", "rt_exports"),
+    ("CanonicalRoutingInstance", "rt_imports"),
+    ("CanonicalSNMP", "community"),
+    ("CanonicalSNMP", "contact"),
+    ("CanonicalSNMP", "location"),
+    ("CanonicalSNMP", "trap_hosts"),
+    ("CanonicalSNMPv3User", "auth_passphrase"),
+    ("CanonicalSNMPv3User", "engine_id"),
+    ("CanonicalSNMPv3User", "priv_passphrase"),
+    ("CanonicalStaticRoute", "gateway"),
+    ("CanonicalVxlan", "flood_list"),
+    ("CanonicalVxlan", "mcast_group"),
+    ("CanonicalLocalUser", "hashed_password"),
+    ("CanonicalVRRPGroup", "authentication"),
+    ("CanonicalVRRPGroup", "virtual_ips"),
+    ("CanonicalVRRPGroup", "virtual_ipv6s"),
+})
+
+#: Sensitive str leaves the sanitiser does NOT cover yet — surfaced + tracked +
+#: deferred. REDACTION_NOT_WIRED: a clean follow-up wires it (a redact_mac
+#: primitive; static-route-destination redact_cidr). TIER3_OPAQUE: verbatim
+#: vendor text the STRUCTURED sanitiser can't reach (sanitize_text re-parses +
+#: sanitises the text path, but the intent-level walk treats these as a blob).
+_SENSITIVE_GAP: dict[tuple[str, str], tuple[str, str]] = {
+    ("CanonicalIPv4Address", "virtual_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast vMAC; redact_mac follow-up"),
+    ("CanonicalIPv6Address", "virtual_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast vMAC; redact_mac follow-up"),
+    ("CanonicalVRRPGroup", "virtual_mac"): ("REDACTION_NOT_WIRED", "VRRP vMAC; redact_mac follow-up"),
+    ("CanonicalIntent", "anycast_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast-gateway MAC; redact_mac follow-up"),
+    ("CanonicalStaticRoute", "destination"): ("REDACTION_NOT_WIRED", "public dest CIDR unredacted; redact_cidr later"),
+    ("CanonicalIntent", "raw_sections"): ("TIER3_OPAQUE", "Tier-3 verbatim text; structural walk can't reach it"),
+    ("CanonicalIntent", "group_content"): ("TIER3_OPAQUE", "Junos group bodies (verbatim); not structurally sanitised"),
+    ("CanonicalIntent", "dropped_tier3_sections"): ("TIER3_OPAQUE", "dropped-section text; not structurally sanitised"),
+}
+
+#: str leaves that carry no operator secret / public IP — names, enums,
+#: interface references, operator free text, tool provenance. Each reason is one
+#: a reviewer can challenge (a real IP/secret leaf has no honest code here).
+_NON_SENSITIVE: dict[tuple[str, str], tuple[str, str]] = {
+    ("CanonicalDHCPPool", "domain_name"): ("IDENTIFIER", "DHCP-offered DNS domain; passed through"),
+    ("CanonicalDHCPPool", "interface"): ("IFACE_REF", "bind interface name"),
+    ("CanonicalEvpnType5Route", "vrf"): ("IDENTIFIER", "VRF name"),
+    ("CanonicalIPv6Address", "scope"): ("ENUM", "global | link-local"),
+    ("CanonicalIntent", "apply_groups"): ("METADATA", "Junos apply-group names"),
+    ("CanonicalIntent", "domain"): ("IDENTIFIER", "device DNS domain; passed through"),
+    ("CanonicalIntent", "hostname"): ("IDENTIFIER", "device hostname; passed through by design"),
+    ("CanonicalIntent", "source_format"): ("METADATA", "source input_format hint"),
+    ("CanonicalIntent", "source_vendor"): ("METADATA", "producing codec"),
+    ("CanonicalIntent", "source_version"): ("METADATA", "source OS-version hint"),
+    ("CanonicalIntent", "timezone"): ("IDENTIFIER", "tz name (e.g. UTC)"),
+    ("CanonicalInterface", "default_name"): ("IDENTIFIER", "factory interface name"),
+    ("CanonicalInterface", "description"): ("FREE_TEXT", "interface description"),
+    ("CanonicalInterface", "dhcp_client_v6"): ("ENUM", "dhcp6 mode token"),
+    ("CanonicalInterface", "interface_type"): ("ENUM", "ianaift interface-type token"),
+    ("CanonicalInterface", "kind"): ("ENUM", "transform kind hint"),
+    ("CanonicalInterface", "lag_member_of"): ("IFACE_REF", "parent LAG name"),
+    ("CanonicalInterface", "name"): ("IDENTIFIER", "interface name"),
+    ("CanonicalInterface", "switchport_mode"): ("ENUM", "access | trunk"),
+    ("CanonicalInterface", "tunnel_type"): ("ENUM", "tunnel encapsulation token"),
+    ("CanonicalInterface", "vrf"): ("IDENTIFIER", "VRF name"),
+    ("CanonicalLAG", "members"): ("IFACE_REF", "member interface names"),
+    ("CanonicalLAG", "mode"): ("ENUM", "active | passive | on"),
+    ("CanonicalLAG", "name"): ("IDENTIFIER", "LAG name"),
+    ("CanonicalLocalUser", "name"): ("IDENTIFIER", "account name; passed through (not a secret)"),
+    ("CanonicalLocalUser", "role"): ("ENUM", "role / privilege keyword"),
+    ("CanonicalRoutingInstance", "description"): ("FREE_TEXT", "VRF description"),
+    ("CanonicalRoutingInstance", "instance_type"): ("ENUM", "vrf | mac-vrf"),
+    ("CanonicalRoutingInstance", "name"): ("IDENTIFIER", "VRF name"),
+    ("CanonicalSNMPv3User", "auth_protocol"): ("ENUM", "md5 | sha | ..."),
+    ("CanonicalSNMPv3User", "group"): ("IDENTIFIER", "VACM group name"),
+    ("CanonicalSNMPv3User", "name"): ("IDENTIFIER", "SNMPv3 user name; passed through"),
+    ("CanonicalSNMPv3User", "priv_protocol"): ("ENUM", "des | aes | ..."),
+    ("CanonicalStaticRoute", "description"): ("FREE_TEXT", "route description"),
+    ("CanonicalStaticRoute", "interface"): ("IFACE_REF", "egress interface name"),
+    ("CanonicalStaticRoute", "vrf"): ("IDENTIFIER", "VRF name"),
+    ("CanonicalVlan", "description"): ("FREE_TEXT", "VLAN description"),
+    ("CanonicalVlan", "name"): ("IDENTIFIER", "VLAN name"),
+    ("CanonicalVlan", "tagged_ports"): ("IFACE_REF", "tagged member interface names"),
+    ("CanonicalVlan", "untagged_ports"): ("IFACE_REF", "untagged member interface names"),
+    ("CanonicalVxlan", "source_interface"): ("IFACE_REF", "VTEP source interface name"),
+    ("CanonicalVRRPGroup", "description"): ("FREE_TEXT", "group description"),
+    ("CanonicalVRRPGroup", "mode"): ("ENUM", "vrrp | hsrp | carp"),
+    ("CanonicalVRRPGroup", "track_interfaces"): ("IFACE_REF", "tracked interface names"),
+}
+
+
+def _classified() -> set[tuple[str, str]]:
+    return _SENSITIVE_REDACTED | set(_SENSITIVE_GAP) | set(_NON_SENSITIVE)
+
+
+class TestSanitizerFieldPartition:
+    """Every str / list[str] leaf is consciously classified — the class-kill."""
+
+    def test_every_str_leaf_is_classified(self):
+        """Partition completeness: every str/list[str] leaf reachable from
+        CanonicalIntent is in exactly one of redacted / sensitive-gap /
+        non-sensitive. A NEW str leaf (even a deceptively-named IP) in none of
+        the three turns this RED — the existence-trigger a name-based guard lacks
+        (review finding MF-2)."""
+        unclassified = sorted(str_leaves(CanonicalIntent) - _classified())
+        assert not unclassified, (
+            "str-bearing canonical leaf/leaves are unclassified — the sanitiser "
+            "default for a new field is leak-verbatim (the sanitizer-bypass class). "
+            "Classify each: redact it in sanitize_intent + add to _SENSITIVE_REDACTED; "
+            "OR add to _SENSITIVE_GAP (sensitive, redaction deferred) with a code; OR "
+            f"add to _NON_SENSITIVE (no secret/IP) with a code: {unclassified}"
+        )
+
+    def test_buckets_are_disjoint(self):
+        red, gap, non = _SENSITIVE_REDACTED, set(_SENSITIVE_GAP), set(_NON_SENSITIVE)
+        assert not (red & gap), f"in both redacted and gap: {sorted(red & gap)}"
+        assert not (red & non), f"in both redacted and non-sensitive: {sorted(red & non)}"
+        assert not (gap & non), f"in both gap and non-sensitive: {sorted(gap & non)}"
+
+    def test_no_stale_classifications(self):
+        """Every classified key is still a real str leaf — a removed/renamed
+        field must drop out, else the classification rots into a lie."""
+        stale = sorted(_classified() - str_leaves(CanonicalIntent))
+        assert not stale, f"classification(s) reference non-existent str leaves: {stale}"
+
+    def test_reason_codes_are_structured(self):
+        bad_gap = sorted(
+            f"{c}.{f} -> {code!r}"
+            for (c, f), (code, _n) in _SENSITIVE_GAP.items()
+            if code not in _GAP_CODES
+        )
+        assert not bad_gap, f"_SENSITIVE_GAP entries with unknown code: {bad_gap}"
+        bad_non = sorted(
+            f"{c}.{f} -> {code!r}"
+            for (c, f), (code, _n) in _NON_SENSITIVE.items()
+            if code not in _NON_SENSITIVE_CODES
+        )
+        assert not bad_non, f"_NON_SENSITIVE entries with unknown code: {bad_non}"
+
+    def test_guard_catches_a_synthetic_deceptively_named_ip_field(self):
+        """Prove the class-kill: a deceptively-named NEW IP field (the S4 case a
+        name-regex guard misses) is flagged because the partition triggers on
+        existence, not name. A ``CanonicalBGPNeighbor.peer`` leaf is in none of
+        the three sets -> unclassified -> RED."""
+        synthetic = ("CanonicalBGPNeighbor", "peer")  # a neighbour IP, non-IP-ish name
+        leaves = str_leaves(CanonicalIntent) | {synthetic}
+        assert synthetic in (leaves - _classified()), (
+            "the partition would NOT flag a deceptively-named new IP field — the "
+            "class-kill is broken (it must trigger on existence, not name)"
+        )


### PR DESCRIPTION
## What

Two reflection-driven **completeness guards** that close the recurring blind-spot *classes* the five blind audits kept finding new instances of — rather than patching one more instance. Both are **CI tests: zero runtime change, zero phase4 movement.**

- **Class 1 — silent capability-loss** (`tests/unit/migration/test_walker_completeness.py`): every scalar leaf reachable from `CanonicalIntent` (recursing into nested models) must be walked by `_walk_canonical` or carry a reason-coded exemption. A new unwalked leaf now turns CI red instead of silently classifying `supported` (switchport → static-route → VXLAN → VLAN-ports #172 → VLAN-SVI #175 were all this class).
- **Class 2 — sanitizer-bypass** (`tests/unit/tools/test_sanitize_completeness.py`): every `str`/`list[str]` leaf is partitioned into redacted / sensitive-gap / non-sensitive. A new IP/secret-bearing field — **even a deceptively-named one** (`peer: str`) — in none of the three turns CI red (IPv4 → IPv6 → RD/RT → anycast-VGA #174 were all this class).

Both guards **trigger on a field's existence, not its name** — the only mechanism faithful to "fail-surfaced defaults" (a name-regex/allow-list just relocates the blind spot one level up; a typed marker adds a contributor discipline that fails silently when forgotten). Committed proof tests pin the class-kill (a synthetic new leaf is flagged; a same-named collision is *not* falsely matched).

## How it was designed

8-agent ultracode **blackboard** run (census → design → adversarial review); both reviews GO-WITH-FIXES. Full design record + synthesis under `docs/reviews/2026-06-24-fail-surfaced-defaults/`. Review must-fixes applied: structured exemption reason codes (no lazy free-text door); the leaf enumerator is itself unit-tested (MF-3); walked-ness is a robust per-class-container derivation (~23 rule rows), not a 70-row hand map, and is collision-safe for same-named new fields.

## Shared util + a latent bug fixed

Extracts the reflection engine to `tests/support/canonical_reflection.py` (both guards + the existing secret guard use it). Fixes a real robustness bug it surfaced: with `from __future__ import annotations`, `CanonicalInterface.vrrp_groups: list[CanonicalVRRPGroup]` is an unresolved `ForwardRef` (VRRPGroup is defined later in `intent.py`), so `CanonicalVRRPGroup` — and its secret `authentication` + IP `virtual_ips` leaves — was **invisible** to the reflection unless an intent had been constructed first. `reachable_models` now `model_rebuild(force=True)`s to resolve refs deterministically; regression test added.

## Deferred (the guards now surface + track these — not in this PR)

- **Class 1:** walk the ~11 HIGH currently-unwalked leaves (VRRP mode/priority/preempt/auth/…, SNMPv3 priv-passphrase/protocols, IPv6 scope, instance-type) — behaviour-changing + phase4-regen (the St3 precedent); shipped as `KNOWN_GAP` exemptions.
- **Class 2:** wire `redact_mac` (4 virtual/anycast MACs) + static-route-destination `redact_cidr` — shipped as `REDACTION_NOT_WIRED` gaps. Tier-3 verbatim text (`raw_sections`/`group_content`/`dropped_tier3_sections`) flagged `TIER3_OPAQUE`.
- The runtime blanket `ip_address()` rule and the typed marker are **declined** (rationale in the synthesis).

## Verification

Full `tests/unit` green (incl. `tests/unit/audit` — zero phase4 reclassification, confirmed: neither guard is on the migrate-validate / cross-mesh path). Lint + the class-kill proof tests pass. Test-only ⇒ no runtime/behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
