### PR TITLE
fix(parse): harden 5 config-parser regexes against polynomial ReDoS (CodeQL py/polynomial-redos #124-#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Hardened five config-parser regexes against polynomial ReDoS** (CodeQL
+  `py/polynomial-redos`, alerts #124-#128). The Arista DHCP `dns-server`, the
+  AOS-CX `vlan trunk allowed`, the NX-OS and IOS-XE VRF `description`, and the
+  IOS-XE `ip route` patterns each paired a `\s+` separator (or a greedy next-hop
+  `(\S+)`) with a value group whose character class overlapped it, so a long
+  attacker-controlled line pasted through the migrate / sanitize API could drive
+  super-linear backtracking. Anchored each value boundary on a disjoint class
+  (`\S` for the value patterns, `\s` for the static-route trailing group);
+  behaviour is identical for every real config because each consumer already
+  `.split()`s or `.strip()`s the captured group (confirmed by a render -> parse
+  equivalence check, pinned by `tests/unit/migration/test_redos_hardening.py`).
+
 * **Static-route next-hop, routing-instance type, and IPv6 address scope no
   longer report a green `severity: ok` when dropped on translation.** Live
   validation walked the `/routing/static-route`, `/routing-instances/instance`,

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -237,8 +237,13 @@ _DHCP_DEFAULT_ROUTER_RE = re.compile(
     r"^\s+default-router\s+(\d+\.\d+\.\d+\.\d+)",
     re.IGNORECASE,
 )
+# Anchor the value on a leading ``\S`` (not ``.+``) so the ``\s+`` separator
+# and the value group cannot both match the same run of spaces -- that overlap
+# is the polynomial-ReDoS CodeQL flagged (py/polynomial-redos #124).  The
+# consumer ``.split()``s the group, so requiring a non-space first char is
+# behaviour-identical for every real ``dns-server`` line.
 _DHCP_DNS_SERVER_RE = re.compile(
-    r"^\s+dns-server\s+(.+)$", re.IGNORECASE,
+    r"^\s+dns-server\s+(\S.*)$", re.IGNORECASE,
 )
 _DHCP_DOMAIN_NAME_RE = re.compile(
     r"^\s+domain-name\s+(\S+)", re.IGNORECASE,

--- a/netcanon/migration/codecs/aruba_aoscx/parse.py
+++ b/netcanon/migration/codecs/aruba_aoscx/parse.py
@@ -144,8 +144,14 @@ _VLAN_TRUNK_NATIVE_RE = re.compile(
 )
 #: ``vlan trunk allowed <list|all>`` — ``all`` maps to an empty
 #: allowed-list (the render re-emits ``all`` for an empty list).
+# Anchor the value on a leading ``\S`` and let the consumer ``.strip()`` the
+# trailing whitespace, instead of ``(.+?)\s*$`` -- the lazy ``.+?`` overlapped
+# both the leading ``\s+`` separator and the trailing ``\s*`` (polynomial
+# ReDoS, CodeQL py/polynomial-redos #125).  Every real trunk line has a VLAN
+# list or ``all``; a value-less ``vlan trunk allowed`` was degenerate config
+# (it set trunk_allowed=[] == "all") and is now skipped.
 _VLAN_TRUNK_ALLOWED_RE = re.compile(
-    r"^\s+vlan\s+trunk\s+allowed\s+(.+?)\s*$", re.IGNORECASE,
+    r"^\s+vlan\s+trunk\s+allowed\s+(\S.*)$", re.IGNORECASE,
 )
 #: ``lag <N>`` on a physical port declares it a member of ``lag <N>``.
 _LAG_MEMBER_RE = re.compile(r"^\s+lag\s+(\d+)\s*$", re.IGNORECASE)

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -235,7 +235,13 @@ _VLAN_NAME_RE = re.compile(r"^\s+name\s+(.+)", re.IGNORECASE)
 _STATIC_ROUTE_RE = re.compile(
     r"^ip\s+route\s+(?:vrf\s+(\S+)\s+)?"
     r"(\d+\.\d+\.\d+\.\d+)\s+(\d+\.\d+\.\d+\.\d+)\s+(\S+)"
-    r"(.*)$",  # group 5: trailing tokens (admin distance / name / tag / ...)
+    # group 5: trailing tokens (admin distance / name / tag / ...).  ``(\s.*)?``
+    # not ``(.*)`` so the next-hop ``(\S+)`` and the trailing group can't both
+    # match the same non-space run -- that overlap was the polynomial ReDoS
+    # CodeQL flagged (py/polynomial-redos #128).  ``(.*)`` after a greedy
+    # ``(\S+)`` already began at the first space, so ``(\s.*)?`` captures the
+    # identical value (None when absent, normalised by ``or ""`` downstream).
+    r"(\s.*)?$",
     re.IGNORECASE,
 )
 # ``ip default-gateway X`` is the L2-switch form of a default route.
@@ -335,8 +341,12 @@ _TOP_NTP_SERVER_RE = re.compile(
 _VRF_DEFINITION_RE = re.compile(
     r"^vrf\s+definition\s+(\S+)\s*$", re.IGNORECASE,
 )
+# ``(\S.*)`` (not ``(.+)``) so the ``\s+`` separator and the value can't both
+# match the same spaces -- the polynomial-ReDoS overlap CodeQL flagged
+# (py/polynomial-redos #127).  The consumer ``.strip()``s the group, so a
+# non-space first char is behaviour-identical for any real description.
 _VRF_DESCRIPTION_RE = re.compile(
-    r"^\s+description\s+(.+)$", re.IGNORECASE,
+    r"^\s+description\s+(\S.*)$", re.IGNORECASE,
 )
 _VRF_RD_RE = re.compile(
     r"^\s+rd\s+(\S+)\s*$", re.IGNORECASE,

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -230,7 +230,11 @@ _FABRIC_AG_MODE_RE = re.compile(
 
 #: ``vrf context <name>`` opens a top-level VRF stanza.
 _VRF_CONTEXT_RE = re.compile(r"^vrf\s+context\s+(\S+)\s*$", re.IGNORECASE)
-_VRF_DESCRIPTION_RE = re.compile(r"^\s+description\s+(.+)$", re.IGNORECASE)
+# ``(\S.*)`` (not ``(.+)``) so the ``\s+`` separator and the value can't both
+# match the same spaces -- the polynomial-ReDoS overlap CodeQL flagged
+# (py/polynomial-redos #126).  The consumer ``.strip()``s the group, so a
+# non-space first char is behaviour-identical for any real description.
+_VRF_DESCRIPTION_RE = re.compile(r"^\s+description\s+(\S.*)$", re.IGNORECASE)
 # ── VRF RD / route-target + per-VRF static route (Phase 3) ──
 #: ``rd <asn>:<nn>`` / ``rd <ip>:<nn>`` / ``rd auto`` inside a ``vrf
 #: context`` block.  ``auto`` (NX-OS derives the RD from the BGP ASN +

--- a/tests/unit/migration/test_redos_hardening.py
+++ b/tests/unit/migration/test_redos_hardening.py
@@ -1,0 +1,102 @@
+"""ReDoS hardening guard for the five parse.py regexes CodeQL flagged
+(``py/polynomial-redos`` alerts #124-#128).
+
+Each pattern paired a ``\\s+`` separator (or a greedy ``(\\S+)`` next-hop) with a
+value group whose character class OVERLAPPED it (``.+`` / ``.+?`` / ``.*`` all
+match whitespace; ``.`` matches the same non-space the next-hop did), so the
+engine could split the same run two ways -> polynomial backtracking on a long
+attacker-controlled line (the migrate / sanitize API parses pasted config text).
+
+The fix anchors the value boundary on a disjoint class (``\\S`` for the
+value-capturing patterns, ``\\s`` for the static-route trailing group), which is
+unambiguous AND behaviour-identical because every consumer ``.split()``s or
+``.strip()``s the captured group.  This guard pins BOTH halves:
+
+* the patterns still CAPTURE the right value on representative real lines, and
+* the exact attack strings CodeQL named complete in linear time (a regression to
+  a catastrophic pattern would blow the budget).
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from netcanon.migration.codecs.arista_eos.parse import _DHCP_DNS_SERVER_RE
+from netcanon.migration.codecs.aruba_aoscx.parse import _VLAN_TRUNK_ALLOWED_RE
+from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
+    _STATIC_ROUTE_RE,
+)
+from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
+    _VRF_DESCRIPTION_RE as _IOSXE_VRF_DESCRIPTION_RE,
+)
+from netcanon.migration.codecs.cisco_nxos.parse import (
+    _VRF_DESCRIPTION_RE as _NXOS_VRF_DESCRIPTION_RE,
+)
+
+pytestmark = pytest.mark.unit
+
+#: Generous ceiling: the hardened patterns are linear (microseconds on these
+#: inputs); a polynomial/exponential regression would take seconds-to-minutes.
+_BUDGET_S = 1.0
+_REPS = 200_000
+
+
+def _timed_match(rx, text):
+    start = time.perf_counter()
+    m = rx.match(text)
+    return m, time.perf_counter() - start
+
+
+# ---------------------------------------------------------------------------
+# Behaviour preserved: the hardened patterns still capture the right value.
+# ---------------------------------------------------------------------------
+
+
+def test_dns_server_still_captures():
+    m = _DHCP_DNS_SERVER_RE.match("   dns-server   8.8.8.8   1.1.1.1  ")
+    assert m and m.group(1).split() == ["8.8.8.8", "1.1.1.1"]
+
+
+def test_vlan_trunk_allowed_still_captures():
+    assert _VLAN_TRUNK_ALLOWED_RE.match("   vlan trunk allowed 10-20,30 ").group(1).strip() == "10-20,30"
+    assert _VLAN_TRUNK_ALLOWED_RE.match("   vlan trunk allowed all").group(1).strip() == "all"
+
+
+def test_vrf_description_still_captures():
+    for rx in (_NXOS_VRF_DESCRIPTION_RE, _IOSXE_VRF_DESCRIPTION_RE):
+        assert rx.match("  description   Uplink to core  ").group(1).strip() == "Uplink to core"
+
+
+def test_static_route_still_captures_and_keeps_trailing_tokens():
+    m = _STATIC_ROUTE_RE.match("ip route vrf RED 10.0.0.0 255.0.0.0 192.0.2.1 200 name UP")
+    assert m.group(1, 2, 3, 4) == ("RED", "10.0.0.0", "255.0.0.0", "192.0.2.1")
+    assert (m.group(5) or "").split() == ["200", "name", "UP"]
+    # No trailing tokens -> next-hop is the last token, trailing group is empty.
+    bare = _STATIC_ROUTE_RE.match("ip route 0.0.0.0 0.0.0.0 192.0.2.1")
+    assert bare.group(2, 3, 4) == ("0.0.0.0", "0.0.0.0", "192.0.2.1")
+    assert (bare.group(5) or "").split() == []
+
+
+# ---------------------------------------------------------------------------
+# ReDoS gone: CodeQL's own attack strings complete in linear time.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rx", "attack"),
+    [
+        (_DHCP_DNS_SERVER_RE, "   dns-server " + "  " * _REPS),          # #124
+        (_VLAN_TRUNK_ALLOWED_RE, "   vlan trunk allowed " + "  " * _REPS),  # #125
+        (_NXOS_VRF_DESCRIPTION_RE, "   description " + "  " * _REPS),     # #126
+        (_IOSXE_VRF_DESCRIPTION_RE, "   description " + "  " * _REPS),    # #127
+        (_STATIC_ROUTE_RE, "ip route 9.9.9.9 9.9.9.9 !" + "!!" * _REPS),  # #128
+    ],
+    ids=["dns-server", "vlan-trunk", "nxos-desc", "iosxe-desc", "static-route"],
+)
+def test_attack_string_is_linear_time(rx, attack):
+    _m, elapsed = _timed_match(rx, attack)
+    assert elapsed < _BUDGET_S, (
+        f"regex took {elapsed:.3f}s on a {len(attack)}-char attack line "
+        f"-- possible ReDoS regression (budget {_BUDGET_S}s)"
+    )


### PR DESCRIPTION
## What

Closes the **Cluster A** code-scanning alerts — 5× CodeQL `py/polynomial-redos` (high), alerts #124–#128 — by hardening the flagged config-parser regexes.

Each paired a `\s+` separator (or a greedy `(\S+)` next-hop) with a value group whose character class **overlapped** it (`.+` / `.+?` / `.*` all match whitespace; `.` matches the same non-space the next-hop did), so the engine could split the same run two ways → super-linear backtracking on a long attacker-controlled line. The migrate / sanitize API parses pasted config text, so the input is reachable (bounded, but real).

| codec | regex | before | after |
|---|---|---|---|
| arista_eos | `_DHCP_DNS_SERVER_RE` | `\s+(.+)$` | `\s+(\S.*)$` |
| aruba_aoscx | `_VLAN_TRUNK_ALLOWED_RE` | `\s+(.+?)\s*$` | `\s+(\S.*)$` |
| cisco_nxos | `_VRF_DESCRIPTION_RE` | `\s+(.+)$` | `\s+(\S.*)$` |
| cisco_iosxe_cli | `_VRF_DESCRIPTION_RE` | `\s+(.+)$` | `\s+(\S.*)$` |
| cisco_iosxe_cli | `_STATIC_ROUTE_RE` | `(\S+)(.*)$` | `(\S+)(\s.*)?$` |

Anchoring each value boundary on a **disjoint** class (`\S` for the value patterns, `\s` for the static-route trailing group) makes the split unambiguous and removes the polynomial backtracking.

## Why it's behaviour-preserving

Every consumer already `.split()`s or `.strip()`s the captured group, so requiring the value to start on a non-space char (or the static-route trailing token to start on a space — which it already did, after the greedy `(\S+)`) yields the identical result. Verified two ways:

- An **old-vs-new equivalence sweep** over representative + edge inputs: every realistic line produces an identical `.split()` / `.strip()` / `group(1..5)` result.
- The full **unit + integration** suites pass (they parse the real fixtures through these regexes).

The only behaviour delta is a degenerate **value-less** `vlan trunk allowed` line — no real AOS-CX switch emits it (it had set `trunk_allowed=[]`, i.e. equivalent to `all`), and it's now skipped (arguably more correct).

## Fidelity impact: none

`CROSS_MESH_RESULTS.md` and `PHASE4_RECONCILIATION.md` are **byte-identical** after regen — the change is parse-side only and reaches no fidelity cell.

## Tests

New guard `tests/unit/migration/test_redos_hardening.py` pins both halves: the patterns still capture the right value on real lines, and CodeQL's own attack strings (`ip route 9.9.9.9 9.9.9.9 !` + `!!`×N, ` description ` + `  `×N, …) complete in linear time against a 1 s budget.

## Not in scope (other clusters, parked)

- **Cluster B** (2× paramiko host-key, #120/#121) — by-design TOFU (#169/#170); dismiss-with-justification in the UI, not a code change.
- **Cluster C** (5× zizmor workflow-permission/pin nits) — release-pipeline hygiene, lowest priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
