### PR TITLE
fix(sanitize): redact VRF / routing-instance names (audit 81d9740 #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **VRF / routing-instance names are now redacted by the sanitiser.** A VRF
+  name can encode customer / tenant identity (`Tenant_A`, `ACME-MGMT`) -- the
+  same risk class as a VLAN name, which was already redacted, yet VRF names
+  passed through verbatim (an inconsistency an earlier release deliberately
+  deferred). `CanonicalRoutingInstance.name`, `CanonicalInterface.vrf`,
+  `CanonicalStaticRoute.vrf`, and `CanonicalEvpnType5Route.vrf` now map to a
+  stable `vrf-N` placeholder, cross-reference-stable so the routing-instance
+  definition and every `vrf <name>` reference rename together (the round-trip
+  stays valid). Found by an independent blind audit (`81d9740`, #5).
 * **The SNMPv3 lossy warning now names the cryptographic downgrade, not just
   a "re-key".** AOS-CX renders SNMPv3 with SHA-1 auth and AES-128 priv only,
   so a stronger source algorithm (e.g. SHA-256, AES-256) is silently

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -82,6 +82,12 @@ Field-typed rules (counter-per-session):
 * ``CanonicalStaticRoute.gateway`` (public) → docs range
 * ``CanonicalStaticRoute.destination`` (public destination CIDR) → docs
   range, prefix length preserved
+* VRF / routing-instance names (``CanonicalRoutingInstance.name``,
+  ``CanonicalInterface.vrf``, ``CanonicalStaticRoute.vrf``,
+  ``CanonicalEvpnType5Route.vrf``) → ``vrf-N`` — a VRF name can encode
+  customer / tenant identity (``Tenant_A``); cross-reference-stable so the
+  routing-instance definition and every ``vrf <name>`` reference rename
+  together (same risk class as a VLAN name)
 * ``CanonicalIntent.dropped_tier3_sections`` → stripped entirely
   (Tier-3 carry-through may contain anything; never share)
 
@@ -306,6 +312,16 @@ def sanitize_intent(
                 redacted=redacted_desc,
             ))
             iface.description = redacted_desc
+
+        if iface.vrf:
+            new_vrf = table.redact_vrf_name(iface.vrf)
+            subs.append(Substitution(
+                category="vrf-name",
+                field=f"interfaces[{i}].vrf",
+                original=iface.vrf,
+                redacted=new_vrf,
+            ))
+            iface.vrf = new_vrf
 
         for j, addr in enumerate(iface.ipv4_addresses):
             new_ip = table.redact_ipv4(addr.ip)
@@ -789,6 +805,15 @@ def sanitize_intent(
                 redacted="description redacted",
             ))
             route.description = "description redacted"
+        if route.vrf:
+            new_vrf = table.redact_vrf_name(route.vrf)
+            subs.append(Substitution(
+                category="vrf-name",
+                field=f"static_routes[{i}].vrf",
+                original=route.vrf,
+                redacted=new_vrf,
+            ))
+            route.vrf = new_vrf
 
     # ---- Tier-3 carry-through — strip entirely ----
     if sanitized.dropped_tier3_sections:
@@ -818,6 +843,15 @@ def sanitize_intent(
 
     # ---- routing-instance descriptions + RD / route-targets ----
     for i, ri in enumerate(sanitized.routing_instances):
+        if ri.name:
+            new_name = table.redact_vrf_name(ri.name)
+            subs.append(Substitution(
+                category="vrf-name",
+                field=f"routing_instances[{i}].name",
+                original=ri.name,
+                redacted=new_name,
+            ))
+            ri.name = new_name
         if ri.description:
             subs.append(Substitution(
                 category="routing-instance-description",
@@ -860,6 +894,15 @@ def sanitize_intent(
             vni.flood_list, f"vxlan_vnis[{i}].flood_list", "vtep-flood", table, subs
         )
     for i, r5 in enumerate(sanitized.evpn_type5_routes):
+        if r5.vrf:
+            new_vrf = table.redact_vrf_name(r5.vrf)
+            subs.append(Substitution(
+                category="vrf-name",
+                field=f"evpn_type5_routes[{i}].vrf",
+                original=r5.vrf,
+                redacted=new_vrf,
+            ))
+            r5.vrf = new_vrf
         r5.rt_imports = _redact_route_target_list(
             r5.rt_imports, f"evpn_type5_routes[{i}].rt_imports", table, subs
         )
@@ -942,6 +985,13 @@ class _SubstitutionTable:
         self._local_user_names: dict[str, str] = {}
         self._snmpv3_user_names: dict[str, str] = {}
         self._vlan_names: dict[str, str] = {}
+        # VRF / routing-instance names — operator-chosen labels that can encode
+        # customer / tenant identity (``Tenant_A``, ``ACME-MGMT``), the same
+        # risk class as a VLAN name.  Keyed by name string across the
+        # routing-instance definition AND every interface / static-route /
+        # EVPN-Type5 record that references it, so the rename is
+        # cross-reference-stable (audit 81d9740 #5).
+        self._vrf_names: dict[str, str] = {}
         # Overlay (EVPN/VXLAN/VRF) identifiers — network-identifying AND
         # cross-referenced (a VRF's RD recurs as a route-target across
         # sibling VRFs + EVPN Type-5 routes; a VXLAN BUM group recurs
@@ -1216,6 +1266,22 @@ class _SubstitutionTable:
         if name not in self._vlan_names:
             self._vlan_names[name] = f"vlan-{len(self._vlan_names) + 1}"
         return self._vlan_names[name]
+
+    def redact_vrf_name(self, name: str) -> str:
+        """Cross-reference-stable VRF / routing-instance name redaction.
+
+        A VRF name is an operator-chosen label that can encode customer /
+        tenant identity (``Tenant_A``, ``ACME-MGMT``) — the same risk class
+        as a VLAN name (which is redacted).  VRF membership is keyed by the
+        name string across the routing-instance definition AND every
+        interface / static-route / EVPN-Type5 record that references it, so
+        the rename MUST be cross-reference-stable: same input -> same
+        ``vrf-N`` placeholder everywhere, or the round-trip breaks (a renamed
+        ``ip route vrf <name>`` would dangle off its definition).
+        """
+        if name not in self._vrf_names:
+            self._vrf_names[name] = f"vrf-{len(self._vrf_names) + 1}"
+        return self._vrf_names[name]
 
     def redact_local_user_name(self, name: str) -> str:
         """Cross-reference-stable local-user-name redaction.

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -1262,6 +1262,54 @@ class TestVirtualMacRedaction:
         assert "00:1c:73" not in rendered                   # ...and colon form
 
 
+class TestVRFNameRedaction:
+    """VRF / routing-instance names are redacted cross-reference-stable
+    (blind audit ``81d9740`` #5).  A VRF name can encode customer / tenant
+    identity (``Tenant_A``) — the same risk class as a VLAN name, which IS
+    redacted.  The rename must apply to the routing-instance definition AND
+    every interface / static-route / EVPN-Type5 record that references it, or
+    a ``ip route vrf <name>`` reference would dangle off its definition."""
+
+    def test_vrf_names_redacted_across_all_four_sites(self):
+        intent = CanonicalIntent(
+            hostname="r1",
+            routing_instances=[CanonicalRoutingInstance(name="Tenant_A")],
+            interfaces=[CanonicalInterface(
+                name="Gi0/1", default_name="Gi0/1", vrf="Tenant_A")],
+            static_routes=[CanonicalStaticRoute(
+                destination="10.0.0.0/24", gateway="10.0.0.1", vrf="Tenant_A")],
+            evpn_type5_routes=[CanonicalEvpnType5Route(
+                vrf="Tenant_A", prefix="10.1.0.0/24")],
+        )
+        sanitized, subs = sanitize_intent(intent)
+        # The operator-chosen name is gone from every site...
+        assert sanitized.routing_instances[0].name != "Tenant_A"
+        assert sanitized.interfaces[0].vrf != "Tenant_A"
+        assert sanitized.static_routes[0].vrf != "Tenant_A"
+        assert sanitized.evpn_type5_routes[0].vrf != "Tenant_A"
+        # ...replaced by a vrf-N placeholder...
+        placeholder = sanitized.routing_instances[0].name
+        assert placeholder.startswith("vrf-")
+        # ...the SAME placeholder everywhere (cross-reference stable).
+        assert sanitized.interfaces[0].vrf == placeholder
+        assert sanitized.static_routes[0].vrf == placeholder
+        assert sanitized.evpn_type5_routes[0].vrf == placeholder
+        assert any(s.category == "vrf-name" for s in subs)
+
+    def test_distinct_vrf_names_get_distinct_placeholders(self):
+        intent = CanonicalIntent(
+            hostname="r1",
+            routing_instances=[
+                CanonicalRoutingInstance(name="Tenant_A"),
+                CanonicalRoutingInstance(name="Tenant_B"),
+            ],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        names = {ri.name for ri in sanitized.routing_instances}
+        assert len(names) == 2                      # distinct in -> distinct out
+        assert "Tenant_A" not in names and "Tenant_B" not in names
+
+
 def test_raw_sections_stripped_by_sanitiser():
     """DATA-02: Tier-3 ``raw_sections`` (verbatim vendor text) is cleared.
 

--- a/tests/unit/tools/test_sanitize_completeness.py
+++ b/tests/unit/tools/test_sanitize_completeness.py
@@ -87,6 +87,12 @@ _SENSITIVE_REDACTED = frozenset({
     ("CanonicalVRRPGroup", "virtual_ips"),
     ("CanonicalVRRPGroup", "virtual_ipv6s"),
     ("CanonicalVRRPGroup", "virtual_mac"),
+    # VRF / routing-instance names — can encode customer/tenant identity,
+    # redacted cross-reference-stable to vrf-N (audit 81d9740 #5).
+    ("CanonicalRoutingInstance", "name"),
+    ("CanonicalInterface", "vrf"),
+    ("CanonicalStaticRoute", "vrf"),
+    ("CanonicalEvpnType5Route", "vrf"),
 })
 
 #: Sensitive str leaves the sanitiser does NOT cover yet — surfaced + tracked +
@@ -106,7 +112,6 @@ _SENSITIVE_GAP: dict[tuple[str, str], tuple[str, str]] = {
 #: a reviewer can challenge (a real IP/secret leaf has no honest code here).
 _NON_SENSITIVE: dict[tuple[str, str], tuple[str, str]] = {
     ("CanonicalDHCPPool", "interface"): ("IFACE_REF", "bind interface name"),
-    ("CanonicalEvpnType5Route", "vrf"): ("IDENTIFIER", "VRF name"),
     ("CanonicalIPv6Address", "scope"): ("ENUM", "global | link-local"),
     ("CanonicalIntent", "apply_groups"): ("METADATA", "Junos apply-group names"),
     ("CanonicalIntent", "hostname"): ("IDENTIFIER", "device hostname; passed through by design"),
@@ -123,7 +128,6 @@ _NON_SENSITIVE: dict[tuple[str, str], tuple[str, str]] = {
     ("CanonicalInterface", "name"): ("IDENTIFIER", "interface name"),
     ("CanonicalInterface", "switchport_mode"): ("ENUM", "access | trunk"),
     ("CanonicalInterface", "tunnel_type"): ("ENUM", "tunnel encapsulation token"),
-    ("CanonicalInterface", "vrf"): ("IDENTIFIER", "VRF name"),
     ("CanonicalLAG", "members"): ("IFACE_REF", "member interface names"),
     ("CanonicalLAG", "mode"): ("ENUM", "active | passive | on"),
     ("CanonicalLAG", "name"): ("IDENTIFIER", "LAG name"),
@@ -131,14 +135,12 @@ _NON_SENSITIVE: dict[tuple[str, str], tuple[str, str]] = {
     ("CanonicalLocalUser", "role"): ("ENUM", "role / privilege keyword"),
     ("CanonicalRoutingInstance", "description"): ("FREE_TEXT", "VRF description"),
     ("CanonicalRoutingInstance", "instance_type"): ("ENUM", "vrf | mac-vrf"),
-    ("CanonicalRoutingInstance", "name"): ("IDENTIFIER", "VRF name"),
     ("CanonicalSNMPv3User", "auth_protocol"): ("ENUM", "md5 | sha | ..."),
     ("CanonicalSNMPv3User", "group"): ("IDENTIFIER", "VACM group name"),
     ("CanonicalSNMPv3User", "name"): ("IDENTIFIER", "SNMPv3 user name; passed through"),
     ("CanonicalSNMPv3User", "priv_protocol"): ("ENUM", "des | aes | ..."),
     ("CanonicalStaticRoute", "description"): ("FREE_TEXT", "route description"),
     ("CanonicalStaticRoute", "interface"): ("IFACE_REF", "egress interface name"),
-    ("CanonicalStaticRoute", "vrf"): ("IDENTIFIER", "VRF name"),
     ("CanonicalVlan", "description"): ("FREE_TEXT", "VLAN description"),
     ("CanonicalVlan", "name"): ("IDENTIFIER", "VLAN name"),
     ("CanonicalVlan", "tagged_ports"): ("IFACE_REF", "tagged member interface names"),


### PR DESCRIPTION
## What
The sanitiser now redacts **VRF / routing-instance names**, closing the inconsistency where VLAN names were redacted but VRF names passed through verbatim.

## Why — audit `81d9740`, #5 (PARTIAL — deliberate-but-inconsistent)
A VRF name can encode customer / tenant identity (`Tenant_A`, `ACME-MGMT`) — the same risk class as a VLAN name (`CEO-OFFICE`), which the sanitiser already redacts. VRF names passed through verbatim; an earlier release deliberately deferred this ("What's still NOT redacted") pending feedback, but treating two operator-chosen labels of the same risk class oppositely is hard to defend once flagged.

## How
- New `redact_vrf_name` → stable `vrf-N` placeholder (mirrors `redact_vlan_name`).
- Applied at **all four** VRF-bearing sites: `CanonicalRoutingInstance.name`, `CanonicalInterface.vrf`, `CanonicalStaticRoute.vrf`, `CanonicalEvpnType5Route.vrf`.
- **Cross-reference-stable** — VRF membership is keyed by the name string, so the routing-instance definition and every `vrf <name>` reference rename to the *same* placeholder, or a `ip route vrf <name>` would dangle off its definition.
- Moved the 4 keys `_NON_SENSITIVE` → `_SENSITIVE_REDACTED` in the completeness partition guard; added the VRF-name rule to the module-docstring "Field-typed rules" list; a new `[Unreleased]` CHANGELOG entry supersedes the historical carve-out.

## Verification
- Forward test: redaction at all 4 sites, cross-reference stability (same placeholder everywhere), distinct names → distinct placeholders.
- Sanitiser-only (not the migration matrix) → **no capability-matrix / phase4 impact**. Full `tests/unit` + sanitize integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
