### PR TITLE
fix(backup): fail closed when a paramiko shell stream never settles (audit 276eaeb T0-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Paramiko shell collector fails closed on a never-settling stream**
+  (audit 276eaeb T0-3): when a device kept streaming up to the
+  `_MAX_SECONDS` cap without the read ever going idle, `_collect_output`
+  used to *return* the truncated buffer, which the backup runner then
+  saved with `status="success"` — a silently-corrupted backup. It now
+  raises `TimeoutError` on that path (restoring parity with the
+  read-timeout fail-closed `NetmikoCollector`), so a partial capture
+  surfaces as a failed backup instead of a good-looking truncated one.
+
 ## [0.4.8] - 2026-06-29
 
 ### Fixed

--- a/netcanon/collectors/paramiko_collector.py
+++ b/netcanon/collectors/paramiko_collector.py
@@ -373,7 +373,12 @@ class ParamikoShellCollector(BaseCollector):
            polls (approximately 3 seconds of silence).
 
         An absolute ``_MAX_SECONDS`` cap prevents hanging forever if a
-        device produces a never-ending stream.
+        device produces a never-ending stream.  Hitting that cap while
+        output is still arriving raises ``TimeoutError`` (fail closed)
+        rather than returning the truncated buffer — a partial config
+        must never be persisted as a successful backup (audit 276eaeb
+        T0-3; the NetmikoCollector sibling fails closed the same way via
+        its read timeout).
 
         If *command* is supplied, the accumulated buffer is post-
         processed to strip the echoed command from the head — PTY
@@ -398,11 +403,16 @@ class ParamikoShellCollector(BaseCollector):
             line removed from the head.
 
         Raises:
-            TimeoutError: If no output at all arrives within ``_MAX_SECONDS``.
+            TimeoutError: If no output at all arrives within
+                ``_MAX_SECONDS``, or if output is still arriving when the
+                ``_MAX_SECONDS`` cap is hit (the idle window was never
+                reached, so the buffer would be truncated — fail closed
+                rather than save a partial config).
         """
         buf = ""
         idle_count = 0
         started = False
+        settled = False
         deadline = time.monotonic() + _MAX_SECONDS
 
         while time.monotonic() < deadline:
@@ -425,11 +435,25 @@ class ParamikoShellCollector(BaseCollector):
                         host,
                         len(buf.splitlines()),
                     )
+                    settled = True
                     break
 
         if not buf:
             raise TimeoutError(
                 f"No output received from {host} within {_MAX_SECONDS}s"
+            )
+
+        if not settled:
+            # Fell through the absolute _MAX_SECONDS cap while the device
+            # was still streaming — the idle window was never reached, so
+            # the buffer is almost certainly truncated mid-config.  Fail
+            # closed: a partial capture must surface as a failed backup,
+            # never be saved as "success" (audit 276eaeb T0-3 — restores
+            # parity with the read-timeout fail-closed NetmikoCollector).
+            raise TimeoutError(
+                f"Output from {host} never settled within {_MAX_SECONDS}s "
+                f"({len(buf.splitlines())} lines captured, stream still "
+                "active) — refusing to save a truncated backup"
             )
 
         if command:

--- a/tests/unit/test_paramiko_collector.py
+++ b/tests/unit/test_paramiko_collector.py
@@ -10,9 +10,15 @@ config.xml\\r\\r\\n`` preamble that breaks the migration parser.
 """
 from __future__ import annotations
 
+import types
+
 import pytest
 
-from netcanon.collectors.paramiko_collector import _strip_command_echo
+from netcanon.collectors import paramiko_collector
+from netcanon.collectors.paramiko_collector import (
+    ParamikoShellCollector,
+    _strip_command_echo,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -178,3 +184,98 @@ class TestStripShellPromptTail:
         out = _strip_command_echo(buf, "cat /conf/config.xml")
         assert out.startswith('<?xml')
         assert "root@host" not in out
+
+
+class _VirtualClock:
+    """A no-real-wait clock for driving ``_collect_output`` to its
+    ``_MAX_SECONDS`` deadline deterministically.  ``sleep`` advances a
+    virtual monotonic counter instead of blocking, so a 120 s timeout
+    elapses in microseconds of test wall-clock."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def sleep(self, secs: float) -> None:
+        self.t += secs
+
+
+class _NeverIdleChannel:
+    """A ``paramiko.Channel`` stand-in that always has data ready and
+    never goes idle — simulates a device emitting an unbounded stream
+    (or one so slow / chatty it never settles within the idle window).
+    ``_collect_output`` must hit the absolute cap on this channel."""
+
+    def recv_ready(self) -> bool:
+        return True
+
+    def recv(self, _n: int) -> bytes:
+        return b"flood flood flood\n"
+
+
+class _SettlingChannel:
+    """Emits a fixed list of chunks, then reports idle forever — the
+    normal, healthy completion shape: output starts, finishes, the
+    channel goes quiet, and the idle threshold fires a clean stop."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    def recv_ready(self) -> bool:
+        return bool(self._chunks)
+
+    def recv(self, _n: int) -> bytes:
+        return self._chunks.pop(0)
+
+
+def _collector() -> ParamikoShellCollector:
+    # __new__ bypasses BaseCollector.__init__ (no definition needed):
+    # _collect_output reads only its args + module constants, never self.
+    return ParamikoShellCollector.__new__(ParamikoShellCollector)
+
+
+class TestCollectOutputFailsClosedOnTruncation:
+    """Regression guard for audit 276eaeb T0-3: a device that never
+    stops streaming used to fall through the ``_MAX_SECONDS`` cap and
+    *return* the truncated buffer, which ``backup_runner`` then saved
+    as a ``success`` — a silently-corrupted backup.  The collector must
+    now fail closed (raise ``TimeoutError``) when the idle window is
+    never reached, mirroring the read-timeout-driven NetmikoCollector."""
+
+    @pytest.fixture(autouse=True)
+    def _virtual_time(self, monkeypatch):
+        clock = _VirtualClock()
+        monkeypatch.setattr(
+            paramiko_collector,
+            "time",
+            types.SimpleNamespace(monotonic=clock.monotonic, sleep=clock.sleep),
+        )
+        return clock
+
+    def test_never_ending_stream_raises_not_truncates(self):
+        """The bug shape: unbounded output → cap hit while data is
+        still arriving → must raise, NOT return a partial buffer."""
+        with pytest.raises(TimeoutError) as exc:
+            _collector()._collect_output(_NeverIdleChannel(), "stream.example")
+        msg = str(exc.value)
+        assert "never settled" in msg
+        assert "truncated" in msg
+
+    def test_settled_stream_returns_buffer(self):
+        """Happy path is preserved: output that starts, finishes, and
+        goes idle returns normally (the fix must not break the clean
+        idle-threshold exit)."""
+        shell = _SettlingChannel([b"line one\n", b"line two\n"])
+        out = _collector()._collect_output(shell, "quiet.example")
+        assert "line one" in out
+        assert "line two" in out
+
+    def test_silent_device_still_raises_empty_timeout(self):
+        """A device that emits nothing at all keeps the original
+        empty-buffer ``TimeoutError`` (distinct from the truncation
+        path — buffer is empty, not partial)."""
+        with pytest.raises(TimeoutError) as exc:
+            _collector()._collect_output(_SettlingChannel([]), "silent.example")
+        assert "No output received" in str(exc.value)


### PR DESCRIPTION
## What

The paramiko shell collector's `_collect_output` reads until the device goes idle for `_IDLE_THRESHOLD` polls, with an absolute `_MAX_SECONDS` cap as a backstop. The cap was reached by simply falling out of the `while time.monotonic() < deadline` loop, after which the method **returned** whatever partial buffer it had — raising `TimeoutError` only when the buffer was completely empty.

So a device that streamed continuously (or trickled output past the cap without ever going idle) produced a **truncated capture** that `backup_runner` then persisted with `status="success"`: a silently-corrupted backup. The `NetmikoCollector` sibling fails closed on its read timeout; this path did not.

## Fix

Track whether the loop exited via the clean idle-threshold `break` vs the absolute deadline (`settled` flag). On a dirty deadline exit with a non-empty buffer, raise `TimeoutError` so `backup_runner` records the device as **failed** instead of saving a partial config. The empty-buffer `"No output received"` timeout is unchanged.

## Tests

New `TestCollectOutputFailsClosedOnTruncation` (virtual-clock driven — no real sleep, the 120 s cap elapses in microseconds):
- never-idle channel → raises (`"never settled" … "truncated"`)
- settling channel → still returns its buffer (happy path preserved)
- silent channel → keeps the original empty-buffer `"No output received"` timeout

Full `tests/unit` green (incl. the mccabe complexity ratchet — the extra branch did not breach 25); backup integration (`test_backup_probe_wiring`, `test_backups_api`) green.

Audit `276eaeb` finding **T0-3** (MED). `NOTICE.md` records a prior real corrupted-OPNsense-backup from this exact collector path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)