### PR TITLE
docs: fix three stale references surfaced by the audit (276eaeb #12 #25 #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **Doc-drift corrections** (audit 276eaeb): `SECURITY.md` listed the
+  hash-locked dependency manifest as "Pending" though `requirements.lock`
+  shipped in v0.4.8; the `aruba_to_arista.md` walkthrough cited a dead
+  `POST /api/v1/migration/run` endpoint and a non-existent `rename_overrides`
+  field (the real endpoint is `/api/v1/migration/plan`, the field is
+  `port_rename_map` plus four sibling `*_rename_map` fields); and the
+  `paramiko_collector` docstrings still described `auto_add` as the
+  host-key-checking default (the default has been `tofu` since v0.4.5).
 - **Multi-address interfaces no longer report a silent `ok` when extra
   addresses are dropped** (audit 276eaeb T0-1). The capability walker
   emitted `/interfaces/interface/ipv{4,6}/address/secondary-ip` only when

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -600,10 +600,18 @@ in regulated environments should pull from GHCR to get the attested
 provenance chain.  Operators in casual environments who just want
 the image working can use either.
 
-**Pending:** a pinned dependency manifest (`requirements.lock` /
-`uv.lock`).  Production builds currently resolve from `pyproject.toml`
-ranges; lock-file resolution is a follow-up wave for operators in
-regulated environments.
+**Shipped (v0.4.8):** a hash-pinned dependency manifest
+(`requirements.lock`).  The Docker image installs its dependencies with
+`pip --require-hashes -r requirements.lock` (see the `Dockerfile` builder
+stage), so the shipped container's dependency input set is constrained
+and integrity-verified rather than re-resolved from `pyproject.toml`
+ranges at build time.  The lock is resolved *inside* the digest-pinned
+base image (`tools/gen_requirements_lock.sh`) so its pins + hashes match
+the deploy platform, and `tests/unit/test_requirements_lock.py` fails CI
+if it drifts out of sync with `pyproject.toml`.  The PyPI sdist/wheel
+deliberately keeps `pyproject`'s version *ranges* — that artifact is a
+library and must let downstream resolvers co-install it; the lock
+constrains the *application* (the container).
 
 ---
 

--- a/docs/walkthroughs/aruba_to_arista.md
+++ b/docs/walkthroughs/aruba_to_arista.md
@@ -86,10 +86,13 @@ per-port `switchport access vlan` directives via the
 (`interface 1`, `interface 2`, ...) — Arista accepts both bare-
 numeric and `Ethernet<N>` forms.  If you want the Arista-canonical
 `Ethernet1` / `Ethernet2` form, use the migrate-page rename modal
-(web UI) or pass `rename_overrides` in the `POST /api/v1/migration/run`
-payload — the rename mesh handles the AOS-S-numeric → Arista-
-`Ethernet<N>` mapping across all bound categories (VLANs, LAGs,
-SNMP communities, etc., not just port names).
+(web UI) or pass `port_rename_map` in the `POST /api/v1/migration/plan`
+payload — the rename mesh propagates each AOS-S-numeric → Arista-
+`Ethernet<N>` port rewrite to every surface that *references* the port
+(VLAN tagged/untagged lists, LAG members, etc.), not just the interface
+itself.  Renaming other identity classes has its own sibling fields
+(`vlan_rename_map`, `local_user_rename_map`, `snmp_community_rename_map`,
+`snmpv3_user_rename_map`).
 
 ## Tier-3 boundary in this scenario
 

--- a/netcanon/collectors/paramiko_collector.py
+++ b/netcanon/collectors/paramiko_collector.py
@@ -20,9 +20,10 @@ Netcanon is operator-trust-anchor by design: the operator who registers
 a backup target in the UI is asserting that the target's IP + port pair
 is the device they intend to reach.  Host-key verification is governed by
 ``Settings.ssh_host_key_checking`` (see :mod:`netcanon.collectors.hostkey`):
-``auto_add`` (default) keeps the historical trust-on-first-use-without-
-persistence behaviour for a trusted management VLAN; ``tofu`` persists the
-first key under ``{data_dir}/known_hosts`` and rejects a later changed key;
+``tofu`` (default since v0.4.5) persists the first key seen under
+``{data_dir}/known_hosts`` and rejects a later changed key; ``auto_add``
+(legacy opt-out) keeps the historical trust-on-first-use-*without*-
+persistence behaviour for a trusted management VLAN and warns at startup;
 ``reject`` only connects to already-known hosts.  Both
 :meth:`ParamikoShellCollector.collect` and ``.probe`` apply the configured
 policy + persist (TOFU) after a successful connect.
@@ -164,8 +165,9 @@ class ParamikoShellCollector(BaseCollector):
         """
         client = paramiko.SSHClient()
         # Host-key verification policy (see module "Security model" +
-        # netcanon.collectors.hostkey): auto_add (default, legacy) / tofu /
-        # reject, driven by Settings.ssh_host_key_checking.
+        # netcanon.collectors.hostkey): tofu (default since v0.4.5) /
+        # auto_add (legacy opt-out) / reject, driven by
+        # Settings.ssh_host_key_checking.
         settings = self._effective_settings()
         apply_paramiko_policy(client, settings)
 


### PR DESCRIPTION
Documentation-only corrections for three stale references the audit flagged. No code behaviour change.

## #12 — `SECURITY.md`
The supply-chain section listed a hash-locked dependency manifest as **"Pending"**, but `requirements.lock` **shipped in v0.4.8** (#212). Rewritten to "Shipped (v0.4.8)" describing the mechanism — Docker `pip --require-hashes -r requirements.lock`, resolved inside the digest-pinned base (`tools/gen_requirements_lock.sh`), guarded by `tests/unit/test_requirements_lock.py` — and the deliberate library-keeps-ranges (PyPI wheel) vs application-locks (container) split.

## #25 — `docs/walkthroughs/aruba_to_arista.md`
Cited a dead `POST /api/v1/migration/run` endpoint and a non-existent `rename_overrides` field. Corrected to the real endpoint `/api/v1/migration/plan` and field `port_rename_map` (verified against `netcanon/models/migration.py`, `migrate.html`, `demo.py`), with the four sibling `*_rename_map` fields named and the reference-cascade described accurately.

## #14 — `netcanon/collectors/paramiko_collector.py`
The module docstring and the connect-path comment still called `auto_add` the host-key-checking **default**. The default has been **`tofu` since v0.4.5** (#170); `auto_add` is the legacy opt-out that warns at startup. Reworded both to match `config.py:186` (`= "tofu"`).

Changelog guard green; no test asserts the changed strings (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)