### PR TITLE
fix(sanitize): cap the /api/v1/sanitize upload size (audit 276eaeb #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **`POST /api/v1/sanitize` now caps the upload size** (audit 276eaeb
+  #19). The endpoint read the entire request body into memory and fed it
+  to the synchronous parse->redact->render pipeline with no limit, so an
+  oversized upload was an availability footgun. It now reads at most
+  `NETCANON_MAX_SANITIZE_UPLOAD_BYTES` (default 16 MiB) and returns `413`
+  beyond that. Real configs are far below the cap; raise the env var or
+  run the CLI `netcanon sanitize` for anything larger.
 - **Doc-drift corrections** (audit 276eaeb): `SECURITY.md` listed the
   hash-locked dependency manifest as "Pending" though `requirements.lock`
   shipped in v0.4.8; the `aruba_to_arista.md` walkthrough cited a dead

--- a/netcanon/api/routes/sanitize.py
+++ b/netcanon/api/routes/sanitize.py
@@ -21,6 +21,7 @@ import logging
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, PlainTextResponse
 
+from ... import config as app_config
 from ...migration.codecs.base import ParseError
 from ...migration.codecs.registry import list_public_codecs
 from ...tools.sanitize import sanitize_text
@@ -52,7 +53,22 @@ async def post_sanitize(
             detail=f"Unknown source_vendor {source_vendor!r}; available: {available}",
         )
 
-    raw_bytes = await config.read()
+    # Bound the read: without a cap the whole body is pulled into memory and
+    # fed to the synchronous parse→redact→render pipeline, so an oversized
+    # upload is an availability footgun (blind-audit 276eaeb #19).  Read at
+    # most cap+1 bytes — if we get more than the cap, the body is too large.
+    # The cap is read at request time so it stays env-overridable + testable.
+    cap = app_config.MAX_SANITIZE_UPLOAD_BYTES
+    raw_bytes = await config.read(cap + 1)
+    if len(raw_bytes) > cap:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Config upload exceeds the {cap} byte limit. Raise "
+                "NETCANON_MAX_SANITIZE_UPLOAD_BYTES if you must sanitize a "
+                "larger file, or run the CLI 'netcanon sanitize' locally."
+            ),
+        )
     raw = raw_bytes.decode("utf-8", errors="replace")
 
     try:

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -66,6 +66,44 @@ def _resolve_global_backup_ceiling() -> int:
 MAX_GLOBAL_BACKUP_CONCURRENCY: int = _resolve_global_backup_ceiling()
 
 
+#: Default ceiling on a single ``POST /api/v1/sanitize`` upload (16 MiB).
+#: Network configs are well under a megabyte even for large chassis, so 16 MiB
+#: is generous headroom while still bounding the work an unauthenticated /
+#: anonymous caller can force: without a cap the endpoint read the entire body
+#: into memory and ran the synchronous parse→redact→render pipeline on it, so a
+#: multi-gigabyte upload was an availability footgun (blind-audit 276eaeb #19).
+_DEFAULT_MAX_SANITIZE_UPLOAD_BYTES: int = 16 * 1024 * 1024
+
+
+def _resolve_sanitize_upload_cap() -> int:
+    """Read the ``/sanitize`` upload ceiling from the environment.
+
+    Module-level (not a :class:`Settings` field) so the route can read it at
+    request time and a test can monkeypatch it cheaply.  Reads
+    ``NETCANON_MAX_SANITIZE_UPLOAD_BYTES``, falling back to
+    :data:`_DEFAULT_MAX_SANITIZE_UPLOAD_BYTES` when unset or unparseable;
+    floored at 1 KiB so an operator can't accidentally set a cap that rejects
+    every real config.
+    """
+    raw = os.environ.get("NETCANON_MAX_SANITIZE_UPLOAD_BYTES")
+    if raw is None:
+        return _DEFAULT_MAX_SANITIZE_UPLOAD_BYTES
+    try:
+        return max(1024, int(raw))
+    except ValueError:
+        warnings.warn(
+            f"NETCANON_MAX_SANITIZE_UPLOAD_BYTES={raw!r} is not an integer; "
+            f"falling back to {_DEFAULT_MAX_SANITIZE_UPLOAD_BYTES}",
+            stacklevel=2,
+        )
+        return _DEFAULT_MAX_SANITIZE_UPLOAD_BYTES
+
+
+#: Resolved at import; the route reads ``config.MAX_SANITIZE_UPLOAD_BYTES`` at
+#: request time (see :mod:`netcanon.api.routes.sanitize`).
+MAX_SANITIZE_UPLOAD_BYTES: int = _resolve_sanitize_upload_cap()
+
+
 def _default_definitions_dir() -> Path:
     """Resolve the default device-definition library root.
 

--- a/tests/integration/test_sanitize_api.py
+++ b/tests/integration/test_sanitize_api.py
@@ -48,6 +48,34 @@ class TestSanitizeEndpoint:
         # Original hostname should not survive
         assert "SW-1OG-01" not in body
 
+    def test_oversized_upload_rejected_413(self, client, monkeypatch):
+        """blind-audit 276eaeb #19: an upload larger than the cap is
+        rejected with 413 instead of being read whole into memory and
+        pushed through the synchronous parse pipeline."""
+        import netcanon.config as cfg
+        monkeypatch.setattr(cfg, "MAX_SANITIZE_UPLOAD_BYTES", 64)
+        big = b"hostname x\n" * 50  # ~550 bytes, well over the 64-byte cap
+        response = client.post(
+            "/api/v1/sanitize",
+            data={"source_vendor": "aruba_aoss"},
+            files={"config": ("big.cfg", big, "text/plain")},
+        )
+        assert response.status_code == 413
+        assert "limit" in response.json()["detail"].lower()
+
+    def test_upload_at_cap_is_not_size_rejected(self, client, monkeypatch):
+        """A body within the cap is not size-rejected (it proceeds to the
+        normal parse path — the cap guards size only, nothing else)."""
+        import netcanon.config as cfg
+        monkeypatch.setattr(cfg, "MAX_SANITIZE_UPLOAD_BYTES", 10_000)
+        with open(ARUBA_FIXTURE, "rb") as f:
+            response = client.post(
+                "/api/v1/sanitize",
+                data={"source_vendor": "aruba_aoss"},
+                files={"config": ("test.cfg", f, "text/plain")},
+            )
+        assert response.status_code == 200
+
     def test_dry_run_returns_json_audit(self, client):
         with open(ARUBA_FIXTURE, "rb") as f:
             response = client.post(


### PR DESCRIPTION
## What

`post_sanitize` did `await config.read()` with **no limit**, pulling the entire request body into memory and then running the synchronous `parse → redact → render` pipeline on it. An oversized (multi-GB) upload was an availability footgun on an endpoint reachable by any peer that can hit the server.

## Fix

- New env-overridable ceiling `MAX_SANITIZE_UPLOAD_BYTES` in `config.py` (default **16 MiB**, `NETCANON_MAX_SANITIZE_UPLOAD_BYTES`, floored at 1 KiB), following the existing `MAX_GLOBAL_BACKUP_CONCURRENCY` resolver pattern.
- The route reads **at most `cap + 1` bytes** (bounding memory) and returns **`413`** when the body exceeds the cap. It reads the value from the config module at request time, so it stays env-overridable and cheap to monkeypatch in tests.

16 MiB is generous — real device configs are well under a megabyte even for large chassis. Operators with a genuinely larger file can raise the env var or run the CLI `netcanon sanitize` locally.

## Tests

Two integration tests: an oversized upload → `413`; a body within the cap still proceeds to the normal parse path. Full `tests/unit` + sanitize integration green.

Audit `276eaeb` finding **#19** (MED, availability). Endpoint-level cap; a full multipart-body limit at the ASGI layer would be a broader change and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)