### PR TITLE
docs(changelog): cut [0.4.9] - 2026-06-29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-06-29
+
 ### Added
 
 - **`POST /api/v1/configs/diff` accepts an opt-in `context` fold control**


### PR DESCRIPTION
Roll the `[Unreleased]` entries into a dated **`[0.4.9] - 2026-06-29`** section ahead of the `v0.4.9` tag.

Bundles the **audit `276eaeb`** remediation:

**Fixed**
- T0-3 — paramiko shell collector fails closed on a never-settling stream (was saving truncated backups as `success`)
- T0-4 — IPv6 transition addresses (6to4 / NAT64 / IPv4-mapped / -compatible / Teredo) no longer leak their embedded public IPv4 in the sanitizer
- T0-1 — multi-address interface drops surface by cardinality, not the `is_secondary` flag (no more silent `ok`)
- #19 — `/api/v1/sanitize` upload size cap (availability)
- T0-5 — `/api/v1/configs/diff` walks the config store once, not twice
- #9 — OpenAPI advertises the `/api/v1` bearer scheme when a key is set
- doc-drift #12/#25/#14 — SECURITY.md lock status, walkthrough endpoint/field, `auto_add`→`tofu` docstrings

**Added**
- #18 — opt-in `context` fold control on the JSON diff endpoint

All patch/minor-additive — no breaking change. A fresh empty `[Unreleased]` is left for the next cycle. setuptools_scm derives the version from the tag, so this CHANGELOG cut is the only change; the `v0.4.9` tag follows once on-main CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)