### PR TITLE
fix(ui): run server-rendered page handlers off the event loop (audit e5b77d7 #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Server-rendered UI pages no longer block the asyncio event loop.** The
+  nine GET page handlers (`/`, `/jobs`, `/schedules`, `/configs`, the diff
+  view, `/devices`, `/definitions`, `/migrate`, `/sanitize`) were declared
+  `async def` but ran fully synchronous bodies -- five of them doing a
+  blocking full-tree `list_configs()` filesystem walk (the diff view also two
+  `get_content()` reads) directly on the event loop, stalling every
+  concurrent request for the duration of the walk. They are now plain `def`
+  handlers, so Starlette runs them in its threadpool -- matching the sibling
+  API / migration routes and the storage layer's own non-blocking contract.
+  Page output is unchanged. Found by an independent blind audit
+  (`e5b77d7`, #3).
 * **The `X-Netcanon-Job-Status` automation header is now declared in the
   OpenAPI schema.** All seven job-running migration POST endpoints (`/plan`,
   `/plan/ports`, `/plan/vlans`, `/plan/local_users`, `/plan/snmp`,

--- a/netcanon/api/routes/ui.py
+++ b/netcanon/api/routes/ui.py
@@ -173,7 +173,7 @@ def register_exception_handlers(app: FastAPI) -> None:
 
 
 @router.get("/", response_class=HTMLResponse)
-async def index(request: Request) -> HTMLResponse:
+def index(request: Request) -> HTMLResponse:
     """Dashboard: recent jobs summary and backup form."""
     jobs = heapq.nlargest(
         10,
@@ -200,7 +200,7 @@ async def index(request: Request) -> HTMLResponse:
 
 
 @router.get("/jobs", response_class=HTMLResponse)
-async def jobs_page(request: Request) -> HTMLResponse:
+def jobs_page(request: Request) -> HTMLResponse:
     """Full job history: all backup jobs with per-device config file links."""
     jobs = sorted(
         request.app.state.jobs.values(),
@@ -224,7 +224,7 @@ async def jobs_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/schedules", response_class=HTMLResponse)
-async def schedules_page(request: Request) -> HTMLResponse:
+def schedules_page(request: Request) -> HTMLResponse:
     """Schedule manager: create and manage recurring backup schedules."""
     schedules = sorted(
         request.app.state.schedules.values(),
@@ -251,7 +251,7 @@ async def schedules_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/configs", response_class=HTMLResponse)
-async def configs_page(request: Request) -> HTMLResponse:
+def configs_page(request: Request) -> HTMLResponse:
     """Config browser: list and delete stored configuration files."""
     configs = request.app.state.storage.list_configs()
     return _templates.TemplateResponse(
@@ -271,7 +271,7 @@ async def configs_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/configs/{left}/vs/{right}", response_class=HTMLResponse)
-async def diff_page(
+def diff_page(
     left: str, right: str, request: Request, force: bool = False
 ) -> HTMLResponse:
     """Render a line-level textual diff between two stored configs.
@@ -361,7 +361,7 @@ async def diff_page(
 
 
 @router.get("/devices", response_class=HTMLResponse)
-async def devices_page(request: Request) -> HTMLResponse:
+def devices_page(request: Request) -> HTMLResponse:
     """Device profile manager: create and manage persistent device profiles."""
     profiles = sorted(
         request.app.state.device_profiles.values(),
@@ -397,7 +397,7 @@ async def devices_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/definitions", response_class=HTMLResponse)
-async def definitions_page(request: Request) -> HTMLResponse:
+def definitions_page(request: Request) -> HTMLResponse:
     """Definition browser: surfaces every Netcanon data-source the
     user cares about.  Four sections:
 
@@ -496,7 +496,7 @@ async def definitions_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/migrate", response_class=HTMLResponse)
-async def migrate_page(request: Request) -> HTMLResponse:
+def migrate_page(request: Request) -> HTMLResponse:
     """Translator workbench: pick source + target adapters, paste or
     select a config, submit to ``POST /api/v1/migration/plan``, and
     review the validation report + rendered output in-page.
@@ -518,7 +518,7 @@ async def migrate_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/sanitize", response_class=HTMLResponse)
-async def sanitize_page(request: Request) -> HTMLResponse:
+def sanitize_page(request: Request) -> HTMLResponse:
     """Sanitize workbench: pick source vendor, paste or select a
     config, submit to ``POST /api/v1/sanitize``, and review the
     redaction audit + sanitized output in-page.


### PR DESCRIPTION
## What

Closes audit **#3** (`e5b77d7`, graded UNJUSTIFIED-oversight): server-rendered UI pages ran blocking I/O on the asyncio event loop.

The nine GET page handlers in `api/routes/ui.py` were declared `async def` but have **fully synchronous bodies**. Five of them — `/configs`, the diff view (`/configs/{l}/vs/{r}`), `/devices`, `/migrate`, `/sanitize` — call a blocking full-tree `storage.list_configs()` filesystem walk directly on the event loop (the diff view also two `storage.get_content()` reads), stalling **every concurrent request** for the duration of the walk. This is the cross-cutting "async-boundary discipline applied inconsistently" theme: the sibling API/migration routes and the sanitize POST handler are already plain `def`.

## Change

Convert all nine page handlers (`index`, `jobs`, `schedules`, `configs`, `diff`, `devices`, `definitions`, `migrate`, `sanitize`) from `async def` to plain `def`. FastAPI/Starlette runs sync route handlers in a worker threadpool, so the blocking I/O no longer touches the loop and the handlers match their siblings. The two **exception handlers stay `async def`** (out of scope, different mechanism).

This is the audit's **Option A** (sync body ⇒ `def`), not a blanket `asyncio.to_thread` wrap — the audit's "siblings use `to_thread`" premise was inaccurate; the siblings are plain `def`.

## Scope / risk

**Behavior-preserving.** Verified there is no `await`/`asyncio` anywhere in the page bodies, and no test awaits/imports these handlers directly (only the sync `_format_interval` helper is imported). Page output is unchanged — confirmed by the UI route + sanitize + error-page + swagger integration tests (87 green locally) and exercised by the CI e2e (Playwright) suite. No phase4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
