### PR TITLE
docs(changelog): cut [0.4.8] - 2026-06-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-06-28
+
 ### Fixed
 
 * **Hardened five config-parser regexes against polynomial ReDoS** (CodeQL


### PR DESCRIPTION
## What

Cuts **v0.4.8** by renaming `## [Unreleased]` → `## [0.4.8] - 2026-06-28` and opening a fresh empty `[Unreleased]`. The diff is 2 inserted lines — no content moved or dropped.

`setuptools_scm` derives the version from the git tag, so there is no version file to bump. **Pushing the annotated `v0.4.8` tag is the publish step (PyPI + GHCR/Docker Hub + Windows MSI) and is gated separately** — this PR only lands the CHANGELOG header so the tag↔changelog guard (and the publish-time CI gate) pass.

## v0.4.8 contents (14 `### Fixed` bullets, all unreleased on `main`)

A patch release — bug fixes, fidelity-honesty improvements, and security hardening; **no breaking changes** (the deferred T0-1 insecure-bind sliver is *not* in this batch).

- **Cluster A** — ReDoS hardening of 5 parser regexes (#208, CodeQL `py/polynomial-redos` #124–#128)
- **PR-2 walk-expansion** — SNMPv3 (#205), VRRP/FHRP (#206), singletons gateway/instance-type/scope (#207); closes the silent capability-loss class
- **9th audit** — sanitiser FQDN leak (#204), UI event-loop (#203), job-status OpenAPI header (#202), "Validation OK" banner honesty (#201), ARCHITECTURE label (#200)
- **8th audit** — VRF/routing-instance redaction (#199), SNMPv3 downgrade naming (#198), interface-ACL surfacing (#197), developer-doc labels (#196), backup false-`completed` (#195)

## Checks

The `test_changelog.py` guard passes locally (`[Unreleased]` present, headers unique + strictly descending, `[0.4.8]` dated, every existing tag still has a header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
