### PR TITLE
fix(sanitize): redact FQDN host fields so they don't re-leak the org domain (audit 65f9c01 #20)

### DIFF
--- a/BUG_REPORTING.md
+++ b/BUG_REPORTING.md
@@ -145,7 +145,7 @@ the same redacted value all 5 times).
 | SNMPv3 user names (USM securityName) | `snmpv3userN` (independent counter from local-user-name) |
 | SNMPv3 auth/priv passphrases | `REDACTED-AUTH-N` / `REDACTED-PRIV-N` |
 | RADIUS shared secrets | `REDACTED-RADIUS-N` |
-| RADIUS server / SNMP trap-target / DHCP gateway+range+subnet hosts | Public IPv4 / IPv6 → docs ranges; private / hostname preserved |
+| RADIUS / SNMP-trap / NTP / syslog / DHCP gateway+range+subnet hosts | Public IPv4 / IPv6 → docs ranges; an FQDN NTP / syslog / trap / RADIUS target → `host-N.example.test`; private IP + bare single label preserved |
 | Interface IPv6 addresses | Public / global IPv6 → `2001:db8::`; ULA / link-local / loopback / multicast preserved |
 | VLAN-SVI IPv4 addresses (the VLAN interface's L3 config) | Public IPv4 → docs ranges; private preserved |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
@@ -167,12 +167,13 @@ Full rules and limitations in the sanitiser's module docstring at
 - **Banner / comment text not redacted.**  These aren't in the
   canonical model.  Most are parse-and-ignored.  If your config has
   sensitive banner text, hand-edit it after sanitising.
-- **Host fields given as DNS names pass through.**  IP-typed
-  redaction (interface / SVI / VRRP-VIP / RADIUS server / SNMP trap
-  target / DHCP gateway+range) covers bare IPv4 *and* IPv6 literals
-  (v0.4.1); a target written as a hostname (`nms.corp.example`) is
-  free text the model does not classify, so it is preserved.
-  Hand-edit name-form hosts if they are identifying.
+- **FQDN host targets redacted; unmodelled host references not.**  The
+  modelled host fields (NTP / syslog / SNMP-trap / RADIUS targets) now
+  redact an FQDN to a stable `host-N.example.test` placeholder so the org
+  domain does not re-leak; bare IPv4 / IPv6 literals → docs ranges and a
+  bare single label (`localhost`) is preserved.  A host written into a
+  region the canonical model does not type as a host (Tier-3 / banner
+  text) still passes through — hand-edit those before sharing.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,19 @@ timestamp if your timezone matters for an audit.
   redacted to an RFC 5737 / RFC 3849 documentation range with the prefix
   length preserved (via the existing `redact_cidr`); the default route
   (`0.0.0.0/0`) and private aggregates are preserved. Found by an
-  independent blind audit (`65f9c01`, #20). (The companion DNS-name host
-  re-leak the same finding notes remains a documented sanitiser
-  limitation -- host fields written as FQDNs still pass through.)
+  independent blind audit (`65f9c01`, #20).
+* **DNS-name host fields no longer re-leak the org domain.** NTP /
+  syslog / SNMP-trap / RADIUS targets written as FQDNs
+  (`syslog.corp.example.com`, or a bare registered domain `acme.com`)
+  passed through `netcanon sanitize` verbatim -- the IP-typed redaction
+  only caught literal addresses -- so the operator's domain re-leaked
+  into a shared config. Such fields now redact to a stable
+  `host-N.example.test` placeholder (the WHOLE name, since the
+  registered-domain boundary can't be found reliably without a
+  public-suffix list); IP entries are unchanged and a bare single label
+  (`localhost`) is preserved. This deliberately also redacts public
+  service names (`pool.ntp.org`) -- harmless for a config meant for
+  sharing. Completes the second half of audit `65f9c01` #20.
 * **Anycast / VARP virtual-gateway address no longer leaks through the
   sanitizer.** `CanonicalIPv4Address` / `CanonicalIPv6Address.virtual_gateway_address`
   -- the anycast gateway IP rendered verbatim by Arista (`ip address

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -380,7 +380,7 @@ on the canonical model:
 | SNMP contact / location (operator PII) | `<contact redacted>` / `<location redacted>` |
 | SNMPv3 auth/priv passphrases | `REDACTED-AUTH-N` / `REDACTED-PRIV-N` |
 | RADIUS shared secrets | `REDACTED-RADIUS-N` |
-| RADIUS server / SNMP trap-target / DHCP gateway+range+subnet hosts (public IPv4 / IPv6) | RFC 5737 / RFC 3849 docs ranges |
+| RADIUS / SNMP-trap / NTP / syslog / DHCP gateway+range+subnet hosts (public IPv4 / IPv6) | RFC 5737 / RFC 3849 docs ranges; an FQDN NTP / syslog / trap / RADIUS target → `host-N.example.test` (bare single label preserved) |
 | VLAN-SVI IPv4 addresses (public) | RFC 5737 docs ranges |
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
 | VRRP / CARP virtual IPs (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
@@ -395,9 +395,9 @@ gets the same redacted value all 5 times).  `--dry-run` prints the
 substitution table for operator review before writing output.
 
 Known limitations are listed in
-[`BUG_REPORTING.md`](BUG_REPORTING.md) — IP-typed redaction now covers
-both IPv4 and IPv6, but host fields given as DNS names (a RADIUS / trap
-target like `nms.corp.example`) still pass through, and banner / comment
+[`BUG_REPORTING.md`](BUG_REPORTING.md) — IP-typed redaction covers both
+IPv4 and IPv6, FQDN-form NTP / syslog / SNMP-trap / RADIUS host targets
+are redacted to a `host-N.example.test` placeholder, and banner / comment
 text is parse-and-ignored rather than redacted.
 
 ---
@@ -617,7 +617,7 @@ regulated environments.
 | Key loss (keyring entry deleted / env var unset on restart / `.fernet_key` deleted) | Encrypted profiles become unreadable | Accepted | User must re-enter credentials; profiles are low-volume.  Operators using tier 1 / tier 3 should back the key up alongside their other infrastructure secrets |
 | SSH host-key trust-on-first-use | A MITM present on the **first** connect to a given device is trusted + pinned (the classic TOFU window) | Yes (TOFU is the default, v0.4.5+) | Default `ssh_host_key_checking=tofu`: the first key seen per device is pinned under `{data_dir}/known_hosts` and a later **changed** key is rejected (`BadHostKeyException`) — on both collectors (Paramiko inline; Netmiko via an auth-less `verify_host_key` pre-flight that reads + pins/rejects before Netmiko connects `ssh_strict`).  Eliminate the first-connect window with `reject` + a pre-seeded store.  `auto_add` (legacy trust-anything, no pinning) remains an opt-out and warns at startup.  A legitimately re-keyed device needs its line cleared from the store before the next backup. |
 | Banner / comment text not sanitised | Operator-submitted bug reports may leak banner content | Documented | Sanitiser is canonical-model-driven; banner text is parse-and-ignored.  See `BUG_REPORTING.md`; hand-redact banners before submission. |
-| DNS-name host fields not redacted | A RADIUS / SNMP-trap / NTP target given as a DNS name (`nms.corp.example`) passes through verbatim | Documented | IP-typed redaction covers IPv4 + IPv6 literals (v0.4.1); name-form hosts are free text the model does not classify.  Hand-redact named targets before submission. |
+| DNS-name in an UNMODELLED host region | An FQDN inside a Tier-3 / banner / comment region the canonical model doesn't type as a host passes through verbatim | Documented (narrowed) | The modelled host fields (NTP / syslog / SNMP-trap / RADIUS) now redact an FQDN target to `host-N.example.test`; only hosts the model can't see (Tier-3 / banner text, itself parse-and-ignored) remain.  Hand-redact those before submission. |
 | Backup artifacts (`configs/`) stored plaintext | Fetched device configs contain device secrets (`$9$`/type-7/`$6$`, SNMP/RADIUS/IKE) written verbatim | Yes (deliberate) | A backup must be the real, complete, diffable config; recommended at-rest control is an OS-encrypted volume (covers `configs/` + the key in one layer; offline-threat only).  See "Credential Storage → Backup artifacts" |
 | Backup-engine resource exhaustion (many concurrent jobs) | The per-job worker pool caps a *single* job at `MAX_BACKUP_CONCURRENCY` (10), but several schedules firing together — or a schedule firing during a manual run — each spin up their own pool, so the total SSH/NETCONF session count was unbounded (N jobs x per-job cap), able to exhaust threads / file descriptors on the backup host | No (mitigated) | A process-wide `BoundedSemaphore` (`netcanon/services/backup_runner.py`) caps the *sum* of in-flight device collections across all concurrent jobs at `MAX_GLOBAL_BACKUP_CONCURRENCY` (defaults to the per-job cap, so single-job behaviour is unchanged); an over-limit worker blocks (back-pressure) until a slot frees, never failing.  Raise via `NETCANON_MAX_GLOBAL_BACKUP_CONCURRENCY`.  The 500-device per-request cap + opt-in egress allow-list bound the surface further.  (blind audit `3ec11f3`, r7) |
 

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -36,13 +36,18 @@ Field-typed rules (counter-per-session):
   email / name)
 * ``CanonicalSNMP.location`` → ``<location redacted>`` (operator PII —
   site / address)
-* ``CanonicalSNMP.trap_hosts`` (public entries) → docs range
+* ``CanonicalSNMP.trap_hosts`` (public IP → docs range; FQDN →
+  ``host-N.example.test``)
 * ``CanonicalSNMPv3User.name`` → ``snmpv3userN`` (Phase-3 R6.1 — same
   rationale as local-user-name above)
 * ``CanonicalSNMPv3User.auth_passphrase`` → ``REDACTED-AUTH-N``
 * ``CanonicalSNMPv3User.priv_passphrase`` → ``REDACTED-PRIV-N``
 * ``CanonicalRADIUSServer.key`` → ``REDACTED-RADIUS-N``
-* ``CanonicalRADIUSServer.host`` (public) → docs range
+* ``CanonicalRADIUSServer.host`` (public IP → docs range; FQDN →
+  ``host-N.example.test``)
+* ``CanonicalIntent.ntp_servers`` / ``syslog_servers`` (public IP → docs
+  range; FQDN → ``host-N.example.test`` — a DNS name re-leaks the org
+  domain).  ``dns_servers`` are IP-only by protocol (resolver addresses)
 * ``CanonicalVRRPGroup.authentication`` → ``<scheme>:REDACTED-VRRP-AUTH-N``
   — the ``<scheme>:`` prefix (``plain:`` / ``md5:`` / ``carp-key:``) is
   metadata and is preserved so the renderer still emits valid syntax;
@@ -80,10 +85,14 @@ Limitations:
   Tier-3 content is dropped on parse, banners are typically
   parse-and-ignore.
 * IP-typed redaction covers both IPv4 and IPv6 (interface / SVI /
-  DHCP / RADIUS / trap-target / VRRP-VIP addresses).  Host fields
-  given as DNS NAMES (e.g. a RADIUS / trap target of
-  ``nms.corp.example``) still pass through verbatim — hand-edit those
-  before sharing.
+  DHCP / VRRP-VIP addresses).  Host fields that legitimately hold DNS
+  NAMES (NTP / syslog / SNMP-trap / RADIUS targets) are also redacted:
+  a multi-label FQDN (``nms.corp.example``) → a stable
+  ``host-N.example.test`` placeholder so the org domain does not
+  re-leak; a bare single label (``localhost``) has no domain and is
+  preserved.  A host written into a field the model does NOT type as a
+  host (e.g. inside an unmodelled Tier-3 stanza) still passes through —
+  hand-edit those before sharing.
 * Round-trip is sub-lossless: parse drops Tier-3 content, and render
   emits only what the codec models.  Operators sharing a sanitized
   config get the supported subset, not a byte-identical-shape
@@ -107,10 +116,23 @@ from __future__ import annotations
 
 import ipaddress
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from ..migration.canonical.intent import CanonicalIntent
 from ..migration.codecs.registry import get_codec
+
+#: A DNS hostname: dot-separated labels (alnum + internal hyphen), at least
+#: two labels (the leading ``(?:...)`` + the ``(?:\.…)+`` group), <= 253
+#: chars.  Used by :meth:`_SubstitutionTable.redact_host` to tell an FQDN
+#: host field (whose domain suffix re-leaks the org) from a bare single
+#: label (``localhost`` / ``nms`` — no domain to leak) or free text.  IP
+#: literals are matched + handled BEFORE this regex, so the fact that a
+#: dotted-quad also matches the shape is moot.
+_HOSTNAME_RE = re.compile(
+    r"^(?=.{1,253}$)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$"
+)
 
 # ---------------------------------------------------------------------------
 # Public API — dataclasses
@@ -240,13 +262,18 @@ def sanitize_intent(
         ))
         sanitized.domain = new_value
 
-    # ---- IP-list scalars (DNS / NTP / syslog) ----
+    # ---- host-list scalars (DNS / NTP / syslog) ----
+    # DNS resolvers are IPs by protocol (RFC 2132 option 6); NTP + syslog
+    # targets are commonly FQDNs, so those two also redact a DNS-name entry
+    # (org-domain re-leak) via ``redact_host``.
     sanitized.dns_servers = _redact_ip_list(
         sanitized.dns_servers, "dns_servers", "ipv4-public", table, subs)
     sanitized.ntp_servers = _redact_ip_list(
-        sanitized.ntp_servers, "ntp_servers", "ipv4-public", table, subs)
+        sanitized.ntp_servers, "ntp_servers", "ipv4-public", table, subs,
+        redactor=table.redact_host)
     sanitized.syslog_servers = _redact_ip_list(
-        sanitized.syslog_servers, "syslog_servers", "ipv4-public", table, subs)
+        sanitized.syslog_servers, "syslog_servers", "ipv4-public", table, subs,
+        redactor=table.redact_host)
 
     # ---- interfaces ----
     for i, iface in enumerate(sanitized.interfaces):
@@ -495,12 +522,13 @@ def sanitize_intent(
             ))
             sanitized.snmp.location = redacted_location
 
-        # R-16 / CF-04: SNMP trap-target hosts.  Public IPv4 → docs
-        # range; private / loopback / hostname forms preserved (same
-        # policy as every other IP field).
+        # R-16 / CF-04: SNMP trap-target hosts.  Public IPv4/IPv6 → docs
+        # range; private / loopback preserved.  A trap target written as an
+        # FQDN re-leaks the org domain, so route through ``redact_host``
+        # (65f9c01 #20) — bare single labels still pass through.
         new_traps: list[str] = []
         for j, host in enumerate(sanitized.snmp.trap_hosts):
-            new_host = table.redact_ip_string(host)
+            new_host = table.redact_host(host)
             if new_host != host:
                 subs.append(Substitution(
                     category="ipv4-public",
@@ -555,10 +583,11 @@ def sanitize_intent(
     # ---- RADIUS server host + shared secret (field name: ``key``) ----
     for i, server in enumerate(sanitized.radius_servers):
         # R-16 / CF-04: the RADIUS server address is network-
-        # identifying.  Public IPv4 → docs range; private / hostname
-        # preserved (same IP policy as everywhere else).
+        # identifying.  Public IPv4/IPv6 → docs range; private preserved.
+        # An FQDN target re-leaks the org domain, so route through
+        # ``redact_host`` (65f9c01 #20) — bare single labels pass through.
         if server.host:
-            new_host = table.redact_ip_string(server.host)
+            new_host = table.redact_host(server.host)
             if new_host != server.host:
                 subs.append(Substitution(
                     category="ipv4-public",
@@ -853,6 +882,10 @@ class _SubstitutionTable:
         # name maps above.
         self._route_targets: dict[str, str] = {}
         self._mcast_groups: dict[str, str] = {}
+        # DNS-name host fields (NTP / syslog / SNMP-trap / RADIUS targets
+        # written as FQDNs) re-leak the org domain.  Map each distinct
+        # name to a stable opaque placeholder so cross-references survive.
+        self._host_names: dict[str, str] = {}
 
     def redact_hostname(self, name: str) -> str:
         if name not in self._hostnames:
@@ -957,6 +990,44 @@ class _SubstitutionTable:
         addr, sep, prefix = value.partition("/")
         new_addr = self.redact_ip_string(addr)
         return f"{new_addr}{sep}{prefix}" if sep else new_addr
+
+    def redact_host(self, value: str) -> str:
+        """Redact a host field that may be an IP *OR* a DNS name.
+
+        IP literals go through :meth:`redact_ip_string` (public → docs
+        range; private / loopback preserved) — unchanged behaviour.
+
+        A multi-label DNS name re-leaks the operator's domain: not just
+        ``syslog.corp.example.com`` (where the suffix is the org domain)
+        but also a bare registered domain like ``acme.com`` (where the
+        *first* label is the org).  Because the registered-domain boundary
+        can't be found reliably without a public-suffix list, the whole
+        name is mapped to a stable opaque placeholder
+        (``host-N.example.test``) — same name → same placeholder across the
+        config, so cross-references survive.  This deliberately also
+        redacts public service names (``pool.ntp.org``): a sanitised config
+        is for sharing, and over-redacting a public pool is harmless.
+
+        A bare single label (``localhost`` / ``nms`` — no dot, no domain to
+        leak) and any non-host free text are returned unchanged.
+        """
+        try:
+            ipaddress.IPv4Address(value)
+            return self.redact_ipv4(value)
+        except ValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(value)
+            return self.redact_ipv6(value)
+        except ValueError:
+            pass
+        if "." in value and _HOSTNAME_RE.match(value):
+            if value not in self._host_names:
+                self._host_names[value] = (
+                    f"host-{len(self._host_names) + 1}.example.test"
+                )
+            return self._host_names[value]
+        return value
 
     def redact_route_target(self, value: str) -> str:
         """Cross-reference-stable RD / route-target redaction.
@@ -1134,11 +1205,20 @@ def _redact_ip_list(
     category: str,
     table: _SubstitutionTable,
     subs: list[Substitution],
+    *,
+    redactor: Callable[[str], str] | None = None,
 ) -> list[str]:
-    """Redact a list of IP-string entries; record substitutions inline."""
+    """Redact a list of host-string entries; record substitutions inline.
+
+    *redactor* defaults to :meth:`_SubstitutionTable.redact_ip_string`
+    (IP-only — VTEP flood-list, DNS resolvers).  Pass
+    :meth:`_SubstitutionTable.redact_host` for fields that legitimately
+    hold FQDNs (NTP / syslog targets) so a DNS-name entry is redacted too.
+    """
+    fn = redactor or table.redact_ip_string
     out: list[str] = []
     for j, ip in enumerate(values):
-        new_ip = table.redact_ip_string(ip)
+        new_ip = fn(ip)
         if new_ip != ip:
             subs.append(Substitution(
                 category=category,

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -551,6 +551,66 @@ class TestStaticRouteRedaction:
         ), "destination redaction must be recorded in the substitution log"
 
 
+class TestDnsNameHostFieldRedaction:
+    """DNS-name host fields (NTP / syslog / SNMP-trap / RADIUS targets) must
+    not re-leak the org domain (audit 65f9c01 #20)."""
+
+    def test_fqdn_maps_to_stable_opaque_placeholder(self):
+        table = _SubstitutionTable()
+        out = table.redact_host("syslog.corp.example.com")
+        assert out == "host-1.example.test"
+        assert "corp.example.com" not in out and "example.com" not in out
+        # stable: same FQDN -> same placeholder (cross-reference survives)
+        assert table.redact_host("syslog.corp.example.com") == "host-1.example.test"
+        # distinct FQDN -> distinct placeholder
+        assert table.redact_host("ntp.corp.example.com") == "host-2.example.test"
+
+    def test_two_label_org_domain_not_leaked_in_first_label(self):
+        """The org name lives in the FIRST label of a bare registered domain
+        (``acmecorp.com``); preserving the first label would leak it, so the
+        whole name is replaced."""
+        out = _SubstitutionTable().redact_host("acmecorp.com")
+        assert "acmecorp" not in out
+        assert out == "host-1.example.test"
+
+    def test_ip_behaviour_unchanged(self):
+        table = _SubstitutionTable()
+        # public IP -> docs range (as before)
+        assert table.redact_host("8.8.8.8").startswith(
+            ("192.0.2.", "198.51.100.", "203.0.113.")
+        )
+        # private IP preserved
+        assert table.redact_host("10.0.0.5") == "10.0.0.5"
+
+    def test_bare_single_label_preserved(self):
+        table = _SubstitutionTable()
+        assert table.redact_host("localhost") == "localhost"
+        assert table.redact_host("nms") == "nms"
+
+    def test_fqdn_servers_redacted_through_sanitize_intent(self):
+        intent = CanonicalIntent(
+            ntp_servers=["ntp.corp.example.com", "10.0.0.1"],
+            syslog_servers=["logs.corp.example.com"],
+            snmp=CanonicalSNMP(trap_hosts=["nms.corp.example.com"]),
+            radius_servers=[
+                CanonicalRADIUSServer(
+                    host="radius.corp.example.com", key="s3cret"
+                )
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        # The org domain must not survive in ANY host field.
+        assert all("corp.example.com" not in h for h in sanitized.ntp_servers)
+        assert all("corp.example.com" not in h for h in sanitized.syslog_servers)
+        assert all(
+            "corp.example.com" not in h for h in sanitized.snmp.trap_hosts
+        )
+        assert "corp.example.com" not in sanitized.radius_servers[0].host
+        # FQDN entry became a host placeholder; the private IP is preserved.
+        assert sanitized.ntp_servers[0].endswith(".example.test")
+        assert sanitized.ntp_servers[1] == "10.0.0.1"
+
+
 class TestTier3Stripped:
     def test_dropped_tier3_sections_emptied(self):
         intent = CanonicalIntent(
@@ -820,7 +880,7 @@ class TestSNMPContactLocationRedaction:
 
 class TestSNMPTrapHostRedaction:
     """SNMP trap-target hosts: public IPv4 → docs range, private
-    preserved, hostname preserved."""
+    preserved, FQDN → host placeholder (audit 65f9c01 #20)."""
 
     def test_public_trap_host_redacted_private_preserved(self):
         intent = CanonicalIntent(
@@ -837,13 +897,17 @@ class TestSNMPTrapHostRedaction:
         assert sanitized.snmp.trap_hosts[1] == "192.168.50.5"  # private kept
         assert len([s for s in subs if s.category == "ipv4-public"]) == 1
 
-    def test_hostname_trap_target_preserved(self):
+    def test_fqdn_trap_target_redacted(self):
         intent = CanonicalIntent(
             snmp=CanonicalSNMP(community="", trap_hosts=["nms.corp.example"])
         )
         sanitized, _ = sanitize_intent(intent)
-        # Documented residual: name-form hosts pass through.
-        assert sanitized.snmp.trap_hosts[0] == "nms.corp.example"
+        # An FQDN trap target re-leaks the org domain — now redacted to a
+        # stable host placeholder (audit 65f9c01 #20, was a documented
+        # residual passthrough before).
+        assert sanitized.snmp.trap_hosts[0] != "nms.corp.example"
+        assert "corp.example" not in sanitized.snmp.trap_hosts[0]
+        assert sanitized.snmp.trap_hosts[0].endswith(".example.test")
 
 
 class TestRADIUSHostRedaction:

--- a/tests/unit/tools/test_sanitize_completeness.py
+++ b/tests/unit/tools/test_sanitize_completeness.py
@@ -47,6 +47,7 @@ _NON_SENSITIVE_CODES = frozenset(
 #: test_sanitize.py; this set documents coverage and anchors the partition.
 _SENSITIVE_REDACTED = frozenset({
     ("CanonicalDHCPPool", "dns_servers"),
+    ("CanonicalDHCPPool", "domain_name"),
     ("CanonicalDHCPPool", "end_ip"),
     ("CanonicalDHCPPool", "gateway"),
     ("CanonicalDHCPPool", "network"),
@@ -59,6 +60,7 @@ _SENSITIVE_REDACTED = frozenset({
     ("CanonicalIPv6Address", "ip"),
     ("CanonicalIPv6Address", "virtual_gateway_address"),
     ("CanonicalIntent", "dns_servers"),
+    ("CanonicalIntent", "domain"),
     ("CanonicalIntent", "ntp_servers"),
     ("CanonicalIntent", "syslog_servers"),
     ("CanonicalRADIUSServer", "host"),
@@ -102,12 +104,10 @@ _SENSITIVE_GAP: dict[tuple[str, str], tuple[str, str]] = {
 #: interface references, operator free text, tool provenance. Each reason is one
 #: a reviewer can challenge (a real IP/secret leaf has no honest code here).
 _NON_SENSITIVE: dict[tuple[str, str], tuple[str, str]] = {
-    ("CanonicalDHCPPool", "domain_name"): ("IDENTIFIER", "DHCP-offered DNS domain; passed through"),
     ("CanonicalDHCPPool", "interface"): ("IFACE_REF", "bind interface name"),
     ("CanonicalEvpnType5Route", "vrf"): ("IDENTIFIER", "VRF name"),
     ("CanonicalIPv6Address", "scope"): ("ENUM", "global | link-local"),
     ("CanonicalIntent", "apply_groups"): ("METADATA", "Junos apply-group names"),
-    ("CanonicalIntent", "domain"): ("IDENTIFIER", "device DNS domain; passed through"),
     ("CanonicalIntent", "hostname"): ("IDENTIFIER", "device hostname; passed through by design"),
     ("CanonicalIntent", "source_format"): ("METADATA", "source input_format hint"),
     ("CanonicalIntent", "source_vendor"): ("METADATA", "producing codec"),


### PR DESCRIPTION
## What

Closes the **second half of #20** (data-privacy) from the 6th blind audit (`65f9c01`): a NTP / syslog / SNMP-trap / RADIUS host target written as an **FQDN** (`syslog.corp.example.com`, or a bare `acme.com`) passed through `netcanon sanitize` verbatim — the IP-typed redaction only caught literal addresses — so the operator's **org domain re-leaked** into a shared config. (The static-route destination half shipped in #184.)

## Fix

New `_SubstitutionTable.redact_host`:
- **IP** → existing `redact_ip_string` (public → docs range, private preserved) — unchanged.
- **Multi-label DNS name** → a stable `host-N.example.test` placeholder. The *whole* name is replaced (not preserve-first-label): without a public-suffix list the registered-domain boundary is unknowable, and preserving the first label would leak the org in the 2-label `acme.com` case.
- **Bare single label** (`localhost`, `nms`) → unchanged (no domain to leak).
- Cross-reference stable (same name → same placeholder).

Wired into the FQDN-capable fields: `ntp_servers`, `syslog_servers`, `snmp.trap_hosts`, `radius_servers[].host`. `dns_servers` stay IP-only (resolver addresses are IPs by protocol).

**Trade-off (approved):** also redacts public service names (`pool.ntp.org` → `host-N.example.test`) — harmless for a config meant for sharing.

## Also

- Corrects a **#180 completeness-guard misclassification**: `CanonicalIntent.domain` + `CanonicalDHCPPool.domain_name` *are* redacted (via `redact_domain`) but were filed under `_NON_SENSITIVE` "passed through" → moved to `_SENSITIVE_REDACTED`.
- Updated the now-reversed passthrough test (`test_hostname_trap_target_preserved` → `test_fqdn_trap_target_redacted`), the `sanitize.py` Limitations, SECURITY.md (coverage row + threat-model note + narrowed Known-Limitations row), and BUG_REPORTING.md.

## Verification

- New `TestDnsNameHostFieldRedaction` (FQDN → placeholder, 2-label org-not-leaked, IP behaviour unchanged, bare label preserved, end-to-end via `sanitize_intent`).
- Sanitizer is not in the codec round-trip → **no cross-mesh / phase4 regen**.
- Full `tests/unit` + sanitize integration (`test_sanitize_api`/`test_sanitize_page`) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
