### PR TITLE
fix(pipeline): surface whole-input rejection as partial, not silent completed (audit 65f9c01 T0-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,20 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Unrecognized input no longer reports `completed` via the API /
+  automation contract.** A non-empty config the source codec couldn't
+  parse (wrong source vendor, garbage) produced an empty canonical tree,
+  rendered a banner-only stub, and the job -- plus the
+  `X-Netcanon-Job-Status` header -- reported `completed` with zero
+  warnings, so a CI gate checking only status saw green for a translation
+  that produced nothing. The web UI already flagged this (the empty-result
+  banner); the backend now does too -- `run_plan` downgrades a whole-input
+  rejection to `partial` with an explanatory `error`. Tightly gated
+  (non-trivial input + zero recognized paths + no Tier-3 detected + a real
+  `CanonicalIntent` tree) so a minimal-but-valid config, an all-Tier-3
+  config, and the internal mock codec are never mislabelled. This is the
+  OUTPUT-side half of the silent-loss meta-finding (#180 closed the
+  input-walk half). Found by an independent blind audit (`65f9c01`, T0-2).
 * **Per-port voice VLAN (`switchport voice vlan N`) is no longer
   silently dropped at parse.** `cisco_iosxe_cli` *rendered* the line but
   never *parsed* it, so a real Cisco config's voice binding parsed to

--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -205,8 +205,13 @@ def plan_migration(
 
     * ``completed`` — every stage ran, validation severity is ``ok``
       or ``warn``, rendered output is in ``job.rendered``.
-    * ``partial``  — rendered output exists but validation severity
-      is ``block``; review before deploying.
+    * ``partial``  — rendered output exists but it is not a clean
+      success: EITHER validation severity is ``block`` (target can't
+      faithfully consume the tree), OR the input was non-empty yet
+      parsed to an empty configuration (0 recognized paths, banner-only
+      render — the source vendor most likely doesn't match the input).
+      ``job.error`` explains which.  Review before deploying; an
+      automation gate should treat ``partial`` as a non-success.
     * ``failed``   — a stage raised; ``job.error`` has the summary.
 
     Use ``force=true`` in the request body to override the stage-0

--- a/netcanon/services/migration_pipeline.py
+++ b/netcanon/services/migration_pipeline.py
@@ -124,6 +124,65 @@ logger = logging.getLogger(__name__)
 TransformCallable = Callable[[Any], Any]
 
 
+def _input_not_recognized(raw_text: str, tree: Any, job: MigrationJob) -> bool:
+    """True when *non-trivial* input parsed to an empty canonical tree.
+
+    This is the **whole-input-rejection** silent-success surface (blind
+    audit ``65f9c01`` T0-2, the output-side half of the silent-loss
+    meta-finding): a permissive ``parse()`` returns an empty intent for
+    input it doesn't understand (wrong source vendor, garbage, a config
+    in a format this codec can't read), the validator then walks nothing,
+    severity stays ``ok``, and the job would otherwise reach ``completed``
+    with a banner-only render and zero warnings.  The web UI already flags
+    this (``migrate.html`` ``isEmptyCompleted`` → parse-failure banner),
+    but the backend ``MigrationJob.status`` — and therefore the HTTP /
+    automation contract (``X-Netcanon-Job-Status``) — stayed ``completed``,
+    so a CI gate that only checks status saw a green light for a translation
+    that produced nothing.  This lifts the UI's signal to the pipeline.
+
+    Gated tightly so a legitimate translation is never mislabelled:
+
+      * the input must be **non-trivial** (non-whitespace) — an empty
+        submission is vacuously empty, not a rejection (and most codecs
+        raise ``ParseError`` on empty input anyway, never reaching here);
+      * the validator must have recognized **zero** paths — any supported
+        / lossy / unsupported path means the parse understood something,
+        so a tiny-but-valid config (e.g. just ``hostname R1``) is safe;
+      * **no Tier-3 sections were detected** — an all-Tier-3 config (e.g.
+        a firewall-only ruleset) already carries its own honest "detected
+        in source but not translated" signal via
+        ``dropped_tier3_sections``, so it is a *recognized* (if
+        untranslatable) input, not a rejection.
+
+    Mirrors the UI's ``isEmptyCompleted`` zero-path test, plus the Tier-3
+    exemption so the backend signal is at least as precise as the banner.
+
+    Only applies to a real :class:`CanonicalIntent` tree: the internal
+    ``mock`` reference codec and ad-hoc test stubs return a plain ``dict``
+    by design (a deliberate no-op parse, not a parse that "recognized
+    nothing"), so they are never flagged — same non-canonical guard the
+    port-name orchestrator uses.
+    """
+    # Lazy import — mirrors translate_port_names' non-canonical guard and
+    # avoids any import-time coupling from this codec-agnostic orchestrator.
+    from ..migration.canonical.intent import CanonicalIntent
+
+    if not isinstance(tree, CanonicalIntent):
+        return False
+    if not (raw_text or "").strip():
+        return False
+    if job.dropped_tier3_sections:
+        return False
+    report = job.validation
+    if report is None:
+        return False
+    return not (
+        report.supported_paths
+        or report.lossy_paths
+        or report.unsupported_paths
+    )
+
+
 def run_plan(
     source: CodecBase,
     target: CodecBase,
@@ -277,6 +336,21 @@ def run_plan(
                 "Render completed but target adapter reported unsupported "
                 "or error-level lossy paths — output may not be safe to "
                 "deploy as-is."
+            )
+        elif _input_not_recognized(raw_text, tree, job):
+            # Whole-input rejection (audit 65f9c01 T0-2): non-trivial
+            # input parsed to an empty tree — the source vendor almost
+            # certainly doesn't match the input.  Surfacing this as
+            # `partial` (not `completed`) makes the API / automation
+            # contract honest, matching the UI's empty-result banner.
+            job.status = MigrationJobStatus.partial
+            job.error = (
+                "No source constructs were recognized: the input is "
+                "non-empty but parsed to an empty configuration (0 "
+                "supported / lossy / unsupported paths) and rendered only "
+                "a bare scaffold. The selected source vendor most likely "
+                "does not match the input format — treat this as a failed "
+                "translation, not a clean result."
             )
         else:
             job.status = MigrationJobStatus.completed

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -286,6 +286,31 @@ class TestPlanEndpoint:
         assert job["rendered"] is not None
         assert job["validation"]["severity"] == "ok"
 
+    def test_unrecognized_input_is_partial_not_silent_completed(self, client):
+        """Audit 65f9c01 T0-2: non-trivial input the source codec can't
+        recognize must NOT report ``completed`` via the automation contract.
+
+        Previously a permissive parser returned an empty tree, severity
+        stayed ``ok`` and the job (and ``X-Netcanon-Job-Status`` header) said
+        ``completed`` with a banner-only render — a naive CI gate saw green
+        for a translation that produced nothing. It now reports ``partial``.
+        """
+        resp = client.post(
+            "/api/v1/migration/plan",
+            json={
+                "source": "cisco_iosxe_cli",
+                "target": "arista_eos",
+                "raw_text": "@@@ this is not a real config @@@\nlorem ipsum\n",
+            },
+        )
+        # Still HTTP 200 (the job body is always returned) ...
+        assert resp.status_code == 200
+        job = resp.json()
+        # ... but the disposition is honest on BOTH the body and the header.
+        assert job["status"] == "partial"
+        assert resp.headers["X-Netcanon-Job-Status"] == "partial"
+        assert job["error"] and "recognized" in job["error"].lower()
+
     def test_422_for_unknown_source_codec(self, client):
         resp = client.post(
             "/api/v1/migration/plan",

--- a/tests/unit/migration/test_empty_render_honesty.py
+++ b/tests/unit/migration/test_empty_render_honesty.py
@@ -1,0 +1,117 @@
+"""Output-side completeness: whole-input rejection is NOT silent success
+(blind audit ``65f9c01`` T0-2 — the output-side half of the silent-loss
+meta-finding).
+
+#180 closed the *input-walk* completeness class (a dropped leaf can't ride
+the ``classify()`` default). This closes the symmetric *output-side* surface
+the input-walk guard structurally can't see: a permissive ``parse()`` returns
+an empty canonical tree for input it doesn't understand (wrong source vendor,
+garbage), the validator walks nothing, severity stays ``ok``, and the job
+would reach ``completed`` with a banner-only render and zero warnings. The web
+UI already flagged this (``isEmptyCompleted`` -> parse-failure banner) but the
+backend / HTTP-automation contract (``X-Netcanon-Job-Status``) reported
+``completed`` — so a CI gate checking only status saw green for a translation
+that produced nothing.
+
+``run_plan`` now downgrades such a result to ``partial`` with an explanatory
+``error``, tightly gated so a legitimate translation is never mislabelled:
+non-trivial input + zero recognized paths + no Tier-3 detected + a real
+``CanonicalIntent`` tree (the internal mock / stub codecs return a plain dict
+by design and are exempt).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import CanonicalIntent
+from netcanon.migration.codecs.arista_eos import AristaEOSCodec
+from netcanon.migration.codecs.cisco_iosxe_cli import CiscoIOSXECLICodec
+from netcanon.migration.codecs.registry import get_codec
+from netcanon.models.migration import (
+    MigrationJob,
+    MigrationJobStatus,
+    ValidationReport,
+)
+from netcanon.services.migration_pipeline import (
+    _input_not_recognized,
+    run_plan,
+)
+
+pytestmark = pytest.mark.unit
+
+# A non-empty input that the cisco_iosxe_cli parser recognizes nothing in
+# (not XML/JSON-shaped, so it bypasses the shape guard and falls through the
+# line-scan loop to an empty intent) — the audit's exact T0-2 repro shape.
+_GARBAGE = "@@@ this is not a real network config @@@\nlorem ipsum dolor\n"
+
+
+class TestWholeInputRejectionStatus:
+    def test_garbage_input_is_partial_not_completed(self):
+        job = run_plan(CiscoIOSXECLICodec(), AristaEOSCodec(), _GARBAGE)
+        assert job.status is MigrationJobStatus.partial, (
+            "non-trivial input that parsed to an empty tree must report "
+            "partial, not a silent completed (audit T0-2)"
+        )
+        assert job.error and "recognized" in job.error.lower()
+        # Confirm the precondition: the validator genuinely recognized nothing.
+        v = job.validation
+        assert not (v.supported_paths or v.lossy_paths or v.unsupported_paths)
+
+    def test_minimal_valid_input_stays_completed(self):
+        # `hostname EDGE1` IS recognized (one supported path) -> a real,
+        # if tiny, translation. Must NOT be mislabelled partial.
+        job = run_plan(CiscoIOSXECLICodec(), AristaEOSCodec(), "hostname EDGE1\n")
+        assert job.status is MigrationJobStatus.completed
+        assert job.error is None
+        assert job.validation.supported_paths
+
+    def test_mock_dict_tree_is_exempt(self):
+        # The internal mock codec returns a plain dict (a deliberate no-op
+        # parse), not a CanonicalIntent — it is not a real "recognized
+        # nothing" signal and must stay completed even though its tree has
+        # zero recognized paths. `{}` is the mock's valid (JSON) input shape.
+        mock = get_codec("mock")
+        job = run_plan(mock, mock, "{}")
+        assert job.status is MigrationJobStatus.completed
+
+
+class TestInputNotRecognizedHelper:
+    """White-box: the tightly-gated predicate behind the status downgrade."""
+
+    def _job(self, *, supported=(), tier3=()):
+        return MigrationJob(
+            source_codec="src",
+            target_codec="tgt",
+            validation=ValidationReport(
+                compatible=True, severity="ok", supported_paths=list(supported)
+            ),
+            dropped_tier3_sections=list(tier3),
+        )
+
+    def test_flags_empty_canonical_from_nontrivial_input(self):
+        assert _input_not_recognized("real text", CanonicalIntent(), self._job())
+
+    def test_empty_or_whitespace_input_not_flagged(self):
+        assert not _input_not_recognized("   ", CanonicalIntent(), self._job())
+
+    def test_a_recognized_path_is_not_flagged(self):
+        assert not _input_not_recognized(
+            "real", CanonicalIntent(),
+            self._job(supported=["/system/hostname"]),
+        )
+
+    def test_tier3_detected_is_not_flagged(self):
+        # An all-Tier-3 config carries its own honest "detected but not
+        # translated" signal -> recognized (if untranslatable), not rejected.
+        assert not _input_not_recognized(
+            "real", CanonicalIntent(), self._job(tier3=["firewall"])
+        )
+
+    def test_non_canonical_tree_is_not_flagged(self):
+        # mock / stub dict tree -> not a real parse, exempt.
+        assert not _input_not_recognized("real", {"a": "b"}, self._job())
+
+    def test_missing_validation_is_not_flagged(self):
+        job = MigrationJob(source_codec="src", target_codec="tgt")
+        assert not _input_not_recognized("real", CanonicalIntent(), job)


### PR DESCRIPTION
## What

Closes blind-audit `65f9c01` **T0-2** — *"Silent success / empty render on unrecognized input"* (HIGH) — the **output-side** half of the silent-loss meta-finding (the audit's architectural headline). #180 closed the *input-walk* half (a dropped leaf can't ride the `classify()` default); this closes the symmetric output-side surface the input-walk guard structurally can't see.

A non-empty config the source codec couldn't parse (wrong source vendor, plain garbage) returned an empty `CanonicalIntent`, rendered a banner-only stub, and the job reached `completed` — because `run_plan`'s terminal-`else` only downgrades to `partial` on `validation.severity == "block"`. The HTTP/automation contract (`X-Netcanon-Job-Status: completed`, `error=None`, `severity=ok`) then reported success for a translation that produced **nothing**. A naive CI gate checking only status saw green.

The maintainer already knew this symptom (commit `883a8fa`) and fixed it **UI-only** (the `isEmptyCompleted` empty-result banner) — the backend/API contract was left as-is.

## Fix (verify-first; reproduced exactly — `@@@ garbage @@@` → `completed` before, `partial` after)

`run_plan` now downgrades a **whole-input rejection** to `partial` with an explanatory `error`, lifting the UI's long-standing signal to the pipeline so **every** caller (API, desktop, automation) gets the honest disposition.

Tightly gated so a legitimate translation is never mislabelled:
- **non-trivial input** (whitespace-only is vacuously empty; most codecs raise `ParseError` on empty input anyway);
- the validator recognized **zero paths** (a tiny-but-valid config like `hostname R1` has ≥1 supported path → stays `completed`);
- **no Tier-3 detected** (an all-Tier-3 config carries its own honest "detected but not translated" signal via `dropped_tier3_sections` → recognized, not rejected);
- a real **`CanonicalIntent`** tree — the internal `mock` codec + ad-hoc test stubs return a plain `dict` by design (a no-op parse, not a real "recognized nothing"), so they're exempt (same non-canonical guard `translate_port_names` uses). **This kept every existing device-class-guard test green with zero test changes.**

## Tests
- New `tests/unit/migration/test_empty_render_honesty.py` — status black-box (garbage→partial, minimal-valid→completed, mock→exempt) + helper white-box (non-trivial-empty→flag, whitespace→no, recognized-path→no, Tier-3→no, non-canonical→no, no-validation→no).
- API regression in `test_migration_api.py` reproducing the audit's exact scenario: `POST /plan` garbage → `status: partial` **and** `X-Netcanon-Job-Status: partial`.

## Scope / no regen
Status-disposition fix only — no codec/matrix change, so **no cross-mesh/phase4 regen**. The `/plan` docstring now documents that `partial` also covers the empty-result case and that automation should treat `partial` as a non-success.

**Meta-finding note:** this closes the whole-input-rejection arm. The value-corruption arm (a leaf *is* walked but parsed wrong, e.g. T0-1 trunk collapse) is closed instance-by-instance, not by a general detector.

## Verification
- `ruff` clean; full `tests/unit` + `tests/integration` green (pytest exit 0); changelog guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
