### PR TITLE
docs(changelog): cut [0.4.10] - 2026-06-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.4.10] - 2026-06-30
+
 ### Fixed
 
 - **Arista LACP mode no longer silently corrupted on round-trip**


### PR DESCRIPTION
Roll the `[Unreleased]` entry into a dated **`[0.4.10] - 2026-06-30`** section ahead of the `v0.4.10` tag.

Single fix this release: the **Arista LACP-mode round-trip corruption** (audit `bb47f21` T0-1, [#223](https://github.com/netcanon/netcanon/pull/223)) — a HIGH correctness hole where a `passive`/static Arista LAG silently re-parsed as `active` — plus the verified `/lags/lag/mode` lossy declarations on the codecs that genuinely can't preserve the mode. A fresh empty `[Unreleased]` is left for the next cycle.

setuptools_scm derives the version from the tag, so this CHANGELOG cut is the only change; the `v0.4.10` tag follows once on-main CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)