### PR TITLE
fix(ui): "Validation OK" banner scopes to checked fields (audit e5b77d7 T0-2 interim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **The green "Validation OK" migration banner no longer overstates its
+  coverage.** It claimed "every field that translates maps to a supported
+  path on the target", but live validation walks only a subset of the
+  canonical tree -- ~13 enumerated, CI-tracked leaves (SNMPv3 auth/privacy
+  algorithms, VRRP priority/preempt/mode, static-route gateway, and others;
+  see `tests/unit/migration/test_walker_completeness.py`) are not yet
+  inspected, so a green banner could accompany a silently-downgraded SNMPv3
+  privacy cipher or a dropped VRRP failover parameter. The banner now reads
+  "Validation OK for the checked fields" and names representative
+  not-yet-checked sub-fields, so the operator-facing severity stops implying
+  full coverage while the walk-expansion (PR-2) is pending. Found by an
+  independent blind audit (`e5b77d7`, T0-2 interim).
 * **`ARCHITECTURE.md` no longer mislabels the bidirectional
   `cisco_iosxe_cli` codec as "parse-only" and no longer omits four shipped
   codecs.** The Phase-1 roadmap entry called the IOS-XE CLI codec parse-only

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -1519,9 +1519,12 @@
     var v = job.validation;
     if (!v) return '<em>No validation report.</em>';
     if (v.severity === 'ok') {
-      return '<div>&#10003; Validation OK — every field that translates maps '
-           + 'to a supported path on the target. Review before applying; '
-           + 'Netcanon has no deploy path.</div>';
+      return '<div>&#10003; Validation OK for the checked fields. Every '
+           + 'translatable field Netcanon inspects maps to a supported path '
+           + 'on the target, but some advanced sub-fields (e.g. SNMPv3 '
+           + 'auth/privacy algorithms, VRRP priority/preempt) are not yet '
+           + 'checked — review the output before applying; Netcanon has no '
+           + 'deploy path.</div>';
     }
     var lines = v.reasons.map(function(r) {
       return '<li>' + escapeHtml(r) + '</li>';


### PR DESCRIPTION
## What

The **zero-phase4 interim** the 9th blind audit recommended (twice) for **T0-2** — the silent-loss class that is now a bounded, CI-tracked ~13-leaf `KNOWN_GAP` set.

The `severity: ok` migration banner claimed *"every field that translates maps to a supported path on the target"* — but live validation walks only a **subset** of the canonical tree. ~13 enumerated, CI-tracked leaves (`tests/unit/migration/test_walker_completeness.py`) — SNMPv3 auth/privacy algorithms, VRRP priority/preempt/mode, static-route gateway, IPv6 scope, routing-instance instance_type — are not yet inspected. So a green banner could accompany a silently-downgraded SNMPv3 privacy cipher or a dropped VRRP failover parameter.

## Change

One JS string in `renderBannerContents` (migrate.html):

> &#10003; Validation OK **for the checked fields**. Every translatable field Netcanon inspects maps to a supported path on the target, **but some advanced sub-fields (e.g. SNMPv3 auth/privacy algorithms, VRRP priority/preempt) are not yet checked** — review the output before applying; Netcanon has no deploy path.

## Scope / risk

Template text only — **no logic, schema, or phase4 change.** No test asserts the banner copy (grep-verified; it still begins "Validation OK", so any substring assertions stay green). The already-accurate static output review-note (`migrate-output-review-note`) was reviewed and left unchanged — it makes no false "OK" claim.

The **durable fix** — walking the 13 leaves + per-codec lossy/unsupported declarations (the maintainer's own **PR-2**) — remains the tracked follow-up; this interim closes the operator-facing harm in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
