### PR TITLE
fix(sanitize): redact trailing-dot and underscore FQDN host fields (audit e5b77d7 #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **The sanitiser no longer leaks the org domain for trailing-dot or
+  underscore FQDNs.** `redact_host` maps a multi-label FQDN host field (NTP /
+  syslog / SNMP-trap / RADIUS target) to an opaque `host-N.example.test`
+  placeholder, but its hostname regex required the name to end in an
+  alphanumeric label and allowed only hyphens -- so a rooted FQDN with a
+  trailing root dot (`nms.corp.example.`) and a host whose label contains an
+  underscore (`srv_01.corp.example`, common in AD / SRV / operator names)
+  failed to match and passed through verbatim, re-leaking the domain. The
+  regex now accepts an optional trailing dot and underscores in labels; bare
+  single labels (`localhost`, `srv_01`) with no dot still pass through (no
+  domain to leak, no over-match). Found by an independent blind audit
+  (`e5b77d7`, #12).
 * **Server-rendered UI pages no longer block the asyncio event loop.** The
   nine GET page handlers (`/`, `/jobs`, `/schedules`, `/configs`, the diff
   view, `/devices`, `/definitions`, `/migrate`, `/sanitize`) were declared

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -136,16 +136,19 @@ from dataclasses import dataclass, field
 from ..migration.canonical.intent import CanonicalIntent
 from ..migration.codecs.registry import get_codec
 
-#: A DNS hostname: dot-separated labels (alnum + internal hyphen), at least
-#: two labels (the leading ``(?:...)`` + the ``(?:\.…)+`` group), <= 253
-#: chars.  Used by :meth:`_SubstitutionTable.redact_host` to tell an FQDN
-#: host field (whose domain suffix re-leaks the org) from a bare single
-#: label (``localhost`` / ``nms`` — no domain to leak) or free text.  IP
-#: literals are matched + handled BEFORE this regex, so the fact that a
-#: dotted-quad also matches the shape is moot.
+#: A DNS hostname: dot-separated labels (alnum, internal hyphen, and
+#: underscore — some operator / AD / SRV host names use ``_``), at least two
+#: labels (the leading label + the ``(?:\.…)+`` group), with an optional
+#: trailing root dot (``nms.corp.example.``), <= 254 chars.  Used by
+#: :meth:`_SubstitutionTable.redact_host` to tell an FQDN host field (whose
+#: domain suffix re-leaks the org) from a bare single label (``localhost`` /
+#: ``nms`` — no domain to leak) or free text.  IP literals are matched +
+#: handled BEFORE this regex, so the fact that a dotted-quad also matches the
+#: shape is moot.  (Trailing-dot and underscore FQDNs previously slipped
+#: through unredacted, re-leaking the org domain — audit e5b77d7 #12.)
 _HOSTNAME_RE = re.compile(
-    r"^(?=.{1,253}$)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
-    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$"
+    r"^(?=.{1,254}$)[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?"
+    r"(?:\.[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?)+\.?$"
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -587,6 +587,27 @@ class TestDnsNameHostFieldRedaction:
         assert table.redact_host("localhost") == "localhost"
         assert table.redact_host("nms") == "nms"
 
+    def test_trailing_dot_fqdn_redacted(self):
+        """A rooted FQDN with a trailing dot (``nms.corp.example.``) is still
+        an org-domain leak and must be redacted, not passed through verbatim
+        (audit e5b77d7 #12)."""
+        out = _SubstitutionTable().redact_host("nms.corp.example.")
+        assert out == "host-1.example.test"
+        assert "corp" not in out
+
+    def test_underscore_label_fqdn_redacted(self):
+        """A host label containing an underscore (``srv_01.corp.example`` —
+        common in AD / SRV / operator-named hosts) must be redacted, not
+        leaked (audit e5b77d7 #12)."""
+        out = _SubstitutionTable().redact_host("srv_01.corp.example")
+        assert out == "host-1.example.test"
+        assert "srv_01" not in out and "corp" not in out
+
+    def test_bare_underscore_label_preserved(self):
+        """A bare single label with an underscore but no dot has no domain to
+        leak — the widened FQDN regex must not over-match it."""
+        assert _SubstitutionTable().redact_host("srv_01") == "srv_01"
+
     def test_fqdn_servers_redacted_through_sanitize_intent(self):
         intent = CanonicalIntent(
             ntp_servers=["ntp.corp.example.com", "10.0.0.1"],


### PR DESCRIPTION
## What

Closes audit **#12** (`e5b77d7`, MED, graded UNJUSTIFIED-oversight): the sanitiser leaked the org domain for two real FQDN forms.

`redact_host` maps a multi-label FQDN host field (NTP / syslog / SNMP-trap / RADIUS target) to an opaque `host-N.example.test` placeholder so the domain suffix does not re-leak. But `_HOSTNAME_RE` required each label to be alnum-bounded and allowed only internal hyphens, so two forms passed the IP guards, **failed the hostname match, and returned verbatim** — re-leaking the domain:

- a rooted FQDN with a trailing root dot — `nms.corp.example.`
- a host whose label contains an underscore — `srv_01.corp.example` (common in AD / SRV records / operator-named hosts)

## Change

Widen `_HOSTNAME_RE`: allow `_` in both label character classes, an optional trailing root dot, and bump the length lookahead `{1,253}`→`{1,254}` (the trailing dot adds a char). The `"." in value` gate is unchanged.

## Scope / risk

Verified against a battery of inputs through the real `_SubstitutionTable`:
- **Now redacted:** `nms.corp.example.`, `srv_01.corp.example`, `_dmarc.corp.example` (+ existing `syslog.corp.example.com`, `acmecorp.com`, `pool.ntp.org`).
- **Still preserved (no over-match):** bare `localhost` / `nms` / `srv_01` (no dot), single-label trailing-dot `nms.`, private IP `10.0.0.5`, empty string.
- **IP unchanged:** public `8.8.8.8` → docs range (not a host placeholder); IP literals are handled before the regex.

Strict superset of the old regex (only adds allowed chars + an optional trailing element), so no previously-matching input changes. Adds 3 regression tests. **Full `tests/unit` + `tests/integration` green** (incl. the forward/reverse no-leaked-secret guards). No phase4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
