### PR TITLE
fix(sanitize): redact IPv6 transition addresses that embed a public IPv4 (audit 276eaeb T0-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **IPv6 transition addresses no longer leak their embedded public IPv4**
+  (audit 276eaeb T0-4): 6to4 (`2002::/16`), NAT64 (`64:ff9b::/96` +
+  the RFC 8215 `64:ff9b:1::/48`), IPv4-mapped, IPv4-compatible, and
+  Teredo addresses carry a routable IPv4 in their low bits but often
+  classify as private/reserved at the v6 layer, so the sanitizer's
+  preserve branch emitted them verbatim — leaking e.g.
+  `2002:0808:0808::1` (→ 8.8.8.8) and `64:ff9b::8.8.8.8`. They are now
+  redacted to a docs `2001:db8::N` address whenever the embedded IPv4
+  is public; transition addresses wrapping a *private* IPv4 (e.g.
+  `2002:c0a8:0101::`) are still preserved.
 - **Paramiko shell collector fails closed on a never-settling stream**
   (audit 276eaeb T0-3): when a device kept streaming up to the
   `_MAX_SECONDS` cap without the read ever going idle, `_collect_output`

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -957,6 +957,71 @@ def sanitize_intent(  # noqa: C901
 # Substitution-table — counter-per-session for cross-reference stability
 # ---------------------------------------------------------------------------
 
+# NAT64 carries the IPv4 in its low 32 bits but — unlike 6to4 / IPv4-mapped /
+# Teredo — has no ``ipaddress`` accessor, so we recognise the prefixes and
+# slice the bits ourselves.  Both the well-known prefix (RFC 6052) and the
+# RFC 8215 local-use prefix are in play.
+_NAT64_NETWORKS = (
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+)
+
+
+def _ipv4_is_public(addr: ipaddress.IPv4Address) -> bool:
+    """True iff *addr* is a globally-routable IPv4 the sanitizer must
+    redact — the exact inverse of :meth:`_SubstitutionTable.redact_ipv4`'s
+    preserve set (private / loopback / link-local / multicast / reserved /
+    unspecified, the three RFC 5737 docs ranges, and CGNAT)."""
+    if (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    ):
+        return False
+    if str(addr).startswith(("192.0.2.", "198.51.100.", "203.0.113.")):
+        return False
+    return addr not in ipaddress.ip_network("100.64.0.0/10")
+
+
+def _embedded_public_ipv4(
+    addr: ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | None:
+    """Return the embedded IPv4 of an IPv6 *transition* address (6to4,
+    IPv4-mapped, IPv4-compatible, NAT64, Teredo) **iff** that IPv4 is
+    public/global and would otherwise leak.
+
+    These formats carry a routable IPv4 in their low bits, but the
+    address frequently classifies as ``is_private`` / ``is_reserved`` at
+    the v6 layer (6to4 ``2002::/16`` is private, NAT64 ``64:ff9b::/96``
+    is reserved, Teredo ``2001:0::/32`` is private), so ``redact_ipv6``'s
+    preserve branch emitted them verbatim — leaking the embedded public
+    IPv4 (audit 276eaeb T0-4).  Returns ``None`` when no transition IPv4
+    is present, or the embedded IPv4 is itself private / docs / reserved
+    (nothing to leak — e.g. ``2002:c0a8:0101::`` embeds 192.168.1.1)."""
+    candidates: list[ipaddress.IPv4Address] = []
+    if addr.sixtofour is not None:
+        candidates.append(addr.sixtofour)
+    if addr.ipv4_mapped is not None:
+        candidates.append(addr.ipv4_mapped)
+    if addr.teredo is not None:
+        # (server, client): both are clear-text routable IPv4s.
+        candidates.extend(addr.teredo)
+    if any(addr in net for net in _NAT64_NETWORKS):
+        candidates.append(ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF))
+    if not candidates:
+        # IPv4-compatible (deprecated): ``::a.b.c.d`` — all high bits zero
+        # with a non-trivial low word (exclude ``::`` and ``::1``).
+        low = int(addr) & 0xFFFFFFFF
+        if (int(addr) >> 32) == 0 and low > 1:
+            candidates.append(ipaddress.IPv4Address(low))
+    for v4 in candidates:
+        if _ipv4_is_public(v4):
+            return v4
+    return None
+
 
 class _SubstitutionTable:
     """Per-session redaction table.
@@ -1031,20 +1096,9 @@ class _SubstitutionTable:
             addr = ipaddress.IPv4Address(ip)
         except ValueError:
             return ip
-        if (
-            addr.is_private
-            or addr.is_loopback
-            or addr.is_link_local
-            or addr.is_multicast
-            or addr.is_reserved
-            or addr.is_unspecified
-        ):
-            return ip
-        # Already in docs ranges
-        if str(addr).startswith(("192.0.2.", "198.51.100.", "203.0.113.")):
-            return ip
-        # CGNAT
-        if addr in ipaddress.ip_network("100.64.0.0/10"):
+        if not _ipv4_is_public(addr):
+            # private / loopback / link-local / multicast / reserved /
+            # unspecified / docs-range / CGNAT — preserve verbatim.
             return ip
         # Public — substitute via cycle through the three docs ranges
         ranges = ["192.0.2", "198.51.100", "203.0.113"]
@@ -1068,6 +1122,12 @@ class _SubstitutionTable:
         as-is: ULA ``fc00::/7``, link-local ``fe80::/10``, loopback
         ``::1``, unspecified ``::``, multicast ``ff00::/8``, reserved,
         and the documentation range ``2001:db8::/32`` itself.
+
+        Exception (audit 276eaeb T0-4): IPv6 *transition* formats (6to4,
+        IPv4-mapped, IPv4-compatible, NAT64, Teredo) embed a routable
+        IPv4 yet often classify as private/reserved at the v6 layer, so
+        they are checked *before* the preserve branch and redacted when
+        the embedded IPv4 is public — see :func:`_embedded_public_ipv4`.
         """
         if ip in self._ipv6:
             return self._ipv6[ip]
@@ -1075,6 +1135,10 @@ class _SubstitutionTable:
             addr = ipaddress.IPv6Address(ip)
         except ValueError:
             return ip
+        # Transition address embedding a public IPv4 — redact before the
+        # preserve branch below would emit it verbatim and leak the v4.
+        if _embedded_public_ipv4(addr) is not None:
+            return self._substitute_ipv6(ip)
         # ``is_private`` already covers ULA, link-local, loopback,
         # unspecified, and the 2001:db8::/32 docs range; the rest are
         # listed explicitly for self-documentation / defensive belt.
@@ -1090,6 +1154,11 @@ class _SubstitutionTable:
         if addr in ipaddress.ip_network("2001:db8::/32"):
             return ip
         # Public global unicast — substitute a deterministic docs address.
+        return self._substitute_ipv6(ip)
+
+    def _substitute_ipv6(self, ip: str) -> str:
+        """Allocate the next deterministic RFC 3849 docs address
+        (``2001:db8::N``) for *ip* and cache it (cross-reference stable)."""
         self._ipv6_counter += 1
         new_ip = f"2001:db8::{self._ipv6_counter:x}"
         self._ipv6[ip] = new_ip

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -1524,6 +1524,72 @@ class TestIPv6Redaction:
         assert a != c           # distinct sources stay distinct
 
 
+class TestIPv6TransitionAddressRedaction:
+    """audit 276eaeb T0-4: IPv6 *transition* formats (6to4, IPv4-mapped,
+    IPv4-compatible, NAT64, Teredo) embed a routable IPv4 in their low
+    bits, yet classify as ``is_private`` / ``is_reserved`` at the v6
+    layer — so ``redact_ipv6`` used to emit them verbatim and leak the
+    embedded public IPv4.  They are now redacted iff the embedded IPv4
+    is public; transition addresses wrapping a *private* IPv4 are still
+    preserved (the wrapper carries no public information)."""
+
+    # Each embeds the public 8.8.8.8 (Teredo embeds public 65.54.227.120
+    # as its server) and must NOT survive verbatim, and must NOT leak the
+    # embedded v4 anywhere in the substitute.
+    @pytest.mark.parametrize(
+        "addr, leaked_v4",
+        [
+            ("2002:0808:0808::1", "8.8.8.8"),                 # 6to4
+            ("64:ff9b::8.8.8.8", "8.8.8.8"),                  # NAT64 well-known
+            ("64:ff9b:1::8.8.8.8", "8.8.8.8"),                # NAT64 RFC 8215
+            ("::ffff:8.8.8.8", "8.8.8.8"),                    # IPv4-mapped
+            ("::8.8.8.8", "8.8.8.8"),                         # IPv4-compatible
+            ("2001:0000:4136:e378:8000:63bf:3fff:fdd2",       # Teredo
+             "65.54.227.120"),
+        ],
+    )
+    def test_transition_with_public_v4_is_redacted(self, addr, leaked_v4):
+        table = _SubstitutionTable()
+        out = table.redact_ipv6(addr)
+        assert out != addr, f"transition address survived verbatim: {addr}"
+        assert out.startswith("2001:db8::")
+        assert leaked_v4 not in out, f"embedded public IPv4 leaked: {leaked_v4}"
+
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "2002:c0a8:0101::1",     # 6to4 wrapping 192.168.1.1 (private)
+            "::ffff:192.168.1.1",    # IPv4-mapped wrapping a private v4
+            "::ffff:10.0.0.1",       # IPv4-mapped wrapping RFC 1918
+            "2002:c633:6401::1",     # 6to4 wrapping 198.51.100.1 (docs)
+        ],
+    )
+    def test_transition_with_nonpublic_v4_is_preserved(self, addr):
+        """No public information to leak → preserve verbatim (don't
+        manufacture a false redaction that would corrupt a real config)."""
+        table = _SubstitutionTable()
+        assert table.redact_ipv6(addr) == addr
+
+    def test_end_to_end_transition_leak_closed_on_interface(self):
+        """Full pipeline: a 6to4 + a NAT64 address on an interface must
+        not appear anywhere in the sanitized dump."""
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(
+                name="Vlan10",
+                ipv6_addresses=[
+                    CanonicalIPv6Address(ip="2002:0808:0808::1",
+                                         prefix_length=64),
+                    CanonicalIPv6Address(ip="64:ff9b::8.8.8.8",
+                                         prefix_length=96),
+                ],
+            )],
+        )
+        sanitized, _ = sanitize_intent(intent)
+        blob = sanitized.model_dump_json()
+        for leaked in ("2002:0808:0808::1", "64:ff9b::8.8.8.8", "8.8.8.8"):
+            assert leaked not in blob, f"transition leak survived: {leaked!r}"
+
+
 class TestVRRPVirtualIPRedaction:
     """v0.4.1: the VRRP / CARP virtual IP — frequently the public HA
     gateway — was passed through verbatim while its sibling auth secret


### PR DESCRIPTION
## What

6to4 (`2002::/16`), NAT64 (`64:ff9b::/96` + the RFC 8215 `64:ff9b:1::/48`), IPv4-mapped (`::ffff:0:0/96`), IPv4-compatible (`::a.b.c.d`), and Teredo (`2001:0::/32`) addresses carry a **routable IPv4 in their low bits**. But those v6 prefixes classify as `is_private` / `is_reserved`, so `redact_ipv6`'s preserve branch emitted them **verbatim** — leaking the embedded public IPv4. Contradicts the documented "public IPv6 is redacted" guarantee (SECURITY.md).

Reproduced against current `main`:

| input | embedded v4 | old output |
|---|---|---|
| `2002:0808:0808::1` | 8.8.8.8 | preserved verbatim ❌ |
| `64:ff9b::8.8.8.8` | 8.8.8.8 | preserved verbatim ❌ |
| `64:ff9b:1::8.8.8.8` | 8.8.8.8 | preserved verbatim ❌ |
| `::8.8.8.8` | 8.8.8.8 | preserved verbatim ❌ |
| `2001:0000:4136:e378:8000:63bf:3fff:fdd2` | 65.54.227.120 (Teredo server) | preserved verbatim ❌ |

## Fix

- `_embedded_public_ipv4(addr)` extracts the embedded IPv4 from any transition format (`.sixtofour` / `.ipv4_mapped` / `.teredo`, the two NAT64 prefixes, and the all-high-zero ipv4-compatible shape) and returns it **only when it is public**.
- `redact_ipv6` checks this **before** the preserve branch and substitutes a docs `2001:db8::N` address when an embedded public IPv4 is found.
- Transition addresses wrapping a **private / docs / reserved** IPv4 (e.g. `2002:c0a8:0101::` → 192.168.1.1) are still **preserved** — no public information, and a false redaction would corrupt a real config.
- The public-IPv4 predicate is factored into `_ipv4_is_public` and reused in both `redact_ipv4` and the new helper so the two stay in lock-step. `_substitute_ipv6` is extracted to keep `redact_ipv6` within the mccabe-25 gate.

## Tests

`TestIPv6TransitionAddressRedaction`: all five public-embedding formats redact with no v4 leak; private/docs-embedding wrappers preserve; plus an end-to-end interface-dump leak check. Full `tests/unit` green (incl. the complexity ratchet and the existing `redact_ipv4` suite covering the refactor); sanitize integration green.

Audit `276eaeb` finding **T0-4** (MED). Twin of the prior sanitizer-leak fixes (#134 / #162 / #174 / #204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)