### PR TITLE
fix(codecs): apply trunk allowed-vlan add/remove relatively, not overwrite (audit 65f9c01 T0-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,21 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Trunk `switchport trunk allowed vlan add` / `remove` no longer
+  collapses VLAN membership.** `show running-config` renders a long
+  trunk allowed-list across multiple lines using the relative keyword
+  forms (`... add 30,40`, `... remove 20`), but `cisco_iosxe_cli`,
+  `cisco_nxos` and `arista_eos` overwrote the allowed-list per line
+  (keeping only the last) and glued the leading keyword onto the first
+  id token (`"add 30"` -> non-numeric -> silently skipped), so `allowed
+  vlan 10,20` followed by `allowed vlan add 30,40` collapsed to `[40]`
+  with no warning and `severity: ok` -- silently changing L2
+  segmentation. All three now route through a shared
+  `merge_trunk_allowed` helper that strips the keyword and applies it
+  (set / add / remove / none / all / except) relative to the running
+  list; the bare single-line form is byte-identical, so existing
+  round-trips are unchanged. Found by an independent blind audit
+  (`65f9c01`, T0-1).
 * **Silent loss of VLAN SVI / management L3 addresses to router / firewall
   codecs.** A VLAN's SVI L3 carried on the VLAN record itself (the Junos
   `irb` / Aruba SVI-on-VLAN shape, folded onto

--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -135,6 +135,63 @@ def _parse_vlan_list(text: str) -> list[int]:
     return result
 
 
+#: Leading keywords in the Cisco / Arista / NX-OS ``switchport trunk
+#: allowed vlan`` grammar that make the line RELATIVE to the running list
+#: rather than a fresh assignment.  ``show running-config`` emits a long
+#: allowed-list as an initial set line followed by ``... add`` continuation
+#: lines, so a parser that overwrites per line (instead of applying the
+#: keyword) silently keeps only the last line.
+_TRUNK_ALLOWED_KEYWORDS = frozenset(
+    {"add", "remove", "except", "none", "all"}
+)
+
+
+def merge_trunk_allowed(existing: list[int], remainder: str) -> list[int]:
+    """Apply one ``switchport trunk allowed vlan`` *remainder* to *existing*.
+
+    The Cisco / Arista / NX-OS grammar renders a long allowed-list across
+    multiple lines using relative keywords::
+
+        switchport trunk allowed vlan 10,20      # set      -> [10, 20]
+        switchport trunk allowed vlan add 30,40  # union    -> [10, 20, 30, 40]
+        switchport trunk allowed vlan remove 20  # subtract -> [10, 30, 40]
+
+    A bare list (no keyword) SETS the membership; ``none`` clears it;
+    ``all`` is the full 1-4094 space; ``except L`` is everything but *L*.
+    The keyword must be stripped before the id list is parsed — otherwise
+    it glues onto the first token (``"add 30"``), which is non-numeric and
+    is silently dropped, so ``allowed vlan add 30,40`` collapsed to
+    ``[40]`` and (because each line overwrote the previous) any earlier set
+    line vanished entirely (blind-audit ``65f9c01`` T0-1).
+
+    The bare-list path is byte-identical to :func:`_parse_vlan_list` (same
+    input order, no de-dup) so the common single-line form round-trips
+    exactly as before; only the keyword forms — which no prior code handled
+    — change behaviour.  ``add``/``remove`` preserve *existing* order and
+    append/drop in place.
+    """
+    tokens = remainder.split(None, 1)
+    keyword = tokens[0].lower() if tokens else ""
+    if keyword not in _TRUNK_ALLOWED_KEYWORDS:
+        # Bare ``<id-list>`` — preserve the exact prior parse behaviour.
+        return _parse_vlan_list(remainder)
+    if keyword == "none":
+        return []
+    if keyword == "all":
+        return list(range(1, 4095))
+    rest = tokens[1] if len(tokens) > 1 else ""
+    ids = _parse_vlan_list(rest)
+    if keyword == "except":
+        blocked = set(ids)
+        return [vid for vid in range(1, 4095) if vid not in blocked]
+    base = list(existing)
+    if keyword == "add":
+        return base + [vid for vid in ids if vid not in base]
+    # keyword == "remove"
+    drop = set(ids)
+    return [vid for vid in base if vid not in drop]
+
+
 def _run_token(lo: int, hi: int) -> str:
     """Format a single consecutive run for :func:`_coalesce_vlan_ids`.
 

--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import ipaddress
 import re
+from collections.abc import Callable
 
 from .base import ParseError, RenderError
 
@@ -146,7 +147,12 @@ _TRUNK_ALLOWED_KEYWORDS = frozenset(
 )
 
 
-def merge_trunk_allowed(existing: list[int], remainder: str) -> list[int]:
+def merge_trunk_allowed(
+    existing: list[int],
+    remainder: str,
+    *,
+    parse_ids: Callable[[str], list[int]] = _parse_vlan_list,
+) -> list[int]:
     """Apply one ``switchport trunk allowed vlan`` *remainder* to *existing*.
 
     The Cisco / Arista / NX-OS grammar renders a long allowed-list across
@@ -164,23 +170,27 @@ def merge_trunk_allowed(existing: list[int], remainder: str) -> list[int]:
     ``[40]`` and (because each line overwrote the previous) any earlier set
     line vanished entirely (blind-audit ``65f9c01`` T0-1).
 
-    The bare-list path is byte-identical to :func:`_parse_vlan_list` (same
-    input order, no de-dup) so the common single-line form round-trips
-    exactly as before; only the keyword forms — which no prior code handled
-    — change behaviour.  ``add``/``remove`` preserve *existing* order and
-    append/drop in place.
+    *parse_ids* parses a comma/hyphen id-list into ``list[int]``; it
+    defaults to the shared :func:`_parse_vlan_list` but a codec injects its
+    own near-twin (``arista_eos._expand_vlan_list``) so this keyword logic
+    can be shared without converging the codec's deliberately-divergent
+    id-list parser.  Because the bare-list path delegates straight to
+    *parse_ids*, the common single-line form round-trips exactly as before;
+    only the keyword forms — which no prior code handled — change
+    behaviour.  ``add``/``remove`` preserve *existing* order and append /
+    drop in place.
     """
     tokens = remainder.split(None, 1)
     keyword = tokens[0].lower() if tokens else ""
     if keyword not in _TRUNK_ALLOWED_KEYWORDS:
         # Bare ``<id-list>`` — preserve the exact prior parse behaviour.
-        return _parse_vlan_list(remainder)
+        return parse_ids(remainder)
     if keyword == "none":
         return []
     if keyword == "all":
         return list(range(1, 4095))
     rest = tokens[1] if len(tokens) > 1 else ""
-    ids = _parse_vlan_list(rest)
+    ids = parse_ids(rest)
     if keyword == "except":
         blocked = set(ids)
         return [vid for vid in range(1, 4095) if vid not in blocked]

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -12,7 +12,7 @@ Module layout (post-split):
 * ``parse.py`` — line-scan + per-stanza dispatch over EOS
   ``show running-config`` text.  Hosts the regex constants, the
   router-bgp + interface walkers, and helpers like
-  ``_infer_iface_type``.
+  ``_infer_iface_type`` / ``_expand_vlan_list``.
 * ``render.py`` — canonical tree → EOS CLI text.
 
 Structural strategy: EOS CLI is line-oriented with ``!`` delimiters,

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -12,7 +12,7 @@ Module layout (post-split):
 * ``parse.py`` — line-scan + per-stanza dispatch over EOS
   ``show running-config`` text.  Hosts the regex constants, the
   router-bgp + interface walkers, and helpers like
-  ``_infer_iface_type`` / ``_expand_vlan_list``.
+  ``_infer_iface_type``.
 * ``render.py`` — canonical tree → EOS CLI text.
 
 Structural strategy: EOS CLI is line-oriented with ``!`` delimiters,

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -27,9 +27,9 @@ codec module's ``parse()`` method is now a one-line delegator to
 :func:`parse_intent`.
 
 Internal helpers (``_parse_stanzas``, ``_parse_router_bgp``,
-``_apply_iface_subcommand``, ``_infer_iface_type``,
-``_expand_vlan_list``) and the module-level regex constants
-(``_HOSTNAME_RE`` etc.) live here because they are parse-only.
+``_apply_iface_subcommand``, ``_infer_iface_type``) and the
+module-level regex constants (``_HOSTNAME_RE`` etc.) live here
+because they are parse-only.
 """
 
 from __future__ import annotations
@@ -56,7 +56,7 @@ from ...canonical.intent import (
     CanonicalVRRPGroup,
     CanonicalVxlan,
 )
-from .._helpers import _mask_to_prefix
+from .._helpers import _mask_to_prefix, merge_trunk_allowed
 from .._input_shape import detect_input_shape
 from .._scanner import scan_stanzas
 from ..base import ParseError
@@ -1115,7 +1115,9 @@ def _apply_iface_subcommand(
         # so a lingering access_vlan would silently drop on round-trip.
         iface.access_vlan = None
         tail = line.split(None, 4)[-1]
-        iface.trunk_allowed_vlans = _expand_vlan_list(tail)
+        iface.trunk_allowed_vlans = merge_trunk_allowed(
+            iface.trunk_allowed_vlans, tail
+        )
         return
     if line.startswith("switchport trunk native vlan "):
         # Phase 4b Wave 7c-C: ``switchport trunk native vlan <N>``.
@@ -1376,29 +1378,3 @@ def _infer_iface_type(name: str) -> str:
     if lower.startswith("tunnel"):
         return "ianaift:tunnel"
     return ""
-
-
-def _expand_vlan_list(spec: str) -> list[int]:
-    """Expand a VLAN-list spec like ``10,20,30-35`` into [10,20,30..35]."""
-    out: list[int] = []
-    for chunk in spec.split(","):
-        chunk = chunk.strip()
-        if not chunk:
-            continue
-        if "-" in chunk:
-            a, b = chunk.split("-", 1)
-            try:
-                a_i, b_i = int(a), int(b)
-            except ValueError:
-                continue
-            # Clamp to the valid VLAN space before materializing so a huge
-            # span cannot OOM the process (valid sub-range preserved).
-            a_i, b_i = max(1, a_i), min(4094, b_i)
-            if a_i <= b_i:
-                out.extend(range(a_i, b_i + 1))
-        else:
-            try:
-                out.append(int(chunk))
-            except ValueError:
-                continue
-    return out

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -27,9 +27,9 @@ codec module's ``parse()`` method is now a one-line delegator to
 :func:`parse_intent`.
 
 Internal helpers (``_parse_stanzas``, ``_parse_router_bgp``,
-``_apply_iface_subcommand``, ``_infer_iface_type``) and the
-module-level regex constants (``_HOSTNAME_RE`` etc.) live here
-because they are parse-only.
+``_apply_iface_subcommand``, ``_infer_iface_type``,
+``_expand_vlan_list``) and the module-level regex constants
+(``_HOSTNAME_RE`` etc.) live here because they are parse-only.
 """
 
 from __future__ import annotations
@@ -1116,7 +1116,7 @@ def _apply_iface_subcommand(
         iface.access_vlan = None
         tail = line.split(None, 4)[-1]
         iface.trunk_allowed_vlans = merge_trunk_allowed(
-            iface.trunk_allowed_vlans, tail
+            iface.trunk_allowed_vlans, tail, parse_ids=_expand_vlan_list
         )
         return
     if line.startswith("switchport trunk native vlan "):
@@ -1378,3 +1378,38 @@ def _infer_iface_type(name: str) -> str:
     if lower.startswith("tunnel"):
         return "ianaift:tunnel"
     return ""
+
+
+def _expand_vlan_list(spec: str) -> list[int]:
+    """Expand a VLAN-list spec like ``10,20,30-35`` into [10,20,30..35].
+
+    Arista's near-twin of the shared ``_helpers._parse_vlan_list``: it is
+    deliberately NOT converged because it accepts ``int(chunk)`` forms
+    (``"+10"``) that the canonical ``str.isdigit()`` gate rejects (see
+    ``tests/.../test_helpers_equivalence.py``).  It is injected into
+    :func:`.._helpers.merge_trunk_allowed` as that function's ``parse_ids``
+    so the trunk add/remove keyword logic is shared without changing
+    arista's id-list behaviour.
+    """
+    out: list[int] = []
+    for chunk in spec.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "-" in chunk:
+            a, b = chunk.split("-", 1)
+            try:
+                a_i, b_i = int(a), int(b)
+            except ValueError:
+                continue
+            # Clamp to the valid VLAN space before materializing so a huge
+            # span cannot OOM the process (valid sub-range preserved).
+            a_i, b_i = max(1, a_i), min(4094, b_i)
+            if a_i <= b_i:
+                out.extend(range(a_i, b_i + 1))
+        else:
+            try:
+                out.append(int(chunk))
+            except ValueError:
+                continue
+    return out

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -63,7 +63,7 @@ from .._helpers import (
     _is_link_local_v6,
     _mask_to_prefix,
     _normalise_mac_to_colon_hex,
-    _parse_vlan_list,
+    merge_trunk_allowed,
 )
 from .._input_shape import detect_input_shape
 from .._scanner import scan_stanzas
@@ -790,7 +790,9 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
 
         tm = _SWITCHPORT_TRUNK_ALLOWED_RE.match(line)
         if tm:
-            current["trunk_allowed"] = _parse_vlan_list(tm.group(1).strip())
+            current["trunk_allowed"] = merge_trunk_allowed(
+                current["trunk_allowed"], tm.group(1).strip()
+            )
             return
 
         nm = _SWITCHPORT_TRUNK_NATIVE_RE.match(line)

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -70,6 +70,7 @@ from .._helpers import (
     _is_link_local_v6,
     _normalise_mac_to_colon_hex,
     _parse_vlan_list,
+    merge_trunk_allowed,
 )
 from .._input_shape import detect_input_shape
 from .._scanner import scan_stanzas
@@ -754,7 +755,9 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
         tam = _SWITCHPORT_TRUNK_ALLOWED_RE.match(line)
         if tam:
             current["switchport_mode"] = current["switchport_mode"] or "trunk"
-            current["trunk_allowed"] = _parse_vlan_list(tam.group(1).strip())
+            current["trunk_allowed"] = merge_trunk_allowed(
+                current["trunk_allowed"], tam.group(1).strip()
+            )
             return
         tnm = _SWITCHPORT_TRUNK_NATIVE_RE.match(line)
         if tnm:

--- a/tests/unit/migration/codecs/test_helpers_equivalence.py
+++ b/tests/unit/migration/codecs/test_helpers_equivalence.py
@@ -33,9 +33,6 @@ from netcanon.migration.codecs.aruba_aoscx.parse import (
 from netcanon.migration.codecs.aruba_aoscx.render import (
     _coalesce_vlan_ids as _aoscx_coalesce,
 )
-from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
-    _parse_vlan_list as _iosxe_parse,
-)
 from netcanon.migration.codecs.cisco_nxos.parse import (
     _parse_vlan_list as _nxos_parse,
 )
@@ -44,7 +41,10 @@ from netcanon.migration.codecs.cisco_nxos.render import (
 )
 
 # Inline copies that the shared _parse_vlan_list must reproduce exactly.
-_PARSE_INLINE_COPIES = (_nxos_parse, _iosxe_parse, _aoscx_parse)
+# (cisco_iosxe_cli no longer imports _parse_vlan_list directly -- its only
+# caller, the trunk allowed-vlan line, now routes through the shared
+# ``merge_trunk_allowed`` helper -- so it is no longer a surviving copy.)
+_PARSE_INLINE_COPIES = (_nxos_parse, _aoscx_parse)
 # Inline copies that the shared _coalesce_vlan_ids must reproduce exactly.
 _COALESCE_INLINE_COPIES = (_nxos_coalesce, _aoscx_coalesce)
 

--- a/tests/unit/migration/test_trunk_allowed_vlan_add.py
+++ b/tests/unit/migration/test_trunk_allowed_vlan_add.py
@@ -1,0 +1,164 @@
+"""
+Regression tests for the trunk ``allowed vlan add`` / ``remove`` collapse
+(blind-audit ``65f9c01`` T0-1).
+
+``show running-config`` renders a long trunk allowed-list across multiple
+lines using the relative keyword forms::
+
+    switchport trunk allowed vlan 10,20
+    switchport trunk allowed vlan add 30,40
+
+Before the fix, every Cisco-family parser (``cisco_iosxe_cli``,
+``cisco_nxos``, ``arista_eos``) OVERWROTE ``trunk_allowed`` per line
+(keeping only the last) AND the leading ``add`` keyword glued onto the
+first id token (``"add 30"`` -> non-numeric -> silently skipped).  So the
+sequence above collapsed to ``[40]`` — VLANs 10/20 lost to the overwrite,
+30 lost as non-numeric — with no warning and ``severity=ok``.  This is the
+*default* rendering of a long allowed-list, not an edge case.
+
+The fix routes all three through
+:func:`netcanon.migration.codecs._helpers.merge_trunk_allowed`, which
+strips the keyword and applies it (union / subtract / set / none / all /
+except) relative to the running list.  The bare single-line form is
+byte-identical to the prior behaviour, so existing round-trips are
+unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs._helpers import merge_trunk_allowed
+from netcanon.migration.codecs.arista_eos import AristaEOSCodec
+from netcanon.migration.codecs.cisco_iosxe_cli import CiscoIOSXECLICodec
+from netcanon.migration.codecs.cisco_nxos import CiscoNXOSCodec
+
+pytestmark = pytest.mark.unit
+
+
+# ── shared-helper logic ───────────────────────────────────────────────
+
+
+class TestMergeTrunkAllowed:
+    def test_bare_list_sets_membership(self) -> None:
+        # No keyword -> identical to the prior ``_parse_vlan_list`` path:
+        # input order preserved, ranges expanded, no de-dup.
+        assert merge_trunk_allowed([], "10,20,30-32") == [10, 20, 30, 31, 32]
+
+    def test_bare_list_replaces_existing(self) -> None:
+        # A second bare line SETS (replaces) — Cisco's non-keyword form.
+        assert merge_trunk_allowed([10, 20], "30,40") == [30, 40]
+
+    def test_add_unions_in_order(self) -> None:
+        assert merge_trunk_allowed([10, 20], "add 30,40") == [10, 20, 30, 40]
+
+    def test_add_with_no_prior_list(self) -> None:
+        # The exact audit repro for a lone ``add`` line: used to drop to
+        # [40] (``"add 30"`` eaten), now keeps both ids.
+        assert merge_trunk_allowed([], "add 30,40") == [30, 40]
+
+    def test_add_is_idempotent_on_duplicates(self) -> None:
+        assert merge_trunk_allowed([10, 20], "add 20,30") == [10, 20, 30]
+
+    def test_remove_subtracts_preserving_order(self) -> None:
+        assert merge_trunk_allowed([10, 20, 30, 40], "remove 20") == [
+            10,
+            30,
+            40,
+        ]
+
+    def test_none_clears(self) -> None:
+        assert merge_trunk_allowed([10, 20], "none") == []
+
+    def test_all_is_full_range(self) -> None:
+        assert merge_trunk_allowed([10], "all") == list(range(1, 4095))
+
+    def test_except_is_complement(self) -> None:
+        result = merge_trunk_allowed([10], "except 100,200")
+        assert 100 not in result and 200 not in result
+        assert result[0] == 1 and result[-1] == 4094
+        assert len(result) == 4094 - 2
+
+    def test_keyword_is_case_insensitive(self) -> None:
+        assert merge_trunk_allowed([10], "ADD 20") == [10, 20]
+
+
+# ── per-codec wiring (the regex must capture the keyword and the call
+#    must route through the merge helper) ──────────────────────────────
+
+
+def _iosxe_trunk(*allowed_lines: str) -> list[int]:
+    cfg = (
+        "hostname r1\n"
+        "!\n"
+        "interface GigabitEthernet0/0/0\n"
+        " switchport mode trunk\n"
+        + "".join(f" switchport trunk allowed vlan {ln}\n" for ln in allowed_lines)
+        + "!\n"
+        "end\n"
+    )
+    intent = CiscoIOSXECLICodec().parse(cfg)
+    iface = next(
+        i for i in intent.interfaces if i.name == "GigabitEthernet0/0/0"
+    )
+    return iface.trunk_allowed_vlans
+
+
+def _nxos_trunk(*allowed_lines: str) -> list[int]:
+    cfg = (
+        "hostname r1\n"
+        "feature interface-vlan\n"
+        "interface Ethernet1/1\n"
+        "  switchport mode trunk\n"
+        + "".join(
+            f"  switchport trunk allowed vlan {ln}\n" for ln in allowed_lines
+        )
+    )
+    intent = CiscoNXOSCodec().parse(cfg)
+    iface = next(i for i in intent.interfaces if i.name == "Ethernet1/1")
+    return iface.trunk_allowed_vlans
+
+
+def _arista_trunk(*allowed_lines: str) -> list[int]:
+    cfg = (
+        "hostname sw1\n"
+        "interface Ethernet1\n"
+        "   switchport mode trunk\n"
+        + "".join(
+            f"   switchport trunk allowed vlan {ln}\n" for ln in allowed_lines
+        )
+    )
+    intent = AristaEOSCodec().parse(cfg)
+    iface = next(i for i in intent.interfaces if i.name == "Ethernet1")
+    return iface.trunk_allowed_vlans
+
+
+class TestMultiLineAddWiring:
+    """The continuation-line ``add`` form must union, not collapse to
+    ``[40]``, for every Cisco-family codec."""
+
+    def test_iosxe_add_unions(self) -> None:
+        assert _iosxe_trunk("10,20", "add 30,40") == [10, 20, 30, 40]
+
+    def test_nxos_add_unions(self) -> None:
+        assert _nxos_trunk("10,20", "add 30,40") == [10, 20, 30, 40]
+
+    def test_arista_add_unions(self) -> None:
+        assert _arista_trunk("10,20", "add 30,40") == [10, 20, 30, 40]
+
+    def test_iosxe_remove_subtracts(self) -> None:
+        assert _iosxe_trunk("10,20,30", "remove 20") == [10, 30]
+
+    def test_nxos_remove_subtracts(self) -> None:
+        assert _nxos_trunk("10,20,30", "remove 20") == [10, 30]
+
+    def test_arista_remove_subtracts(self) -> None:
+        assert _arista_trunk("10,20,30", "remove 20") == [10, 30]
+
+    def test_bare_single_line_unchanged_iosxe(self) -> None:
+        # Lock the byte-identical single-line behaviour the whole corpus
+        # relies on (input order preserved, range expanded).
+        assert _iosxe_trunk("10,20,30-32") == [10, 20, 30, 31, 32]
+
+    def test_bare_single_line_unchanged_arista(self) -> None:
+        assert _arista_trunk("10,20,30-32") == [10, 20, 30, 31, 32]

--- a/tests/unit/migration/test_vlan_expansion_bounds.py
+++ b/tests/unit/migration/test_vlan_expansion_bounds.py
@@ -12,12 +12,20 @@ from __future__ import annotations
 
 import pytest
 
+from netcanon.migration.codecs._helpers import merge_trunk_allowed
 from netcanon.migration.codecs.arista_eos.parse import _expand_vlan_list as eos
 from netcanon.migration.codecs.aruba_aoscx.parse import _parse_vlan_list as aoscx
-from netcanon.migration.codecs.cisco_iosxe_cli.parse import _parse_vlan_list as iosxe
 from netcanon.migration.codecs.cisco_nxos.parse import _parse_vlan_list as nxos
 
 pytestmark = pytest.mark.unit
+
+
+def iosxe(spec: str) -> list[int]:
+    # cisco_iosxe_cli expands a trunk allowed-list via the shared
+    # ``merge_trunk_allowed`` bare path (default ``parse_ids`` is
+    # ``_parse_vlan_list``), which carries the OOM clamp.
+    return merge_trunk_allowed([], spec)
+
 
 # Each codec's comma/range VLAN-list expander (cisco family + arista).
 _EXPANDERS = [


### PR DESCRIPTION
## What

Fixes the trunk `switchport trunk allowed vlan add` / `remove` collapse — **T0-1 (HIGH)** from the 6th blind audit (`65f9c01`), verified-real in all three Cisco-family codecs.

`show running-config` renders a long trunk allowed-list across multiple lines using relative keyword forms:

```
switchport trunk allowed vlan 10,20
switchport trunk allowed vlan add 30,40
```

`cisco_iosxe_cli`, `cisco_nxos` and `arista_eos` **overwrote** `trunk_allowed` per line (keeping only the last) and the leading keyword glued onto the first id token (`"add 30"` → non-numeric → silently skipped by the vlan-list parser). So the sequence above collapsed to `[40]` — 10/20 lost to the overwrite, 30 lost as non-numeric — with **no warning** and `severity: ok`. This is the default rendering of a long allowed-list, not an edge case; it silently changes L2 segmentation.

## Fix

- New shared `merge_trunk_allowed(existing, remainder, *, parse_ids=_parse_vlan_list)` in `codecs/_helpers.py` strips a leading `add`/`remove`/`none`/`all`/`except` keyword and applies it relative to the running list (union / subtract / clear / full 1-4094 / complement). A bare list still **sets** membership exactly as before.
- All three Cisco-family codecs route their `switchport trunk allowed vlan` line through it.
- `parse_ids` is injectable so the keyword logic is shared in one place **without converging each codec's id-list parser**: `arista_eos` keeps its deliberately-divergent `_expand_vlan_list` (which accepts `int()` forms like `"+10"` the shared `str.isdigit()` gate rejects — a non-convergence pinned by `test_helpers_equivalence.py`) and passes it as `parse_ids`.

## Safety / regen

- The **bare single-line form is byte-identical** to the prior parse path — only the keyword forms (which no prior code handled) change behaviour.
- **No real fixture uses the keyword forms** (`add`/`remove`/`none`/`all`/`except` on `switchport trunk allowed vlan`) — verified by grep across `tests/fixtures/real/`. So the entire existing corpus parses unchanged and **no cross-mesh / phase4 regen is needed**. (The 10 `vlan trunk allowed all` hits are all **aoscx**, intentionally out of scope: AOS-CX has no `add`/`remove` continuation form and its `all`→`[]` convention is preserved.)
- Full `tests/unit` + the **entire `tests/integration` suite** pass with zero drift.

## Docs

The existing vendor-reference docs (`arista_eos_to_cisco_iosxe_cli/switchport.md`, `cisco_iosxe_cli_to_juniper_junos/vlans.md`) already describe the `add` form flattening to a single canonical list — they were *aspirational* (the code was buggy). The audit's endorsed resolution was "fix the claim or fix the code"; fixing the code makes those docs accurate, now backed by a regression test.

## Tests

- `tests/unit/migration/test_trunk_allowed_vlan_add.py` (new) — shared-helper logic (set/add/remove/none/all/except + the exact `add 30,40`→`[40]` regression) plus per-codec wiring proving the multi-line `add` unions for iosxe/nxos/arista.
- `test_helpers_equivalence.py` / `test_vlan_expansion_bounds.py` updated: `cisco_iosxe_cli` no longer imports `_parse_vlan_list` directly (its only caller now routes through `merge_trunk_allowed`), so the iosxe entry moves to exercise that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
