### PR TITLE
fix(sanitize): redact static-route destination prefix (audit 65f9c01 #20)

### DIFF
--- a/BUG_REPORTING.md
+++ b/BUG_REPORTING.md
@@ -150,6 +150,7 @@ the same redacted value all 5 times).
 | VLAN-SVI IPv4 addresses (the VLAN interface's L3 config) | Public IPv4 → docs ranges; private preserved |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
 | VRRP / CARP virtual IPs (v4 + v6) | Public → docs ranges; private / ULA preserved |
+| Static-route destination prefix + next-hop | Public IPv4 / IPv6 → docs ranges (prefix length preserved); default route + private aggregates preserved |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall, NAT, VPN) | Stripped entirely |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ timestamp if your timezone matters for an audit.
 
 ### Security
 
+* **Static-route destination prefixes are now redacted by the
+  sanitiser.** `netcanon sanitize` redacted a static route's next-hop
+  (`gateway`) but passed its `destination` CIDR through verbatim, so a
+  route to a public provider / peer / branch block leaked the real prefix
+  into a shared sanitised config or bug report. The destination is now
+  redacted to an RFC 5737 / RFC 3849 documentation range with the prefix
+  length preserved (via the existing `redact_cidr`); the default route
+  (`0.0.0.0/0`) and private aggregates are preserved. Found by an
+  independent blind audit (`65f9c01`, #20). (The companion DNS-name host
+  re-leak the same finding notes remains a documented sanitiser
+  limitation -- host fields written as FQDNs still pass through.)
 * **Anycast / VARP virtual-gateway address no longer leaks through the
   sanitizer.** `CanonicalIPv4Address` / `CanonicalIPv6Address.virtual_gateway_address`
   -- the anycast gateway IP rendered verbatim by Arista (`ip address

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -385,6 +385,7 @@ on the canonical model:
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
 | VRRP / CARP virtual IPs (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
 | Anycast / VARP virtual-gateway addresses (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
+| Static-route destination prefix + next-hop (public) | RFC 5737 / RFC 3849 docs ranges (prefix length preserved) |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall / NAT / VPN) | Stripped entirely |
 

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -67,6 +67,8 @@ Field-typed rules (counter-per-session):
   range — SEPARATE field from ``interfaces[].ipv4_addresses``; the
   Aruba / Junos SVI-on-VLAN model renders these directly
 * ``CanonicalStaticRoute.gateway`` (public) → docs range
+* ``CanonicalStaticRoute.destination`` (public destination CIDR) → docs
+  range, prefix length preserved
 * ``CanonicalIntent.dropped_tier3_sections`` → stripped entirely
   (Tier-3 carry-through may contain anything; never share)
 
@@ -655,8 +657,24 @@ def sanitize_intent(
             ))
             pool.domain_name = new_domain
 
-    # ---- static-route gateways + descriptions ----
+    # ---- static-route destinations + gateways + descriptions ----
     for i, route in enumerate(sanitized.static_routes):
+        # The destination prefix is a sibling of the already-redacted
+        # gateway on the same record — a public destination CIDR (a route
+        # to a provider / peer / branch block) is as network-identifying as
+        # the next hop, yet bypassed sanitisation entirely before this.
+        # ``redact_cidr`` preserves the prefix length; private destinations
+        # (the common LAN / aggregate case) are preserved (audit 65f9c01 #20).
+        if route.destination:
+            new_dest = table.redact_cidr(route.destination)
+            if new_dest != route.destination:
+                subs.append(Substitution(
+                    category="ipv4-public",
+                    field=f"static_routes[{i}].destination",
+                    original=route.destination,
+                    redacted=new_dest,
+                ))
+                route.destination = new_dest
         if route.gateway:
             new_gw = table.redact_ip_string(route.gateway)
             if new_gw != route.gateway:

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -525,6 +525,31 @@ class TestStaticRouteRedaction:
         # Private gateway preserved
         assert sanitized.static_routes[1].gateway == "192.168.1.1"
 
+    def test_public_destination_redacted_prefix_preserved(self):
+        """A public destination CIDR (a route to a provider / peer block) is
+        redacted to a docs range with its prefix length preserved; the
+        default route and private aggregates are preserved (audit 65f9c01 #20)."""
+        intent = CanonicalIntent(
+            static_routes=[
+                # 44.21.0.0/16 is clearly public (44/8 is allocated + routable,
+                # and NOT one of the RFC 5737 docs ranges the redactor skips).
+                CanonicalStaticRoute(destination="44.21.0.0/16", gateway="44.21.0.1"),
+                # default route — 0.0.0.0 is unspecified, left as-is.
+                CanonicalStaticRoute(destination="0.0.0.0/0", gateway="192.0.2.1"),
+                # private aggregate preserved (the common LAN case).
+                CanonicalStaticRoute(destination="10.20.0.0/16", gateway="10.0.0.1"),
+            ]
+        )
+        sanitized, subs = sanitize_intent(intent)
+        public_dest = sanitized.static_routes[0].destination
+        assert public_dest != "44.21.0.0/16"      # public dest redacted
+        assert public_dest.endswith("/16")         # prefix length preserved
+        assert sanitized.static_routes[1].destination == "0.0.0.0/0"
+        assert sanitized.static_routes[2].destination == "10.20.0.0/16"
+        assert any(
+            s.field == "static_routes[0].destination" for s in subs
+        ), "destination redaction must be recorded in the substitution log"
+
 
 class TestTier3Stripped:
     def test_dropped_tier3_sections_emptied(self):

--- a/tests/unit/tools/test_sanitize_completeness.py
+++ b/tests/unit/tools/test_sanitize_completeness.py
@@ -73,6 +73,7 @@ _SENSITIVE_REDACTED = frozenset({
     ("CanonicalSNMPv3User", "auth_passphrase"),
     ("CanonicalSNMPv3User", "engine_id"),
     ("CanonicalSNMPv3User", "priv_passphrase"),
+    ("CanonicalStaticRoute", "destination"),
     ("CanonicalStaticRoute", "gateway"),
     ("CanonicalVxlan", "flood_list"),
     ("CanonicalVxlan", "mcast_group"),
@@ -84,7 +85,7 @@ _SENSITIVE_REDACTED = frozenset({
 
 #: Sensitive str leaves the sanitiser does NOT cover yet — surfaced + tracked +
 #: deferred. REDACTION_NOT_WIRED: a clean follow-up wires it (a redact_mac
-#: primitive; static-route-destination redact_cidr). TIER3_OPAQUE: verbatim
+#: primitive for the anycast / VRRP virtual-MAC fields). TIER3_OPAQUE: verbatim
 #: vendor text the STRUCTURED sanitiser can't reach (sanitize_text re-parses +
 #: sanitises the text path, but the intent-level walk treats these as a blob).
 _SENSITIVE_GAP: dict[tuple[str, str], tuple[str, str]] = {
@@ -92,7 +93,6 @@ _SENSITIVE_GAP: dict[tuple[str, str], tuple[str, str]] = {
     ("CanonicalIPv6Address", "virtual_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast vMAC; redact_mac follow-up"),
     ("CanonicalVRRPGroup", "virtual_mac"): ("REDACTION_NOT_WIRED", "VRRP vMAC; redact_mac follow-up"),
     ("CanonicalIntent", "anycast_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast-gateway MAC; redact_mac follow-up"),
-    ("CanonicalStaticRoute", "destination"): ("REDACTION_NOT_WIRED", "public dest CIDR unredacted; redact_cidr later"),
     ("CanonicalIntent", "raw_sections"): ("TIER3_OPAQUE", "Tier-3 verbatim text; structural walk can't reach it"),
     ("CanonicalIntent", "group_content"): ("TIER3_OPAQUE", "Junos group bodies (verbatim); not structurally sanitised"),
     ("CanonicalIntent", "dropped_tier3_sections"): ("TIER3_OPAQUE", "dropped-section text; not structurally sanitised"),


### PR DESCRIPTION
## What

Closes the concrete half of **#20 (MEDIUM, data-privacy)** from the 6th blind audit (`65f9c01`): the sanitiser redacted a static route's next-hop (`gateway`) but **passed its `destination` CIDR through verbatim**, so a route to a public provider / peer / branch block leaked the real prefix into a shared sanitised config. This is exactly the `REDACTION_NOT_WIRED` gap my #180 completeness guard already flagged and tracked.

## Fix

- `CanonicalStaticRoute.destination` → existing `redact_cidr` (public address → RFC 5737/3849 docs range, **prefix length preserved**; `0.0.0.0/0` default route and private aggregates preserved). Mirrors the EVPN Type-5 `prefix` redaction already in the file.
- #180 sanitizer-completeness guard: `destination` moves from `_SENSITIVE_GAP` (`REDACTION_NOT_WIRED`) → `_SENSITIVE_REDACTED`.
- Forward test in `TestStaticRouteRedaction` (public dest redacted + prefix preserved + default/private preserved + substitution logged).
- SECURITY.md + BUG_REPORTING.md sanitiser-coverage rows.

## Scope note (the other half of #20)

Audit #20 also flags *"DNS-name host fields re-leak org domain"* — an FQDN syslog / RADIUS / NTP / trap target passing through verbatim. That is a **separate, deliberately-documented** sanitiser limitation (`sanitize.py` Limitations: *"Host fields given as DNS names pass through … hand-edit those before sharing"*). Closing it reverses a documented decision and over-redacts public pools (`pool.ntp.org`), so per verify-first discipline I've **left it as-is pending an explicit decision** rather than bundle a behavior change here. Flagging it for a yes/no.

## Verification

- `redact_cidr` already existed (used by DHCP `network` + EVPN `prefix`) — no new primitive.
- Sanitiser is not in the codec round-trip → **no cross-mesh / phase4 regen**.
- Full `tests/unit` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
