### PR TITLE
release: cut 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-06-25
+
 ### Security
 
 * **Static-route destination prefixes are now redacted by the


### PR DESCRIPTION
## Release cut: 0.4.6

CHANGELOG-only cut — converts `[Unreleased]` → `## [0.4.6] - 2026-06-25`, leaving a fresh empty `[Unreleased]`. setuptools_scm derives the package version from the `v0.4.6` tag pushed after this merges (no version file to bump).

Bundles the 5th-audit Bucket-C residuals + the full 6th-audit (`65f9c01`) remediation:

**Security:** static-route destination redaction (#20a), FQDN host re-leak (#20b), anycast/VARP VGA leak (#174), API-key doc fix (#176), credential fail-closed doc (#177), global backup-concurrency ceiling (#178), publish-run test gate (#179), publish requires full-CI-success (#181).

**Fixed:** unrecognized input → `partial` not silent `completed` (T0-2), voice-VLAN parse+declare (#11), FortiGate hw-switch advisory (#7), trunk `allowed vlan add/remove` collapse (T0-1), stale `definitions/` doc paths (#17), VLAN SVI/mgmt L3 silent loss, VLAN port-membership silent loss.

Patch bump — no breaking default-flip. Changelog guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
