### PR TITLE
fix(migration): walk VRRP/FHRP sub-fields so redundancy losses stop reporting ok (audit e5b77d7 PR-2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **VRRP / FHRP redundancy sub-field losses no longer report a green
+  `severity: ok`.** Live validation walked the
+  `/interfaces/interface/vrrp-groups/group` anchor but not its election /
+  timer / family sub-fields, so a migration that reinterpreted the FHRP
+  family (e.g. HSRP -> VRRP), dropped the master-election priority / preempt /
+  advertisement-interval, or lost the IPv6 virtual addresses / FHRP
+  authentication / group description showed a green banner on a real
+  redundancy loss. The walker now yields seven sub-paths (mode / priority /
+  preempt / advertisement-interval / authentication / virtual-ipv6s /
+  description) and all 12 codecs declare them per their actual render
+  behaviour. Notably `mode` (the VRRP / HSRP / CARP discriminator) is lossy
+  or unsupported on EVERY codec -- none renders all three families, so a
+  cross-family translation always warrants review. Second surface of the
+  tracked `KNOWN_GAP` walk-expansion ("PR-2"). Found by an independent blind
+  audit (`e5b77d7`, T0-2 / PR-2b).
 * **SNMPv3 USM sub-field losses no longer report a green `severity: ok`.**
   Live validation walked the `/snmp/v3-user` anchor but not its
   auth-protocol / priv-protocol / priv-passphrase / VACM-group sub-fields, so

--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -145,6 +145,22 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
             yield "/interfaces/interface/voice-vlan"
         for grp in iface.vrrp_groups:
             yield "/interfaces/interface/vrrp-groups/group"
+            # FHRP family discriminator + election / timer params (audit
+            # e5b77d7, PR-2b walk-expansion).  mode/priority/preempt/advert
+            # are always populated (schema defaults), so a target codec that
+            # renders only its native FHRP family (or no FHRP at all) declares
+            # them lossy/unsupported -- a cross-family downgrade or a dropped
+            # election parameter is no longer silently 'ok'.
+            yield "/interfaces/interface/vrrp-groups/group/mode"
+            yield "/interfaces/interface/vrrp-groups/group/priority"
+            yield "/interfaces/interface/vrrp-groups/group/preempt"
+            yield "/interfaces/interface/vrrp-groups/group/advertisement-interval"
+            if grp.authentication:
+                yield "/interfaces/interface/vrrp-groups/group/authentication"
+            if grp.virtual_ipv6s:
+                yield "/interfaces/interface/vrrp-groups/group/virtual-ipv6s"
+            if grp.description:
+                yield "/interfaces/interface/vrrp-groups/group/description"
             # Sub-field losses several codecs declare lossy (FortiGate /
             # AOS-S keep one VIP + drop secondaries / virtual-mac / track
             # objects).  Walk them only when the loss condition holds, so

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -141,6 +141,16 @@ class AristaEOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "Arista EOS renders only IETF VRRP; a cross-family source "
+                    "mode (HSRP / CARP) drops to a review comment on render, so "
+                    "the FHRP protocol silently changes -- verify the "
+                    "redundancy intent survived."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/secondary-ip",
                 reason=(
                     "VLAN-SVI mount render gap: this codec renders a VLAN's L3 "

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -410,6 +410,55 @@ class ArubaAOSCXCodec(CodecBase):
         ],
         unsupported=[
             UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "AOS-CX VRRP is a deferred phase (the group anchor is "
+                    "unsupported); the FHRP mode is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/priority",
+                reason=(
+                    "AOS-CX VRRP is a deferred phase (the group anchor is "
+                    "unsupported); the master-election priority is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/preempt",
+                reason=(
+                    "AOS-CX VRRP is a deferred phase (the group anchor is "
+                    "unsupported); the preempt flag is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/advertisement-interval",
+                reason=(
+                    "AOS-CX VRRP is a deferred phase (the group anchor is "
+                    "unsupported); the advertisement interval is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/authentication",
+                reason=(
+                    "AOS-CX VRRP is a deferred phase (the group anchor is "
+                    "unsupported); the FHRP authentication secret is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/virtual-ipv6s",
+                reason=(
+                    "AOS-CX VRRP is a deferred phase (the group anchor is "
+                    "unsupported); the IPv6 virtual addresses are dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "AOS-CX VRRP is a deferred phase (the group anchor is "
+                    "unsupported); the group description is dropped."
+                ),
+            ),
+            UnsupportedPath(
                 path="/interfaces/interface/voice-vlan",
                 reason=(
                     "This codec does not model AOS-CX per-port voice VLAN; "

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -157,6 +157,49 @@ class ArubaAOSSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "AOS-S renders only IETF VRRP; a cross-family source mode "
+                    "(HSRP / CARP) drops to a review comment on render -- the "
+                    "FHRP protocol silently changes, verify."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/advertisement-interval",
+                reason=(
+                    "AOS-S VRRP has no per-group advertisement-interval stanza; "
+                    "the group renders but the election timer is dropped (the "
+                    "target falls back to its 1s default)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/authentication",
+                reason=(
+                    "AOS-S VRRP renders only the plaintext-password auth "
+                    "scheme; an md5 / carp-key source scheme surfaces a review "
+                    "comment rather than the secret."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/virtual-ipv6s",
+                reason=(
+                    "AOS-S VRRP has only an IPv4 virtual-ip-address grammar; "
+                    "IPv6 virtual addresses (VRRPv3) are dropped on render."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "AOS-S VRRP stanzas carry no description / name field; the "
+                    "group renders but the operator description is dropped."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/secondary-ip",
                 reason=(
                     "VLAN-SVI mount: AOS-S renders the SVI L3 from the VLAN "

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -255,6 +255,55 @@ class CiscoIOSXECodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "VRRP / HSRP / CARP parse-and-ignore in the Phase-0.5 stub "
+                    "(the group anchor is unsupported); the FHRP mode is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/priority",
+                reason=(
+                    "VRRP parse-and-ignore in the Phase-0.5 stub (the group "
+                    "anchor is unsupported); the election priority is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/preempt",
+                reason=(
+                    "VRRP parse-and-ignore in the Phase-0.5 stub (the group "
+                    "anchor is unsupported); the preempt flag is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/advertisement-interval",
+                reason=(
+                    "VRRP parse-and-ignore in the Phase-0.5 stub (the group "
+                    "anchor is unsupported); the advertisement interval is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/authentication",
+                reason=(
+                    "VRRP parse-and-ignore in the Phase-0.5 stub (the group "
+                    "anchor is unsupported); the FHRP authentication is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/virtual-ipv6s",
+                reason=(
+                    "VRRP parse-and-ignore in the Phase-0.5 stub (the group "
+                    "anchor is unsupported); the IPv6 virtual addresses are dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "VRRP parse-and-ignore in the Phase-0.5 stub (the group "
+                    "anchor is unsupported); the group description is dropped."
+                ),
+            ),
             # VLAN-SVI L3 sub-fields (blind-audit f92e97a T0-2).  This
             # OpenConfig/NETCONF stub renders no VLAN-record L3 at all (the
             # whole /vlans subtree is unsupported), so any L3 sub-field carried

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -154,6 +154,16 @@ class CiscoIOSXECLICodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "Cisco IOS-XE CLI renders only IETF VRRP (`vrrp`); a "
+                    "cross-family source mode (HSRP / CARP) drops to a review "
+                    "comment on render -- the FHRP protocol silently changes, "
+                    "verify."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/virtual-gateway-address",
                 reason=(
                     "VLAN-SVI mount render gap: the synthesized `interface "

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -282,6 +282,62 @@ class CiscoIOSXRCodec(CodecBase):
         ],
         unsupported=[
             UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group",
+                reason=(
+                    "VRRP / FHRP redundancy groups are out of the v1 IOS-XR "
+                    "scope; the group is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "VRRP / FHRP is out of the v1 IOS-XR scope (see the group "
+                    "anchor); the FHRP mode is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/priority",
+                reason=(
+                    "VRRP / FHRP is out of the v1 IOS-XR scope (see the group "
+                    "anchor); the election priority is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/preempt",
+                reason=(
+                    "VRRP / FHRP is out of the v1 IOS-XR scope (see the group "
+                    "anchor); the preempt flag is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/advertisement-interval",
+                reason=(
+                    "VRRP / FHRP is out of the v1 IOS-XR scope (see the group "
+                    "anchor); the advertisement interval is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/authentication",
+                reason=(
+                    "VRRP / FHRP is out of the v1 IOS-XR scope (see the group "
+                    "anchor); the FHRP authentication is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/virtual-ipv6s",
+                reason=(
+                    "VRRP / FHRP is out of the v1 IOS-XR scope (see the group "
+                    "anchor); the IPv6 virtual addresses are dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "VRRP / FHRP is out of the v1 IOS-XR scope (see the group "
+                    "anchor); the group description is dropped."
+                ),
+            ),
+            UnsupportedPath(
                 path="/interfaces/interface/ipv4/address/virtual-gateway-address",
                 reason=(
                     "IOS-XR has no VARP / anycast-gateway grammar; render "

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -181,6 +181,41 @@ class CiscoNXOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "NX-OS renders only HSRP; a cross-family source mode "
+                    "(VRRP / CARP) is reinterpreted as HSRP on render -- the "
+                    "FHRP protocol silently changes, verify the redundancy "
+                    "intent survived."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/advertisement-interval",
+                reason=(
+                    "The NX-OS HSRP codec does not model the advertisement / "
+                    "hello timer; the group renders but the interval is dropped "
+                    "(the target uses its default)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/virtual-ipv6s",
+                reason=(
+                    "The NX-OS HSRP codec models only IPv4 virtual IPs; IPv6 "
+                    "virtual addresses are dropped on render."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "The NX-OS HSRP group grammar carries no description; the "
+                    "group renders but the operator description is dropped."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/ip",
                 reason=(
                     "Renders VLAN SVI / management L3 only from a sibling "

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -166,6 +166,23 @@ class FortiGateCLICodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "FortiOS renders only IETF VRRP; a cross-family source "
+                    "mode (HSRP / CARP) drops to a review comment on render -- "
+                    "the FHRP protocol silently changes, verify."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "FortiOS `config vrrp` carries no per-group description; "
+                    "the group renders but the operator description is dropped."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/description",
                 reason=(
                     "Render emits the VLAN name but not a separate "

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -159,6 +159,15 @@ class JunosCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "Junos renders only IETF VRRP; a cross-family source mode "
+                    "(HSRP / CARP) is skipped on render -- the FHRP protocol "
+                    "silently changes, verify the redundancy intent survived."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/secondary-ip",
                 reason=(
                     "VLAN-SVI mount: Junos models the SVI as an `irb` unit "

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -161,6 +161,24 @@ class MikroTikRouterOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "RouterOS renders only IETF VRRP; a cross-family source "
+                    "mode (HSRP / CARP) drops to a review comment on render -- "
+                    "the FHRP protocol silently changes, verify."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "RouterOS `/interface vrrp` carries no description / "
+                    "comment field on the group; the group renders but the "
+                    "operator description is dropped."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/ip",
                 reason=(
                     "Renders VLAN SVI / management L3 only from a sibling "

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -167,6 +167,25 @@ class OPNsenseCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "OPNsense renders only BSD CARP; a non-CARP source mode "
+                    "(VRRP / HSRP) is skipped on render and the whole group "
+                    "drops -- verify the redundancy was re-created on the "
+                    "target."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/vrrp-groups/group/preempt",
+                reason=(
+                    "OPNsense's CARP `<vip>` grammar has no preempt element; "
+                    "the group renders but the preempt flag is dropped on "
+                    "render."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/ip",
                 reason=(
                     "Renders VLAN SVI / management L3 only from a sibling "

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -322,6 +322,62 @@ class VyOSCodec(CodecBase):
         ],
         unsupported=[
             UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group",
+                reason=(
+                    "VyOS VRRP / VRRPv3 is not modelled by the codec; the "
+                    "group is dropped on migration."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/mode",
+                reason=(
+                    "VyOS VRRP is not modelled (see the group anchor); the "
+                    "FHRP mode is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/priority",
+                reason=(
+                    "VyOS VRRP is not modelled (see the group anchor); the "
+                    "election priority is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/preempt",
+                reason=(
+                    "VyOS VRRP is not modelled (see the group anchor); the "
+                    "preempt flag is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/advertisement-interval",
+                reason=(
+                    "VyOS VRRP is not modelled (see the group anchor); the "
+                    "advertisement interval is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/authentication",
+                reason=(
+                    "VyOS VRRP is not modelled (see the group anchor); the "
+                    "FHRP authentication is dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/virtual-ipv6s",
+                reason=(
+                    "VyOS VRRP is not modelled (see the group anchor); the "
+                    "IPv6 virtual addresses are dropped."
+                ),
+            ),
+            UnsupportedPath(
+                path="/interfaces/interface/vrrp-groups/group/description",
+                reason=(
+                    "VyOS VRRP is not modelled (see the group anchor); the "
+                    "group description is dropped."
+                ),
+            ),
+            UnsupportedPath(
                 path="/vlans/vlan/ipv4/address/secondary-ip",
                 reason=(
                     "VLAN-SVI mount: VyOS models 802.1Q only as `vif` sub-"

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -9786,7 +9786,7 @@ One section per non-OK synthetic cell (133 total).  Sections are ordered by sour
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 426, in render
+  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 436, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 546, in render_intent
     dest, mask = _cidr_to_dest_mask(route.destination)
@@ -9829,7 +9829,7 @@ netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 ou
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 485, in render
+  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 502, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\fortigate_cli\render.py", line 948, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -166,12 +166,15 @@ def _maximal_intent() -> CanonicalIntent:
         vrf="TENANT",
         vrrp_groups=[CanonicalVRRPGroup(
             group_id=10,
-            # >1 VIP + virtual_mac + track exercise the VRRP sub-field
-            # losses several codecs declare lossy, so the walker yields
-            # those granular xpaths and reverse-parity confirms the lossy
-            # declarations are reachable.
+            # >1 VIP + virtual_mac + track + the PR-2b sub-fields (auth /
+            # v6-VIP / description) exercise the VRRP sub-field losses several
+            # codecs declare lossy, so the walker yields those granular xpaths
+            # and reverse-parity confirms the lossy declarations are reachable.
             virtual_ips=["10.0.0.254", "10.0.0.253"],
+            virtual_ipv6s=["fd00::1:0a"],
             virtual_mac="00:00:5e:00:01:0a",
+            authentication="md5:vrrpkey",
+            description="uplink-redundancy",
             track_interfaces=["Ethernet2"])],
     )
     iface2 = CanonicalInterface(

--- a/tests/unit/migration/test_vrrp_subfield_walk_expansion.py
+++ b/tests/unit/migration/test_vrrp_subfield_walk_expansion.py
@@ -1,0 +1,97 @@
+"""PR-2b (audit e5b77d7) walk-expansion guard for the VRRP/FHRP sub-fields.
+
+The seven VRRP sub-field leaves (mode / priority / preempt /
+advertisement_interval / authentication / virtual_ipv6s / description) were
+tracked ``KNOWN_GAP`` exemptions in ``test_walker_completeness.py``: the group
+anchor (``/interfaces/interface/vrrp-groups/group``) was walked but these
+sub-paths were not, so ``classify()`` fail-opened any codec that downgrades or
+drops them to ``supported`` -- a silent FHRP loss reported ``severity: ok``
+(a cross-family mode reinterpretation, a dropped election parameter, etc.).
+
+PR-2b walks them and adds the per-codec dispositions.  This guard pins BOTH
+halves so a regression -- un-walking a path, or dropping a declaration so
+``classify()`` silently fail-opens again -- turns RED.
+"""
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.xpath_walker import _walk_canonical
+from netcanon.migration.codecs.registry import get_codec, list_public_codecs
+from tests.unit.migration.test_registry_capability_honesty import _maximal_intent
+
+_BASE = "/interfaces/interface/vrrp-groups/group/"
+_SUBPATHS = [
+    _BASE + leaf for leaf in (
+        "mode", "priority", "preempt", "advertisement-interval",
+        "authentication", "virtual-ipv6s", "description",
+    )
+]
+
+# The four codecs that render no FHRP at all -> every sub-path is unsupported.
+_NO_FHRP = ("aruba_aoscx", "cisco_iosxe", "cisco_iosxr", "vyos")
+
+# Verified disposition matrix (PR-2b).  A codec ABSENT from a leaf's dict
+# relies on the classify() supported default BECAUSE it renders the field
+# faithfully (verified against each codec's render.py); a codec LISTED here
+# must carry an explicit lossy/unsupported declaration or the silent loss
+# returns.  `mode` is lossy/unsupported on ALL 12 -- no codec renders every
+# FHRP family, so the family discriminator never round-trips guaranteed.
+_EXPECTED: dict[str, dict[str, str]] = {
+    _BASE + "mode": dict.fromkeys(_NO_FHRP, "unsupported") | dict.fromkeys(
+        (
+            "arista_eos", "aruba_aoss", "cisco_iosxe_cli", "cisco_nxos",
+            "fortigate_cli", "juniper_junos", "mikrotik_routeros", "opnsense",
+        ),
+        "lossy",
+    ),
+    _BASE + "priority": dict.fromkeys(_NO_FHRP, "unsupported"),
+    _BASE + "preempt": dict.fromkeys(_NO_FHRP, "unsupported") | {"opnsense": "lossy"},
+    _BASE + "advertisement-interval": dict.fromkeys(_NO_FHRP, "unsupported") | {
+        "aruba_aoss": "lossy", "cisco_nxos": "lossy",
+    },
+    _BASE + "authentication": dict.fromkeys(_NO_FHRP, "unsupported") | {
+        "aruba_aoss": "lossy",
+    },
+    _BASE + "virtual-ipv6s": dict.fromkeys(_NO_FHRP, "unsupported") | {
+        "aruba_aoss": "lossy", "cisco_nxos": "lossy",
+    },
+    _BASE + "description": dict.fromkeys(_NO_FHRP, "unsupported") | {
+        "aruba_aoss": "lossy", "cisco_nxos": "lossy",
+        "fortigate_cli": "lossy", "mikrotik_routeros": "lossy",
+    },
+}
+
+
+@pytest.mark.parametrize("path", _SUBPATHS)
+def test_subpath_is_walked(path: str) -> None:
+    """The maximal intent populates a full VRRP group, so every sub-path must
+    be emitted by the walker (else classify() never sees it = silent loss)."""
+    walked = set(_walk_canonical(_maximal_intent()))
+    assert path in walked, f"{path} is no longer walked -- PR-2b regressed"
+
+
+@pytest.mark.parametrize("path", _SUBPATHS)
+def test_every_codec_declares_or_faithfully_supports(path: str) -> None:
+    """Every codec classifies each sub-path per the verified matrix; a codec
+    that drops or downgrades the field must NOT silently rely on the supported
+    default (that is exactly the silent loss the walk-expansion closes)."""
+    for name in list_public_codecs():
+        got = get_codec(name).capabilities.classify(path)
+        exp = _EXPECTED[path].get(name, "supported")
+        assert got == exp, (
+            f"{name} classifies {path} as {got!r}, expected {exp!r} "
+            f"(PR-2b disposition regression)"
+        )
+
+
+def test_mode_is_never_silently_supported() -> None:
+    """The FHRP family discriminator can never round-trip guaranteed (no codec
+    renders all of VRRP/HSRP/CARP), so EVERY codec must declare it lossy or
+    unsupported -- never the supported fail-open default."""
+    for name in list_public_codecs():
+        d = get_codec(name).capabilities.classify(_BASE + "mode")
+        assert d in {"lossy", "unsupported"}, (
+            f"{name} classifies VRRP mode as {d!r} -- a cross-family FHRP "
+            f"reinterpretation would report severity:ok"
+        )

--- a/tests/unit/migration/test_walker_completeness.py
+++ b/tests/unit/migration/test_walker_completeness.py
@@ -177,13 +177,6 @@ _WALK_EXEMPT: dict[tuple[str, str], tuple[str, str]] = {
     # ── KNOWN_GAP: real currently-silent losses, deferred to walk-expansion ──
     ("CanonicalIPv6Address", "scope"): ("KNOWN_GAP", "link-local discriminator not walked; PR-2"),
     ("CanonicalRoutingInstance", "instance_type"): ("KNOWN_GAP", "mac-vrf vs vrf not walked; PR-2"),
-    ("CanonicalVRRPGroup", "mode"): ("KNOWN_GAP", "FHRP family (hsrp/carp/vrrp) not walked; PR-2"),
-    ("CanonicalVRRPGroup", "priority"): ("KNOWN_GAP", "master-election priority not walked; PR-2"),
-    ("CanonicalVRRPGroup", "preempt"): ("KNOWN_GAP", "failover preempt not walked; PR-2"),
-    ("CanonicalVRRPGroup", "advertisement_interval"): ("KNOWN_GAP", "advert timer not walked; PR-2"),
-    ("CanonicalVRRPGroup", "authentication"): ("KNOWN_GAP", "FHRP auth unwalked; sanitizer redacts it; PR-2"),
-    ("CanonicalVRRPGroup", "virtual_ipv6s"): ("KNOWN_GAP", "IPv6 VIP list not walked; PR-2"),
-    ("CanonicalVRRPGroup", "description"): ("KNOWN_GAP", "group free-text not walked; PR-2 (low stakes)"),
     ("CanonicalStaticRoute", "gateway"): ("KNOWN_GAP", "next-hop not walked; PR-2"),
 }
 


### PR DESCRIPTION
## What

**PR-2b** — the **VRRP/FHRP** surface of the PR-2 walk-expansion (9th audit `e5b77d7`, T0-2), the second of three staged PRs after PR-2a (SNMPv3, #205).

The canonical walker yielded the `/interfaces/interface/vrrp-groups/group` anchor but **not** its election / timer / family sub-fields. Because `classify()` is exact-match + fail-open, every codec reported them `supported` — so a migration that **reinterpreted the FHRP family** (HSRP ↔ VRRP ↔ CARP), **dropped priority / preempt / advertisement-interval**, or lost the **IPv6 virtual addresses / FHRP auth / group description** showed a green `severity: ok` banner on a real redundancy loss. These were the seven tracked `KNOWN_GAP` exemptions.

## Change

- **Walker**: yields 7 sub-paths — `mode`/`priority`/`preempt`/`advertisement-interval` always (schema defaults), `authentication`/`virtual-ipv6s`/`description` when populated.
- **~46 declarations across all 12 codecs**, each verified against `render.py` + the lossy-vs-unsupported rule (anchor renders → lossy; anchor absent → unsupported):
  - **`mode` is lossy/unsupported on ALL 12** — no codec renders every FHRP family, so the discriminator never round-trips guaranteed.
  - `priority`/`preempt`/`advert`/`auth`/`v6s`/`desc`: **supported** where rendered faithfully; **lossy** where the group renders but the field drops (aoss advert/auth/v6s/desc · nxos advert/v6s/desc · fortigate+mikrotik desc · opnsense preempt); **unsupported** on the 4 codecs that render no FHRP at all (aoscx deferred, cisco_iosxe stub, cisco_iosxr out-of-scope, vyos not-modelled — **iosxr/vyos also gain the previously-undeclared group anchor**, closing a pre-existing fail-open).
- Corrected several first-pass agent calls against source: a dropped sub-field of a *rendered* group is **lossy** (not unsupported), per the #191/#192 precedent.
- Delete the 7 VRRP `KNOWN_GAP` exemptions; extend `_maximal_intent`'s VRRP group (auth/v6s/description) so the new paths land in `_WALKABLE`; add a registry-wide guard `test_vrrp_subfield_walk_expansion` pinning the walk + the full matrix + that `mode` is never silently supported.

## phase4 / behavior

- **Behavior change (the point):** VRRP migrations now `warn` (lossy) / declared-`unsupported` instead of silent `ok`; cross-family `mode` always flags review.
- **Regenerated cross-mesh + phase4 → ZERO fidelity impact:** **CODEC_BUG flat at 5**, `PHASE4_RECONCILIATION.md` byte-identical. The only `CROSS_MESH_RESULTS.md` changes are two traceback line-number shifts from the iosxe_cli + fortigate `codec.py` edits. `latest.json` timestamp churn reverted (#191 precedent).
- Full `tests/unit` + `tests/integration` green locally.

Remaining: **PR-2c** (singletons — gateway / instance_type / scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
