### PR TITLE
fix(migration): walk SNMPv3 USM sub-fields so crypto downgrades stop reporting ok (audit e5b77d7 PR-2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **SNMPv3 USM sub-field losses no longer report a green `severity: ok`.**
+  Live validation walked the `/snmp/v3-user` anchor but not its
+  auth-protocol / priv-protocol / priv-passphrase / VACM-group sub-fields, so
+  a migration that downgraded the SNMPv3 auth algorithm (e.g. SHA-256 ->
+  SHA-1 on AOS-CX / VyOS), substituted the privacy cipher (3DES -> AES on
+  FortiGate), re-keyed the opaque passphrase, or dropped the group showed a
+  green banner on a real cryptographic downgrade. The canonical walker now
+  yields these four sub-paths and the 12 codecs declare them per their actual
+  render behaviour: faithful round-trips stay supported; auth/priv downgrades
+  and key re-keys are `lossy` (reasons naming the downgrade); codecs that
+  render no SNMPv3 (the cisco_iosxe NETCONF stub, cisco_iosxr, opnsense)
+  declare them unsupported. First surface of the tracked `KNOWN_GAP`
+  walk-expansion ("PR-2"). Found by an independent blind audit (`e5b77d7`,
+  T0-2 / PR-2a).
 * **The sanitiser no longer leaks the org domain for trailing-dot or
   underscore FQDNs.** `redact_host` maps a multi-label FQDN host field (NTP /
   syslog / SNMP-trap / RADIUS target) to an opaque `host-N.example.test`

--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -223,8 +223,22 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
             yield "/snmp/trap-host"
         for v3 in intent.snmp.v3_users:
             yield "/snmp/v3-user"
+            # Sub-field losses (audit e5b77d7, PR-2a walk-expansion): codecs
+            # that render the v3-user but DOWNGRADE the auth/priv algorithm,
+            # re-key the opaque passphrase, or drop the VACM group declare
+            # these lossy/unsupported.  Walk them only when populated so the
+            # declaration fires in the live report instead of classify()
+            # fail-opening to 'supported' (a silent crypto downgrade).
+            if v3.auth_protocol:
+                yield "/snmp/v3-user/auth-protocol"
             if v3.auth_passphrase:
                 yield "/snmp/v3-user/auth-passphrase"
+            if v3.priv_protocol:
+                yield "/snmp/v3-user/priv-protocol"
+            if v3.priv_passphrase:
+                yield "/snmp/v3-user/priv-passphrase"
+            if v3.group:
+                yield "/snmp/v3-user/group"
             if v3.engine_id:
                 yield "/snmp/v3-user/engine-id"
     for _ in intent.dhcp_servers:

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -324,6 +324,46 @@ class ArubaAOSCXCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/snmp/v3-user/auth-protocol",
+                reason=(
+                    "AOS-CX renders SNMPv3 auth with SHA-1 only: a stronger "
+                    "source auth algorithm (SHA-224/256/384/512) is silently "
+                    "DOWNGRADED to SHA-1 on render -- a cryptographic "
+                    "downgrade, not a re-key; verify the resulting security "
+                    "level is acceptable."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason=(
+                    "AOS-CX renders SNMPv3 privacy with AES-128 / DES only: a "
+                    "stronger source cipher (AES-192/256) is DOWNGRADED to "
+                    "AES-128 and 3DES to DES on render -- a cryptographic "
+                    "downgrade, verify the resulting security level."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/priv-passphrase",
+                reason=(
+                    "The SNMPv3 privacy key is a `ciphertext` blob encrypted "
+                    "with the device key (portable same-device only); cross-"
+                    "vendor / cross-device migration emits it verbatim and the "
+                    "operator must RE-KEY the user on the target."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/group",
+                reason=(
+                    "AOS-CX `snmpv3 user` syntax carries no VACM group "
+                    "binding; the user renders but the canonical group is "
+                    "dropped on render."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vxlan-vnis/source-interface",
                 reason=(
                     "AOS-CX states the VTEP source as an IPv4 *address* "

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -430,6 +430,22 @@ class CiscoIOSXECodec(CodecBase):
                 ),
             ),
             UnsupportedPath(
+                path="/snmp/v3-user/auth-protocol",
+                reason="SNMPv3 USM not wired in the Phase-0.5 stub (see /snmp/v3-user); the auth algorithm is dropped.",
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason="SNMPv3 USM not wired in the Phase-0.5 stub (see /snmp/v3-user); the privacy cipher is dropped.",
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/priv-passphrase",
+                reason="SNMPv3 USM not wired in the Phase-0.5 stub (see /snmp/v3-user); the privacy key is dropped.",
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/group",
+                reason="SNMPv3 USM not wired in the Phase-0.5 stub (see /snmp/v3-user); the VACM group is dropped.",
+            ),
+            UnsupportedPath(
                 path="/vxlan-vnis/vni",
                 reason=(
                     "VXLAN not modelled in this NETCONF/OpenConfig "

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -361,6 +361,34 @@ class CiscoIOSXRCodec(CodecBase):
                 path="/snmp/community",
                 reason="SNMP parse + render is out of the v1 XR scope.",
             ),
+            UnsupportedPath(
+                path="/snmp/v3-user/auth-protocol",
+                reason=(
+                    "SNMP is out of the v1 XR scope (see /snmp/community); "
+                    "the SNMPv3 auth algorithm is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason=(
+                    "SNMP is out of the v1 XR scope (see /snmp/community); "
+                    "the SNMPv3 privacy cipher is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/priv-passphrase",
+                reason=(
+                    "SNMP is out of the v1 XR scope (see /snmp/community); "
+                    "the SNMPv3 privacy key is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/group",
+                reason=(
+                    "SNMP is out of the v1 XR scope (see /snmp/community); "
+                    "the SNMPv3 VACM group is dropped on migration."
+                ),
+            ),
             # ── Routing protocols — Tier 3 ──
             UnsupportedPath(
                 path="/routing/bgp",

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -331,6 +331,16 @@ class CiscoNXOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/snmp/v3-user/priv-passphrase",
+                reason=(
+                    "Same as the auth key: the NX-OS privacy key uses the "
+                    "`localizedkey` digest form, so operators migrating "
+                    "between OS versions or vendors must re-key the SNMPv3 "
+                    "user on the target device."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/snmp/v3-user/engine-id",
                 reason=(
                     "NX-OS emits engineID in colon-decimal "

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -186,6 +186,25 @@ class FortiGateCLICodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason=(
+                    "FortiOS has no 3DES privacy cipher; a `3des` source "
+                    "cipher is substituted with AES on render (a cipher "
+                    "change, not a re-key) -- verify the resulting security "
+                    "level.  AES-128/192/256 and DES round-trip faithfully."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/group",
+                reason=(
+                    "FortiOS `config system snmp user` carries no VACM group "
+                    "(users are grouped implicitly by security-level); the "
+                    "user renders but the canonical group is dropped."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop + device only; the "

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -215,6 +215,15 @@ class MikroTikRouterOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/snmp/v3-user/group",
+                reason=(
+                    "RouterOS overloads `/snmp community` for v3 users and "
+                    "carries no VACM group binding there; the user renders "
+                    "but the canonical group is dropped."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + gateway + comment only; the "

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -421,6 +421,34 @@ class OPNsenseCodec(CodecBase):
                 ),
             ),
             UnsupportedPath(
+                path="/snmp/v3-user/auth-protocol",
+                reason=(
+                    "SNMPv3 users are not in OPNsense config.xml (see "
+                    "/snmp/v3-user); the auth algorithm is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason=(
+                    "SNMPv3 users are not in OPNsense config.xml (see "
+                    "/snmp/v3-user); the privacy cipher is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/priv-passphrase",
+                reason=(
+                    "SNMPv3 users are not in OPNsense config.xml (see "
+                    "/snmp/v3-user); the privacy key is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/snmp/v3-user/group",
+                reason=(
+                    "SNMPv3 users are not in OPNsense config.xml (see "
+                    "/snmp/v3-user); the VACM group is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
                 path="/vxlan-vnis/vni",
                 reason="VXLAN not modelled — OPNsense is a firewall codec.",
             ),

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -244,6 +244,36 @@ class VyOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/snmp/v3-user/auth-protocol",
+                reason=(
+                    "VyOS `snmp v3 user ... auth type` renders only md5 / sha; "
+                    "a stronger source auth algorithm (SHA-224/256/384/512) is "
+                    "collapsed to `sha` (SHA-1) on render -- a cryptographic "
+                    "downgrade requiring a re-key on the target."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason=(
+                    "VyOS `snmp v3 user ... privacy type` renders only bare "
+                    "`des` / `aes`; AES key-length variants (AES-192/256) and "
+                    "3DES lose their exact strength on render -- a "
+                    "cryptographic downgrade requiring a re-key."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/priv-passphrase",
+                reason=(
+                    "Same as the auth key: the VyOS privacy key is an opaque "
+                    "`encrypted-password` blob; it round-trips verbatim same-"
+                    "vendor but cross-vendor migration requires re-keying on "
+                    "the target."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/snmp/v3-user/engine-id",
                 reason=(
                     "VyOS declares a single config-wide `engineid` for the "

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -9829,7 +9829,7 @@ netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 ou
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 466, in render
+  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 485, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\fortigate_cli\render.py", line 948, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)

--- a/tests/unit/migration/test_aruba_aoscx.py
+++ b/tests/unit/migration/test_aruba_aoscx.py
@@ -597,28 +597,35 @@ def test_matrix_supported(codec: ArubaAOSCXCodec, path: str) -> None:
     "/interfaces/interface/config/type",
     "/local-users/user/privilege-level",
     "/snmp/v3-user/auth-passphrase",
+    # PR-2a (audit e5b77d7): the SNMPv3 sub-field leaves are now WALKED, so
+    # AOS-CX's auth/priv downgrade + key re-key + dropped VACM group are
+    # declared lossy (were silent KNOWN_GAP before).
+    "/snmp/v3-user/auth-protocol",
+    "/snmp/v3-user/priv-protocol",
+    "/snmp/v3-user/priv-passphrase",
+    "/snmp/v3-user/group",
     "/vxlan-vnis/source-interface",
 ])
 def test_matrix_lossy(codec: ArubaAOSCXCodec, path: str) -> None:
     assert codec.capabilities.classify(path) == "lossy"
 
 
-def test_snmpv3_auth_passphrase_reason_names_the_downgrade(
+def test_snmpv3_crypto_downgrade_reasons_name_the_downgrade(
     codec: ArubaAOSCXCodec,
 ) -> None:
-    # Audit 81d9740 T0-3: AOS-CX collapses SNMPv3 auth -> SHA-1 and priv ->
-    # AES-128. The operator-facing lossy reason on the (walked) auth-passphrase
-    # path must NAME that cryptographic downgrade, not merely a re-key, so a
-    # security downgrade is never mislabelled as routine. (The mikrotik/
-    # fortigate priv-side substitutions live on the unwalked priv-protocol /
-    # priv-passphrase leaves — the tracked PR-2 walk-expansion.)
-    reason = next(
-        lp.reason for lp in codec.capabilities.lossy
-        if lp.path == "/snmp/v3-user/auth-passphrase"
-    ).lower()
-    assert "downgrad" in reason
-    assert "sha-1" in reason
-    assert "aes-128" in reason
+    # Audit 81d9740 T0-3 (interim) + e5b77d7 PR-2a: AOS-CX collapses SNMPv3
+    # auth -> SHA-1 and priv -> AES-128. Now that the auth-protocol /
+    # priv-protocol leaves are WALKED (PR-2a), the operator-facing lossy reason
+    # on each must NAME the cryptographic downgrade, not merely a re-key, so a
+    # security downgrade is never mislabelled as routine.
+    reasons = {lp.path: lp.reason.lower() for lp in codec.capabilities.lossy}
+    auth = reasons["/snmp/v3-user/auth-protocol"]
+    assert "downgrad" in auth and "sha-1" in auth
+    priv = reasons["/snmp/v3-user/priv-protocol"]
+    assert "downgrad" in priv and "aes-128" in priv
+    # The walked auth-passphrase reason (the original 81d9740 interim) still
+    # names the downgrade too — kept for continuity.
+    assert "downgrad" in reasons["/snmp/v3-user/auth-passphrase"]
 
 
 @pytest.mark.parametrize("path", [

--- a/tests/unit/migration/test_snmpv3_subfield_walk_expansion.py
+++ b/tests/unit/migration/test_snmpv3_subfield_walk_expansion.py
@@ -1,0 +1,77 @@
+"""PR-2a (audit e5b77d7) walk-expansion guard for the SNMPv3 USM sub-fields.
+
+The four SNMPv3 sub-field leaves (auth_protocol / priv_protocol /
+priv_passphrase / group) were tracked ``KNOWN_GAP`` exemptions in
+``test_walker_completeness.py``: the anchor (``/snmp/v3-user``) was walked but
+these sub-paths were not, so ``classify()`` fail-opened any codec that drops or
+downgrades them to ``supported`` -- a silent SNMPv3 crypto downgrade reported
+``severity: ok``.
+
+PR-2a walks them and adds the per-codec dispositions.  This guard pins BOTH
+halves so a regression -- un-walking a path, or dropping a declaration so
+``classify()`` silently fail-opens again -- turns RED.
+"""
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.xpath_walker import _walk_canonical
+from netcanon.migration.codecs.registry import get_codec, list_public_codecs
+from tests.unit.migration.test_registry_capability_honesty import _maximal_intent
+
+_SUBPATHS = [
+    "/snmp/v3-user/auth-protocol",
+    "/snmp/v3-user/priv-protocol",
+    "/snmp/v3-user/priv-passphrase",
+    "/snmp/v3-user/group",
+]
+
+# Verified disposition matrix (PR-2a).  A codec ABSENT from a leaf's dict relies
+# on the classify() supported default BECAUSE it renders the field faithfully
+# (verified against each codec's render.py); a codec LISTED here must carry an
+# explicit lossy/unsupported declaration or the silent loss returns.
+_EXPECTED: dict[str, dict[str, str]] = {
+    "/snmp/v3-user/auth-protocol": {
+        "aruba_aoscx": "lossy", "vyos": "lossy",
+        "cisco_iosxe": "unsupported", "cisco_iosxr": "unsupported",
+        "opnsense": "unsupported",
+    },
+    "/snmp/v3-user/priv-protocol": {
+        "aruba_aoscx": "lossy", "fortigate_cli": "lossy", "vyos": "lossy",
+        "cisco_iosxe": "unsupported", "cisco_iosxr": "unsupported",
+        "opnsense": "unsupported",
+    },
+    "/snmp/v3-user/priv-passphrase": {
+        "aruba_aoscx": "lossy", "cisco_nxos": "lossy", "vyos": "lossy",
+        "cisco_iosxe": "unsupported", "cisco_iosxr": "unsupported",
+        "opnsense": "unsupported",
+    },
+    "/snmp/v3-user/group": {
+        "aruba_aoscx": "lossy", "fortigate_cli": "lossy",
+        "mikrotik_routeros": "lossy",
+        "cisco_iosxe": "unsupported", "cisco_iosxr": "unsupported",
+        "opnsense": "unsupported",
+    },
+}
+
+
+@pytest.mark.parametrize("path", _SUBPATHS)
+def test_subpath_is_walked(path: str) -> None:
+    """The maximal intent populates a full v3 user, so every sub-path must be
+    emitted by the walker (else classify() never sees it = silent loss)."""
+    walked = set(_walk_canonical(_maximal_intent()))
+    assert path in walked, f"{path} is no longer walked -- PR-2a regressed"
+
+
+@pytest.mark.parametrize("path", _SUBPATHS)
+def test_every_codec_declares_or_faithfully_supports(path: str) -> None:
+    """Every codec classifies each sub-path per the verified matrix; a codec
+    that drops or downgrades the field must NOT silently rely on the supported
+    default (that is exactly the silent loss the walk-expansion closes)."""
+    for name in list_public_codecs():
+        got = get_codec(name).capabilities.classify(path)
+        exp = _EXPECTED[path].get(name, "supported")
+        assert got == exp, (
+            f"{name} classifies {path} as {got!r}, expected {exp!r} "
+            f"(PR-2a disposition regression)"
+        )

--- a/tests/unit/migration/test_walker_completeness.py
+++ b/tests/unit/migration/test_walker_completeness.py
@@ -177,10 +177,6 @@ _WALK_EXEMPT: dict[tuple[str, str], tuple[str, str]] = {
     # ── KNOWN_GAP: real currently-silent losses, deferred to walk-expansion ──
     ("CanonicalIPv6Address", "scope"): ("KNOWN_GAP", "link-local discriminator not walked; PR-2"),
     ("CanonicalRoutingInstance", "instance_type"): ("KNOWN_GAP", "mac-vrf vs vrf not walked; PR-2"),
-    ("CanonicalSNMPv3User", "auth_protocol"): ("KNOWN_GAP", "auth algorithm downgrade not walked; PR-2"),
-    ("CanonicalSNMPv3User", "priv_protocol"): ("KNOWN_GAP", "priv cipher downgrade not walked; PR-2"),
-    ("CanonicalSNMPv3User", "priv_passphrase"): ("KNOWN_GAP", "privacy key unwalked; sanitizer redacts it; PR-2"),
-    ("CanonicalSNMPv3User", "group"): ("KNOWN_GAP", "VACM group not walked; PR-2 (lower)"),
     ("CanonicalVRRPGroup", "mode"): ("KNOWN_GAP", "FHRP family (hsrp/carp/vrrp) not walked; PR-2"),
     ("CanonicalVRRPGroup", "priority"): ("KNOWN_GAP", "master-election priority not walked; PR-2"),
     ("CanonicalVRRPGroup", "preempt"): ("KNOWN_GAP", "failover preempt not walked; PR-2"),


### PR DESCRIPTION
## What

**PR-2a** — the first surface of the maintainer's tracked **PR-2** walk-expansion, closing the **SNMPv3** instance of the silent-loss class (9th audit `e5b77d7`, T0-2). Scoped via the per-codec disposition workflow agreed in the PR-2 plan.

The canonical walker yielded the `/snmp/v3-user` anchor but **not** its `auth-protocol` / `priv-protocol` / `priv-passphrase` / `group` sub-fields. Because `classify()` is exact-match + fail-open, every codec reported these as `supported` — so a migration that **downgraded the SNMPv3 auth algorithm** (SHA-256→SHA-1), **substituted the privacy cipher** (3DES→AES), **re-keyed the opaque passphrase**, or **dropped the VACM group** showed a green `severity: ok` banner on a real cryptographic downgrade. These were four tracked `KNOWN_GAP` exemptions.

## Change

- **Walker**: `xpath_walker.py` now yields the 4 sub-paths (guarded on populated).
- **23 declarations across 8 codecs**, each verified against the codec's `render.py` (corrected 3 first-pass agent calls: arista `priv-protocol` is faithful `aes128→aes`, *not* lossy; fortigate's only priv loss is `3des→aes`; `priv-passphrase` mirrors the existing `auth-passphrase` re-key lossy):

| | supported (faithful) | lossy | unsupported |
|---|---|---|---|
| auth-protocol | arista, aoss, cli, nxos, fortigate, junos, mikrotik | **aoscx, vyos** | iosxe-stub, iosxr, opnsense |
| priv-protocol | aoss, cli, nxos, junos, mikrotik | **arista? no →** aoscx, fortigate, vyos | iosxe-stub, iosxr, opnsense |
| priv-passphrase | arista, aoss, cli, fortigate, junos, mikrotik | **aoscx, nxos, vyos** | iosxe-stub, iosxr, opnsense |
| group | arista, aoss, cli, nxos, junos, vyos | **aoscx, fortigate, mikrotik** | iosxe-stub, iosxr, opnsense |

- **Delete** the 4 SNMPv3 `KNOWN_GAP` exemptions (the `test_walk_exempt_is_not_actually_walked` guard forces this once walked).
- **Evolve** the `81d9740`-T0-3 aoscx downgrade guard onto the now-walked auth-protocol/priv-protocol paths.
- **New registry-wide guard** `test_snmpv3_subfield_walk_expansion.py` pinning both the walk and the full disposition matrix.

## phase4 / behavior

- **Behavior change (the point):** migrations carrying SNMPv3 v3-user crypto now report `warn` (lossy) / declared-`unsupported` instead of silent `ok`.
- **Regenerated cross-mesh + phase4 → ZERO fidelity impact:** **CODEC_BUG flat at 5**, `PHASE4_RECONCILIATION.md` byte-identical. The only `CROSS_MESH_RESULTS.md` change is a traceback line-number shift (`466→485`) caused by the fortigate `codec.py` edit moving `render()` down — kept so the matrix stays reproducible-for-this-tree. `latest.json` timestamp-only churn reverted per the #191 precedent.
- Full `tests/unit` + `tests/integration` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
