### PR TITLE
fix(migration): walk static-route gateway / routing-instance type / IPv6 scope so silent drops stop reporting ok (audit e5b77d7 PR-2c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Static-route next-hop, routing-instance type, and IPv6 address scope no
+  longer report a green `severity: ok` when dropped on translation.** Live
+  validation walked the `/routing/static-route`, `/routing-instances/instance`,
+  and `/interfaces/interface/ipv6/address` anchors but not these three
+  discriminator sub-fields, so a migration that dropped a default-route next-hop,
+  flattened a `mac-vrf` to a plain `vrf`, or lost an address's `link-local`
+  scope showed a green banner on a real loss. The walker now yields
+  `/routing/static-route/gateway`, `/routing-instances/instance/instance-type`,
+  and `/interfaces/interface/ipv6/address/scope`, and every codec declares them
+  per its actual render -- verified by a render -> parse round-trip probe
+  (supported only where the value survives a round-trip; lossy where the anchor
+  renders but the field downgrades; unsupported where the codec renders no such
+  anchor). This closes the last three `KNOWN_GAP` walker exemptions, completing
+  the walk-expansion begun in the SNMPv3 (PR-2a) and VRRP/FHRP (PR-2b) entries
+  below (audit e5b77d7, PR-2c).
+
 * **VRRP / FHRP redundancy sub-field losses no longer report a green
   `severity: ok`.** Live validation walked the
   `/interfaces/interface/vrrp-groups/group` anchor but not its election /

--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -102,6 +102,15 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
         for addr6 in iface.ipv6_addresses:            # GAP-EVPN-3
             yield "/interfaces/interface/ipv6/address/ip"
             yield "/interfaces/interface/ipv6/address/prefix-length"
+            # link-local vs global scope discriminator (audit e5b77d7,
+            # PR-2c walk-expansion).  scope defaults "global" (always
+            # populated), so a codec that renders the address but hardcodes
+            # the scope (FortiGate / VyOS pin "global") or drops it on the
+            # NETCONF stub declares it lossy -- losing the link-local marker
+            # is no longer silently 'ok'.  Codecs that re-infer scope from
+            # the fe80::/10 prefix on parse round-trip it and stay supported.
+            if addr6.scope:
+                yield "/interfaces/interface/ipv6/address/scope"
             if addr6.is_secondary:
                 yield "/interfaces/interface/ipv6/address/secondary-ip"
             if addr6.virtual_gateway_address:
@@ -210,6 +219,13 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
                 yield "/vlans/vlan/ipv4/address/virtual-gateway-mac"
     for route in intent.static_routes:
         yield "/routing/static-route"
+        # Next-hop gateway (audit e5b77d7, PR-2c walk-expansion).  Walk it
+        # when populated so a codec that renders no <staticroutes> at all
+        # (OPNsense) or no static routes whatsoever (the NETCONF stub) has
+        # its lossy/unsupported declaration fire instead of classify()
+        # fail-opening the dropped next-hop to 'supported'.
+        if route.gateway:
+            yield "/routing/static-route/gateway"
         if route.vrf:
             yield "/routing/static-route/vrf"
         # Sub-field losses (run3 audit): several codecs render only the
@@ -288,6 +304,15 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
     for inst in intent.routing_instances:
         yield "/routing-instances/instance"
         yield "/routing-instances/instance/name"
+        # Instance-type discriminator (audit e5b77d7, PR-2c walk-expansion):
+        # mac-vrf vs vrf.  Defaults "vrf" (always populated), so a codec that
+        # renders the routing-instance anchor but cannot represent the type
+        # (most CLI VRF renderers emit a plain `vrf NAME`) declares it lossy,
+        # and a codec that renders no routing-instance at all declares it
+        # unsupported -- only Arista (mac-vrf/vrf branch) and Junos (explicit
+        # `instance-type`) round-trip it and stay supported.
+        if inst.instance_type:
+            yield "/routing-instances/instance/instance-type"
         if inst.description:
             yield "/routing-instances/instance/description"
         if inst.route_distinguisher:

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -177,6 +177,17 @@ class ArubaAOSCXCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "Renders the VRF anchor as a bare `vrf <name>` stanza with no "
+                    "mac-vrf syntax, so the mac-vrf vs vrf instance-type "
+                    "discriminator downgrades to vrf on render. Declared lossy so "
+                    "validate_against surfaces the loss instead of reporting "
+                    "severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/ip",
                 reason=(
                     "Renders VLAN SVI / management L3 only from a sibling "

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -141,6 +141,7 @@ class ArubaAOSSCodec(CodecBase):
             "/interfaces/interface/trunk-allowed-vlans",
             "/interfaces/interface/trunk-native-vlan",
             "/routing/static-route",
+            "/routing/static-route/gateway",      # audit e5b77d7 — next-hop round-trips
             # Tier 2 — SNMP
             "/snmp/community",
             "/snmp/location",
@@ -293,6 +294,14 @@ class ArubaAOSSCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "AOS-S renders no VRF / routing-instance (see "
+                    "/routing-instances/instance), so the mac-vrf vs vrf "
+                    "instance-type discriminator is dropped (audit e5b77d7, PR-2c)."
+                ),
+            ),
             UnsupportedPath(
                 path="/vlans/vlan/ipv4/address/virtual-gateway-address",
                 reason=(

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -233,6 +233,18 @@ class CiscoIOSXECodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/interfaces/interface/ipv6/address/scope",
+                reason=(
+                    "The Phase-0.5 stub renders the IPv6 address (openconfig "
+                    "ip/prefix-length) but emits no scope and does not re-infer "
+                    "link-local from the fe80::/10 prefix on parse, so the "
+                    "link-local vs global discriminator is lost. Declared lossy so "
+                    "the loss surfaces instead of reporting severity:ok "
+                    "(audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/tunnel-type",
                 reason=(
                     "The OpenConfig/NETCONF render emits only "
@@ -255,6 +267,22 @@ class CiscoIOSXECodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing/static-route/gateway",
+                reason=(
+                    "Phase 0.5 stub render does not walk intent.static_routes "
+                    "(see /routing/static-route), so the next-hop gateway is "
+                    "dropped with the route (audit e5b77d7, PR-2c)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "Phase 0.5 stub render emits no <network-instances> (see "
+                    "/routing-instances/instance), so the mac-vrf vs vrf "
+                    "instance-type discriminator is dropped (audit e5b77d7, PR-2c)."
+                ),
+            ),
             UnsupportedPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -154,6 +154,17 @@ class CiscoIOSXECLICodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "Renders the VRF as `vrf definition <name>` (see "
+                    "/routing-instances/instance), which has no mac-vrf form, so "
+                    "the mac-vrf vs vrf instance-type discriminator downgrades to "
+                    "vrf on render. Declared lossy so validate_against surfaces the "
+                    "loss instead of reporting severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(
                     "Cisco IOS-XE CLI renders only IETF VRRP (`vrrp`); a "

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -158,6 +158,17 @@ class CiscoIOSXRCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "Renders the VRF as a plain `vrf <name>` block (see "
+                    "/routing-instances/instance), which has no mac-vrf form, so "
+                    "the mac-vrf vs vrf instance-type discriminator downgrades to "
+                    "vrf on render. Declared lossy so validate_against surfaces the "
+                    "loss instead of reporting severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/vlans/vlan/ipv4/address/ip",
                 reason=(
                     "Renders VLAN SVI / management L3 only from a sibling "

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -181,6 +181,17 @@ class CiscoNXOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "Renders the VRF as `vrf context <name>` (see "
+                    "/routing-instances/instance/name), which has no mac-vrf form, "
+                    "so the mac-vrf vs vrf instance-type discriminator downgrades "
+                    "to vrf on render. Declared lossy so validate_against surfaces "
+                    "the loss instead of reporting severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(
                     "NX-OS renders only HSRP; a cross-family source mode "

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -138,6 +138,7 @@ class FortiGateCLICodec(CodecBase):
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             "/routing/static-route",
+            "/routing/static-route/gateway",     # audit e5b77d7 — next-hop round-trips
             "/routing/static-route/interface",   # run3 — `set device <iface>`
             # Tier 2 — SNMP
             "/snmp/community",
@@ -165,6 +166,17 @@ class FortiGateCLICodec(CodecBase):
             "/interfaces/interface/vrrp-groups/group",
         ],
         lossy=[
+            LossyPath(
+                path="/interfaces/interface/ipv6/address/scope",
+                reason=(
+                    "Renders the IPv6 address but parse hardcodes scope=global "
+                    "(never re-infers link-local from the fe80::/10 prefix), so the "
+                    "link-local vs global discriminator is lost. Declared lossy so "
+                    "validate_against surfaces the loss instead of reporting "
+                    "severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(
@@ -302,6 +314,15 @@ class FortiGateCLICodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "FortiGate models tenancy as VDOMs, not VRFs, and renders no "
+                    "routing-instance (see /routing-instances/instance), so the "
+                    "mac-vrf vs vrf instance-type discriminator is dropped "
+                    "(audit e5b77d7, PR-2c)."
+                ),
+            ),
             UnsupportedPath(
                 path="/vlans/vlan/ipv4/address/secondary-ip",
                 reason=(

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -141,6 +141,7 @@ class MikroTikRouterOSCodec(CodecBase):
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             "/routing/static-route",
+            "/routing/static-route/gateway",      # audit e5b77d7 — next-hop round-trips
             "/routing/static-route/description",  # run3 — `comment=...`
             # Tier 2 — SNMP
             "/snmp/community",
@@ -291,6 +292,14 @@ class MikroTikRouterOSCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "RouterOS renders no VRF / routing-instance (see "
+                    "/routing-instances/instance), so the mac-vrf vs vrf "
+                    "instance-type discriminator is dropped (audit e5b77d7, PR-2c)."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01) — this codec has no
             #    Cisco-style access/trunk port model, so the per-port VLAN
             #    membership the walker yields is dropped on render.  Declared

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -167,6 +167,16 @@ class OPNsenseCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing/static-route/gateway",
+                reason=(
+                    "Renders no <staticroutes> block (see /routing/static-route), "
+                    "so the next-hop gateway is dropped on render. Declared lossy "
+                    "for parity with the route anchor so validate_against surfaces "
+                    "the loss instead of reporting severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(
                     "OPNsense renders only BSD CARP; a non-CARP source mode "
@@ -320,6 +330,14 @@ class OPNsenseCodec(CodecBase):
             ),
         ],
         unsupported=[
+            UnsupportedPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "OPNsense renders no VRF / routing-instance (see "
+                    "/routing-instances/instance), so the mac-vrf vs vrf "
+                    "instance-type discriminator is dropped (audit e5b77d7, PR-2c)."
+                ),
+            ),
             UnsupportedPath(
                 path="/routing/static-route/interface",
                 reason=(

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -168,6 +168,28 @@ class VyOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing-instances/instance/instance-type",
+                reason=(
+                    "Renders the VRF as `set vrf name <name>` (see "
+                    "/routing-instances/instance/name), which has no mac-vrf form, "
+                    "so the mac-vrf vs vrf instance-type discriminator downgrades "
+                    "to vrf on render. Declared lossy so validate_against surfaces "
+                    "the loss instead of reporting severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/interfaces/interface/ipv6/address/scope",
+                reason=(
+                    "Renders the IPv6 address but parse hardcodes scope=global "
+                    "(never re-infers link-local from the fe80::/10 prefix), so the "
+                    "link-local vs global discriminator is lost. Declared lossy so "
+                    "validate_against surfaces the loss instead of reporting "
+                    "severity:ok (audit e5b77d7, PR-2c)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/tunnel-type",
                 reason=(
                     "VyOS models tunnels (GRE/IPIP/IPsec) as separate "

--- a/tests/fixtures/real/CROSS_MESH_RESULTS.md
+++ b/tests/fixtures/real/CROSS_MESH_RESULTS.md
@@ -9786,7 +9786,7 @@ One section per non-OK synthetic cell (133 total).  Sections are ordered by sour
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 436, in render
+  File "netcanon\migration\codecs\cisco_iosxe_cli\codec.py", line 447, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\cisco_iosxe_cli\render.py", line 546, in render_intent
     dest, mask = _cidr_to_dest_mask(route.destination)
@@ -9829,7 +9829,7 @@ netcanon.migration.codecs.base.RenderError: cisco_iosxe_cli: prefix length 48 ou
 Traceback (most recent call last):
   File "tools\run_full_mesh.py", line 665, in process_cell
     rendered = target_codec.render(canonical_source)
-  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 502, in render
+  File "netcanon\migration\codecs\fortigate_cli\codec.py", line 523, in render
     return render_intent(tree)
   File "netcanon\migration\codecs\fortigate_cli\render.py", line 948, in render_intent
     dst_mask = _prefix_to_mask(dst_prefix)

--- a/tests/unit/migration/test_singleton_subfield_walk_expansion.py
+++ b/tests/unit/migration/test_singleton_subfield_walk_expansion.py
@@ -1,0 +1,102 @@
+"""PR-2c (audit e5b77d7) walk-expansion guard for the three singleton leaves.
+
+These were the LAST three ``KNOWN_GAP`` exemptions in
+``test_walker_completeness.py`` -- the tail of the silent capability-loss class
+that PR-2a (SNMPv3) and PR-2b (VRRP/FHRP) began closing:
+
+* ``/routing/static-route/gateway``            -- the next-hop
+* ``/routing-instances/instance/instance-type``-- mac-vrf vs vrf discriminator
+* ``/interfaces/interface/ipv6/address/scope`` -- link-local vs global
+
+The anchors were walked but these sub-paths were not, so ``classify()``
+fail-opened any codec that dropped or downgraded them to ``supported`` -- a
+silent loss reported ``severity: ok`` (a dropped default-route next-hop, a
+mac-vrf flattened to a plain vrf, a link-local address that loses its scope).
+
+PR-2c walks them and adds the per-codec dispositions, verified by a
+render -> parse round-trip probe (``supported`` only where the value actually
+survives the round-trip; ``lossy`` where the anchor renders but the field is
+dropped/downgraded; ``unsupported`` where the codec renders no instance of the
+anchor at all).  This guard pins BOTH halves so a regression -- un-walking a
+path, or dropping a declaration so ``classify()`` silently fail-opens again --
+turns RED.  With this surface closed the ``KNOWN_GAP`` exemption set is empty;
+the walk-expansion is complete.
+"""
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.xpath_walker import _walk_canonical
+from netcanon.migration.codecs.registry import get_codec, list_public_codecs
+from tests.unit.migration.test_registry_capability_honesty import _maximal_intent
+
+pytestmark = pytest.mark.unit
+
+_SR = "/routing/static-route/"
+_RI = "/routing-instances/instance/"
+_V6 = "/interfaces/interface/ipv6/address/"
+
+_SUBPATHS = [_SR + "gateway", _RI + "instance-type", _V6 + "scope"]
+
+#: Verified disposition matrix (PR-2c).  A codec ABSENT from a leaf's dict
+#: relies on the classify() supported default BECAUSE the value round-trips
+#: (render -> parse recovers it -- verified by the round-trip probe); a codec
+#: LISTED here must carry an explicit lossy/unsupported declaration or the
+#: silent loss returns.  ``lossy`` = the anchor renders but the field is
+#: dropped/downgraded; ``unsupported`` = the codec renders no instance of the
+#: anchor at all.
+_EXPECTED: dict[str, dict[str, str]] = {
+    # Gateway: every codec renders `ip route <dest> <next-hop>` faithfully
+    # except OPNsense (renders no <staticroutes> -> lossy, parity with the
+    # route anchor) and the NETCONF stub (renders no static routes -> unsupp).
+    _SR + "gateway": {
+        "opnsense": "lossy",
+        "cisco_iosxe": "unsupported",
+    },
+    # instance-type: only Arista (mac-vrf/vrf branch) and Junos (explicit
+    # `instance-type`) round-trip the discriminator.  The CLI VRF renderers
+    # emit a plain `vrf <name>` (lossy); the codecs with no VRF model at all
+    # are unsupported.
+    _RI + "instance-type": (
+        dict.fromkeys(
+            ("aruba_aoscx", "cisco_iosxe_cli", "cisco_iosxr", "cisco_nxos", "vyos"),
+            "lossy",
+        )
+        | dict.fromkeys(
+            ("aruba_aoss", "cisco_iosxe", "fortigate_cli", "mikrotik_routeros",
+             "opnsense"),
+            "unsupported",
+        )
+    ),
+    # scope: codecs that re-infer link-local from the fe80::/10 prefix on parse
+    # round-trip the scope and stay supported; FortiGate / VyOS hardcode
+    # scope=global on parse and the NETCONF stub emits no scope -> lossy (the
+    # IPv6 address itself still renders, so this is a downgrade, not unsupported).
+    _V6 + "scope": dict.fromkeys(
+        ("cisco_iosxe", "fortigate_cli", "vyos"), "lossy",
+    ),
+}
+
+
+@pytest.mark.parametrize("path", _SUBPATHS)
+def test_subpath_is_walked(path: str) -> None:
+    """The maximal intent populates a gateway route, a routing-instance, and an
+    IPv6 address, so every singleton sub-path must be emitted by the walker
+    (else classify() never sees it = silent loss)."""
+    walked = set(_walk_canonical(_maximal_intent()))
+    assert path in walked, f"{path} is no longer walked -- PR-2c regressed"
+
+
+@pytest.mark.parametrize("path", _SUBPATHS)
+def test_every_codec_declares_or_faithfully_supports(path: str) -> None:
+    """Every codec classifies each singleton sub-path per the verified matrix;
+    a codec that drops or downgrades the field must NOT silently rely on the
+    supported default (that is exactly the silent loss the walk-expansion
+    closes)."""
+    for name in list_public_codecs():
+        got = get_codec(name).capabilities.classify(path)
+        exp = _EXPECTED[path].get(name, "supported")
+        assert got == exp, (
+            f"{name} classifies {path} as {got!r}, expected {exp!r} "
+            f"(PR-2c disposition regression)"
+        )

--- a/tests/unit/migration/test_walker_completeness.py
+++ b/tests/unit/migration/test_walker_completeness.py
@@ -174,10 +174,12 @@ _WALK_EXEMPT: dict[tuple[str, str], tuple[str, str]] = {
     ("CanonicalEvpnType5Route", "rt_exports"): ("ENVELOPE_AUDIT_BACKSTOPPED", "EVPN-Type5 sub-leaf; audit-backstopped"),
     ("CanonicalRADIUSServer", "auth_port"): ("ENVELOPE_AUDIT_BACKSTOPPED", "defaulted 1812; non-default backstopped"),
     ("CanonicalRADIUSServer", "acct_port"): ("ENVELOPE_AUDIT_BACKSTOPPED", "defaulted 1813; non-default backstopped"),
-    # ── KNOWN_GAP: real currently-silent losses, deferred to walk-expansion ──
-    ("CanonicalIPv6Address", "scope"): ("KNOWN_GAP", "link-local discriminator not walked; PR-2"),
-    ("CanonicalRoutingInstance", "instance_type"): ("KNOWN_GAP", "mac-vrf vs vrf not walked; PR-2"),
-    ("CanonicalStaticRoute", "gateway"): ("KNOWN_GAP", "next-hop not walked; PR-2"),
+    # NOTE: the former KNOWN_GAP exemptions (IPv6 scope, routing-instance
+    # instance_type, static-route gateway) are now WALKED -- PR-2c (audit
+    # e5b77d7) closed the last three silent-loss leaves, completing the
+    # walk-expansion that began with PR-2a (SNMPv3) and PR-2b (VRRP/FHRP).
+    # The KNOWN_GAP reason code is retained in _REASON_CODES for any future
+    # deferral; this exemption set now carries none.
 }
 
 


### PR DESCRIPTION
## What

Walk the **last three** `KNOWN_GAP` walker leaves so a silent drop on translation stops reporting a green `severity: ok`:

| sub-path | discriminator |
|---|---|
| `/routing/static-route/gateway` | the next-hop |
| `/routing-instances/instance/instance-type` | `mac-vrf` vs `vrf` |
| `/interfaces/interface/ipv6/address/scope` | `link-local` vs `global` |

The anchors were walked but these sub-fields were not, so `classify()` fail-opened any codec that dropped or downgraded them to `supported` — a dropped default-route next-hop, a `mac-vrf` flattened to a plain `vrf`, or a lost `link-local` scope showed a green banner on a real loss.

This **completes the PR-2 walk-expansion** begun in #205 (SNMPv3, PR-2a) and #206 (VRRP/FHRP, PR-2b). The `KNOWN_GAP` exemption set in `test_walker_completeness.py` is now empty — the silent capability-loss class the blind-audit meta-finding named is closed for every modelled leaf.

## Verify-first dispositions

Every per-codec call was checked against the actual `render`/`parse`, then confirmed with a `render -> parse` round-trip probe (ground truth for *supported* vs *lossy*):

- **gateway** — supported on the 10 codecs that render `ip route <dest> <next-hop>`; **lossy** on OPNsense (renders no `<staticroutes>`, parity with the route anchor); **unsupported** on the NETCONF stub (renders no static routes).
- **instance-type** — supported only on Arista (mac-vrf/vrf render branch) and Junos (explicit `instance-type`); **lossy** on aoscx / iosxe_cli / iosxr / nxos / vyos (render a plain `vrf <name>`); **unsupported** on aoss / stub / fortigate / mikrotik / opnsense (no VRF model).
- **scope** — **lossy** on the stub / FortiGate / VyOS (render the IPv6 address but hardcode `scope=global` / emit no scope); supported on the rest, which re-infer `link-local` from the `fe80::/10` prefix on parse and round-trip it. (The draft matrix had this backwards — the parse-side inference is what makes most codecs supported, not lossy.)

## Tests

- New guard `tests/unit/migration/test_singleton_subfield_walk_expansion.py` pins both the walked-ness and the full per-codec disposition matrix.
- The 3 `KNOWN_GAP` exemptions are deleted (forced by `test_walk_exempt_is_not_actually_walked` once the leaves are walked).
- Full `tests/unit` + `tests/integration` green locally.

## Fidelity impact: none

`PHASE4_RECONCILIATION.md` byte-identical, `CODEC_BUG` flat. The only `CROSS_MESH_RESULTS.md` change is embedded-traceback line numbers shifting as the `codec.py` edits move `render()` down (reproducible-for-tree, kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
