### PR TITLE
feat(diff): opt-in context fold for the JSON diff endpoint (audit 276eaeb #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Added
+
+- **`POST /api/v1/configs/diff` accepts an opt-in `context` fold control**
+  (audit 276eaeb #18). The JSON diff serialised every line, including all
+  unchanged ones — tens of thousands of rows for two large near-identical
+  configs. Passing `context: <int>` now collapses runs of equal lines more
+  than that many lines from any change: those cold lines are omitted from
+  `lines` and counted in `stats.collapsed` (the `equal` stat still reflects
+  the full diff). Omitting `context` returns the full report exactly as
+  before — no contract change for existing callers.
+
 ### Fixed
 
 - **OpenAPI schema now advertises the `/api/v1` bearer-token requirement**

--- a/netcanon/api/routes/configs.py
+++ b/netcanon/api/routes/configs.py
@@ -285,8 +285,10 @@ def diff_configs(
     render a warning banner.
 
     Args:
-        body: Request payload with ``left``, ``right``, and optional
-            ``force`` flag.
+        body: Request payload with ``left``, ``right``, an optional
+            ``force`` flag, and an optional ``context`` fold control
+            (omit for the full line-by-line report; set to an int to
+            collapse cold equal runs — see :class:`DiffRequest`).
 
     Raises:
         HTTPException 404: If either filename is not known to the store.
@@ -319,6 +321,25 @@ def diff_configs(
     report = compute_diff(
         left_rec, left_text, right_rec, right_text, force=body.force
     )
+
+    # Opt-in fold (audit 276eaeb #18): when the caller passes `context`,
+    # drop equal lines that are more than `context` lines from any change
+    # so a diff of two large near-identical configs doesn't serialise tens
+    # of thousands of unchanged lines.  Default (context=None) is the full
+    # report, unchanged.  The `equal` stat still reflects the full diff; a
+    # `collapsed` stat records how many equal lines were omitted.
+    if body.context is not None:
+        from ...services.diff import fold_context
+
+        groups = fold_context(report.lines, context=body.context)
+        visible = [
+            line for g in groups if g.kind != "collapsed" for line in g.lines
+        ]
+        collapsed = sum(len(g.lines) for g in groups if g.kind == "collapsed")
+        report = report.model_copy(
+            update={"lines": visible, "stats": {**report.stats, "collapsed": collapsed}}
+        )
+
     logger.info(
         "Diff %s vs %s: +%d / -%d (compat=%s, force=%s)",
         body.left,

--- a/netcanon/models/diff.py
+++ b/netcanon/models/diff.py
@@ -74,11 +74,20 @@ class DiffRequest(BaseModel):
             a ``block`` severity no longer produces a 422.  Exists to
             support deliberate cross-vendor comparisons; the rendered
             output carries a red warning banner.
+        context: Opt-in fold control.  ``None`` (default) returns every
+            line — the full-fidelity report, unchanged.  An integer ``>= 0``
+            collapses runs of equal lines that are more than ``context``
+            lines from any change: those cold lines are OMITTED from
+            ``lines`` and counted in ``stats["collapsed"]``, so a diff of
+            two large near-identical configs no longer serialises tens of
+            thousands of unchanged lines to the client (audit 276eaeb #18).
+            ``3`` matches the git unified-diff convention.
     """
 
     left: str
     right: str
     force: bool = False
+    context: int | None = Field(default=None, ge=0)
 
 
 class DiffReport(BaseModel):
@@ -88,10 +97,15 @@ class DiffReport(BaseModel):
         left: Metadata record of the left-hand file.
         right: Metadata record of the right-hand file.
         compatibility: Pre-flight compatibility report.
-        lines: Ordered sequence of ``DiffLine`` rows.
-        stats: Count of each kind — ``added``, ``removed``, ``equal``.
-            Computed once by the service layer so the UI doesn't have
-            to re-scan ``lines``.
+        lines: Ordered sequence of ``DiffLine`` rows.  When the request
+            sets ``context`` (opt-in fold), cold equal lines are omitted
+            here and counted in ``stats["collapsed"]``.
+        stats: Count of each kind — ``added``, ``removed``, ``equal``
+            (the ``equal`` count always reflects the FULL diff, even when
+            folded).  Carries an extra ``collapsed`` key — the number of
+            equal lines omitted from ``lines`` — only when ``context`` was
+            requested.  Computed by the service layer so the UI doesn't
+            have to re-scan ``lines``.
     """
 
     left: ConfigRecord

--- a/tests/integration/test_configs_api.py
+++ b/tests/integration/test_configs_api.py
@@ -393,6 +393,89 @@ class TestDiffEfficiency:
         assert spy.call_count == 1
 
 
+class TestDiffContextFold:
+    """audit 276eaeb #18: opt-in `context` collapses cold equal runs out of
+    the JSON diff payload, so two large near-identical configs don't
+    serialise tens of thousands of unchanged lines.  Default (no `context`)
+    is the full report, unchanged."""
+
+    def _seed_pair(self, client):
+        """Two diff-compatible Cisco configs sharing a long common block
+        with a single differing line in the middle — enough cold equal
+        runs to fold."""
+        from datetime import UTC, datetime
+
+        storage = client.app.state.storage
+        common = "\n".join(f"line{i}" for i in range(100))
+        left = f"{common}\nCHANGED-LEFT\n{common}\n"
+        right = f"{common}\nCHANGED-RIGHT\n{common}\n"
+        rec_l = storage.save(
+            device_type="Cisco", host="10.7.7.1",
+            timestamp=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+            extension="cfg", content=left, device_profile_id=None,
+        )
+        rec_r = storage.save(
+            device_type="Cisco", host="10.7.7.2",
+            timestamp=datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC),
+            extension="cfg", content=right, device_profile_id=None,
+        )
+        return rec_l.filename, rec_r.filename
+
+    def test_context_omitted_returns_full_report(self, client):
+        left, right = self._seed_pair(client)
+        report = client.post(
+            "/api/v1/configs/diff", json={"left": left, "right": right}
+        ).json()
+        # No fold requested → no `collapsed` key, every line present.
+        assert "collapsed" not in report["stats"]
+        assert len(report["lines"]) > 150  # ~200 equal + the change rows
+
+    def test_context_folds_cold_equal_runs(self, client):
+        left, right = self._seed_pair(client)
+        full = client.post(
+            "/api/v1/configs/diff", json={"left": left, "right": right}
+        ).json()
+        folded = client.post(
+            "/api/v1/configs/diff",
+            json={"left": left, "right": right, "context": 3},
+        ).json()
+
+        assert folded["stats"]["collapsed"] > 0
+        assert len(folded["lines"]) < len(full["lines"])
+        # The `equal` stat still reflects the FULL diff, not the folded view.
+        assert folded["stats"]["equal"] == full["stats"]["equal"]
+        # Invariant: nothing is lost — visible + collapsed == full line count.
+        assert (
+            len(folded["lines"]) + folded["stats"]["collapsed"]
+            == len(full["lines"])
+        )
+        # The actual change survives the fold (it is never cold).
+        texts = [line["text"] for line in folded["lines"]]
+        assert "CHANGED-LEFT" in texts
+        assert "CHANGED-RIGHT" in texts
+
+    def test_large_context_collapses_nothing(self, client):
+        left, right = self._seed_pair(client)
+        full = client.post(
+            "/api/v1/configs/diff", json={"left": left, "right": right}
+        ).json()
+        folded = client.post(
+            "/api/v1/configs/diff",
+            json={"left": left, "right": right, "context": 10_000},
+        ).json()
+        # Context wider than the file → nothing is cold.
+        assert folded["stats"]["collapsed"] == 0
+        assert len(folded["lines"]) == len(full["lines"])
+
+    def test_negative_context_rejected_422(self, client):
+        left, right = self._seed_pair(client)
+        resp = client.post(
+            "/api/v1/configs/diff",
+            json={"left": left, "right": right, "context": -1},
+        )
+        assert resp.status_code == 422
+
+
 class TestDiffOutput:
     """Structural checks on the diff body — stats, line kinds, numbers."""
 


### PR DESCRIPTION
## What

`POST /api/v1/configs/diff` serialised the **full** `DiffReport` — every line, including all unchanged ones. For two large near-identical configs that's tens of thousands of equal rows on the wire (the `DiffReport` docstring already flags this). The HTML UI folds via `fold_context()`, but the JSON API had no equivalent.

## Fix (non-breaking, opt-in)

Add an optional `context: int | None` field to `DiffRequest` (`Field(ge=0)`):
- **omitted (default `None`)** → the full report, exactly as before. **No contract change for existing callers.**
- **set** → fold via the existing `fold_context` helper: equal lines more than `context` lines from any change are **omitted** from `lines` and counted in a new `stats["collapsed"]` key.

The `equal` stat still reports the full diff (so the client knows the true picture), and the change rows are never cold, so they always survive the fold. This keeps the API contract honest — completeness by default, a smaller payload on request — rather than breaking it by folding unconditionally.

## Tests

`TestDiffContextFold`: full report when omitted (no `collapsed` key); cold runs collapse with the change preserved + the `visible + collapsed == full` invariant; a wide `context` collapses nothing; a negative `context` → `422`. Full `tests/unit` + configs API integration green.

Audit `276eaeb` finding **#18** (LOW/payload). Implemented as an opt-in param (chosen over an unconditional fold, which would break the JSON completeness contract the existing `test_same_file_diff_has_all_equal_lines` relies on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)