### PR TITLE
fix(fortigate): advise on cross-vendor hw-switch member remap (audit 65f9c01 #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,21 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **FortiGate hardware-switch members no longer remap silently across
+  vendors.** On small appliances (40F/60F/80F) `internal1`-`internalN`
+  and `lanN` are switched ports of the `internal` / `lan` L2 fabric, but
+  they classified as plain physical ports and were remapped to a
+  positional target name (`internal3` -> MikroTik `ether3`) with no
+  advisory at all -- the bare `internal` / `lan` aggregate warned, the
+  numbered member did not, silently dropping the L2-fabric-membership
+  semantic the project's own `fortigate_60f.yaml` profile records. The
+  source classifier now flags the member
+  (`PortIdentity.hw_switch_member`) and the vendor-agnostic port-name
+  orchestrator surfaces a soft "verify cabling / L2 role" advisory on
+  cross-vendor runs (same-vendor round-trips losslessly, so none fires;
+  the generic `portN` form is left clean to avoid over-firing). The
+  rename still happens -- the advisory rides alongside it. Found by an
+  independent blind audit (`65f9c01`, #7).
 * **Trunk `switchport trunk allowed vlan add` / `remove` no longer
   collapses VLAN membership.** `show running-config` renders a long
   trunk allowed-list across multiple lines using the relative keyword

--- a/docs/vendors/fortigate.md
+++ b/docs/vendors/fortigate.md
@@ -35,6 +35,16 @@ firewall translation is your primary need, see
   flag before `set mtu` takes effect on physical ports).  `mtu` is declared
   `supported` in the codec capability matrix.  Per-interface VRF is
   routing-instance-scoped, not a Tier-1 binding.
+  **hardware-switch members:** on small appliances (40F/60F/80F)
+  `internal1`-`internalN` / `lanN` are *switched ports* of the
+  `internal` / `lan` L2 fabric, not standalone routed ports.  They
+  translate to a positional target name (`internal3` → MikroTik
+  `ether3`, etc.), so a **cross-vendor** run surfaces a soft advisory in
+  the port-rename panel: the name maps by shape only and does **not**
+  carry the L2-switch membership — verify the target port's physical
+  cabling and L2 role.  Same-vendor round-trip preserves the name, so no
+  advisory fires.  The bare aggregate (`internal` / `lan` with no
+  number) has no cross-vendor equivalent at all and warns separately.
 - VLANs — VLAN sub-interface form (`config system interface` →
   `set type vlan` + `set vlanid <N>`)
 - Static routes (`config router static`)

--- a/netcanon/migration/canonical/port_names.py
+++ b/netcanon/migration/canonical/port_names.py
@@ -171,6 +171,24 @@ class PortIdentity(BaseModel):
     #: membership info without re-parsing.
     aggregate_members: list[str] = Field(default_factory=list)
 
+    #: Source-side advisory flag: this PHYSICAL port is a member of a
+    #: hardware-switch L2 fabric on the source device.  FortiGate
+    #: ``internalN`` / ``lanN`` on small appliances (40F/60F/80F) are
+    #: switched ports of the ``internal`` / ``lan`` fabric, NOT
+    #: standalone routed ports — the bare ``internal`` / ``lan`` form
+    #: classifies as ``hw_aggregate`` (and warns), but the numbered
+    #: member historically classified as plain ``physical`` and was
+    #: remapped to a positional target name with no advisory at all.
+    #: The cross-vendor name mapping is purely positional (name-shape)
+    #: and cannot carry the L2-switch membership, so the orchestrator
+    #: surfaces a soft "verify cabling / L2 role" advisory when source
+    #: and target vendors differ.  ``kind`` STAYS ``physical`` (the
+    #: port IS a real port) — this flag only drives the advisory, never
+    #: the rename or drop.  Vendor-agnostic: any codec whose classifier
+    #: can detect hw-switch membership may set it; today only FortiGate
+    #: does.  Same-vendor round-trip preserves the name, so no advisory.
+    hw_switch_member: bool = False
+
     #: Verbatim source name — used as fallback when the target codec
     #: can't format this identity (``format_port_identity`` returns
     #: ``None``).  Always populated by the source classifier.
@@ -449,6 +467,25 @@ def translate_port_names(
                 dropped_set.add(name)
             memo[name] = name
             return name
+        # A structurally-clean rename can STILL drop a source-side
+        # semantic the target can't carry.  A hardware-switch member
+        # (FortiGate ``internalN`` / ``lanN``) maps to a positional
+        # target name by name-shape only — the L2-fabric membership is
+        # lost even though the rename "succeeded".  This is the
+        # success-branch analogue of the ``hw_aggregate`` warning above
+        # (which fires for the bare ``internal`` / ``lan`` aggregate).
+        # Same-vendor round-trip reproduces the name losslessly, so
+        # gate on a cross-vendor pair to avoid spurious noise.  The
+        # rename is still applied + recorded; the advisory rides
+        # alongside it (the operator needs both).
+        if ident.hw_switch_member and source_codec.name != target_codec.name:
+            warnings.append(
+                f"{target_codec.name}: {source_codec.name} port {name!r} is "
+                f"a hardware-switch (L2 fabric) member; the mapping to {out!r} "
+                f"is positional (name-shape only) and does NOT carry the "
+                f"L2-switch membership — verify the target port's physical "
+                f"cabling and L2 role."
+            )
         memo[name] = out
         if out != name:
             applied[name] = out

--- a/netcanon/migration/codecs/fortigate_cli/port_names.py
+++ b/netcanon/migration/codecs/fortigate_cli/port_names.py
@@ -158,6 +158,12 @@ def classify_port_name(name: str) -> PortIdentity:
             kind="physical",
             port=int(m.group(1)),
             meta={"fortigate_role": "lan"},
+            # Numbered ``lanN`` is a switched member of the ``lan``
+            # hardware-switch fabric on small FortiGates — flag it so
+            # cross-vendor translation surfaces a positional-mapping
+            # advisory (the bare ``lan`` form already warns via
+            # hw_aggregate; the member historically warned for nothing).
+            hw_switch_member=True,
             original=name,
         )
 
@@ -176,6 +182,11 @@ def classify_port_name(name: str) -> PortIdentity:
             kind="physical",
             port=int(m.group(1)),
             meta={"fortigate_role": "internal"},
+            # Numbered ``internalN`` is a switched member of the
+            # ``internal`` hardware-switch fabric (see fortigate_60f.yaml
+            # device profile: ``internal1-5`` = hw-switch default) —
+            # flag it for the cross-vendor positional-mapping advisory.
+            hw_switch_member=True,
             original=name,
         )
 

--- a/tests/unit/migration/test_port_names.py
+++ b/tests/unit/migration/test_port_names.py
@@ -851,6 +851,93 @@ class TestAutoDropUnmappable:
         assert not any("Vlan11" in w for w in result.warnings)
 
 
+class TestHwSwitchMemberAdvisory:
+    """FortiGate numbered hw-switch members (``internalN`` / ``lanN``)
+    must carry a soft positional-mapping advisory on CROSS-vendor
+    translation — blind-audit ``65f9c01`` finding #7.
+
+    The bare ``internal`` / ``lan`` aggregate already warns (kind=
+    hw_aggregate).  The numbered member classified as plain physical
+    and was remapped to a positional target name with NO advisory at
+    all, silently dropping the L2-fabric-membership semantic the
+    project's own ``fortigate_60f.yaml`` profile records.  The fix flags
+    the member on :class:`PortIdentity` and the orchestrator surfaces a
+    "verify cabling" advisory — but only cross-vendor (same-vendor
+    round-trips losslessly) and only for the fabric-member names (the
+    generic ``portN`` form is left clean to avoid over-firing).
+    """
+
+    def test_classifier_flags_numbered_members_not_generic_ports(self):
+        f = FortiGateCLICodec()
+        for member in ("internal3", "internal1", "lan2", "lan5"):
+            ident = f.classify_port_name(member)
+            assert ident.kind == "physical", member
+            assert ident.hw_switch_member is True, (
+                f"{member!r} is a hw-switch member — must set the flag"
+            )
+        # Generic / role-coded ports are NOT fabric members.
+        for routed in ("port5", "port1", "wan1", "dmz1", "mgmt", "a"):
+            ident = f.classify_port_name(routed)
+            assert ident.hw_switch_member is False, (
+                f"{routed!r} is not a hw-switch member — flag must stay False"
+            )
+        # The bare aggregate stays hw_aggregate (its own warning path).
+        for bare in ("internal", "lan"):
+            ident = f.classify_port_name(bare)
+            assert ident.kind == "hw_aggregate", bare
+            assert ident.hw_switch_member is False, bare
+
+    def test_member_advisory_fires_cross_vendor(self):
+        """FortiGate ``internalN`` → MikroTik: rename SUCCEEDS (positional
+        ``etherN``) AND a hardware-switch advisory rides alongside it."""
+        intent = CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(name="internal3"),
+                CanonicalInterface(name="lan2"),
+            ],
+        )
+        result = translate_port_names(
+            intent, FortiGateCLICodec(), MikroTikRouterOSCodec(),
+        )
+        # Rename still happened — the port IS real, just positionally
+        # mapped; it is NOT dropped.
+        assert "internal3" in result.applied
+        assert "internal3" not in result.dropped
+        assert "lan2" in result.applied
+        # The advisory names the source port + the hardware-switch loss.
+        assert any(
+            "internal3" in w and "hardware-switch" in w
+            for w in result.warnings
+        ), result.warnings
+        assert any(
+            "lan2" in w and "hardware-switch" in w for w in result.warnings
+        ), result.warnings
+
+    def test_no_advisory_same_vendor_round_trip(self):
+        """FortiGate → FortiGate reproduces ``internal3`` losslessly, so
+        no advisory (would be spurious noise)."""
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(name="internal3")],
+        )
+        result = translate_port_names(
+            intent, FortiGateCLICodec(), FortiGateCLICodec(),
+        )
+        assert intent.interfaces[0].name == "internal3"
+        assert not any("hardware-switch" in w for w in result.warnings)
+
+    def test_generic_port_no_hw_switch_advisory_cross_vendor(self):
+        """``portN`` is the generic FG-100F+ form (standalone routed),
+        NOT a fabric member — it must not draw the advisory even
+        cross-vendor (the over-fire the design deliberately avoids)."""
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(name="port5")],
+        )
+        result = translate_port_names(
+            intent, FortiGateCLICodec(), MikroTikRouterOSCodec(),
+        )
+        assert not any("hardware-switch" in w for w in result.warnings)
+
+
 # ---------------------------------------------------------------------------
 # Integration: run_plan_with_rename against the real Cat 9300-24UX fixture
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Closes blind-audit `65f9c01` finding **#7** — *"Positional/ordinal port mapping emitted as confident success with no topology warning"* (graded 🔴 UNJUSTIFIED oversight in the audit's `JUSTIFICATION.md`).

FortiGate `internalN` / `lanN` on small appliances (40F/60F/80F) are switched ports of the `internal` / `lan` L2 **hardware-switch** fabric, not standalone routed ports. They classified as plain `physical`, so the target codec's `format_port_identity` returned a real positional name (`internal3` → MikroTik `ether3`) → the orchestrator took the **success** branch with **no advisory**. Meanwhile the *bare* `internal` / `lan` form (kind=`hw_aggregate`) already warns. The project's own `netcanon/definitions/library/target_profiles/fortigate_60f.yaml` records `internal1-5` as the hw-switch default — so the tool *knew* and dropped the L2-membership semantic silently.

## Fix (verify-first; the finding reproduced exactly)

- **`PortIdentity.hw_switch_member: bool`** — a new vendor-agnostic flag. FortiGate's classifier sets it for `internalN` / `lanN`. `kind` stays `physical` (the port is real) — the flag only drives the advisory.
- **Orchestrator** (`canonical/port_names.py`) surfaces a soft *"verify cabling / L2 role"* advisory in the success branch when `ident.hw_switch_member` **and** source ≠ target vendor. The rename still happens and is recorded in `applied`; the advisory rides alongside it (the success-branch analogue of the existing `hw_aggregate` warning).
- **Vendor-agnostic by construction**: the orchestrator reads only the generic flag and the source/target codec *identity* (cross- vs same-vendor) — it never names a vendor, per the module's "never hard-codes a vendor name" contract. Any future codec that detects hw-switch membership gets the advisory for free.

### Scoping (matches the audit's own soundness assessment)
- **Same-vendor** FortiGate→FortiGate round-trips `internal3` losslessly → **no** advisory (would be spurious noise).
- **Generic `portN`** (the FG-100F+ standalone-routed form) is **not** flagged → no over-fire. Blanket-warning every physical port was explicitly rejected as noisy.

## Tests
New `TestHwSwitchMemberAdvisory` (4 tests):
- classifier flags members / clears generic+role ports / clears the bare aggregate;
- advisory fires cross-vendor with the rename **still applied** (not dropped);
- no advisory same-vendor;
- no advisory on `portN`.

`docs/vendors/fortigate.md` gains an honest note (the audit cited it as framing numbered internals as ordinary physical with no membership-loss mention).

## No regen
Pure additive advisory — only `PortRenameResult.warnings` grows. No rendered-config / canonical-tree / matrix-disposition change, so cross-mesh + phase4 snapshots are unaffected.

## Verification
- `ruff` clean on all changed files.
- `tests/unit` full suite green (138 in `test_port_names.py`, +4 new).
- Relevant `tests/integration` (cross-vendor / cross-mesh / fortigate / port-name / rename) green.
- CHANGELOG `[Unreleased] → Fixed` bullet added; changelog guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
