### PR TITLE
fix(opnsense): declare /routing/static-route lossy — close silent route drop (audit f92e97a T0-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ timestamp if your timezone matters for an audit.
   The comment now documents the loopback default and warns that `0.0.0.0`
   should only be used behind an authenticating reverse proxy. Found by an
   independent blind audit (`f92e97a`, T0-4 residual).
+* **OPNsense no longer silently drops static routes.** The OPNsense
+  codec's `config.xml` renderer emits no `<staticroutes>` block, so a
+  translated static route dropped entirely on render -- yet
+  `/routing/static-route` was the one routing-codec base path left
+  undeclared in the capability matrix, so `classify()` defaulted it to
+  `supported` and `validate_against` reported `severity: ok` while the
+  whole route vanished. It is now declared `lossy` (warn) -- matching this
+  codec's cross-vendor expectation dispositions and the #175 SVI-total-
+  drop precedent -- so the loss surfaces as a warning instead of a silent
+  all-clear; operators re-add routes on the OPNsense target. Three
+  misleading sub-field reasons (which claimed "render emits destination +
+  next-hop only") were corrected, and a new registry-wide guard pins that
+  any codec rendering a plain gateway route to nothing must declare the
+  base path. Found by an independent blind audit (`f92e97a`, T0-1).
 
 ## [0.4.6] - 2026-06-25
 

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -190,18 +190,44 @@ class OPNsenseCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                # Base static-route path.  Previously UNDECLARED — so
+                # classify() defaulted it to ``supported`` and a whole
+                # gateway route rendered to nothing while validate_against
+                # reported ``severity: ok`` (audit f92e97a T0-1).  OPNsense's
+                # config.xml renderer emits no <staticroutes>/<route> block at
+                # all (see render.py), so the ENTIRE route — destination +
+                # next-hop — drops on render.  Declared lossy (warn, matching
+                # the cross_vendor_expectations dispositions for this codec)
+                # so the loss surfaces instead of reporting ok; operators
+                # re-add routes on the OPNsense target.  (Interface-only
+                # connected routes are the harder loss and stay unsupported /
+                # block below.)
+                path="/routing/static-route",
+                reason=(
+                    "OPNsense's config.xml renderer emits no "
+                    "<staticroutes>/<route> block, so the entire static route "
+                    "(destination + next-hop) is dropped on render. Declared "
+                    "lossy so validate_against surfaces the loss instead of "
+                    "reporting severity:ok (audit f92e97a T0-1)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
-                    "Render emits destination + next-hop only; the static-"
-                    "route administrative distance (metric) is dropped (run3)."
+                    "Subsumed by the whole-route drop (see "
+                    "/routing/static-route): no <staticroutes> block is "
+                    "rendered, so the administrative distance (metric) is "
+                    "dropped with the route (audit f92e97a T0-1)."
                 ),
                 severity="warn",
             ),
             LossyPath(
                 path="/routing/static-route/description",
                 reason=(
-                    "Render emits destination + next-hop only; the static-"
-                    "route name / description is dropped (run3)."
+                    "Subsumed by the whole-route drop (see "
+                    "/routing/static-route): the route name / description is "
+                    "dropped with the unrendered route (audit f92e97a T0-1)."
                 ),
                 severity="warn",
             ),
@@ -247,9 +273,12 @@ class OPNsenseCodec(CodecBase):
             UnsupportedPath(
                 path="/routing/static-route/interface",
                 reason=(
-                    "Render emits gateway-based routes only; a gateway-less "
-                    "/ interface-only (connected) static route is dropped "
-                    "(run3)."
+                    "No <staticroutes> block is rendered (see "
+                    "/routing/static-route), so an interface-only (connected) "
+                    "static route — which has no gateway to fall back on — is "
+                    "dropped entirely. Declared unsupported (block) to surface "
+                    "the connected-route reachability loss as harder than a "
+                    "gateway route's lossy drop (audit f92e97a T0-1)."
                 ),
             ),
             UnsupportedPath(

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -277,6 +277,14 @@ _NAMING_INDEPENDENT_DROP_FIELDS: dict[str, tuple[str, ...]] = {
     "dhcp_servers": ("/dhcp-servers/pool",),
     "radius_servers": ("/radius-servers/server/host", "/radius-servers/server/key"),
     "routing_instances": ("/routing-instances/instance", "/routing-instances/instance/name"),
+    # NB: `static_routes` is intentionally absent here even though its base
+    # path IS naming-independent: the shared `_maximal_intent` route carries a
+    # VRF binding, and codecs that declare `/routing/static-route/vrf`
+    # unsupported (aruba_aoscx et al.) drop that whole VRF-bound route while
+    # still rendering plain routes — a declared sub-field drop this base-path
+    # check would mis-attribute.  The whole-route silent-drop gap (audit
+    # f92e97a T0-1, opnsense) is instead pinned by
+    # `test_whole_static_route_drop_is_declared` with a PLAIN gateway route.
     # NB: `vlans` is intentionally absent.  Its drop is codec-specific, not a
     # clean universal pattern: SP-router codecs (cisco_iosxr) model VLANs as
     # dot1q sub-interface encapsulation rather than a standalone VLAN DB, so a
@@ -673,3 +681,41 @@ def test_connected_route_loss_blocks_on_vanishing_codecs(name: str):
         u.path for u in report.unsupported_paths
     }
     assert report.severity == "block" and report.compatible is False
+
+
+@pytest.mark.parametrize("name", _CODEC_NAMES)
+def test_whole_static_route_drop_is_declared(name: str):
+    """A codec that renders a PLAIN gateway static route to nothing — the whole
+    route vanishes — must declare ``/routing/static-route`` lossy/unsupported,
+    else validate_against reports ``severity: ok`` while the route is silently
+    discarded.
+
+    A plain destination+next-hop route (NO VRF, interface-nexthop, metric, or
+    description) is unambiguous: every codec with a static-route render path
+    round-trips it, so a total drop means the codec has no render path at all
+    — opnsense's ``config.xml`` emits no ``<staticroutes>`` block.  This was
+    the f92e97a audit's T0-1: opnsense left the BASE path undeclared, so
+    classify() defaulted it to ``supported`` and a whole gateway route vanished
+    silently.
+
+    Sub-fields are deliberately omitted so a declared sub-field drop (e.g. the
+    VRF binding, which aruba_aoscx drops by dropping the whole VRF-bound route
+    while still rendering plain routes) is never mis-attributed to the base
+    path — see the note on ``_NAMING_INDEPENDENT_DROP_FIELDS``."""
+    codec = get_codec(name)
+    caps = codec.capabilities
+    declared = {u.path for u in caps.unsupported} | {lp.path for lp in caps.lossy}
+    if "/routing/static-route" in declared:
+        return  # honestly declared (lossy or unsupported) — loss surfaces
+    tree = CanonicalIntent(
+        hostname="r1",
+        static_routes=[CanonicalStaticRoute(destination="10.9.0.0/24",
+                                            gateway="10.0.0.2")],
+    )
+    rp = codec.parse(codec.render(tree))
+    assert rp.static_routes, (
+        f"{name}: renders a plain gateway static route to nothing yet declares "
+        f"/routing/static-route neither lossy nor unsupported — "
+        f"validate_against reports 'supported' while the route silently "
+        f"vanishes (audit f92e97a T0-1). Add a LossyPath/UnsupportedPath."
+    )


### PR DESCRIPTION
## What

Closes **T0-1** from the 7th blind audit (`f92e97a`): OPNsense silently drops **all** static routes while `validate_against` reports `severity: ok`.

## Root cause (verify-first reproduced)

OPNsense's `config.xml` renderer emits no `<staticroutes>`/`<route>` block (confirmed: `render.py` has zero route references; its docstring enumerates `<system>`→`<interfaces>`→`<vlans>`→`<dhcpd>`→`<laggs>`→`<snmpd>`→`<virtualip>` only). So a translated static route is dropped entirely on render. But `/routing/static-route` was the **one** routing-codec base path left **undeclared** — every other routing codec declares it. With it undeclared, `classify()` defaults to `"supported"` ([migration.py:227](netcanon/models/migration.py:227)), so a plain gateway route → render emits nothing → report says `ok`. Matches the audit's PoC exactly.

## Fix — disposition: `lossy` (not `unsupported`)

The audit's REPORT suggested `UnsupportedPath`, but I chose **`lossy` (warn)** deliberately:
- It matches all 7 `cross_vendor_expectations/*__opnsense.yaml` dispositions (`static_routes: lossy`) **and** the deferral doc the audit itself cited as intending lossy — so the phase4 reconciliation stays consistent (zero cell reclassification) and no YAMLs need rewriting.
- It matches the #175 precedent for the sibling SVI-total-drop on this same codec.
- `unsupported` would force `severity: block` on every source→opnsense migration carrying a route, hard-blocking an otherwise-fine firewall translation. `lossy` surfaces the loss as a warning (operator re-adds routes on the target) — which is what the finding asks for (the bug is the *silent* `ok`, not the absence of a block).
- Interface-only (connected) routes **stay** `unsupported`/`block` — the harder reachability loss, pinned by the existing `test_connected_route_loss_blocks_on_vanishing_codecs`.

Also corrected three sub-field reasons that falsely claimed *"render emits destination + next-hop only"* (no route XML is rendered at all).

## Durable guard

New registry-wide `test_whole_static_route_drop_is_declared`: renders a **plain** gateway route through every codec and fails any that drops it without declaring the base path. Deliberately a *plain* route — adding `static_routes` to the existing `_NAMING_INDEPENDENT_DROP_FIELDS` kitchen-sink check false-positived on `aruba_aoscx`, which drops the *VRF-bound* kitchen-sink route (a **declared** `/routing/static-route/vrf` loss) while rendering plain routes fine. A plain route is unambiguous.

## Verification
- PoC: `classify('/routing/static-route')` → `lossy`; `severity` `ok`→`warn`; `/routing/static-route` now in `lossy_paths`.
- Full `tests/unit` green; full `tests/integration` green; changelog guard green; ruff clean.
- Cross-mesh + phase4 **regenerated**: `CODEC_BUG` flat at **5**, `.md` snapshots byte-identical, `latest.json` only timestamp-churn (reverted) — confirming zero reconciliation impact.

Found by an independent blind audit (`f92e97a`, T0-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
