### PR TITLE
fix(aoscx): SNMPv3 lossy reason names the crypto downgrade, not just a re-key (audit 81d9740 T0-3 interim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **The SNMPv3 lossy warning now names the cryptographic downgrade, not just
+  a "re-key".** AOS-CX renders SNMPv3 with SHA-1 auth and AES-128 priv only,
+  so a stronger source algorithm (e.g. SHA-256, AES-256) is silently
+  downgraded on render -- but the operator-facing lossy reason on the
+  `/snmp/v3-user/auth-passphrase` path only mentioned re-keying the
+  ciphertext, mislabelling a security downgrade as routine. The reason now
+  states the SHA-1 / AES-128 ceiling and that this is a cryptographic
+  downgrade. (Full per-codec surfacing of the unwalked `auth-protocol` /
+  `priv-protocol` / `priv-passphrase` leaves -- incl. the mikrotik 3DES->DES
+  and fortigate 3DES->AES priv substitutions -- remains the tracked
+  walk-expansion follow-up.) Found by an independent blind audit
+  (`81d9740`, T0-3).
 * **An interface-bound ACL (`ip access-group ... in/out`) is no longer
   dropped silently with no banner.** The IOS-XE Tier-3 detector matched only
   column-0 ACL *definitions* (`^ip access-list ...`); the per-interface

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -308,13 +308,18 @@ class ArubaAOSCXCodec(CodecBase):
             LossyPath(
                 path="/snmp/v3-user/auth-passphrase",
                 reason=(
-                    "AOS-CX SNMPv3 auth/priv keys are `ciphertext` blobs "
-                    "encrypted with the device key (portable same-device "
-                    "only).  Cross-vendor / cross-device migration emits "
-                    "the blob verbatim under `ciphertext`, but the operator "
-                    "must re-key the SNMPv3 user on the target; the "
+                    "AOS-CX renders SNMPv3 with SHA-1 auth and AES-128 priv "
+                    "ONLY: a stronger source algorithm (SHA-224/256/384/512 "
+                    "auth, or AES-192/256 / 3DES priv) is silently DOWNGRADED "
+                    "to fit the target's grammar -- verify the resulting "
+                    "security level is acceptable, this is a cryptographic "
+                    "downgrade, not just a re-key.  The auth/priv keys are "
+                    "also `ciphertext` blobs encrypted with the device key "
+                    "(portable same-device only), so cross-vendor / cross-"
+                    "device migration emits the blob verbatim and the "
+                    "operator must RE-KEY the SNMPv3 user on the target (the "
                     "`plaintext` key form is normalised to `ciphertext` on "
-                    "render."
+                    "render)."
                 ),
                 severity="warn",
             ),

--- a/tests/unit/migration/test_aruba_aoscx.py
+++ b/tests/unit/migration/test_aruba_aoscx.py
@@ -603,6 +603,24 @@ def test_matrix_lossy(codec: ArubaAOSCXCodec, path: str) -> None:
     assert codec.capabilities.classify(path) == "lossy"
 
 
+def test_snmpv3_auth_passphrase_reason_names_the_downgrade(
+    codec: ArubaAOSCXCodec,
+) -> None:
+    # Audit 81d9740 T0-3: AOS-CX collapses SNMPv3 auth -> SHA-1 and priv ->
+    # AES-128. The operator-facing lossy reason on the (walked) auth-passphrase
+    # path must NAME that cryptographic downgrade, not merely a re-key, so a
+    # security downgrade is never mislabelled as routine. (The mikrotik/
+    # fortigate priv-side substitutions live on the unwalked priv-protocol /
+    # priv-passphrase leaves — the tracked PR-2 walk-expansion.)
+    reason = next(
+        lp.reason for lp in codec.capabilities.lossy
+        if lp.path == "/snmp/v3-user/auth-passphrase"
+    ).lower()
+    assert "downgrad" in reason
+    assert "sha-1" in reason
+    assert "aes-128" in reason
+
+
 @pytest.mark.parametrize("path", [
     "/snmp/trap-host",
     "/vxlan-vnis/l2vni-route-target",


### PR DESCRIPTION
## What
The SNMPv3 lossy warning on AOS-CX now **names the cryptographic downgrade** instead of mislabelling it as a routine re-key.

## Why — audit `81d9740`, T0-3 (ACKNOWLEDGED-DEFERRED), interim
AOS-CX renders SNMPv3 with **SHA-1 auth and AES-128 priv only**, so a stronger source algorithm (SHA-256/384/512, AES-192/256) is silently downgraded on render. The audit's reproduced case (`arista_eos → aruba_aoscx`, `auth sha256 priv aes-256`) rendered SHA-1 + AES-128 but the operator-facing lossy reason on `/snmp/v3-user/auth-passphrase` only talked about re-keying the ciphertext — so a **security downgrade read as routine**.

## How (zero-phase4 interim)
Reword the reason on the already-lossy `/snmp/v3-user/auth-passphrase` path to state the SHA-1 / AES-128 ceiling and that this is a cryptographic downgrade. **Reason-string only — the disposition is unchanged**, so there's no `classify()` / cross-mesh / phase4 impact.

### Why only aruba_aoscx (the precise scoping)
The algorithm substitution happens on `auth_protocol` / `priv_protocol`, which are **unwalked** (`KNOWN_GAP`/PR-2). The only **walked** surface is `auth-passphrase`. aruba_aoscx is the one codec whose walked auth surface genuinely *downgrades auth* (SHA→SHA-1). By contrast mikrotik *upgrades* auth (sha224→SHA256) and fortigate preserves all auth — their real losses are **priv-side** (`3DES→DES`, `3DES→AES`) on the **unwalked** `priv-protocol`/`priv-passphrase` leaves. Surfacing those honestly needs the walk-expansion (the tracked PR-2); declaring them on the auth surface would misattribute the loss. So the full per-codec surfacing remains the deferred follow-up.

## Verification
- Guard test pins that the reason names the downgrade (`SHA-1` + `AES-128`) so it can't regress to a re-key-only message.
- Full `tests/unit` green. No phase4 regen (disposition unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
