### PR TITLE
fix(backup): unknown type_key -> honest per-device failure, not false completed (audit 81d9740 T0-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Fixed
+
+* **Backup jobs no longer report a false `completed` (or hang at
+  `running`) when a device has an unknown `type_key`.** A typo'd or renamed
+  device type (ordinary operator data -- device profiles and schedules do
+  not validate it against the loaded definition library) hit a bare
+  `definitions[type_key]` dict subscript *outside* the per-device error
+  handler. The serial path let the `KeyError` strand the whole job at
+  `running`; the parallel path left the device `queued` so the terminal
+  logic counted zero failures and marked the job `completed` though the
+  device never ran. The lookup now resolves an unknown type to an honest
+  per-device `failed` result, and a terminal-time safety net forces any
+  still-non-terminal device to `failed` so "the device never ran" can never
+  read as success. Found by an independent blind audit (`81d9740`, T0-2).
+
 ## [0.4.7] - 2026-06-25
 
 ### Fixed

--- a/netcanon/services/backup_runner.py
+++ b/netcanon/services/backup_runner.py
@@ -209,9 +209,11 @@ def _process_one_device(
             collectors to resolve on demand.
 
     All exceptions are caught and recorded on the ``BackupResult``; this
-    function therefore never raises under normal operation.  Any exception
-    that does escape indicates a programming bug in the backup runner
-    itself (e.g. an invalid definition lookup) and should surface.
+    function therefore never raises under normal operation.  Ordinary
+    operator-data problems (e.g. an unknown ``type_key`` absent from the
+    definition library) are converted to a per-device ``failed`` result, not
+    raised.  Any exception that does still escape indicates a programming bug
+    in the backup runner itself and should surface.
 
     Thread safety: ``job.results[idx]`` is mutated only by the single
     worker assigned to index *idx*.  Other workers touch other indices,
@@ -226,7 +228,28 @@ def _process_one_device(
     # module at load time).
     from ..api.routes import backups as _backups_route
 
-    family_base = definitions[device.type_key]
+    result = job.results[idx]
+    # Guard the definition lookup. A typo'd / renamed type_key is ordinary
+    # operator data — device profiles and schedules do NOT validate it against
+    # the loaded library — not a programming bug. A bare definitions[type_key]
+    # KeyError here escapes the per-device try/except below: serial path leaves
+    # the job stranded at "running" forever; parallel path leaves this device
+    # "queued" so the terminal logic counts no failure and marks the job a
+    # false "completed". Resolve an unknown type to an honest per-device
+    # failure instead (blind audit 81d9740 T0-2).
+    family_base = definitions.get(device.type_key)
+    if family_base is None:
+        result.status = "failed"
+        result.error = (
+            f"{device.host}: unknown device type {device.type_key!r} — not in "
+            f"the loaded definition library. Check the device profile's type."
+        )[:500]
+        logger.error(
+            "Job %s: device %s/%s has an unknown type_key %r (not in the "
+            "definition library) — marking the device failed.",
+            job.id, device.type_key, device.host, device.type_key,
+        )
+        return
     # Use the family-base collector for probe — connection-layer
     # settings (netmiko_device_type, auth) are stable across overlays.
     base_collector = _backups_route.get_collector(family_base)
@@ -306,7 +329,6 @@ def _process_one_device(
     # the family base even though connection params are stable.
     collector = _backups_route.get_collector(definition)
     collector.settings = settings  # share the job-level snapshot (see above)
-    result = job.results[idx]
     result.status = "running"
     start = time.monotonic()
     try:
@@ -493,6 +515,23 @@ def run_backup_job(
                         "Job %s: worker raised unexpected exception: %s",
                         job.id, exc, exc_info=exc,
                     )
+
+    # Safety net: any device still non-terminal (queued/running) here never
+    # reached a success/failed verdict — e.g. an unexpected worker escape
+    # before its per-device try/except. The parallel path above logs such an
+    # exception without re-raising, which would otherwise leave the device
+    # "queued" so the terminal logic below counts zero failures and marks a
+    # never-ran device a clean "completed". Force any non-terminal result to
+    # "failed" so "the device never ran" can never read as success (blind
+    # audit 81d9740 T0-2).
+    for r in job.results:
+        if r.status not in ("success", "failed"):
+            r.status = "failed"
+            if not r.error:
+                r.error = (
+                    f"{r.host}: backup did not run to completion "
+                    "(the worker did not reach a terminal state)."
+                )
 
     job.completed_at = datetime.now(UTC)
     success = sum(1 for r in job.results if r.status == "success")

--- a/tests/unit/test_backup_unknown_type_key.py
+++ b/tests/unit/test_backup_unknown_type_key.py
@@ -1,0 +1,107 @@
+"""Backup runner: an unknown ``type_key`` must produce an honest per-device
+failure, never a false ``completed`` or a job stranded at ``running``
+(blind audit ``81d9740`` T0-2).
+
+Before the fix, ``family_base = definitions[device.type_key]`` was a bare dict
+subscript *outside* the per-device try/except. A typo'd / renamed ``type_key``
+is ordinary operator data — device profiles and schedules do not validate it
+against the loaded library — so it raised ``KeyError``:
+
+* the **serial** path let it escape ``run_backup_job`` entirely, so the job was
+  stranded at ``running`` forever and never persisted; and
+* the **parallel** path logged-but-did-not-raise the future exception, leaving
+  the device ``queued`` so the terminal logic counted zero failures and marked
+  the job ``completed`` though the device never ran.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from netcanon.config import Settings
+from netcanon.models.backup import BackupJob, ConfigRecord, JobStatus
+from netcanon.models.device import BackupRequest, DeviceCredentials, DeviceTarget
+from netcanon.services import backup_runner
+
+pytestmark = pytest.mark.unit
+
+# No probe command (skips the probe branch without a loader) + a file extension.
+_STUB_DEF = SimpleNamespace(probe=SimpleNamespace(command=""), file_extension="txt")
+
+
+class _OkCollector:
+    """Returns a config without touching the network (known-type devices)."""
+
+    def collect(self, device, definition) -> str:
+        return "synthetic-config"
+
+
+class _StubStorage:
+    def save(self, *, device_type, host, timestamp, extension, content,
+             device_profile_id=None) -> ConfigRecord:
+        return ConfigRecord(
+            device_type=device_type, host=host, timestamp=timestamp,
+            filename=f"{host}.{extension}", file_extension=extension,
+            size_bytes=len(content), device_profile_id=device_profile_id,
+        )
+
+
+def _job() -> BackupJob:
+    return BackupJob(id="job", created_at=datetime.now(UTC))
+
+
+def _device(type_key: str, host: str) -> DeviceTarget:
+    return DeviceTarget(
+        type_key=type_key, host=host,
+        credentials=DeviceCredentials(username="u", password="p"),
+    )
+
+
+def _run(job: BackupJob, devices: list[DeviceTarget],
+         definitions: dict) -> None:
+    # get_collector is only reached for KNOWN types — the unknown-type guard
+    # returns before any collector is built; patch it anyway for the mixed case.
+    with patch("netcanon.api.routes.backups.get_collector",
+               return_value=_OkCollector()):
+        backup_runner.run_backup_job(
+            job, BackupRequest(devices=devices), definitions,
+            storage=_StubStorage(), settings=Settings(),
+        )
+
+
+def test_unknown_type_key_serial_marks_job_failed_not_stuck_running():
+    # Single device -> serial fast-path. Must not raise; must not strand the
+    # job at `running`.
+    job = _job()
+    _run(job, [_device("NOPE", "10.0.0.1")], {"X": _STUB_DEF})
+    assert job.status is JobStatus.failed
+    assert job.completed_at is not None          # reached the terminal block
+    assert job.results[0].status == "failed"
+    assert "unknown device type" in (job.results[0].error or "").lower()
+
+
+def test_unknown_type_key_parallel_not_false_completed():
+    # >1 device -> parallel path, where the future exception was historically
+    # logged-not-raised and the device left `queued` -> false `completed`.
+    job = _job()
+    _run(job, [_device("NOPE", "10.0.0.1"), _device("NOPE", "10.0.0.2")],
+         {"X": _STUB_DEF})
+    assert job.status is JobStatus.failed
+    assert all(r.status == "failed" for r in job.results)
+    # No device may be left in a non-terminal state at the end of the job.
+    assert all(r.status in ("success", "failed") for r in job.results)
+
+
+def test_mixed_known_and_unknown_type_key_is_partial():
+    # One good device + one unknown type -> partial, never a clean completed.
+    job = _job()
+    _run(job, [_device("X", "10.0.0.1"), _device("NOPE", "10.0.0.2")],
+         {"X": _STUB_DEF})
+    assert job.status is JobStatus.partial
+    by_host = {r.host: r for r in job.results}
+    assert by_host["10.0.0.1"].status == "success"
+    assert by_host["10.0.0.2"].status == "failed"


### PR DESCRIPTION
## What
A device with an unknown `type_key` no longer produces a **false `completed`** backup job (parallel path) or a job stranded at **`running`** forever (serial path). It now fails honestly, per-device.

## Why — audit `81d9740`, T0-2 (UNJUSTIFIED-oversight, HIGH)
`family_base = definitions[device.type_key]` was a bare dict subscript **outside** the per-device `try/except`. A typo'd or renamed `type_key` is ordinary operator data — device profiles and schedules don't validate it against the loaded definition library — so it raised `KeyError`:
- **Serial path:** the `KeyError` escaped `run_backup_job` entirely → job stuck `running`, never persisted.
- **Parallel path:** the future exception was logged-but-not-raised → the device stayed `queued` → the terminal logic (`failed_hosts` counts only `"failed"`) saw zero failures and marked the job **`completed`** though the device never ran.

This is the project's own named failure mode — "report success when the operation didn't happen" — escaping the *translation engine* (already fixed at `2ed73a2`, "surface partial not silent completed") into the **backup orchestrator**.

## How
- Guard the lookup: `definitions.get(type_key)` → on `None`, set the device result `failed` with a clear "unknown device type" error and return (no probe/collect attempted).
- **Terminal-time safety net:** before computing job status, force any still-non-terminal (`queued`/`running`) device result to `failed` — so a never-ran device can never be silently counted as a clean `completed`, defending against *any* future worker escape, not just this one.
- Corrected the `_process_one_device` docstring (it claimed an "invalid definition lookup" escape was a programming bug — it's now handled operator data).

## Verification
- New `tests/unit/test_backup_unknown_type_key.py`: serial → `failed` (not stuck `running`), parallel → `failed` (not false `completed`), mixed known+unknown → `partial`.
- Full `tests/unit` + all backup/schedule integration tests green. No capability-matrix impact (service-layer only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
