### PR TITLE
docs(changelog): date [0.4.8] 2026-06-29 to match the tag day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
-## [0.4.8] - 2026-06-28
+## [0.4.8] - 2026-06-29
 
 ### Fixed
 


### PR DESCRIPTION
Bump the `[0.4.8]` header date 2026-06-28 → 2026-06-29: the #4 (complexity gate) and #5 (hash-locked deps) follow-ups landed on the 29th, after the initial cut. Aligns the released-header date with the v0.4.8 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)