### PR TITLE
ci(release): require full CI success for the tagged commit before publishing (audit T0-4)

### DIFF
--- a/.github/workflows/desktop-msi-publish.yml
+++ b/.github/workflows/desktop-msi-publish.yml
@@ -40,6 +40,7 @@ on:
 # release page + upload the MSI as a release asset.
 permissions:
   contents: write
+  actions: read    # read the CI run conclusion for the "require CI success" gate
 
 # Prevent two simultaneous MSI builds for the same ref from racing
 # the release-upload step.  Within a single ref, we let the second
@@ -122,6 +123,37 @@ jobs:
             exit 1
           fi
           echo "OK: build commit $head_sha is on origin/main."
+
+      # Prove the full CI matrix concluded 'success' for this commit, not just
+      # that it is on main (audit T0-4: ancestry != CI success). See
+      # pypi-publish.yml for the full rationale. For a workflow_dispatch backfill
+      # the checked-out ref is inputs.tag, so this gates the backfilled commit
+      # too. Needs `actions: read`.
+      - name: Require CI success for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          head_sha="$(git rev-parse HEAD)"
+          for attempt in $(seq 1 30); do
+            out="$(gh api \
+              "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$head_sha&event=push&per_page=1" \
+              --jq '(.workflow_runs[0].status // "none") + " " + (.workflow_runs[0].conclusion // "none")' \
+              2>/dev/null || true)"
+            status="${out%% *}"; conclusion="${out##* }"
+            if [ "$conclusion" = "success" ]; then
+              echo "CI concluded success for $head_sha."; exit 0
+            fi
+            if [ "$status" = "completed" ]; then
+              echo "::error::CI for $head_sha concluded '$conclusion' (not success) — refusing to publish."
+              exit 1
+            fi
+            echo "CI for $head_sha is '${status:-unknown}' (attempt $attempt/30); waiting 20s..."
+            sleep 20
+          done
+          echo "::error::Timed out waiting for CI to complete for $head_sha — refusing to publish."
+          exit 1
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,7 @@ permissions:
   packages: write
   id-token: write          # cosign keyless signing via Sigstore + GitHub OIDC
   security-events: write   # Trivy SARIF upload to Code Scanning
+  actions: read            # read the CI run conclusion for the "require CI success" gate
 
 # Serialise release runs for a given ref so a re-pushed tag (or a
 # workflow_dispatch racing the tag push) can't double-build / double-push
@@ -95,6 +96,35 @@ jobs:
             exit 1
           fi
           echo "OK: build commit $head_sha is on origin/main."
+
+      # Prove the full CI matrix concluded 'success' for this commit, not just
+      # that it is on main (audit T0-4: ancestry != CI success). See
+      # pypi-publish.yml for the full rationale. Needs `actions: read`.
+      - name: Require CI success for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          head_sha="$(git rev-parse HEAD)"
+          for attempt in $(seq 1 30); do
+            out="$(gh api \
+              "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$head_sha&event=push&per_page=1" \
+              --jq '(.workflow_runs[0].status // "none") + " " + (.workflow_runs[0].conclusion // "none")' \
+              2>/dev/null || true)"
+            status="${out%% *}"; conclusion="${out##* }"
+            if [ "$conclusion" = "success" ]; then
+              echo "CI concluded success for $head_sha."; exit 0
+            fi
+            if [ "$status" = "completed" ]; then
+              echo "::error::CI for $head_sha concluded '$conclusion' (not success) — refusing to publish."
+              exit 1
+            fi
+            echo "CI for $head_sha is '${status:-unknown}' (attempt $attempt/30); waiting 20s..."
+            sleep 20
+          done
+          echo "::error::Timed out waiting for CI to complete for $head_sha — refusing to publish."
+          exit 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: read    # read the CI run conclusion for the "require CI success" gate
 
 # Serialise release runs for a given ref so a re-pushed tag (or a
 # workflow_dispatch racing the tag push) can't double-publish.  Never
@@ -95,6 +96,39 @@ jobs:
             exit 1
           fi
           echo "OK: build commit $head_sha is on origin/main."
+
+      # The ancestry check proves the commit is on main; this proves the full CI
+      # matrix actually concluded 'success' for it (closes audit T0-4: ancestry
+      # != CI success — admin-bypass / a check required only after merge / a
+      # workflow_dispatch on a never-PR'd ref). The in-run Test gate job covers
+      # unit+integration; this covers the surfaces it omits (e2e/desktop/4-Python/
+      # build/docker-smoke) without re-running them. Polls in case the tag was
+      # pushed before the on-main CI run finished. Needs `actions: read`.
+      - name: Require CI success for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          head_sha="$(git rev-parse HEAD)"
+          for attempt in $(seq 1 30); do
+            out="$(gh api \
+              "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$head_sha&event=push&per_page=1" \
+              --jq '(.workflow_runs[0].status // "none") + " " + (.workflow_runs[0].conclusion // "none")' \
+              2>/dev/null || true)"
+            status="${out%% *}"; conclusion="${out##* }"
+            if [ "$conclusion" = "success" ]; then
+              echo "CI concluded success for $head_sha."; exit 0
+            fi
+            if [ "$status" = "completed" ]; then
+              echo "::error::CI for $head_sha concluded '$conclusion' (not success) — refusing to publish."
+              exit 1
+            fi
+            echo "CI for $head_sha is '${status:-unknown}' (attempt $attempt/30); waiting 20s..."
+            sleep 20
+          done
+          echo "::error::Timed out waiting for CI to complete for $head_sha — refusing to publish."
+          exit 1
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,16 @@ timestamp if your timezone matters for an audit.
   still covers the surfaces this fast subset omits. SECURITY.md documents
   both layers + the residual `workflow_dispatch` / admin-bypass risks. Found
   by an independent blind audit (`3ec11f3`, T0-4).
+* **Release publish now also requires the full CI run to have passed for
+  the tagged commit.** On top of the in-run unit+integration test gate, each
+  publish workflow (PyPI / Docker / MSI) adds a `Require CI success for this
+  commit` step that queries the Actions API and refuses to publish unless the
+  CI workflow concluded `success` for that exact commit -- so the *full*
+  matrix (4-Python + e2e + desktop + build + docker-smoke + PII-guard), not
+  just the in-run subset, is proven green. Closes the residual that the
+  on-main ancestry check proves ancestry, not CI success (admin-bypass /
+  force-merge / a never-PR'd `workflow_dispatch`); fails closed on a missing
+  or non-success CI run. Found by an independent blind audit (`3ec11f3`, T0-4).
 
 ### Fixed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -552,15 +552,21 @@ tied to passing tests even if one layer is bypassed.
    not an ancestor of `origin/main`.  So a release tag normally derives from
    a commit that passed the full CI matrix.
 
-2. **Gate-at-publish (in-workflow test job).**  Each publish workflow
+2. **Gate-at-publish (in the publish run itself).**  Each publish workflow
    (`pypi-publish.yml`, `docker-publish.yml`, `desktop-msi-publish.yml`)
-   begins with a `Test gate (unit + integration)` job that the build /
-   publish jobs `needs:`.  It re-runs the unit + integration suite *inside
-   the publish run* on the exact ref being shipped, so the gate is
-   verifiable from the repository itself and holds even if layer 1 was
-   bypassed.  It is a fast single-Python subset (the full 4-version matrix +
-   e2e + desktop already ran at merge) — defense-in-depth, not a re-run of
-   CI.
+   gates the build on tests in two ways, so the guarantee is verifiable from
+   the repository itself and holds even if layer 1 was bypassed:
+   * a `Test gate (unit + integration)` job that the build / publish jobs
+     `needs:` — it re-runs the unit + integration suite *inside the publish
+     run* on the exact ref being shipped (a fast single-Python subset; the
+     full matrix already ran at merge); and
+   * a **`Require CI success for this commit`** step that queries the Actions
+     API for the CI run of the tagged commit and refuses to publish unless it
+     concluded `success` — so the *full* CI matrix (4-Python + e2e + desktop +
+     build + docker-smoke + PII-guard), not just the in-run subset, is proven
+     green for the exact commit. It polls briefly in case the tag was pushed
+     before the on-main CI run finished, and fails closed (a missing /
+     non-`success` / never-completing CI run blocks the publish).
 
 **Residual risks (explicitly accepted).**  Layer 1 lives in GitHub
 branch-protection settings, which are not committed to the tree, and the
@@ -568,11 +574,13 @@ repo-admin role can bypass the ruleset (`bypass_mode: always`) — a
 single-maintainer reality, not a defended boundary.  All three publish
 workflows also expose `workflow_dispatch`, which can publish a ref that
 never went through a PR (e.g. the MSI backfill path that builds an
-operator-supplied `inputs.tag`).  Layer 2 mitigates both: a manual dispatch
-or a bypassed merge still runs the publish-time test job before anything is
-shipped.  What layer 2 does **not** cover is the e2e / desktop / multi-Python
-surface (only layer 1 does) and a defect that no test catches.  See
-blind-audit `3ec11f3` (T0-4).
+operator-supplied `inputs.tag`).  Layer 2 closes most of this: a manual
+dispatch or a bypassed merge still runs the publish-time test job AND must
+clear the `Require CI success` check (a commit an admin force-merged without
+a green CI run has no `success` conclusion, so the publish is refused).  What
+remains is narrow: a defect no test catches, or a commit whose CI run record
+has aged out of GitHub's retention (an old-tag `workflow_dispatch` backfill —
+re-run CI on that ref first).  See blind-audit `3ec11f3` (T0-4).
 
 ### Distribution channels and what each provides
 


### PR DESCRIPTION
## What

Adds a **`Require CI success for this commit`** step to all three publish workflows (PyPI / Docker / MSI), right after the on-main ancestry check. It queries the Actions API for the `ci.yml` run of the tagged commit and **refuses to publish unless that run concluded `success`**.

## Why (closes audit `3ec11f3` T0-4)

[#179](https://github.com/netcanon/netcanon/pull/179) added an *in-run* unit+integration test gate. This closes the audit's remaining literal complaint: the on-main ancestry check proves **ancestry**, not **CI success** — a commit can be an ancestor of `origin/main` yet never have had a green full-CI run (admin-bypass, force-merge, a check required only after merge, or a `workflow_dispatch` on a never-PR'd ref). Now the **full** matrix (4-Python + E2E + Desktop + Build + Docker-smoke + PII-guard) — not just the in-run subset — must be proven green for the exact commit before any artefact is built.

This is the robust equivalent of the audit's preferred `on: workflow_run` gate, which **can't** be used directly because `ci.yml` never runs on tag pushes (only `pull_request` / `push:[main]`). Verifying the commit's existing run via the API gives the same guarantee **without** re-running the matrix at publish time (consistent with the lightweight-not-full-rerun choice in #179).

## How

- New step after the ancestry check in `build` (PyPI) / `build-and-publish` (Docker) / `build-msi` (MSI). Polls up to ~10 min (in case the tag was pushed before the on-main CI run finished) and **fails closed**: a missing / non-`success` / never-completing run blocks the publish.
- Adds `actions: read` to each workflow's `permissions`. The only `${{ }}` are env-mapped (`GH_TOKEN` / `REPO`) — no run-block interpolation (zizmor-safe).
- MSI: the checked-out ref is `inputs.tag || github.ref`, so a `workflow_dispatch` backfill is gated against the backfilled commit's CI run too.

## Residual (documented)

A defect no test catches; or an old-tag `workflow_dispatch` backfill whose CI run record has aged out of GitHub retention (re-run CI on that ref first). SECURITY.md "Release gate" updated; CHANGELOG notes it.

## Note on the other "parked" item

My earlier wrap-up loosely listed a *global cross-job backup concurrency cap* as parked — that already shipped in [#178](https://github.com/netcanon/netcanon/pull/178) (the process-wide `BoundedSemaphore`). **T0-4 is the only remaining 5th-audit item, and this closes it.**

## Caveat

These workflows run **only on tags**, so this PR's CI cannot exercise the new step — it's validated by YAML parse + zizmor here; the gate itself first executes at the next release tag (the class of change that needs the pause-before-merge review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
