### PR TITLE
build(lint): gate cyclomatic complexity at mccabe 25, grandfather hot spots (audit e5b77d7 #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+* **Added a cyclomatic-complexity gate to CI** (audit e5b77d7 finding #4:
+  "19 F-rank functions and no complexity gate"). Ruff's mccabe check (`C90`,
+  `max-complexity = 25`) now fails the `Lint (ruff)` job on any new or
+  modified function above the audit's recommended threshold. The ~25
+  pre-existing hot spots (codec parse/render, the canonical walker, the
+  sanitiser) are grandfathered with an inline `C901` suppression -- a visible,
+  greppable backlog -- and a new ratchet guard
+  (`tests/unit/test_complexity_ratchet.py`) pins that count so the debt can
+  only shrink, never grow.
+
 * **Hardened five config-parser regexes against polynomial ReDoS** (CodeQL
   `py/polynomial-redos`, alerts #124-#128). The Arista DHCP `dns-server`, the
   AOS-CX `vlan trunk allowed`, the NX-OS and IOS-XE VRF `description`, and the

--- a/netcanon/migration/canonical/port_names.py
+++ b/netcanon/migration/canonical/port_names.py
@@ -241,7 +241,7 @@ class PortRenameResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def translate_port_names(
+def translate_port_names(  # noqa: C901
     intent: CanonicalIntent,
     source_codec: CodecBase,
     target_codec: CodecBase,

--- a/netcanon/migration/canonical/vlan_names.py
+++ b/netcanon/migration/canonical/vlan_names.py
@@ -93,7 +93,7 @@ class VlanRenameResult(BaseModel):
     side effects of drops, out-of-range rejections."""
 
 
-def translate_vlan_ids(
+def translate_vlan_ids(  # noqa: C901
     intent: CanonicalIntent,
     rename_map: dict[int, int | None] | None = None,
 ) -> VlanRenameResult:

--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -20,7 +20,7 @@ from collections.abc import Iterable
 from .intent import CanonicalIntent
 
 
-def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:
+def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:  # noqa: C901
     """Yield schema xpaths for every populated field of a CanonicalIntent.
 
     This is the input to :func:`netcanon.services.migration_validate.

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -335,7 +335,7 @@ def _parse_dhcp_pools(raw: str) -> list[CanonicalDHCPPool]:
 # ---------------------------------------------------------------------------
 
 
-def parse_intent(raw: str) -> CanonicalIntent:
+def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     """Parse Arista EOS ``show running-config`` text into a
     :class:`CanonicalIntent`.
 
@@ -753,7 +753,7 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
                 m_iface.lag_member_of = lag_name
 
 
-def _parse_router_bgp(raw: str, intent: CanonicalIntent) -> None:
+def _parse_router_bgp(raw: str, intent: CanonicalIntent) -> None:  # noqa: C901
     """Parse ``router bgp <asn> / vrf <name> / rd <rd> /
     route-target import|export|both <rt>`` — VRF metadata — AND
     ``router bgp <asn> / vlan <N> / rd ... / route-target ...``
@@ -918,7 +918,7 @@ def _parse_router_bgp(raw: str, intent: CanonicalIntent) -> None:
         # CanonicalRoutingInstance.redistribute_*.
 
 
-def _apply_iface_subcommand(
+def _apply_iface_subcommand(  # noqa: C901
     iface: CanonicalInterface,
     line: str,
     lag_members: dict[int, list[str]],

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -144,7 +144,7 @@ def _normalise_lag_name_to_arista(name: str) -> str | None:
     return None
 
 
-def render_intent(tree: Any) -> str:
+def render_intent(tree: Any) -> str:  # noqa: C901
     """Render a :class:`CanonicalIntent` as Arista EOS CLI text.
 
     Raises:

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -773,7 +773,7 @@ def _parse_interface_stanza(
 # ---------------------------------------------------------------------------
 
 
-def parse_intent(raw: str) -> CanonicalIntent:
+def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     """Parse AOS-S ``show running-config`` text into a
     :class:`CanonicalIntent`.
 

--- a/netcanon/migration/codecs/aruba_aoss/render.py
+++ b/netcanon/migration/codecs/aruba_aoss/render.py
@@ -357,7 +357,7 @@ def _format_port_list(ports: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def render_intent(tree: Any) -> str:
+def render_intent(tree: Any) -> str:  # noqa: C901
     """Render a :class:`CanonicalIntent` to AOS-S ``show running-
     config`` text.
 

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -642,7 +642,7 @@ def _parse_routing_instances(raw: str) -> list[CanonicalRoutingInstance]:
     )
 
 
-def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
+def _parse_interfaces(raw: str) -> list[CanonicalInterface]:  # noqa: C901
     """Extract interface stanzas from IOS config text."""
     def _open(m: re.Match[str]) -> dict[str, Any]:
         iface_name = m.group(1)

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -59,7 +59,7 @@ from .._helpers import _prefix_to_mask
 from ..base import RenderError
 
 
-def render_intent(tree: Any) -> str:
+def render_intent(tree: Any) -> str:  # noqa: C901
     """Render a :class:`CanonicalIntent` to IOS-XE
     ``show running-config`` text.
 

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -606,7 +606,7 @@ def _new_iface_scratch(name: str) -> dict:
     }
 
 
-def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
+def _parse_interfaces(raw: str) -> list[CanonicalInterface]:  # noqa: C901
     """Extract ``interface <name>`` stanzas from NX-OS config text.
 
     Per interface: description, enabled (shutdown / no shutdown), mtu,
@@ -631,7 +631,7 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
             return None
         return _new_iface_scratch(name)
 
-    def _on_line(line: str, current: dict) -> None:
+    def _on_line(line: str, current: dict) -> None:  # noqa: C901
         # ── HSRP nested block (Phase 2c) ──
         # ``hsrp <N>`` opens a group; its sub-commands are further-indented
         # (>= 4 spaces).  Any shallower indented line ends the block.  This

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -286,7 +286,7 @@ def _apply_system_ntp(block: _ConfigBlock, intent: CanonicalIntent) -> None:
                 intent.ntp_servers.append(server[0])
 
 
-def _apply_system_interface(
+def _apply_system_interface(  # noqa: C901
     block: _ConfigBlock, intent: CanonicalIntent,
 ) -> None:
     for edit in block.edits:

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -411,7 +411,7 @@ def _is_fortigate_native_name(name: str) -> bool:
     return bool(_IS_FORTIGATE_PHYSICAL_PORT_RE.match(name))
 
 
-def render_intent(tree: Any) -> str:
+def render_intent(tree: Any) -> str:  # noqa: C901
     """Render a :class:`CanonicalIntent` tree to FortiOS CLI text.
 
     Raises:

--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -74,7 +74,7 @@ from ..base import ParseError
 logger = logging.getLogger(__name__)
 
 
-def parse_intent(raw: str) -> CanonicalIntent:
+def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     """Parse Junos ``set``-form (or block-form) text into a
     :class:`CanonicalIntent`.
 
@@ -1181,7 +1181,7 @@ def _apply_system(
             existing.hashed_password = f"junos:{tokens[5]}"
 
 
-def _apply_interfaces(
+def _apply_interfaces(  # noqa: C901
     tokens: list[str],
     iface_state: dict[str, dict[str, Any]],
     range_state: dict[str, dict[str, Any]] | None = None,

--- a/netcanon/migration/codecs/juniper_junos/render.py
+++ b/netcanon/migration/codecs/juniper_junos/render.py
@@ -78,7 +78,7 @@ from ..base import RenderError
 logger = logging.getLogger(__name__)
 
 
-def render_intent(tree: Any) -> str:
+def render_intent(tree: Any) -> str:  # noqa: C901
     """Render a :class:`CanonicalIntent` to Junos ``set``-form text.
 
     Emits commands in a deterministic order so repeated renders of

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def parse_intent(raw: str) -> CanonicalIntent:
+def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     """Parse RouterOS ``/export verbose`` text into a
     :class:`CanonicalIntent`.
 

--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -96,7 +96,7 @@ def _routeros_group_for_privilege(level: int) -> str:
 # ---------------------------------------------------------------------------
 
 
-def render_intent(tree: Any) -> str:
+def render_intent(tree: Any) -> str:  # noqa: C901
     """Render a :class:`CanonicalIntent` to RouterOS ``/export`` text.
 
     Raises:

--- a/netcanon/migration/codecs/opnsense/parse.py
+++ b/netcanon/migration/codecs/opnsense/parse.py
@@ -160,7 +160,7 @@ _trim_xml_prologue = _trim_xml_envelope
 # ---------------------------------------------------------------------------
 
 
-def parse_intent(raw: str) -> CanonicalIntent:
+def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     """Parse an OPNsense ``config.xml`` document into a
     :class:`CanonicalIntent`.
 

--- a/netcanon/migration/codecs/opnsense/render.py
+++ b/netcanon/migration/codecs/opnsense/render.py
@@ -76,7 +76,7 @@ def render_intent(tree: Any) -> str:
     )
 
 
-def render_canonical(intent: CanonicalIntent) -> str:
+def render_canonical(intent: CanonicalIntent) -> str:  # noqa: C901
     """Render from the canonical intent shape."""
     root = ET.Element("opnsense")
 

--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -286,7 +286,7 @@ def _serialise_brace(node: dict, depth: int) -> list[str]:
     return out
 
 
-def parse_intent(raw: str) -> CanonicalIntent:
+def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     """Parse VyOS ``config.boot`` text into a :class:`CanonicalIntent`.
 
     Raises:

--- a/netcanon/services/migration_pipeline.py
+++ b/netcanon/services/migration_pipeline.py
@@ -367,7 +367,7 @@ def run_plan(
     return job
 
 
-def run_plan_with_overrides(
+def run_plan_with_overrides(  # noqa: C901
     source: CodecBase,
     target: CodecBase,
     raw_text: str,

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -238,7 +238,7 @@ def sanitize_text(
     )
 
 
-def sanitize_intent(
+def sanitize_intent(  # noqa: C901
     intent: CanonicalIntent,
 ) -> tuple[CanonicalIntent, list[Substitution]]:
     """Apply field-typed redactions to a :class:`CanonicalIntent`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ select = [
     "PIE",  # flake8-pie — misc lints
     "SIM",  # flake8-simplify
     "RUF",  # ruff-specific
+    "C90",  # mccabe — cyclomatic-complexity ceiling (audit e5b77d7 #4)
 ]
 ignore = [
     # FastAPI's `Depends()`/`Query()`/... dependency-injection markers are
@@ -245,6 +246,17 @@ ignore = [
     # deliberate. Do NOT auto-migrate.
     "UP042",
 ]
+
+[tool.ruff.lint.mccabe]
+# Cyclomatic-complexity ceiling (audit e5b77d7 finding #4: "19 F-rank
+# functions and no complexity gate in CI").  New/modified functions must
+# stay at or below 25 (the audit's recommended threshold); the pre-existing
+# offenders are grandfathered with an explicit ``# noqa: C901`` at their def
+# site -- a visible, greppable backlog -- and capped by
+# tests/unit/test_complexity_ratchet.py so the debt can only shrink, never
+# grow.  Lower this number (and burn down noqas) as the codec parse/render
+# hot spots are refactored.
+max-complexity = 25
 
 [tool.ruff.lint.isort]
 # Lock in the v0.2.0 Stage-1(a) sweep: every module must carry the future

--- a/tests/unit/test_complexity_ratchet.py
+++ b/tests/unit/test_complexity_ratchet.py
@@ -1,0 +1,75 @@
+"""Ratchet guard for the McCabe cyclomatic-complexity gate (audit e5b77d7 #4).
+
+The audit flagged "19 F-rank cyclomatic functions and no complexity gate in CI"
+-- nothing stopped new high-complexity code from merging.  The gate now lives in
+``pyproject.toml`` (``C90`` in ruff's select + ``[tool.ruff.lint.mccabe]
+max-complexity = 25``), enforced by the existing ``Lint (ruff)`` CI job.
+
+A gate alone is not enough for a legacy codebase: the ~25 pre-existing offenders
+(codec parse/render hot spots, the walker, the sanitiser) are grandfathered with
+an inline ``C901`` suppression at their def site.  Without a cap, a contributor
+could dodge the gate by sprinkling more such suppressions instead of refactoring
+-- the exact regression the audit warned about, just relocated.
+
+This guard makes the grandfather list a RATCHET: the count is pinned, so it can
+only go DOWN (refactor a hot spot below 25, drop its suppression, decrement the
+number here) -- never up.  A new function over 25 forces a real choice: refactor
+it, or consciously bump both the suppression AND this ceiling in one diff.
+
+(The marker string is assembled from fragments so this file does not itself
+carry a directive ruff's textual noqa scanner would try to parse.)
+"""
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parents[2]
+_TREES = ("netcanon", "netcanon_desktop", "tools")
+
+#: The inline-suppression marker, assembled so the literal directive text never
+#: appears verbatim in this source file.
+_MARKER = "# noqa:" + " C901"
+
+#: Pre-existing functions over the max-complexity ceiling, grandfathered with an
+#: inline ``C901`` suppression.  RATCHET: decrement as hot spots are refactored;
+#: a new suppression (count > this) must not be added to dodge the gate.
+_GRANDFATHERED = 25
+
+
+def _c901_suppression_count() -> int:
+    n = 0
+    for tree in _TREES:
+        for path in (_ROOT / tree).rglob("*.py"):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if _MARKER in line:
+                    n += 1
+    return n
+
+
+def test_complexity_debt_does_not_grow() -> None:
+    """The grandfathered-complexity backlog can only shrink.  If this fails high,
+    a new over-25 function was suppressed instead of refactored -- refactor it (or
+    consciously raise this ceiling).  If it fails low, you refactored a hot spot
+    below 25: drop the stale suppression and decrement ``_GRANDFATHERED`` to lock
+    in the win."""
+    found = _c901_suppression_count()
+    assert found == _GRANDFATHERED, (
+        f"expected {_GRANDFATHERED} grandfathered C901 suppressions, found {found}. "
+        "The cyclomatic-complexity debt must only ratchet DOWN -- do not add a "
+        "suppression to dodge the max-complexity=25 gate; refactor the function "
+        "(then decrement _GRANDFATHERED), or consciously raise the ceiling here."
+    )
+
+
+def test_mccabe_gate_is_configured() -> None:
+    """The gate itself must stay wired -- a silent removal of ``C90`` from select
+    or of the max-complexity setting would make every suppression above inert."""
+    data = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    lint = data["tool"]["ruff"]["lint"]
+    assert "C90" in lint["select"], "`C90` (mccabe) dropped from ruff select -- the complexity gate is off"
+    assert lint["mccabe"]["max-complexity"] == 25, "mccabe max-complexity ceiling changed unexpectedly"


### PR DESCRIPTION
## What

Closes audit **finding #4** (HIGH, maintainability): *"19 F-rank cyclomatic functions and no complexity gate in CI."* Nothing stopped new high-complexity code from merging.

Adds ruff's mccabe check to the gate — `C90` in `select` + `[tool.ruff.lint.mccabe] max-complexity = 25` (the audit's recommended threshold). **No workflow change**: the gate lives in `pyproject.toml`, and the existing `Lint (ruff)` CI job already runs `ruff check`, so it now fails on any new or modified function over 25.

## Legacy-codebase adoption (grandfather + ratchet)

The 25 pre-existing offenders (codec parse/render, the canonical walker, the sanitiser; current max complexity **136**) are grandfathered with an inline `# noqa: C901` at their def site — a visible, greppable backlog. **Every source diff is a comment-only addition; zero logic change.**

A new ratchet guard (`tests/unit/test_complexity_ratchet.py`) pins the grandfather count at 25 and asserts the gate stays wired, so the debt can **only shrink**: a new over-25 function can't be silently `# noqa`'d in — it forces a refactor, or a conscious bump of both the suppression and the ceiling in one diff.

## Verification

- `ruff check` clean with the gate active; with suppressions ignored it surfaces exactly the 25 (gate proven to have teeth).
- Full `tests/unit` green (comment-only source changes).

## Scope note

Reducing the grandfathered hot spots is deliberate follow-up — a risky refactor of the codec parse/render layer. This PR establishes the enforcement floor the audit asked for; the ratchet drives the number down over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
