### PR TITLE
fix(sanitize): redact virtual/anycast MAC addresses — close burned-in MAC leak (audit f92e97a T0-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **The sanitiser now redacts virtual / anycast MAC addresses.** The
+  anycast virtual-gateway MAC, the per-address virtual-gateway MAC (v4 +
+  v6), the per-group VRRP virtual MAC, and the system-wide
+  anycast-gateway MAC were rendered verbatim by the codecs but bypassed
+  every field-typed redaction, so a burned-in or operator-assigned MAC
+  (the OUI reveals the hardware vendor; the full address is
+  device-unique) leaked into a shared bug report. A new `redact_mac`
+  primitive maps each to a stable RFC 7042 documentation MAC
+  (`00:00:5e:00:53:NN`, separator style preserved); protocol-standard
+  VRRP / HSRP / GLBP / CARP virtual MACs and multicast / broadcast
+  addresses are preserved (they identify nothing). The sanitizer-
+  completeness partition guard moves the four MAC leaves from
+  `REDACTION_NOT_WIRED` to redacted. Found by an independent blind audit
+  (`f92e97a`, T0-3).
 * **Per-pane migration endpoints now set the `X-Netcanon-Job-Status`
   response header.** `/plan` and `/render` surfaced the job disposition
   (`completed` / `partial` / `failed`) in this header so an HTTP-only

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -385,6 +385,7 @@ on the canonical model:
 | VRRP / CARP / HSRP authentication keys | `<scheme>:REDACTED-VRRP-AUTH-N` (scheme prefix preserved, secret value redacted) |
 | VRRP / CARP virtual IPs (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
 | Anycast / VARP virtual-gateway addresses (public, v4 + v6) | RFC 5737 / RFC 3849 docs ranges |
+| Anycast virtual-gateway MAC + VRRP virtual MAC + system anycast-gateway MAC (burned-in / operator-assigned) | RFC 7042 documentation MAC (`00:00:5e:00:53:NN`), separator style preserved; protocol-standard VRRP / HSRP / GLBP / CARP vMACs + multicast / broadcast preserved (identify nothing) |
 | Static-route destination prefix + next-hop (public) | RFC 5737 / RFC 3849 docs ranges (prefix length preserved) |
 | Interface descriptions | `description redacted` |
 | Tier-3 sections (firewall / NAT / VPN) | Stripped entirely |

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -62,6 +62,14 @@ Field-typed rules (counter-per-session):
   VRRP/CARP VIP (a public one reveals real routable infrastructure), and
   is rendered verbatim by Arista/Aruba/Junos/NX-OS/IOS-XE, so it is
   redacted at every address site (interface + VLAN SVI, v4 + v6)
+* ``CanonicalIPv4Address.virtual_gateway_mac`` /
+  ``CanonicalIPv6Address.virtual_gateway_mac`` /
+  ``CanonicalVRRPGroup.virtual_mac`` /
+  ``CanonicalIntent.anycast_gateway_mac`` (burned-in / operator-assigned
+  MAC) → RFC 7042 documentation MAC (``00:00:5e:00:53:N``), separator
+  style preserved.  Protocol-standard VRRP / HSRP / GLBP / CARP virtual
+  MACs (derived from the group ID) and multicast / broadcast / all-zero
+  addresses are preserved — they identify nothing about the operator
 * ``CanonicalInterface.description`` → ``description redacted``
 * ``CanonicalDHCPPool.dns_servers`` (public entries) → docs range
 * ``CanonicalDHCPPool.gateway`` (public) → docs range
@@ -262,6 +270,18 @@ def sanitize_intent(
         ))
         sanitized.domain = new_value
 
+    # ---- anycast-gateway MAC (system-wide DAG / SD-Access / VARP MAC) ----
+    if sanitized.anycast_gateway_mac:
+        new_mac = table.redact_mac(sanitized.anycast_gateway_mac)
+        if new_mac != sanitized.anycast_gateway_mac:
+            subs.append(Substitution(
+                category="mac",
+                field="anycast_gateway_mac",
+                original=sanitized.anycast_gateway_mac,
+                redacted=new_mac,
+            ))
+            sanitized.anycast_gateway_mac = new_mac
+
     # ---- host-list scalars (DNS / NTP / syslog) ----
     # DNS resolvers are IPs by protocol (RFC 2132 option 6); NTP + syslog
     # targets are commonly FQDNs, so those two also redact a DNS-name entry
@@ -313,6 +333,19 @@ def sanitize_intent(
                         redacted=new_vga,
                     ))
                     addr.virtual_gateway_address = new_vga
+            # The anycast / VRRP virtual-gateway MAC sibling — burned-in or
+            # operator-chosen, so the OUI leaks the hardware vendor; redact it
+            # (well-known protocol vMACs are preserved by redact_mac).
+            if addr.virtual_gateway_mac:
+                new_vgm = table.redact_mac(addr.virtual_gateway_mac)
+                if new_vgm != addr.virtual_gateway_mac:
+                    subs.append(Substitution(
+                        category="mac",
+                        field=f"interfaces[{i}].ipv4_addresses[{j}].virtual_gateway_mac",
+                        original=addr.virtual_gateway_mac,
+                        redacted=new_vgm,
+                    ))
+                    addr.virtual_gateway_mac = new_vgm
 
         for j, addr in enumerate(iface.ipv6_addresses):
             new_ip = table.redact_ipv6(addr.ip)
@@ -334,6 +367,16 @@ def sanitize_intent(
                         redacted=new_vga,
                     ))
                     addr.virtual_gateway_address = new_vga
+            if addr.virtual_gateway_mac:
+                new_vgm = table.redact_mac(addr.virtual_gateway_mac)
+                if new_vgm != addr.virtual_gateway_mac:
+                    subs.append(Substitution(
+                        category="mac",
+                        field=f"interfaces[{i}].ipv6_addresses[{j}].virtual_gateway_mac",
+                        original=addr.virtual_gateway_mac,
+                        redacted=new_vgm,
+                    ))
+                    addr.virtual_gateway_mac = new_vgm
 
         # ---- VRRP / CARP / HSRP authentication ----
         # Cleartext-bearing: the ``plain:`` / ``carp-key:`` schemes
@@ -360,6 +403,20 @@ def sanitize_intent(
                     redacted="description redacted",
                 ))
                 group.description = "description redacted"
+            # The per-group virtual MAC — a configured override (Arista VARP /
+            # operator-set) leaks the OUI; redact it.  The protocol-standard
+            # VRRP/HSRP/CARP vMACs derived from the group ID are preserved by
+            # redact_mac (well-known, non-identifying).
+            if group.virtual_mac:
+                new_vmac = table.redact_mac(group.virtual_mac)
+                if new_vmac != group.virtual_mac:
+                    subs.append(Substitution(
+                        category="mac",
+                        field=f"interfaces[{i}].vrrp_groups[{k}].virtual_mac",
+                        original=group.virtual_mac,
+                        redacted=new_vmac,
+                    ))
+                    group.virtual_mac = new_vmac
 
             # The virtual IP is frequently the public-facing HA gateway
             # address — redact it like every other IP field (the sibling
@@ -454,6 +511,16 @@ def sanitize_intent(
                         redacted=new_vga,
                     ))
                     addr.virtual_gateway_address = new_vga
+            if addr.virtual_gateway_mac:
+                new_vgm = table.redact_mac(addr.virtual_gateway_mac)
+                if new_vgm != addr.virtual_gateway_mac:
+                    subs.append(Substitution(
+                        category="mac",
+                        field=f"vlans[{i}].ipv4_addresses[{j}].virtual_gateway_mac",
+                        original=addr.virtual_gateway_mac,
+                        redacted=new_vgm,
+                    ))
+                    addr.virtual_gateway_mac = new_vgm
 
     # ---- local users (usernames + hashed passwords) ----
     # Phase-3 R6.1: redact the username too.  Operator-chosen
@@ -886,6 +953,12 @@ class _SubstitutionTable:
         # written as FQDNs) re-leak the org domain.  Map each distinct
         # name to a stable opaque placeholder so cross-references survive.
         self._host_names: dict[str, str] = {}
+        # Burned-in / operator-assigned MACs (anycast virtual-gateway MAC,
+        # VRRP virtual MAC) — the OUI reveals the hardware vendor and the
+        # full address is device-unique, so a public bug report leaks it.
+        # Map each to a stable RFC 7042 documentation MAC; well-known
+        # protocol vMACs are preserved (see :meth:`redact_mac`).
+        self._macs: dict[str, str] = {}
 
     def redact_hostname(self, name: str) -> str:
         if name not in self._hostnames:
@@ -1068,6 +1141,36 @@ class _SubstitutionTable:
             self._mcast_groups[addr] = f"233.252.0.{host}"
         return self._mcast_groups[addr]
 
+    def redact_mac(self, value: str) -> str:
+        """Redact a burned-in / operator-assigned MAC address.
+
+        The anycast virtual-gateway MAC (NX-OS DAG / IOS-XE SD-Access /
+        Arista VARP) and a VRRP/CARP virtual MAC are rendered verbatim by
+        the codecs, yet a burned-in or operator-chosen MAC leaks the
+        hardware vendor (via the OUI) and a device-unique value into a
+        shared bug report.  Map each distinct MAC to a stable address in
+        the RFC 7042 documentation range (``00:00:5e:00:53:XX``),
+        preserving the input's separator style (Cisco dotted / colon /
+        hyphen / bare) so the renderer still emits valid syntax.
+
+        PRESERVED (derived from a group ID or a standard — leak nothing
+        about the operator, the audit's "well-known VRRP/HSRP MACs"):
+        VRRP IPv4/IPv6 (``00:00:5e:00:01|02:XX``), HSRP v1/v2, GLBP, CARP
+        (shares the VRRP range), every multicast / group address, and the
+        all-zero / broadcast addresses.  Non-MAC-shaped values pass
+        through verbatim.
+
+        Cross-reference stable: same input MAC -> same documentation MAC
+        across the whole config.
+        """
+        digits = _mac_digits(value)
+        if digits is None or _mac_is_well_known(digits):
+            return value
+        if value not in self._macs:
+            n = len(self._macs) % 256
+            self._macs[value] = _format_mac_like(value, f"00005e0053{n:02x}")
+        return self._macs[value]
+
     def redact_community(self, community: str) -> str:
         if community not in self._communities:
             self._communities[community] = f"public_redacted_{len(self._communities) + 1}"
@@ -1197,6 +1300,48 @@ class _SubstitutionTable:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+#: 12 hex digits = a MAC with the separators (``.:-``) stripped.
+_MAC_RE = re.compile(r"^[0-9A-Fa-f]{12}$")
+
+
+def _mac_digits(value: str) -> str | None:
+    """Return the 12 lowercase hex digits of a MAC string (Cisco-dotted,
+    colon, hyphen, or bare), or ``None`` if *value* is not MAC-shaped."""
+    digits = re.sub(r"[.:-]", "", value.strip())
+    return digits.lower() if _MAC_RE.match(digits) else None
+
+
+def _mac_is_well_known(digits: str) -> bool:
+    """True for protocol-standard / group MACs (12 lowercase hex digits in)
+    that are derived from a group ID or a standard and leak nothing about
+    the operator: VRRP v4/v6 (RFC 5798) + CARP, HSRP v1/v2, GLBP, every
+    multicast / group address (I/G bit set), and the all-zero / broadcast
+    addresses.  The RFC 7042 documentation range is also treated as
+    well-known so an already-redacted value is idempotent."""
+    if digits in ("000000000000", "ffffffffffff"):
+        return True
+    if int(digits[:2], 16) & 0x01:  # I/G (multicast / group) bit set
+        return True
+    return digits.startswith((
+        "00005e0001",   # VRRP IPv4 virtual MAC (RFC 5798) / CARP
+        "00005e0002",   # VRRP IPv6 virtual MAC
+        "00000c07ac",   # HSRP v1 virtual MAC
+        "00000c9f",     # HSRP v2 virtual MAC
+        "0007b4",       # GLBP virtual MAC
+        "00005e0053",   # RFC 7042 documentation MAC range (already redacted)
+    ))
+
+
+def _format_mac_like(template: str, digits: str) -> str:
+    """Format 12 hex *digits* with the same separator style as *template*
+    (Cisco dotted ``aaaa.bbbb.cccc`` / colon / hyphen / bare)."""
+    if "." in template:
+        return f"{digits[0:4]}.{digits[4:8]}.{digits[8:12]}"
+    sep = "-" if "-" in template else ":" if ":" in template else ""
+    if not sep:
+        return digits
+    return sep.join(digits[i:i + 2] for i in range(0, 12, 2))
 
 
 def _redact_ip_list(

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -1139,6 +1139,129 @@ class TestVirtualGatewayAddressRedaction:
         assert "9.9.9.1" not in codec.render(sanitized)     # leak closed end-to-end
 
 
+class TestVirtualMacRedaction:
+    """Regression guard for the burned-in / operator MAC leak (blind audit
+    ``f92e97a`` T0-3).  The anycast virtual-gateway MAC and a VRRP virtual MAC
+    are rendered verbatim by the codecs; a burned-in MAC's OUI leaks the
+    hardware vendor and the full address is device-unique.  Redacted to the
+    RFC 7042 documentation range (``00:00:5e:00:53:NN``); protocol-standard
+    VRRP/HSRP vMACs (derived from the group ID) are preserved -- they identify
+    nothing about the operator."""
+
+    #: Arista OUI 00:1c:73 -> identifying (hardware vendor + device-unique).
+    _BURNED_IN = "00:1c:73:0a:0b:0c"
+
+    def test_interface_ipv4_vgmac_redacted(self):
+        intent = CanonicalIntent(
+            hostname="sw",
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                ipv4_addresses=[CanonicalIPv4Address(
+                    ip="10.0.0.2", prefix_length=24,
+                    virtual_gateway_mac=self._BURNED_IN)])],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        vgm = sanitized.interfaces[0].ipv4_addresses[0].virtual_gateway_mac
+        assert vgm != self._BURNED_IN
+        assert vgm.startswith("00:00:5e:00:53:")            # RFC 7042 docs range
+        assert any(
+            s.field.endswith("ipv4_addresses[0].virtual_gateway_mac") for s in subs
+        )
+
+    def test_interface_ipv6_vgmac_redacted(self):
+        intent = CanonicalIntent(
+            hostname="sw",
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                ipv6_addresses=[CanonicalIPv6Address(
+                    ip="2001:db8::2", prefix_length=64,
+                    virtual_gateway_mac=self._BURNED_IN)])],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        assert (
+            sanitized.interfaces[0].ipv6_addresses[0].virtual_gateway_mac
+            != self._BURNED_IN
+        )
+
+    def test_vlan_svi_vgmac_redacted(self):
+        intent = CanonicalIntent(
+            hostname="sw",
+            vlans=[CanonicalVlan(
+                id=10, name="V10",
+                ipv4_addresses=[CanonicalIPv4Address(
+                    ip="10.0.0.2", prefix_length=24,
+                    virtual_gateway_mac=self._BURNED_IN)])],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        assert (
+            sanitized.vlans[0].ipv4_addresses[0].virtual_gateway_mac
+            != self._BURNED_IN
+        )
+
+    def test_vrrp_virtual_mac_redacted(self):
+        intent = CanonicalIntent(
+            hostname="sw",
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                vrrp_groups=[CanonicalVRRPGroup(
+                    group_id=10, virtual_ips=["10.0.0.254"],
+                    virtual_mac=self._BURNED_IN)])],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        assert (
+            sanitized.interfaces[0].vrrp_groups[0].virtual_mac != self._BURNED_IN
+        )
+        assert any(s.field.endswith("vrrp_groups[0].virtual_mac") for s in subs)
+
+    def test_anycast_gateway_mac_redacted(self):
+        intent = CanonicalIntent(hostname="sw", anycast_gateway_mac=self._BURNED_IN)
+        sanitized, subs = sanitize_intent(intent)
+        assert sanitized.anycast_gateway_mac != self._BURNED_IN
+        assert any(s.field == "anycast_gateway_mac" for s in subs)
+
+    def test_wellknown_vrrp_mac_preserved(self):
+        """The protocol-standard VRRP virtual MAC (00:00:5e:00:01:NN, derived
+        from the VRID) identifies nothing and is preserved."""
+        vrrp_mac = "00:00:5e:00:01:0a"
+        intent = CanonicalIntent(
+            hostname="sw",
+            interfaces=[CanonicalInterface(
+                name="Vlan10", default_name="Vlan10",
+                vrrp_groups=[CanonicalVRRPGroup(
+                    group_id=10, virtual_ips=["10.0.0.254"],
+                    virtual_mac=vrrp_mac)])],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        assert sanitized.interfaces[0].vrrp_groups[0].virtual_mac == vrrp_mac
+
+    def test_cisco_dotted_format_preserved(self):
+        """A Cisco dotted-form MAC (aaaa.bbbb.cccc) is redacted in the same
+        format so the renderer still emits valid syntax."""
+        intent = CanonicalIntent(hostname="sw", anycast_gateway_mac="001c.730a.0b0c")
+        sanitized, _ = sanitize_intent(intent)
+        out = sanitized.anycast_gateway_mac
+        assert out != "001c.730a.0b0c"
+        assert out.startswith("0000.5e00.53")              # dotted RFC 7042 form
+
+    def test_burned_in_mac_absent_from_render(self):
+        """End-to-end: the NX-OS ``fabric forwarding anycast-gateway-mac`` line
+        must not emit the burned-in OUI after sanitisation.  Precondition-asserts
+        the codec DOES emit it first, so the test can't pass vacuously."""
+        from netcanon.migration.codecs.registry import get_codec
+
+        intent = CanonicalIntent(
+            hostname="sw",
+            anycast_gateway_mac=self._BURNED_IN,
+            vlans=[CanonicalVlan(id=10, name="V10")],
+        )
+        codec = get_codec("cisco_nxos")
+        assert "001c.730a.0b0c" in codec.render(intent)     # precondition: codec emits the MAC
+        sanitized, _ = sanitize_intent(intent)
+        rendered = codec.render(sanitized)
+        assert "001c.73" not in rendered                    # burned-in OUI gone (dotted form)
+        assert "00:1c:73" not in rendered                   # ...and colon form
+
+
 def test_raw_sections_stripped_by_sanitiser():
     """DATA-02: Tier-3 ``raw_sections`` (verbatim vendor text) is cleared.
 

--- a/tests/unit/tools/test_sanitize_completeness.py
+++ b/tests/unit/tools/test_sanitize_completeness.py
@@ -57,8 +57,10 @@ _SENSITIVE_REDACTED = frozenset({
     ("CanonicalEvpnType5Route", "rt_imports"),
     ("CanonicalIPv4Address", "ip"),
     ("CanonicalIPv4Address", "virtual_gateway_address"),
+    ("CanonicalIPv4Address", "virtual_gateway_mac"),
     ("CanonicalIPv6Address", "ip"),
     ("CanonicalIPv6Address", "virtual_gateway_address"),
+    ("CanonicalIPv6Address", "virtual_gateway_mac"),
     ("CanonicalIntent", "dns_servers"),
     ("CanonicalIntent", "domain"),
     ("CanonicalIntent", "ntp_servers"),
@@ -80,21 +82,20 @@ _SENSITIVE_REDACTED = frozenset({
     ("CanonicalVxlan", "flood_list"),
     ("CanonicalVxlan", "mcast_group"),
     ("CanonicalLocalUser", "hashed_password"),
+    ("CanonicalIntent", "anycast_gateway_mac"),
     ("CanonicalVRRPGroup", "authentication"),
     ("CanonicalVRRPGroup", "virtual_ips"),
     ("CanonicalVRRPGroup", "virtual_ipv6s"),
+    ("CanonicalVRRPGroup", "virtual_mac"),
 })
 
 #: Sensitive str leaves the sanitiser does NOT cover yet — surfaced + tracked +
-#: deferred. REDACTION_NOT_WIRED: a clean follow-up wires it (a redact_mac
-#: primitive for the anycast / VRRP virtual-MAC fields). TIER3_OPAQUE: verbatim
-#: vendor text the STRUCTURED sanitiser can't reach (sanitize_text re-parses +
-#: sanitises the text path, but the intent-level walk treats these as a blob).
+#: deferred. (The four virtual-MAC leaves graduated to _SENSITIVE_REDACTED once
+#: the redact_mac primitive was wired — blind-audit f92e97a T0-3.) TIER3_OPAQUE:
+#: verbatim vendor text the STRUCTURED sanitiser can't reach (sanitize_text
+#: re-parses + sanitises the text path, but the intent-level walk treats these
+#: as a blob).
 _SENSITIVE_GAP: dict[tuple[str, str], tuple[str, str]] = {
-    ("CanonicalIPv4Address", "virtual_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast vMAC; redact_mac follow-up"),
-    ("CanonicalIPv6Address", "virtual_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast vMAC; redact_mac follow-up"),
-    ("CanonicalVRRPGroup", "virtual_mac"): ("REDACTION_NOT_WIRED", "VRRP vMAC; redact_mac follow-up"),
-    ("CanonicalIntent", "anycast_gateway_mac"): ("REDACTION_NOT_WIRED", "anycast-gateway MAC; redact_mac follow-up"),
     ("CanonicalIntent", "raw_sections"): ("TIER3_OPAQUE", "Tier-3 verbatim text; structural walk can't reach it"),
     ("CanonicalIntent", "group_content"): ("TIER3_OPAQUE", "Junos group bodies (verbatim); not structurally sanitised"),
     ("CanonicalIntent", "dropped_tier3_sections"): ("TIER3_OPAQUE", "dropped-section text; not structurally sanitised"),


### PR DESCRIPTION
## What
Wires a `redact_mac` primitive into the config sanitiser so virtual / anycast MAC addresses are redacted instead of leaking verbatim into a shared bug report.

## Why — audit `f92e97a`, T0-3 (ACKNOWLEDGED-DEFERRED)
Four MAC-bearing canonical leaves were rendered verbatim by the codecs but bypassed every field-typed redaction:
- `CanonicalIPv4Address.virtual_gateway_mac` (interface **and** VLAN-SVI mount)
- `CanonicalIPv6Address.virtual_gateway_mac`
- `CanonicalVRRPGroup.virtual_mac`
- `CanonicalIntent.anycast_gateway_mac`

A burned-in or operator-assigned MAC leaks the hardware vendor (via the OUI) and a device-unique value. These were already surfaced + tracked as `REDACTION_NOT_WIRED` in the sanitizer-completeness partition guard, awaiting exactly this `redact_mac` follow-up.

## How
- New `redact_mac` maps a burned-in / operator-assigned MAC to a stable **RFC 7042 documentation MAC** (`00:00:5e:00:53:NN`), preserving the input's separator style (Cisco-dotted / colon / hyphen / bare) so the renderer still emits valid syntax. Cross-reference stable.
- **Preserved** (derived from a group ID or a standard — identify nothing about the operator): VRRP v4/v6 + CARP, HSRP v1/v2, GLBP, every multicast / group address, all-zero / broadcast.
- Wired onto all **5** sites (interface v4/v6 VGM, VLAN-SVI v4 VGM, VRRP `virtual_mac`, top-level `anycast_gateway_mac`).
- The 4 MAC leaves move `REDACTION_NOT_WIRED` → redacted in the completeness guard; `SECURITY.md` coverage table gains the MAC row; module docstring updated.

## Verification
- New `redact_mac` forward tests: per-site redaction, **well-known VRRP preservation**, Cisco-dotted format preservation, and **end-to-end** (the NX-OS `fabric forwarding anycast-gateway-mac` line no longer emits the burned-in OUI; precondition-asserts the codec emits it first, so it can't pass vacuously).
- Full `tests/unit` + `tests/integration` green. Ruff clean. Purely additive sanitiser redaction — no codec/matrix change, no regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
