### PR TITLE
fix(tier3): surface indented interface ACL bindings in the IOS-XE detector (audit 81d9740 T0-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **An interface-bound ACL (`ip access-group ... in/out`) is no longer
+  dropped silently with no banner.** The IOS-XE Tier-3 detector matched only
+  column-0 ACL *definitions* (`^ip access-list ...`); the per-interface
+  *binding* is indented under `interface`, so a config that lost an
+  inbound/outbound packet filter surfaced nothing in the "detected but not
+  translated" banner -- and when the ACL definition lived off-box, nothing
+  fired at all. The detector now also matches the indented `ip`/`ipv6
+  access-group <name> in|out` binding (excluding `ip igmp access-group`, a
+  multicast join-filter) so the dropped security control is surfaced. Shared
+  by the codecs that reuse the IOS-XE detector (Arista EOS, Aruba AOS-S).
+  Found by an independent blind audit (`81d9740`, T0-4).
 * **Developer docs no longer mislabel the bidirectional `cisco_iosxe_cli`
   codec as "parse-only".** Three stale references -- the canonical
   add-a-field worked example (`docs/adding-a-canonical-field.md`), the

--- a/netcanon/migration/_tier3_detection.py
+++ b/netcanon/migration/_tier3_detection.py
@@ -54,6 +54,15 @@ _IOSXE_TIER3_HEADERS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^ip access-list (?:extended|standard)\s+\S+", re.MULTILINE),
     re.compile(r"^ipv6 access-list\s+\S+", re.MULTILINE),
     re.compile(r"^access-list\s+\d+\s+(?:permit|deny)\b.*$", re.MULTILINE),
+    # Indented interface-level ACL binding (`ip access-group BLOCK in`). The
+    # ACL *definition* above is column-0, but the per-interface *binding* is
+    # indented under `interface`, so it slipped past the column-0 anchors —
+    # and a config that lost an inbound/outbound packet filter validated
+    # `severity=ok` with no banner (worse: when the ACL definition lives
+    # off-box, NOTHING fired). Require `ip`/`ipv6` immediately before
+    # `access-group` so `ip igmp access-group` (a multicast join-filter) is
+    # excluded, plus a trailing `in`/`out` direction (blind audit 81d9740 T0-4).
+    re.compile(r"^\s+ip(?:v6)?\s+access-group\s+\S+\s+(?:in|out)\b", re.MULTILINE),
     re.compile(r"^ip nat\s+(?:inside|outside|pool)\b.*$", re.MULTILINE),
     re.compile(r"^class-map\b.*$", re.MULTILINE),
     re.compile(r"^policy-map\b.*$", re.MULTILINE),

--- a/tests/unit/migration/test_tier3_detection.py
+++ b/tests/unit/migration/test_tier3_detection.py
@@ -99,6 +99,36 @@ class TestIOSXECLI:
         result = detect_tier3_sections_iosxe_cli(raw)
         assert result == ["access-list 10 permit 10.0.0.0 0.0.0.255"]
 
+    def test_interface_acl_binding_detected(self) -> None:
+        # The indented per-interface ACL binding is a dropped security control;
+        # it must surface so the "not translated" banner fires, even though the
+        # column-0 anchors (test_extended_acl) only see the definition (audit
+        # 81d9740 T0-4).
+        raw = (
+            "interface GigabitEthernet0/2\n"
+            " ip address 203.0.113.1 255.255.255.0\n"
+            " ip access-group BLOCK in\n"
+            " ipv6 access-group V6OUT out\n"
+            "!\n"
+        )
+        result = detect_tier3_sections_iosxe_cli(raw)
+        assert "ip access-group BLOCK in" in result
+        assert "ipv6 access-group V6OUT out" in result
+
+    def test_interface_acl_binding_off_box_def_still_surfaces(self) -> None:
+        # Worst case: ONLY the binding is in this config (the ACL definition
+        # lives off-box), so the column-0 definition banner never fires — the
+        # binding alone must still surface.
+        raw = "interface Gi0/2\n ip access-group BLOCK in\n!\n"
+        assert detect_tier3_sections_iosxe_cli(raw) == ["ip access-group BLOCK in"]
+
+    def test_igmp_access_group_not_flagged(self) -> None:
+        # `ip igmp access-group` is a multicast join-filter, not an ACL packet
+        # filter — `ip` is not immediately followed by `access-group`, so the
+        # binding pattern must NOT flag it (false-positive guard).
+        raw = "interface Gi0/3\n ip igmp access-group MCAST-FILTER\n!\n"
+        assert detect_tier3_sections_iosxe_cli(raw) == []
+
 
 # ---------------------------------------------------------------------------
 # FortiOS detector
@@ -361,6 +391,26 @@ class TestCodecWiring:
             s.startswith("route-map RM")
             for s in intent.dropped_tier3_sections
         )
+
+    def test_cisco_iosxe_cli_interface_acl_binding_surfaces(self) -> None:
+        # The audit's worst case (81d9740 T0-4): the ONLY ACL signal is the
+        # indented per-interface binding (the ACL definition lives off-box).
+        # Before the detector fix this produced an empty dropped_tier3_sections
+        # and a silent severity=ok migration; the binding must now surface so
+        # the "not translated" banner fires.
+        from netcanon.migration.codecs.cisco_iosxe_cli.codec import (
+            CiscoIOSXECLICodec,
+        )
+
+        raw = (
+            "hostname r1\n"
+            "interface GigabitEthernet0/2\n"
+            " ip address 203.0.113.1 255.255.255.0\n"
+            " ip access-group BLOCK in\n"
+            "!\n"
+        )
+        intent = CiscoIOSXECLICodec().parse(raw)
+        assert "ip access-group BLOCK in" in intent.dropped_tier3_sections
 
     def test_cisco_iosxe_netconf_populates_field_as_empty(self) -> None:
         from netcanon.migration.codecs.cisco_iosxe.codec import (


### PR DESCRIPTION
## What
An interface-bound ACL (`ip access-group <name> in|out`) is no longer dropped silently with no banner — it now surfaces in the "detected but not translated" list so the manual-review banner fires.

## Why — audit `81d9740`, T0-4 (PARTIAL — the *missing banner* is the bug)
The IOS-XE Tier-3 detector's patterns are all column-0 anchored (`^ip access-list ...`). They match the ACL **definition**, but the per-interface **binding** is *indented* under `interface`:
```
interface GigabitEthernet0/2
 ip access-group BLOCK in      <-- invisible to the column-0 anchors
```
So a config that lost an inbound/outbound packet filter validated `severity=ok` / `completed` with the binding nowhere in the banner — and when the ACL definition lived off-box, **nothing** fired at all. (Dropping the ACL *content* is deliberate, documented Tier-3 design — cross-vendor ACL auto-translation is refused; the bug is that the binding was invisible, so no banner.)

## How
Add one pattern to `_IOSXE_TIER3_HEADERS`:
```python
re.compile(r"^\s+ip(?:v6)?\s+access-group\s+\S+\s+(?:in|out)\b", re.MULTILINE)
```
- `ip` must be immediately followed by `access-group` → `ip igmp access-group` (a multicast join-filter) is **excluded**.
- The trailing `in`/`out` direction is required.

**Notification-only surface** — `validate_against` and `render` never read `dropped_tier3_sections`, so there's no canonical-tree / `iter_xpaths` / capability-matrix impact and **no phase4 regen** (confirmed: cross-mesh + real-fixture integration unchanged). The fix is shared by the codecs that reuse the IOS-XE detector (Arista EOS, Aruba AOS-S).

## Verification
- Detector surfaces the v4 + v6 binding, the off-box-definition worst case, and excludes `ip igmp access-group`.
- End-to-end: `cisco_iosxe_cli.parse()` populates `dropped_tier3_sections` with a binding-only config.
- Full `tests/unit` + real-fixture/cross-mesh integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
