### PR TITLE
fix(api): declare X-Netcanon-Job-Status header in the OpenAPI schema (audit e5b77d7 #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **The `X-Netcanon-Job-Status` automation header is now declared in the
+  OpenAPI schema.** All seven job-running migration POST endpoints (`/plan`,
+  `/plan/ports`, `/plan/vlans`, `/plan/local_users`, `/plan/snmp`,
+  `/plan/snmpv3`, `/render`) set this header at runtime so an HTTP-only CI
+  gate can tell `completed` from `partial`/`failed`, but it was absent from
+  `responses=` (which advertised only 404 + 422), so generated clients and
+  contract tools could not discover it. Each 200 response now declares the
+  header with its `completed` / `partial` / `failed` enum (the MigrationJob
+  body schema is unchanged). Found by an independent blind audit
+  (`e5b77d7`, #8).
 * **The green "Validation OK" migration banner no longer overstates its
   coverage.** It claimed "every field that translates maps to a supported
   path on the target", but live validation walks only a subset of the

--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -136,6 +136,35 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/migration", tags=["migration"])
 
 
+# Automation contract (audit f92e97a #7, e5b77d7 #8): every job-running POST
+# endpoint sets the ``X-Netcanon-Job-Status`` response header to the job
+# disposition so a naive CI gate that only reads the HTTP status can still
+# distinguish a non-success -- these endpoints always return 200 with the job
+# body.  Declaring the header on the 200 response (not only setting it at
+# runtime) makes it visible in the OpenAPI schema and generated clients.
+# Shared so all seven job-running handlers stay in lock-step; FastAPI merges
+# this 200 entry with the response_model-derived body schema.
+_JOB_STATUS_RESPONSES: dict[int | str, dict] = {
+    200: {
+        "headers": {
+            "X-Netcanon-Job-Status": {
+                "description": (
+                    "Job disposition: completed / partial / failed. Mirrors "
+                    "``MigrationJob.status`` so an automation gate reading only "
+                    "the HTTP status can still detect a non-success."
+                ),
+                "schema": {
+                    "type": "string",
+                    "enum": ["completed", "partial", "failed"],
+                },
+            },
+        },
+    },
+    404: {"description": "source_filename does not exist"},
+    422: {"description": "Invalid adapter name or input specification"},
+}
+
+
 @router.get(
     "/adapters",
     response_model=list[CodecInfo],
@@ -175,10 +204,7 @@ def get_codec_capabilities(name: str) -> CapabilityMatrix:
     "/plan",
     response_model=MigrationJob,
     summary="Parse + validate a config against a target adapter",
-    responses={
-        404: {"description": "source_filename does not exist"},
-        422: {"description": "Invalid adapter name or input specification"},
-    },
+    responses=_JOB_STATUS_RESPONSES,
 )
 def plan_migration(
     body: MigrationPlanRequest,
@@ -274,10 +300,7 @@ def plan_migration(
     "/plan/ports",
     response_model=MigrationJob,
     summary="Per-pane override endpoint: port-name renames",
-    responses={
-        404: {"description": "source_filename does not exist"},
-        422: {"description": "Invalid adapter name or input specification"},
-    },
+    responses=_JOB_STATUS_RESPONSES,
 )
 def plan_migration_ports(
     body: MigrationPlanRequest,
@@ -336,10 +359,7 @@ def plan_migration_ports(
     "/plan/vlans",
     response_model=MigrationJob,
     summary="Per-pane override endpoint: VLAN ID renames",
-    responses={
-        404: {"description": "source_filename does not exist"},
-        422: {"description": "Invalid adapter name or input specification"},
-    },
+    responses=_JOB_STATUS_RESPONSES,
 )
 def plan_migration_vlans(
     body: MigrationPlanRequest,
@@ -394,10 +414,7 @@ def plan_migration_vlans(
     "/plan/local_users",
     response_model=MigrationJob,
     summary="Per-pane override endpoint: local-user renames",
-    responses={
-        404: {"description": "source_filename does not exist"},
-        422: {"description": "Invalid adapter name or input specification"},
-    },
+    responses=_JOB_STATUS_RESPONSES,
 )
 def plan_migration_local_users(
     body: MigrationPlanRequest,
@@ -460,10 +477,7 @@ def plan_migration_local_users(
     "/plan/snmp",
     response_model=MigrationJob,
     summary="Per-pane override endpoint: SNMP community rename",
-    responses={
-        404: {"description": "source_filename does not exist"},
-        422: {"description": "Invalid adapter name or input specification"},
-    },
+    responses=_JOB_STATUS_RESPONSES,
 )
 def plan_migration_snmp(
     body: MigrationPlanRequest,
@@ -527,10 +541,7 @@ def plan_migration_snmp(
     "/plan/snmpv3",
     response_model=MigrationJob,
     summary="Per-pane override endpoint: SNMPv3 USM user rename",
-    responses={
-        404: {"description": "source_filename does not exist"},
-        422: {"description": "Invalid adapter name or input specification"},
-    },
+    responses=_JOB_STATUS_RESPONSES,
 )
 def plan_migration_snmpv3(
     body: MigrationPlanRequest,
@@ -594,10 +605,7 @@ def plan_migration_snmpv3(
     "/render",
     response_model=MigrationJob,
     summary="Alias of /plan — included for API symmetry and future split",
-    responses={
-        404: {"description": "source_filename does not exist"},
-        422: {"description": "Invalid adapter name or input specification"},
-    },
+    responses=_JOB_STATUS_RESPONSES,
 )
 def render_migration(
     body: MigrationPlanRequest,

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -562,6 +562,43 @@ class TestPerPaneEndpointsSetJobStatusHeader:
         assert resp.headers["X-Netcanon-Job-Status"] == resp.json()["status"]
 
 
+class TestJobStatusHeaderInOpenAPISchema:
+    """The ``X-Netcanon-Job-Status`` automation header must be *declared* in
+    the OpenAPI schema, not only set at runtime.
+
+    The wire-header tests above prove the header is emitted; this proves it is
+    documented, so generated clients / contract tools can discover it.  All
+    seven job-running endpoints emitted the header but none declared it in the
+    schema (``responses=`` advertised only 404 + 422) -- audit e5b77d7 #8.
+    """
+
+    _JOB_PATHS = [
+        "/api/v1/migration/plan",
+        "/api/v1/migration/plan/ports",
+        "/api/v1/migration/plan/vlans",
+        "/api/v1/migration/plan/local_users",
+        "/api/v1/migration/plan/snmp",
+        "/api/v1/migration/plan/snmpv3",
+        "/api/v1/migration/render",
+    ]
+
+    @pytest.mark.parametrize("path", _JOB_PATHS)
+    def test_header_declared_on_200_with_enum(self, client, path):
+        r200 = client.app.openapi()["paths"][path]["post"]["responses"]["200"]
+        hdr = r200.get("headers", {}).get("X-Netcanon-Job-Status")
+        assert hdr is not None, f"{path} 200 response is missing the header"
+        assert hdr["schema"]["enum"] == ["completed", "partial", "failed"]
+        # Declaring the header must NOT clobber the MigrationJob body schema.
+        assert "application/json" in r200.get("content", {})
+
+    def test_detect_endpoint_does_not_declare_the_header(self, client):
+        # /detect returns a candidate list, runs no pipeline, sets no header.
+        r200 = client.app.openapi()["paths"][
+            "/api/v1/migration/detect"
+        ]["post"]["responses"]["200"]
+        assert "X-Netcanon-Job-Status" not in r200.get("headers", {})
+
+
 class TestPlanVlansEndpoint:
     """``POST /api/v1/migration/plan/vlans`` — second per-pane
     override endpoint.  Exercises the ``vlan_rename_map`` surface


### PR DESCRIPTION
## What

Closes audit **#8** (`e5b77d7`, graded UNJUSTIFIED-oversight): the `X-Netcanon-Job-Status` automation header was emitted at runtime by all seven job-running migration POST endpoints but **absent from the OpenAPI schema**.

These endpoints always return HTTP 200 with the job body, so this header is the only signal an HTTP-only CI gate can read to tell `completed` from `partial`/`failed`. The header was set at runtime (audit `f92e97a` #7) but each route's `responses=` advertised only 404 + 422 — so generated clients and contract tools never saw the automation contract.

## Change

- New shared `_JOB_STATUS_RESPONSES` constant declares the header on the **200** response with a `completed` / `partial` / `failed` enum, and all seven handlers (`/plan`, `/plan/ports`, `/plan/vlans`, `/plan/local_users`, `/plan/snmp`, `/plan/snmpv3`, `/render`) point at it. The seven `responses=` blocks were byte-identical, so they now stay in lock-step.
- FastAPI merges this 200 entry with the `response_model`-derived body, so the **`MigrationJob` body schema is unchanged** (verified — `body=YES` for all seven). `/detect` runs no pipeline / sets no header and is correctly left without it.

## Scope / risk

**Schema-only, additive — no runtime behavior change.** New `TestJobStatusHeaderInOpenAPISchema` asserts the header + enum on all seven 200s and its absence on `/detect`; the existing `TestPerPaneEndpointsSetJobStatusHeader` wire tests already cover emission. Full `tests/unit` + `tests/integration/test_migration_api.py` + Swagger-docs test green locally. No phase4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
