### PR TITLE
fix(api): set X-Netcanon-Job-Status on per-pane endpoints + correct .env.example bind default (audit f92e97a #7 + T0-4 residual)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,13 @@
 # Directory where captured configuration files are stored
 # NETCANON_CONFIGS_DIR=configs
 
-# Bind address for the Uvicorn server (0.0.0.0 = all interfaces)
-# NETCANON_HOST=0.0.0.0
+# Bind address for the Uvicorn server.  Defaults to 127.0.0.1 (loopback) so
+# the zero-config posture is never silently internet-exposed.  Set 0.0.0.0 to
+# listen on all interfaces, but ONLY behind an authenticating reverse proxy:
+# the UI is unauthenticated and the /api/v1 surface is auth-gated only when
+# NETCANON_API_KEY is set.  `netcanon serve` refuses a non-loopback bind with
+# no api_key unless NETCANON_ALLOW_INSECURE_BIND=true.  See SECURITY.md.
+# NETCANON_HOST=127.0.0.1
 
 # TCP port for the Uvicorn server
 # NETCANON_PORT=8000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,26 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Fixed
+
+* **Per-pane migration endpoints now set the `X-Netcanon-Job-Status`
+  response header.** `/plan` and `/render` surfaced the job disposition
+  (`completed` / `partial` / `failed`) in this header so an HTTP-only
+  automation gate -- which always sees a 200 with the job in the body --
+  can still tell a real translation from a partial/failed one. The five
+  per-pane override endpoints (`/plan/ports`, `/plan/vlans`,
+  `/plan/local_users`, `/plan/snmp`, `/plan/snmpv3`) run the same pipeline
+  but omitted the header, so a gate watching only the header saw no signal
+  on those routes. They now set it too, and the body-only parity test was
+  extended to compare the header. Found by an independent blind audit
+  (`f92e97a`, #7).
+* **`.env.example` no longer advertises a `0.0.0.0` bind default.** The
+  sample config still showed `# NETCANON_HOST=0.0.0.0`, contradicting the
+  loopback (`127.0.0.1`) bind default the server has shipped since v0.4.5.
+  The comment now documents the loopback default and warns that `0.0.0.0`
+  should only be used behind an authenticating reverse proxy. Found by an
+  independent blind audit (`f92e97a`, T0-4 residual).
+
 ## [0.4.6] - 2026-06-25
 
 ### Security

--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -281,6 +281,7 @@ def plan_migration(
 )
 def plan_migration_ports(
     body: MigrationPlanRequest,
+    response: Response,
     storage: BaseConfigStore = Depends(get_storage),
 ) -> MigrationJob:
     """Port-rename-only entry into the migration pipeline.
@@ -324,6 +325,10 @@ def plan_migration_ports(
         body.target,
         job.status.value,
     )
+    # Automation contract: per-pane endpoints run the same pipeline as
+    # /plan and can yield partial/failed, so they must surface the job
+    # disposition in the response header too (audit f92e97a #7).
+    response.headers["X-Netcanon-Job-Status"] = job.status.value
     return job
 
 
@@ -338,6 +343,7 @@ def plan_migration_ports(
 )
 def plan_migration_vlans(
     body: MigrationPlanRequest,
+    response: Response,
     storage: BaseConfigStore = Depends(get_storage),
 ) -> MigrationJob:
     """VLAN-rename-only entry into the migration pipeline.
@@ -380,6 +386,7 @@ def plan_migration_vlans(
         body.target,
         job.status.value,
     )
+    response.headers["X-Netcanon-Job-Status"] = job.status.value  # audit f92e97a #7
     return job
 
 
@@ -394,6 +401,7 @@ def plan_migration_vlans(
 )
 def plan_migration_local_users(
     body: MigrationPlanRequest,
+    response: Response,
     storage: BaseConfigStore = Depends(get_storage),
 ) -> MigrationJob:
     """Local-user-rename-only entry into the migration pipeline.
@@ -444,6 +452,7 @@ def plan_migration_local_users(
         body.target,
         job.status.value,
     )
+    response.headers["X-Netcanon-Job-Status"] = job.status.value  # audit f92e97a #7
     return job
 
 
@@ -458,6 +467,7 @@ def plan_migration_local_users(
 )
 def plan_migration_snmp(
     body: MigrationPlanRequest,
+    response: Response,
     storage: BaseConfigStore = Depends(get_storage),
 ) -> MigrationJob:
     """SNMP-community-rename-only entry into the migration pipeline.
@@ -509,6 +519,7 @@ def plan_migration_snmp(
         body.target,
         job.status.value,
     )
+    response.headers["X-Netcanon-Job-Status"] = job.status.value  # audit f92e97a #7
     return job
 
 
@@ -523,6 +534,7 @@ def plan_migration_snmp(
 )
 def plan_migration_snmpv3(
     body: MigrationPlanRequest,
+    response: Response,
     storage: BaseConfigStore = Depends(get_storage),
 ) -> MigrationJob:
     """SNMPv3-user-rename-only entry into the migration pipeline.
@@ -574,6 +586,7 @@ def plan_migration_snmpv3(
         body.target,
         job.status.value,
     )
+    response.headers["X-Netcanon-Job-Status"] = job.status.value  # audit f92e97a #7
     return job
 
 

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -506,13 +506,60 @@ class TestPlanPortsEndpoint:
             "raw_text": _IOSXE_SIMPLE,
             "port_rename_map": {},   # opt into rename-aware pipeline
         }
-        plan = client.post("/api/v1/migration/plan", json=body).json()
-        plan_ports = client.post("/api/v1/migration/plan/ports", json=body).json()
+        plan_resp = client.post("/api/v1/migration/plan", json=body)
+        plan_ports_resp = client.post("/api/v1/migration/plan/ports", json=body)
+        plan = plan_resp.json()
+        plan_ports = plan_ports_resp.json()
         # Same pipeline outcome (job IDs differ, but status + rendered
         # content match).
         assert plan["status"] == plan_ports["status"]
         assert plan["rendered"] == plan_ports["rendered"]
         assert plan["port_renames"] == plan_ports["port_renames"]
+        # Automation-contract parity: the per-pane endpoint must surface the
+        # same X-Netcanon-Job-Status header as /plan, not just the same JSON
+        # body.  The prior assertion compared only .json() and so missed the
+        # header divergence (audit f92e97a #7).
+        assert (
+            plan_ports_resp.headers["X-Netcanon-Job-Status"] == plan_ports["status"]
+        )
+        assert (
+            plan_resp.headers["X-Netcanon-Job-Status"]
+            == plan_ports_resp.headers["X-Netcanon-Job-Status"]
+        )
+
+
+class TestPerPaneEndpointsSetJobStatusHeader:
+    """Every per-pane override endpoint must set ``X-Netcanon-Job-Status``,
+    matching ``/plan`` and ``/render``.
+
+    The endpoint always returns HTTP 200 with the job in the body, so the
+    header is the only signal an HTTP-only automation gate can read to tell
+    completed from partial/failed.  ``/plan`` set it but the five per-pane
+    siblings did not, and the body-only parity test never noticed (audit
+    f92e97a #7).
+    """
+
+    _PER_PANE_PATHS = [
+        "/api/v1/migration/plan/ports",
+        "/api/v1/migration/plan/vlans",
+        "/api/v1/migration/plan/local_users",
+        "/api/v1/migration/plan/snmp",
+        "/api/v1/migration/plan/snmpv3",
+    ]
+
+    @pytest.mark.parametrize("path", _PER_PANE_PATHS)
+    def test_header_present_and_matches_body_status(self, client, path):
+        resp = client.post(
+            path,
+            json={
+                "source": "cisco_iosxe",
+                "target": "cisco_iosxe",
+                "raw_text": _IOSXE_SIMPLE,
+            },
+        )
+        assert resp.status_code == 200
+        assert "X-Netcanon-Job-Status" in resp.headers
+        assert resp.headers["X-Netcanon-Job-Status"] == resp.json()["status"]
 
 
 class TestPlanVlansEndpoint:


### PR DESCRIPTION
## What

Two small, no-regen fixes from the 7th blind audit (`f92e97a`, v0.4.6):

### `#7` — per-pane endpoints now set `X-Netcanon-Job-Status` (automation)
`/plan` and `/render` set the `X-Netcanon-Job-Status` response header so an HTTP-only automation gate (the endpoints always return `200` with the job in the body) can still distinguish `completed` / `partial` / `failed`. The five per-pane override endpoints — `/plan/ports`, `/plan/vlans`, `/plan/local_users`, `/plan/snmp`, `/plan/snmpv3` — run the **same** `run_plan_with_overrides` pipeline (which can yield `partial`/`failed`) but never set the header, so a gate watching only the header saw no signal on those routes.

They now set it, exactly as `/plan` does. The existing parity test (`test_plan_ports_matches_plan_with_rename_map`) compared only `.json()` and so missed the divergence — it now also asserts header parity, and a new parametrised test (`TestPerPaneEndpointsSetJobStatusHeader`) asserts all five set the header and that it equals the body status.

### `T0-4` residual — `.env.example` bind default
The sample config still showed `# NETCANON_HOST=0.0.0.0`, contradicting the `127.0.0.1` loopback bind default the server has shipped since v0.4.5. The comment now documents the loopback default and warns that `0.0.0.0` should only be used behind an authenticating reverse proxy (with the correct `NETCANON_ALLOW_INSECURE_BIND` opt-out name and a SECURITY.md pointer).

## Verification (verify-first)
- Independently reproduced both: only `plan_migration` set `response.headers[...]`; the 5 per-pane functions never took a `response: Response` param. `config.py:176` is `host: str = "127.0.0.1"` while `.env.example:12` advertised `0.0.0.0`.
- No code path calls these endpoint functions directly (grep) — the new `response: Response` param is FastAPI-injected only, matching `/plan` + `/render`.
- Local gate: `ruff` clean; `tests/integration/test_migration_api.py` green; full `tests/unit` green; changelog guard green.

## Scope
No engine/matrix changes — purely the response header + a docs comment + tests. No regen.

Found by an independent blind audit (`f92e97a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
