### PR TITLE
fix(walker): surface multi-address interface drops by cardinality, not the is_secondary flag (audit 276eaeb T0-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **Multi-address interfaces no longer report a silent `ok` when extra
+  addresses are dropped** (audit 276eaeb T0-1). The capability walker
+  emitted `/interfaces/interface/ipv{4,6}/address/secondary-ip` only when
+  an address carried `is_secondary=True`, but IPv6 has no `secondary`
+  keyword (the flag is never set) and flagless IPv4 sources (Junos /
+  OPNsense parse) leave it False on every address. So a genuinely
+  multi-address interface migrated to a single-address codec (FortiGate /
+  OPNsense, which render only the first address) reported `severity: ok`
+  while a whole subnet's reachability vanished. The walker now keys on
+  address *cardinality* (every address beyond the first), so the dropping
+  codecs' existing `secondary-ip` unsupported declaration fires regardless
+  of the flag. Capability matrices were already honest about which codecs
+  drop extra addresses, so no declaration changes were needed.
 - **IPv6 transition addresses no longer leak their embedded public IPv4**
   (audit 276eaeb T0-4): 6to4 (`2002::/16`), NAT64 (`64:ff9b::/96` +
   the RFC 8215 `64:ff9b:1::/48`), IPv4-mapped, IPv4-compatible, and

--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -79,15 +79,21 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:  # noqa: C901
         yield "/interfaces/interface/config/enabled"
         if iface.interface_type:
             yield "/interfaces/interface/config/type"
-        for addr in iface.ipv4_addresses:
+        for idx, addr in enumerate(iface.ipv4_addresses):
             yield "/interfaces/interface/ipv4/address/ip"
             yield "/interfaces/interface/ipv4/address/prefix-length"
-            # Secondary addresses: single-address platforms (FortiGate /
+            # Additional addresses: single-address platforms (FortiGate /
             # OPNsense) render only the primary and silently drop every
-            # is_secondary address — a whole-subnet reachability loss.
-            # Walk a secondary-specific xpath so those codecs can declare
-            # it unsupported and the loss surfaces instead of reporting ok.
-            if addr.is_secondary:
+            # extra address — a whole-subnet reachability loss.  The
+            # discriminator is CARDINALITY, not the is_secondary flag:
+            # IPv4 sources that don't model a primary/secondary distinction
+            # (Junos / OPNsense parse) leave is_secondary False on every
+            # address, so a flag-gated walk emitted nothing for a genuinely
+            # multi-address interface and the loss reported 'ok' (audit
+            # 276eaeb T0-1).  Walk the secondary xpath for every address
+            # beyond the first so those codecs' unsupported declaration
+            # fires regardless of whether the flag was set.
+            if idx > 0 or addr.is_secondary:
                 yield "/interfaces/interface/ipv4/address/secondary-ip"
             if addr.virtual_gateway_address:
                 yield (
@@ -99,7 +105,7 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:  # noqa: C901
                     "/interfaces/interface/ipv4/address/"
                     "virtual-gateway-mac"
                 )
-        for addr6 in iface.ipv6_addresses:            # GAP-EVPN-3
+        for idx6, addr6 in enumerate(iface.ipv6_addresses):   # GAP-EVPN-3
             yield "/interfaces/interface/ipv6/address/ip"
             yield "/interfaces/interface/ipv6/address/prefix-length"
             # link-local vs global scope discriminator (audit e5b77d7,
@@ -111,7 +117,11 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:  # noqa: C901
             # the fe80::/10 prefix on parse round-trip it and stay supported.
             if addr6.scope:
                 yield "/interfaces/interface/ipv6/address/scope"
-            if addr6.is_secondary:
+            # Cardinality discriminator (see the IPv4 note above): IPv6 has
+            # no `secondary` keyword at all, so is_secondary is structurally
+            # never set — only the address count reveals the drop (audit
+            # 276eaeb T0-1).
+            if idx6 > 0 or addr6.is_secondary:
                 yield "/interfaces/interface/ipv6/address/secondary-ip"
             if addr6.virtual_gateway_address:
                 yield (

--- a/tests/unit/migration/test_multiaddress_cardinality_walk.py
+++ b/tests/unit/migration/test_multiaddress_cardinality_walk.py
@@ -1,0 +1,115 @@
+"""audit 276eaeb T0-1 — multi-address interfaces walk ``secondary-ip`` by
+CARDINALITY, not the ``is_secondary`` flag.
+
+The walker used to yield ``/interfaces/interface/ipv{4,6}/address/secondary-ip``
+only when an address carried ``is_secondary=True``.  But:
+
+* IPv6 has no ``secondary`` keyword at all, so ``is_secondary`` is structurally
+  never set on a v6 address; and
+* IPv4 sources that don't model a primary/secondary distinction (Junos /
+  OPNsense parse) leave ``is_secondary`` False on *every* address.
+
+So a genuinely multi-address interface from such a source emitted NO
+``secondary-ip`` xpath, ``classify()`` was never invoked, and a single-address
+target codec (FortiGate / OPNsense — which render only the first address and
+silently drop the rest) reported ``severity: ok`` while a whole subnet's
+reachability vanished.
+
+The fix walks ``secondary-ip`` for every address beyond the first (cardinality
+> 1), regardless of the flag.  This guard pins that: the flagless multi-address
+case must emit the xpath, a single address must not, and the loss must surface
+end-to-end on a dropping codec.
+"""
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalInterface,
+    CanonicalIPv4Address,
+    CanonicalIPv6Address,
+)
+from netcanon.migration.canonical.xpath_walker import _walk_canonical
+from netcanon.migration.codecs import (  # noqa: F401  (register codecs)
+    cisco_iosxe_cli,
+    fortigate_cli,
+    opnsense,
+)
+from netcanon.migration.codecs.registry import get_codec
+from netcanon.services.migration_validate import validate_against
+
+pytestmark = pytest.mark.unit
+
+_V4_SEC = "/interfaces/interface/ipv4/address/secondary-ip"
+_V6_SEC = "/interfaces/interface/ipv6/address/secondary-ip"
+
+
+def _intent(v4: list[CanonicalIPv4Address], v6: list[CanonicalIPv6Address]):
+    return CanonicalIntent(
+        hostname="r1",
+        interfaces=[CanonicalInterface(
+            name="GigabitEthernet0/1", default_name="GigabitEthernet0/1",
+            ipv4_addresses=v4, ipv6_addresses=v6,
+        )],
+    )
+
+
+def _v4(ip: str, *, sec: bool = False) -> CanonicalIPv4Address:
+    return CanonicalIPv4Address(ip=ip, prefix_length=24, is_secondary=sec)
+
+
+def _v6(ip: str, *, sec: bool = False) -> CanonicalIPv6Address:
+    return CanonicalIPv6Address(ip=ip, prefix_length=64, is_secondary=sec)
+
+
+class TestCardinalityDiscriminator:
+    """``_walk_canonical`` emits ``secondary-ip`` from address count alone."""
+
+    def test_flagless_multi_ipv4_yields_secondary(self):
+        """The core T0-1 bug shape: two IPv4 addresses, NEITHER flagged
+        is_secondary, must still emit the secondary-ip xpath."""
+        paths = set(_walk_canonical(_intent([_v4("10.0.0.1"), _v4("10.0.9.1")], [])))
+        assert _V4_SEC in paths
+
+    def test_flagless_multi_ipv6_yields_secondary(self):
+        """IPv6 can never set is_secondary, so cardinality is the ONLY
+        signal — two v6 addresses must emit the secondary-ip xpath."""
+        paths = set(_walk_canonical(
+            _intent([], [_v6("2001:db8::1"), _v6("2001:db8:9::1")])
+        ))
+        assert _V6_SEC in paths
+
+    def test_single_address_does_not_yield_secondary(self):
+        """No false positive: one address per family emits no secondary-ip
+        (else single-address codecs would be wrongly flagged lossy)."""
+        paths = set(_walk_canonical(_intent([_v4("10.0.0.1")], [_v6("2001:db8::1")])))
+        assert _V4_SEC not in paths
+        assert _V6_SEC not in paths
+
+    def test_explicit_single_secondary_still_yields(self):
+        """Backward-compat: the original flag-based trigger still fires for
+        a lone is_secondary=True address (cisco/arista classic secondary)."""
+        paths = set(_walk_canonical(
+            _intent([_v4("10.0.0.1", sec=True)], [])
+        ))
+        assert _V4_SEC in paths
+
+
+class TestEndToEndLossSurfaces:
+    """The flagless multi-address loss surfaces in the live validation
+    report on a single-address target codec (was a silent ``ok``)."""
+
+    @pytest.mark.parametrize("target", ["opnsense", "fortigate_cli"])
+    def test_flagless_multiaddress_blocks_on_single_address_codec(self, target):
+        tree = _intent(
+            [_v4("10.0.0.1"), _v4("10.0.9.1")],
+            [_v6("2001:db8::1"), _v6("2001:db8:9::1")],
+        )
+        report = validate_against(
+            tree, get_codec(target), source=get_codec("cisco_iosxe_cli"),
+        )
+        unsup = {u.path for u in report.unsupported_paths}
+        assert _V4_SEC in unsup
+        assert _V6_SEC in unsup
+        assert report.compatible is False


### PR DESCRIPTION
## What

The canonical walker emitted `/interfaces/interface/ipv{4,6}/address/secondary-ip` **only** when an address carried `is_secondary=True`. But:

- **IPv6 has no `secondary` keyword** — the flag is structurally never set on a v6 address; and
- **flagless IPv4 sources** (Junos / OPNsense parse) leave `is_secondary` False on *every* address.

So a genuinely multi-address interface from such a source emitted **no** `secondary-ip` xpath, `classify()` was never invoked, and a single-address target codec (FortiGate / OPNsense — which render only the first address and silently drop the rest) reported `severity: ok` while a whole subnet's reachability vanished.

Reproduced on current `main`: a 2×IPv4 + 2×IPv6 interface (neither flagged) → opnsense → live report was silent; with this fix it blocks on both `secondary-ip` paths.

## Fix

The walker keys on address **cardinality** — it yields `secondary-ip` for every address beyond the first (`idx > 0`), regardless of the flag (the original `is_secondary` trigger is kept for the lone-explicit-secondary case).

**No matrix changes needed.** The single-address codecs already declare `secondary-ip` unsupported (ipv4 *and* ipv6), and `test_static_route_subfield_and_secondary_drops_are_declared` already enforces those declarations *reachability-based* (`max_v4 < 2 → must declare`), green on main — i.e. the capability matrices were already honest about which codecs drop extra addresses. The gap was purely in the walker's flag-gated emission.

**No regen.** `run_full_mesh.py` / `run_phase4_reconciliation.py` are model_dump SET-DIFF based and do **not** consume the walker (verified: no `iter_xpaths`/`validate_against`/`_walk_canonical` reference in either tool), so the cross-mesh JSON and `_phase4_runs/latest.json` cannot drift. `tests/unit/audit` phase4 reconciliation passes unchanged.

## Tests

New `test_multiaddress_cardinality_walk`:
- flagless multi-address (v4 and v6) → emits `secondary-ip`
- single address → does **not** (no false positive)
- explicit lone `is_secondary=True` → still emits (backward-compat)
- end-to-end: flagless 2-address → **block** on opnsense + fortigate_cli

Full `tests/unit` green (incl. `tests/unit/migration` honesty guards, the complexity ratchet — `_walk_canonical` stays grandfathered C901, and `tests/unit/audit` phase4); migration integration green.

Audit `276eaeb` finding **T0-1** (MED). The broader architectural follow-up (fail-surfaced walker defaults — yield-every-cardinal so this class can't recur) is noted separately and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)