### PR TITLE
fix(docs): correct stale "parse-only" cisco_iosxe_cli label in 3 developer docs (audit 81d9740 #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Developer docs no longer mislabel the bidirectional `cisco_iosxe_cli`
+  codec as "parse-only".** Three stale references -- the canonical
+  add-a-field worked example (`docs/adding-a-canonical-field.md`), the
+  feature-parity walkthrough, and a `CanonicalSNMPv3User` docstring -- called
+  the codec parse-only even though it is certified `direction = bidirectional`
+  and is a render target in seven cross-vendor fixtures, so a contributor
+  following the worked example would have skipped wiring the Cisco render
+  path. The 2026-05-21 docs-audit had corrected only the user-facing vendor
+  page. Found by an independent blind audit (`81d9740`, #8).
 * **Backup jobs no longer report a false `completed` (or hang at
   `running`) when a device has an unknown `type_key`.** A typo'd or renamed
   device type (ordinary operator data -- device profiles and schedules do

--- a/docs/adding-a-canonical-field.md
+++ b/docs/adding-a-canonical-field.md
@@ -140,7 +140,12 @@ and in `tests/fixtures/real/RESULTS.md`.
 Render side mirrors parse.  Render only when the field is non-default
 to avoid emitting noise:
 
-**Cisco** (parse-only — no render side for this codec).
+**Cisco** (`cisco_iosxe_cli` — bidirectional; renders via an indented
+`out` line):
+```python
+if iface.mtu is not None:
+    out.append(f" mtu {iface.mtu}")
+```
 
 **OPNsense**:
 ```python

--- a/docs/feature-parity-walkthrough.md
+++ b/docs/feature-parity-walkthrough.md
@@ -49,9 +49,10 @@ suspicion.
    `parse.py` + `render.py` siblings), `juniper_junos/codec.py`,
    `mikrotik_routeros/codec.py` each grew parse rules that extract
    USM users from the wire format and render rules that emit them
-   back.  The `parse_only` Cisco IOS-XE CLI codec gained parse-only
-   coverage (it can read v3 user lines from a backup but doesn't
-   render them — see the codec's `direction` ClassVar).
+   back.  The bidirectional Cisco IOS-XE CLI codec gained SNMPv3
+   *parse* coverage — it reads v3 user lines from a backup but does not
+   yet render them, so the v3-user surface is parse-only on this codec
+   even though the codec itself is `direction = bidirectional`.
 3. **Capability declarations — non-supporting codecs.**
    `netcanon/migration/codecs/opnsense/codec.py` and
    `netcanon/migration/codecs/cisco_iosxe/codec.py` (the NETCONF

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -64,7 +64,9 @@ Schema extensions (wire-through in same commit as schema):
     — the SNMPv3 User-based Security Model surface.  Wired on every
     bidirectional codec that has a documented v3 grammar (Arista
     EOS, Aruba AOS-S, FortiGate, MikroTik RouterOS, Juniper Junos)
-    as well as the Cisco IOS-XE CLI parse-only codec.  OPNsense's
+    as well as the Cisco IOS-XE CLI codec, whose v3-user surface is
+    parse-only (parsed, not yet rendered) though the codec itself is
+    bidirectional.  OPNsense's
     SNMPv3 story is Tier-3 (raw ``snmpd.conf`` snippet) and not in
     scope; its capability matrix lists ``/snmp/v3-user`` as
     unsupported.  Rename surface (fifth per-pane category) lives


### PR DESCRIPTION
## What
Corrects three **developer-doc** references that still call the `cisco_iosxe_cli` codec "parse-only".

## Why — audit `81d9740`, #8 (UNJUSTIFIED-oversight)
The codec is certified `direction = bidirectional` (`codec.py:80`, 847-line `render.py`) and is a render target in **7** cross-vendor fixtures. The 2026-05-21 docs-audit corrected only the user-facing `docs/vendors/cisco_iosxe.md`; three developer docs were missed:
- **`docs/adding-a-canonical-field.md`** — the canonical add-a-field worked example. Under "Wire each codec's `render()`", it told contributors "**Cisco** (parse-only — no render side)", so a contributor adding a field would skip wiring the Cisco render path.
- **`docs/feature-parity-walkthrough.md`** — labelled the whole codec `parse_only`.
- **`netcanon/migration/canonical/intent.py`** — the `CanonicalSNMPv3User` docstring.

## How
Each fix **preserves the accurate narrow point** — the SNMPv3 *v3-user surface* is parse-only on this codec (parsed, not yet rendered) — while dropping the false whole-codec label. The worked example now shows the real bidirectional render idiom.

**Deliberately left unchanged** (verified accurate in their narrow scope): `feature-parity-walkthrough.md:126/231` (generic `parse_only` pitfall pattern), `vrf-routing-instances.md:85` (VRF-surface-specific), and `cisco_iosxe_cli/parse.py:35` (describes the parse-side *helpers*, not the codec).

Docs + one docstring only — no runtime/capability-matrix impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
