### PR TITLE
feat(api): advertise the /api/v1 bearer scheme in OpenAPI when a key is set (audit 276eaeb #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **OpenAPI schema now advertises the `/api/v1` bearer-token requirement**
+  (audit 276eaeb #9). `require_api_key` enforced `Authorization: Bearer`
+  as a plain dependency, invisible to OpenAPI, so `/docs` had no Authorize
+  button and the gate wasn't discoverable from the schema. When
+  `NETCANON_API_KEY` is set, the schema now declares a `BearerAuth`
+  security scheme and applies it to every `/api/v1` operation; with no key
+  the schema stays open (honest about the zero-config posture).
 - **`POST /api/v1/configs/diff` walks the config store once, not twice**
   (audit 276eaeb T0-5). The route resolved the left and right records via
   two `_resolve_record` calls that each re-ran `storage.list_configs()`

--- a/netcanon/main.py
+++ b/netcanon/main.py
@@ -323,6 +323,57 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # it wraps the fully-mounted router set.
     ui_router.register_exception_handlers(app)
 
+    # ------------------------------------------------------------------
+    # OpenAPI security scheme (audit 276eaeb #9)
+    # ------------------------------------------------------------------
+    # require_api_key enforces an `Authorization: Bearer <key>` on /api/v1
+    # when NETCANON_API_KEY is set, but it's a plain dependency (not a
+    # fastapi Security scheme), so the generated OpenAPI never advertised
+    # it: /docs had no "Authorize" button and a client couldn't discover
+    # the requirement from the schema.  Inject the BearerAuth scheme — but
+    # ONLY when a key is configured, so the schema stays honest (open with
+    # no key, bearer-gated with one) and the zero-config local schema is
+    # unchanged.  Applied to /api/v1 operations only; /health and the UI
+    # routes are not bearer-gated.
+    from fastapi.openapi.utils import get_openapi
+
+    def _custom_openapi() -> dict:
+        if app.openapi_schema:
+            return app.openapi_schema
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+        # Read the live settings the enforcement uses (state is set in
+        # lifespan; fall back to the resolved closure value otherwise).
+        active = getattr(app.state, "settings", None) or settings
+        if (getattr(active, "api_key", "") or "").strip():
+            schema.setdefault("components", {}).setdefault(
+                "securitySchemes", {}
+            )["BearerAuth"] = {
+                "type": "http",
+                "scheme": "bearer",
+                "description": (
+                    "Static token from NETCANON_API_KEY, sent as "
+                    "`Authorization: Bearer <token>`. Required on /api/v1 "
+                    "when the key is configured (SEC-01)."
+                ),
+            }
+            for path, item in schema.get("paths", {}).items():
+                if not path.startswith("/api/v1"):
+                    continue
+                for operation in item.values():
+                    if isinstance(operation, dict):
+                        operation.setdefault("security", []).append(
+                            {"BearerAuth": []}
+                        )
+        app.openapi_schema = schema
+        return schema
+
+    app.openapi = _custom_openapi
+
     return app
 
 

--- a/tests/integration/test_sec01_api_auth.py
+++ b/tests/integration/test_sec01_api_auth.py
@@ -44,6 +44,47 @@ def test_api_v1_gated_when_api_key_set(client):
     assert client.get("/health").status_code == 200
 
 
+def test_openapi_advertises_bearer_when_key_set(client):
+    """audit 276eaeb #9: with NETCANON_API_KEY configured, the OpenAPI
+    schema declares the ``BearerAuth`` security scheme and applies it to
+    every /api/v1 operation, so /docs renders an Authorize button and a
+    client can discover the requirement from the schema (require_api_key
+    is a plain dependency, invisible to OpenAPI on its own)."""
+    client.app.state.settings.api_key = "s3cret"
+    schema = client.get("/api/v1/openapi.json").json()
+
+    schemes = schema.get("components", {}).get("securitySchemes", {})
+    assert schemes.get("BearerAuth", {}).get("type") == "http"
+    assert schemes.get("BearerAuth", {}).get("scheme") == "bearer"
+
+    api_paths = {
+        p: item for p, item in schema["paths"].items() if p.startswith("/api/v1")
+    }
+    assert api_paths, "no /api/v1 paths in the schema"
+    for path, item in api_paths.items():
+        for op in item.values():
+            if isinstance(op, dict):
+                assert {"BearerAuth": []} in op.get("security", []), (
+                    f"{path} operation does not require BearerAuth in the schema"
+                )
+
+
+def test_openapi_open_when_no_key(client):
+    """No key → no security scheme: the schema is honest about the
+    zero-config open posture (don't claim auth that isn't enforced)."""
+    schema = client.get("/api/v1/openapi.json").json()
+    schemes = schema.get("components", {}).get("securitySchemes", {})
+    assert "BearerAuth" not in schemes
+    for path, item in schema["paths"].items():
+        if not path.startswith("/api/v1"):
+            continue
+        for op in item.values():
+            if isinstance(op, dict):
+                assert "security" not in op, (
+                    f"{path} declares security but no key is configured"
+                )
+
+
 def test_ui_routes_are_not_key_gated_by_design(client):
     """DOCUMENTED DECISION (blind-audit 3ec11f3 T0-1), not an oversight: the
     API key gates ``/api/v1`` ONLY — the server-rendered HTML UI stays open


### PR DESCRIPTION
## What

`require_api_key` enforces an `Authorization: Bearer <key>` on `/api/v1` when `NETCANON_API_KEY` is set, but it's a **plain dependency, not a FastAPI `Security` scheme** — so the generated OpenAPI never advertised it. The `/docs` page had no "Authorize" button, and a programmatic client couldn't discover the requirement from the schema.

## Fix

Override `app.openapi()` to inject a `BearerAuth` (`type: http`, `scheme: bearer`) security scheme and attach it to every `/api/v1` operation — but **only when a key is configured**, so the schema stays honest:
- **no key** → schema open (matches the zero-config local posture)
- **key set** → `BearerAuth` declared + required on `/api/v1` ops

`/health` and the UI routes are never bearer-gated and are left untouched. The `/api/v1/openapi.json` route itself stays open (unchanged) so the unauthenticated `/docs` page can still render the schema. The active key is read from `app.state.settings` (the same source `require_api_key` uses), so the schema always reflects the live enforcement.

## Tests

Two integration tests: with a key, the schema declares `BearerAuth` and applies it to every `/api/v1` operation; with no key, neither the scheme nor any per-op `security` requirement appears. Full `tests/integration` suite green locally (app-wide `create_app` change).

Audit `276eaeb` finding **#9** (LOW/discoverability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)