### PR TITLE
perf(diff): walk the config store once per diff, not once per side (audit 276eaeb T0-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **`POST /api/v1/configs/diff` walks the config store once, not twice**
+  (audit 276eaeb T0-5). The route resolved the left and right records via
+  two `_resolve_record` calls that each re-ran `storage.list_configs()`
+  (a full storage directory walk), so every diff stat'd every stored file
+  twice. It now builds a `{filename: record}` index once and resolves both
+  sides from it, mirroring the HTML diff page. No behaviour change.
 - **`POST /api/v1/sanitize` now caps the upload size** (audit 276eaeb
   #19). The endpoint read the entire request body into memory and fed it
   to the synchronous parse->redact->render pipeline with no limit, so an

--- a/netcanon/api/routes/configs.py
+++ b/netcanon/api/routes/configs.py
@@ -219,9 +219,9 @@ def open_config(
 
 
 def _resolve_record(
-    storage: BaseConfigStore, filename: str, side: str
+    records_by_name: dict[str, ConfigRecord], filename: str, side: str
 ) -> ConfigRecord:
-    """Find the ``ConfigRecord`` for *filename* or raise a 404.
+    """Find the ``ConfigRecord`` for *filename* in a pre-built index or 404.
 
     The config list is authoritative — ``resolve_path`` only proves the
     bytes exist on disk, but the metadata (``device_type``,
@@ -229,27 +229,31 @@ def _resolve_record(
     missing entry here means the filename was never produced by the
     backup engine, so a 404 is honest.
 
+    Takes a ``{filename: record}`` index (built once per request) rather
+    than re-listing the store, so a two-sided diff does a single storage
+    walk instead of one per side (blind-audit 276eaeb T0-5).
+
     Args:
-        storage: Config storage backend whose ``list_configs()`` is
-            treated as the authoritative inventory.
+        records_by_name: ``{filename: ConfigRecord}`` built once from
+            ``storage.list_configs()`` — the authoritative inventory.
         filename: Bare filename as returned by the list endpoint.
         side: Either ``"left"`` or ``"right"``; surfaced verbatim in
             the 404 detail so the client can highlight the offending
             field in the diff form.
 
     Returns:
-        The matching ``ConfigRecord`` from ``storage.list_configs()``.
+        The matching ``ConfigRecord``.
 
     Raises:
         HTTPException 404: If no record's ``filename`` matches.
     """
-    for record in storage.list_configs():
-        if record.filename == filename:
-            return record
-    raise HTTPException(
-        status_code=404,
-        detail=f"{side.capitalize()} config not found: {filename!r}",
-    )
+    record = records_by_name.get(filename)
+    if record is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"{side.capitalize()} config not found: {filename!r}",
+        )
+    return record
 
 
 @router.post(
@@ -289,8 +293,12 @@ def diff_configs(
         HTTPException 422: If the two configs are incompatible and
             ``force`` is not set.
     """
-    left_rec = _resolve_record(storage, body.left, side="left")
-    right_rec = _resolve_record(storage, body.right, side="right")
+    # Index the store once and resolve both sides from it — a two-sided
+    # diff used to call list_configs() per side (a full storage walk x2);
+    # mirrors ui.py's single-walk diff_page (blind-audit 276eaeb T0-5).
+    records_by_name = {r.filename: r for r in storage.list_configs()}
+    left_rec = _resolve_record(records_by_name, body.left, side="left")
+    right_rec = _resolve_record(records_by_name, body.right, side="right")
 
     # Short-circuit the expensive read if we're going to reject anyway.
     from ...services.diff import check_compatibility

--- a/tests/integration/test_configs_api.py
+++ b/tests/integration/test_configs_api.py
@@ -355,6 +355,44 @@ class TestDiffCompatibility:
         assert resp.status_code == 404
 
 
+class TestDiffEfficiency:
+    """blind-audit 276eaeb T0-5: a two-sided diff resolves both records from
+    a SINGLE storage walk, not one ``list_configs()`` per side (the route
+    used to call ``_resolve_record`` — which re-listed the store — once for
+    left and once for right)."""
+
+    def test_diff_lists_store_once(self, client):
+        a = _seed_config_of_type(client, "Cisco", "10.6.6.1")
+        b = _seed_config_of_type(client, "Cisco", "10.6.6.2")
+        storage = client.app.state.storage
+        with patch.object(
+            storage, "list_configs", wraps=storage.list_configs
+        ) as spy:
+            resp = client.post(
+                "/api/v1/configs/diff", json={"left": a, "right": b}
+            )
+        assert resp.status_code == 200
+        assert spy.call_count == 1, (
+            f"diff walked the store {spy.call_count}x; expected 1 "
+            "(build the {filename: record} index once)"
+        )
+
+    def test_diff_404_also_lists_store_once(self, client):
+        """The single-walk holds on the not-found path too (left resolves,
+        right 404s) — the index is built before either lookup."""
+        a = _seed_config_of_type(client, "Cisco", "10.6.6.3")
+        storage = client.app.state.storage
+        with patch.object(
+            storage, "list_configs", wraps=storage.list_configs
+        ) as spy:
+            resp = client.post(
+                "/api/v1/configs/diff",
+                json={"left": a, "right": "Cisco_0-0-0-0_20000101_000000.cfg"},
+            )
+        assert resp.status_code == 404
+        assert spy.call_count == 1
+
+
 class TestDiffOutput:
     """Structural checks on the diff body — stats, line kinds, numbers."""
 


### PR DESCRIPTION
## What

`diff_configs` resolved the left and right records with **two** `_resolve_record` calls, and each call ran `storage.list_configs()` — a full storage-directory walk that stats every stored file. So every `POST /api/v1/configs/diff` walked the store **twice**.

## Fix

Build a `{filename: record}` index once from a single `list_configs()` and resolve both sides from it — mirroring `ui.py`'s `diff_page` (which already does exactly this, `ui.py:293`). `_resolve_record` now takes the pre-built index instead of re-listing; it's private and used only here, so the signature change is contained. Same 404 semantics, same report — no behaviour change.

(The event-loop half of this finding — the synchronous list walk blocking the loop — was already addressed in #203; this closes the double-walk half.)

## Tests

`TestDiffEfficiency`: a two-sided diff, and the left-ok / right-404 path, each walk the store **exactly once** (asserted with a `wraps=` spy on the `app.state.storage` singleton). Full configs API integration green.

Audit `276eaeb` finding **T0-5** (LOW/perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)