### PR TITLE
fix(vlan-svi): walk VLAN-SVI L3 sub-fields + flip completeness guard to all-mounts (audit f92e97a T0-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,25 @@ timestamp if your timezone matters for an audit.
   next-hop only") were corrected, and a new registry-wide guard pins that
   any codec rendering a plain gateway route to nothing must declare the
   base path. Found by an independent blind audit (`f92e97a`, T0-1).
+* **VLAN-SVI L3 sub-fields no longer drop silently.** The xpath walker
+  yielded only `/vlans/vlan/ipv4/address/ip` for a VLAN SVI while the
+  interface mount walked five sub-paths, so a secondary IP, anycast
+  virtual-gateway-address, or virtual-gateway-mac carried on a VLAN
+  record rode the `classify()` default to `supported` and
+  `validate_against` reported `severity: ok` while the value vanished on
+  render (e.g. a Junos `irb` anycast gateway migrated to a target that
+  drops it). The walker now walks all three VLAN-SVI sub-paths, and a
+  12-codec census (verified by an independent multi-agent pass) declared
+  each per target: lossy where the codec renders the SVI L3 but drops the
+  sub-field, unsupported where it has no anycast/secondary grammar at
+  all, supported where it round-trips. The completeness guard that should
+  have caught this had inherited the same blind spot -- it passed a
+  dual-mounted leaf if ANY mount was walked, so the interface-mount walk
+  masked the VLAN-SVI gap; it now requires the three independent-loss
+  sub-fields be walked on EVERY mount. Found by an independent blind
+  audit (`f92e97a`, T0-2). The SVI-fold fidelity enhancement (preserving
+  the sub-fields through `project_svi_to_vlan`) and the IPv6-on-VLAN
+  schema addition are deferred as separate work.
 
 ## [0.4.6] - 2026-06-25
 

--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -175,8 +175,23 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
         # reports severity:ok while the SVI/management IP silently vanishes
         # (the same fail-surfaced principle as the {tagged,untagged}-ports
         # twin above; blind-audit 3ec11f3 T0-2).  Droppers declare it lossy.
-        for _ in vlan.ipv4_addresses:
+        for addr in vlan.ipv4_addresses:
             yield "/vlans/vlan/ipv4/address/ip"
+            # VLAN-SVI L3 sub-fields — the twin of the interface-mount walk
+            # above.  Previously the VLAN-SVI mount yielded ONLY .../ip while
+            # the interface mount walked all five, so a dropped secondary IP /
+            # anycast virtual-gateway-address / virtual-gateway-mac carried on
+            # a VLAN record rode the classify() default to "supported" and
+            # validate_against reported severity:ok while the value vanished
+            # (blind-audit f92e97a T0-2).  Walk them (conditionally, mirroring
+            # the interface loop) so the loss surfaces; droppers declare them
+            # lossy/unsupported per the per-codec capability matrix.
+            if addr.is_secondary:
+                yield "/vlans/vlan/ipv4/address/secondary-ip"
+            if addr.virtual_gateway_address:
+                yield "/vlans/vlan/ipv4/address/virtual-gateway-address"
+            if addr.virtual_gateway_mac:
+                yield "/vlans/vlan/ipv4/address/virtual-gateway-mac"
     for route in intent.static_routes:
         yield "/routing/static-route"
         if route.vrf:

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -141,6 +141,40 @@ class AristaEOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount render gap: this codec renders a VLAN's L3 "
+                    "by synthesizing an `interface Vlan<N>` "
+                    "(synthesize_svis_from_vlan_l3), which copies only "
+                    "ip+prefix_length, so the is_secondary flag on a VLAN-"
+                    "record address is dropped. The SVI L3 itself round-trips, "
+                    "so declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount render gap: the synthesized `interface "
+                    "Vlan<N>` carries only ip+prefix_length, so an anycast/VARP "
+                    "virtual-gateway IP on a VLAN-record address never reaches "
+                    "the `ip address virtual` emit. Declared lossy "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount render gap: the synthesized SVI carries "
+                    "only ip+prefix_length, and EOS has no per-IP virtual-MAC "
+                    "grammar anyway (only the system-wide `ip virtual-router "
+                    "mac-address` rides /anycast-gateway-mac). Declared lossy "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/description",
                 reason=(
                     "Render emits the VLAN name but not a separate "

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -190,6 +190,37 @@ class ArubaAOSCXCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): this codec renders no SVI "
+                    "from the VLAN record, so a secondary IP carried there is "
+                    "dropped with it. Declared lossy so validate_against "
+                    "surfaces the loss (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "IP carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "MAC carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/ipv4/address/virtual-gateway-mac",
                 reason=(
                     "Render emits the per-address active-gateway VIP "

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -157,6 +157,17 @@ class ArubaAOSSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount: AOS-S renders the SVI L3 from the VLAN "
+                    "record as co-equal `ip address X/N` lines (no secondary-IP "
+                    "grammar), so the is_secondary flag drops while the address "
+                    "value round-trips. Declared lossy "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/description",
                 reason=(
                     "Render emits the VLAN name but not a separate "
@@ -239,6 +250,26 @@ class ArubaAOSSCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount: AOS-S is a campus L2/L3 codec with no "
+                    "anycast-gateway / VARP grammar (cf. the interface-mount "
+                    "twin + system-wide /anycast-gateway-mac, both "
+                    "unsupported), so an anycast virtual-gateway IP on a VLAN "
+                    "SVI cannot be modelled at all. Declared unsupported "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount: AOS-S has no anycast-gateway MAC grammar "
+                    "(see the unsupported /anycast-gateway-mac), so a per-"
+                    "address virtual-gateway MAC on a VLAN SVI is dropped. "
+                    "Declared unsupported (blind-audit f92e97a T0-2)."
+                ),
+            ),
             UnsupportedPath(
                 path="/interfaces/interface/voice-vlan",
                 reason=(

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -255,6 +255,38 @@ class CiscoIOSXECodec(CodecBase):
             ),
         ],
         unsupported=[
+            # VLAN-SVI L3 sub-fields (blind-audit f92e97a T0-2).  This
+            # OpenConfig/NETCONF stub renders no VLAN-record L3 at all (the
+            # whole /vlans subtree is unsupported), so any L3 sub-field carried
+            # on a VLAN record is dropped wholesale -> block (not the lossy
+            # render-gap of the SVI-synthesising codecs).
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount: the stub renders no VLAN L3, so a "
+                    "secondary IP on a VLAN record is dropped entirely. "
+                    "Declared unsupported (blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount: the stub renders no VLAN L3 and models no "
+                    "anycast-gateway augment (cf. the unsupported interface-"
+                    "mount twin), so an anycast virtual-gateway IP on a VLAN "
+                    "record is dropped. Declared unsupported "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount: the stub renders no VLAN L3 and no "
+                    "virtual-MAC augment, so a per-address virtual-gateway MAC "
+                    "on a VLAN record is dropped. Declared unsupported "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01 completion, v0.4.0 self-audit).
             #    This OpenConfig/NETCONF stub renders only name/enabled/type
             #    per interface and drops every per-port VLAN-membership

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -154,6 +154,31 @@ class CiscoIOSXECLICodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount render gap: the synthesized `interface "
+                    "Vlan<N>` (synthesize_svis_from_vlan_l3) carries only "
+                    "ip+prefix_length, so an anycast virtual-gateway IP on a "
+                    "VLAN-record address is stripped before the anycast-mode "
+                    "emit fires — even the vga==ip SD-Access partial that "
+                    "round-trips on the interface mount. The secondary-IP flag "
+                    "DOES survive (positional ` secondary` token) so it stays "
+                    "supported. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount render gap: the synthesized SVI carries "
+                    "only ip+prefix_length, and IOS-XE has no per-SVI virtual-"
+                    "MAC line (the chassis-wide anycast MAC rides "
+                    "/anycast-gateway-mac). Declared lossy "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/ipv4/address/virtual-gateway-address",
                 reason=(
                     "SD-Access anycast (virtual_gateway_address == the "

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -171,6 +171,37 @@ class CiscoIOSXRCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): this codec renders no SVI "
+                    "from the VLAN record, so a secondary IP carried there is "
+                    "dropped with it. Declared lossy so validate_against "
+                    "surfaces the loss (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "IP carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "MAC carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/tunnel-type",
                 reason=(
                     "Render emits no `tunnel mode <kind>` for tunnel "

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -194,6 +194,37 @@ class CiscoNXOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): this codec renders no SVI "
+                    "from the VLAN record, so a secondary IP carried there is "
+                    "dropped with it. Declared lossy so validate_against "
+                    "surfaces the loss (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "IP carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "MAC carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/ipv4/address/virtual-gateway-address",
                 reason=(
                     "Distributed Anycast Gateway (virtual_gateway_address "

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -267,6 +267,35 @@ class FortiGateCLICodec(CodecBase):
         ],
         unsupported=[
             UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount: FortiOS models one IP per interface (cf. "
+                    "the unsupported interface-mount twin), so a secondary IP "
+                    "on a VLAN SVI is dropped — a whole-subnet reachability "
+                    "loss. Declared unsupported (blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount: FortiGate is a firewall/edge platform with "
+                    "no anycast-gateway fabric primitive (cf. the unsupported "
+                    "interface-mount twin), so an anycast virtual-gateway IP on "
+                    "a VLAN SVI cannot be modelled. Declared unsupported "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount: FortiOS has no anycast/VARP virtual-MAC "
+                    "surface (see the unsupported system-wide "
+                    "/anycast-gateway-mac), so a per-address virtual-gateway "
+                    "MAC on a VLAN SVI is dropped. Declared unsupported "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
                 path="/interfaces/interface/ipv4/address/secondary-ip",
                 reason=(
                     "Render emits one IPv4 address per interface; "

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -159,6 +159,18 @@ class JunosCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount: Junos models the SVI as an `irb` unit "
+                    "whose `family inet address` lines are co-equal (no "
+                    "primary/secondary distinction), so the is_secondary flag "
+                    "is dropped on render while the address value, VGA and VGM "
+                    "round-trip natively via the irb fold. Declared lossy "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/description",
                 reason=(
                     "Render emits the VLAN name but not a separate "

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -174,6 +174,37 @@ class MikroTikRouterOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): this codec renders no SVI "
+                    "from the VLAN record, so a secondary IP carried there is "
+                    "dropped with it. Declared lossy so validate_against "
+                    "surfaces the loss (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "IP carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "MAC carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/snmp/v3-user/engine-id",
                 reason=(
                     "The SNMPv3 USM user round-trips but a per-user "

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -180,6 +180,37 @@ class OPNsenseCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): this codec renders no SVI "
+                    "from the VLAN record, so a secondary IP carried there is "
+                    "dropped with it. Declared lossy so validate_against "
+                    "surfaces the loss (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "IP carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount, subsumed by the whole-SVI-L3 drop (see "
+                    "/vlans/vlan/ipv4/address/ip): the anycast virtual-gateway "
+                    "MAC carried on the VLAN record drops with the unrendered "
+                    "SVI. Declared lossy (blind-audit f92e97a T0-2)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/description",
                 reason=(
                     "Render emits the VLAN name but not a separate "

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -292,6 +292,35 @@ class VyOSCodec(CodecBase):
         ],
         unsupported=[
             UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/secondary-ip",
+                reason=(
+                    "VLAN-SVI mount: VyOS models 802.1Q only as `vif` sub-"
+                    "interfaces and render never emits VLAN-record L3, so a "
+                    "secondary IP on a VLAN SVI is dropped with the whole VLAN "
+                    "L3 surface. Declared unsupported "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-address",
+                reason=(
+                    "VLAN-SVI mount: VyOS has no anycast-gateway / VARP grammar "
+                    "(cf. the unsupported interface-mount twin) and renders no "
+                    "VLAN-record L3, so an anycast virtual-gateway IP on a VLAN "
+                    "SVI is dropped. Declared unsupported "
+                    "(blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/vlans/vlan/ipv4/address/virtual-gateway-mac",
+                reason=(
+                    "VLAN-SVI mount: VyOS has no anycast/VARP virtual-MAC "
+                    "grammar and renders no VLAN-record L3, so a per-address "
+                    "virtual-gateway MAC on a VLAN SVI is dropped. Declared "
+                    "unsupported (blind-audit f92e97a T0-2)."
+                ),
+            ),
+            UnsupportedPath(
                 path="/interfaces/interface/ipv4/address/virtual-gateway-address",
                 reason=(
                     "VyOS has no anycast-gateway / VARP grammar; render "

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -9786,7 +9786,7 @@ One section per non-OK synthetic cell (133 total).  Sections are ordered by sour
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 401, in render
+  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 426, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 546, in render_intent
     dest, mask = _cidr_to_dest_mask(route.destination)
@@ -9829,7 +9829,7 @@ netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 ou
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 437, in render
+  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 466, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\fortigate_cli\render.py", line 948, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -186,7 +186,13 @@ def _maximal_intent() -> CanonicalIntent:
         vlans=[CanonicalVlan(
             id=10, name="V", description="desc",
             tagged_ports=["Ethernet1"], untagged_ports=["Ethernet2"],
-            ipv4_addresses=[addr4])],
+            # Both a primary (carrying VGA + VGM) AND a secondary address so
+            # every VLAN-SVI mount sub-path the walker now yields
+            # (/vlans/vlan/ipv4/address/{secondary-ip,virtual-gateway-address,
+            # virtual-gateway-mac}) is in _WALKABLE — the all()-over-mounts
+            # completeness guard requires the VLAN mount be walked independently
+            # of the interface mount (blind-audit f92e97a T0-2).
+            ipv4_addresses=[addr4, addr4_sec])],
         static_routes=[CanonicalStaticRoute(
             destination="0.0.0.0/0", gateway="10.0.0.2", vrf="TENANT",
             # metric / description / interface exercise the static-route

--- a/tests/unit/migration/test_walker_completeness.py
+++ b/tests/unit/migration/test_walker_completeness.py
@@ -89,6 +89,25 @@ _CLASS_CONTAINERS: dict[str, tuple[str, ...]] = {
     "CanonicalEvpnType5Route": (),
 }
 
+#: Leaves ``(Model, field)`` that must be walked on EVERY mount of their class,
+#: not just one.  Only ``CanonicalIPv4Address``'s INDEPENDENT-loss sub-fields
+#: qualify: each is mounted on BOTH ``/interfaces/interface/ipv4/address/`` and
+#: ``/vlans/vlan/ipv4/address/``, and the interface-mount walk previously MASKED
+#: the silent VLAN-SVI sub-field drop — a leaf walked on the interface mount
+#: counted as "covered" so the VLAN-SVI gap was structurally invisible to this
+#: guard (blind-audit f92e97a T0-2; the meta-finding that "the fix-the-class
+#: guard inherited the class's own blind spot").  ``ip`` is already walked on
+#: both mounts and ``prefix_length`` travels with it (no independent loss), so
+#: both stay on the default any()-over-mounts test — as does every class whose
+#: multiple _CLASS_CONTAINERS prefixes are segment ALTERNATIVES (CanonicalIntent
+#: /system/ vs /; CanonicalInterface /…/ vs /…/config/), where a field lives
+#: under exactly one prefix.
+_ALL_MOUNTS_REQUIRED: frozenset[tuple[str, str]] = frozenset({
+    ("CanonicalIPv4Address", "is_secondary"),
+    ("CanonicalIPv4Address", "virtual_gateway_address"),
+    ("CanonicalIPv4Address", "virtual_gateway_mac"),
+})
+
 #: Field-name -> xpath-segment overrides where the walker's spelling diverges
 #: from ``field.replace("_", "-")`` (singularised list fields; two renames).
 #: Guarded against staleness by ``test_segment_overrides_reference_real_leaves``.
@@ -184,12 +203,24 @@ def _expected_xpaths(cls: str, field: str) -> tuple[str, ...]:
 
 
 def _walked_leaves() -> set[tuple[str, str]]:
-    """Every scalar leaf whose expected xpath the walker actually emits."""
-    return {
-        leaf
-        for leaf in scalar_leaves(CanonicalIntent)
-        if any(xp in _WALKABLE for xp in _expected_xpaths(*leaf))
-    }
+    """Every scalar leaf whose expected xpath the walker actually emits.
+
+    A leaf in ``_ALL_MOUNTS_REQUIRED`` counts as walked only when EVERY mount
+    is walked (``all``): a leaf walked on one mount must not mask a silent drop
+    on another (blind-audit f92e97a T0-2).  For every other leaf the multiple
+    container prefixes are segment alternatives (or the leaf travels with a
+    base that is walked on every mount), so any one walked prefix suffices
+    (``any``).
+    """
+    out: set[tuple[str, str]] = set()
+    for leaf in scalar_leaves(CanonicalIntent):
+        expected = _expected_xpaths(*leaf)
+        if not expected:
+            continue
+        combine = all if leaf in _ALL_MOUNTS_REQUIRED else any
+        if combine(xp in _WALKABLE for xp in expected):
+            out.add(leaf)
+    return out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Closes **T0-2** from the 7th blind audit (`f92e97a`): VLAN-SVI L3 sub-fields (secondary IP, anycast virtual-gateway-address, virtual-gateway-mac) drop silently — `validate_against` reports `severity: ok` while the value vanishes on render. Also closes the audit's **meta-finding instance**: the completeness guard built to catch this class had inherited the class's own blind spot.

## Root cause (verify-first + 12-codec census)

The shared walker yielded only `/vlans/vlan/ipv4/address/ip` for a VLAN SVI ([xpath_walker.py:178](netcanon/migration/canonical/xpath_walker.py:178)) while the interface mount walked five sub-paths, so a sub-field carried on a VLAN record (the Junos `irb` / Aruba SVI-on-VLAN shape) rode the `classify()` default to `supported`. PoC reproduced: a Junos VLAN anycast gateway → nxos/aoss target reported `ok`; now reports `warn`/`block`.

## Approach — ultracode census, then implement

Per the chosen approach, a multi-agent workflow (12 read-only census agents + 12 independent adversarial verifiers, **0 disagreements, all high-confidence**) determined each codec's VLAN-SVI L3 render behavior via live `parse(render(...))` repro, then I implemented from the verified census (blackboard doctrine: read-only agents → reports, main thread actuates).

## Changes

1. **Walker** — yield the three VLAN-SVI sub-paths (conditionally, mirroring the interface loop). `prefix_length` is deliberately *not* walked on the VLAN mount: it travels with `ip` (no independent loss), and walking it would trip codecs' strict `walker ⊆ declared` guards.
2. **Matrix (12-codec sweep, 22 lossy + 11 unsupported)** — per the census:
   - **lossy** (renders SVI L3 but drops the sub-field): arista_eos, aruba_aoscx, cisco_iosxr, cisco_nxos, mikrotik_routeros, opnsense (all 3); cisco_iosxe_cli (VGA+VGM; secondary round-trips via the positional `secondary` token); juniper_junos + aruba_aoss (secondary only).
   - **unsupported** (no anycast/secondary grammar): aruba_aoss (VGA+VGM), cisco_iosxe stub, fortigate_cli, vyos (all 3).
   - juniper_junos VGA/VGM stay **supported** (native `irb` fold round-trips them).
3. **Guard (`test_walker_completeness`)** — flips `any()`-over-mounts → `all()`-over-mounts for the three *independent-loss* `CanonicalIPv4Address` sub-fields. The guard passed a dual-mounted leaf if ANY mount was walked, so the interface-mount walk masked the VLAN-SVI gap *by construction* — the meta-finding's self-similar recurrence. Scoped to the three sub-fields (not `ip`/`prefix_length`, which are base and walked-on-both / travel-together). Kitchen-sink VLAN now carries a secondary + VGA + VGM so the VLAN-mount paths are walkable.

## Verification
- 12-codec census: 0 verifier disagreements, all high-confidence, each backed by live repro.
- PoC: walker now yields all VLAN-SVI sub-paths; Junos-irb VLAN VGA → `warn` (nxos) / `block` (aoss) / `warn` (junos, its secondary flag is legitimately lossy).
- Full `tests/unit` green; full `tests/integration` green; ruff clean; changelog guard green.
- Regen: **CODEC_BUG flat at 5**, no cell reclassified — the real fixture corpus carries no VLAN-record VGA/secondary, so the declarations are ship-before-wire for that source shape; `CROSS_MESH_RESULTS.md` only refreshes two stale traceback line-numbers, `latest.json` timestamp-only (reverted).

## Deferred (separate work, flagged by the census)
- **SVI-fold fidelity**: `project_svi_to_vlan` / `synthesize_svis_from_vlan_l3` copy only `ip`+`prefix_length`; carrying the sub-fields would *preserve* (not just surface) them on the arista/iosxe synthesis path. High cross-vendor blast radius — out of scope.
- **IPv6-on-VLAN**: `CanonicalVlan` has no `ipv6_addresses` field (schema addition).

Found by an independent blind audit (`f92e97a`, T0-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
