### PR TITLE
fix(detect): cisco_iosxe NETCONF probe must not claim envelopes without <interfaces>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cisco_iosxe` (NETCONF) auto-detection no longer over-claims NETCONF
+  envelopes it can't parse** (surfaced by the dogfood mesh harness on
+  real configs). The `probe()` matched any `<rpc-reply>`/`<data>` envelope,
+  so an IOS-XR config delivered as `<rpc-reply><data><cli>...` was
+  confidently mis-detected as `cisco_iosxe` and then failed parse with
+  "no <interfaces> element found". The envelope branch now requires an
+  `<interfaces>` payload (the only subtree the stub consumes); the
+  OpenConfig-namespace and bare-`<interfaces>` paths are unchanged.
+
 ## [0.4.10] - 2026-06-30
 
 ### Fixed

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -956,10 +956,18 @@ class CiscoIOSXECodec(CodecBase):
                 95,
                 "OpenConfig YANG namespace found — NETCONF payload",
             )
-        # <rpc-reply> is the NETCONF envelope; almost always contains
-        # openconfig in practice but we rank it lower just in case.
-        if "<rpc-reply" in lowered or "<data>" in lowered:
-            return (70, "NETCONF envelope tag present")
+        # <rpc-reply> / <data> is the NETCONF envelope, but this stub can
+        # ONLY consume an OpenConfig `<interfaces>` payload.  A NETCONF reply
+        # carrying some OTHER payload (e.g. an IOS-XR `<cli>` cli-cfg blob)
+        # has no `<interfaces>` element, so claiming it here just routes it
+        # to a parse that fails with "no <interfaces> element found" — a
+        # confident mis-detection.  Require the `<interfaces>` element to be
+        # present before claiming the envelope (dogfood mesh: IOS-XR-cli-in-
+        # NETCONF was mis-detected as cisco_iosxe).
+        if ("<rpc-reply" in lowered or "<data>" in lowered) and (
+            "<interfaces" in lowered
+        ):
+            return (70, "NETCONF envelope with <interfaces> payload")
         # Bare OpenConfig-shaped <interfaces> with XML namespace.
         if ("<interfaces" in lowered and "xmlns" in lowered
                 and "<interface>" in lowered):

--- a/tests/unit/migration/test_detect.py
+++ b/tests/unit/migration/test_detect.py
@@ -74,11 +74,27 @@ class TestCiscoNETCONFProbe:
         assert hit is not None
         assert hit[0] >= 90
 
-    def test_matches_rpc_reply(self):
-        raw = '<rpc-reply><data></data></rpc-reply>'
+    def test_matches_rpc_reply_with_interfaces(self):
+        # A NETCONF envelope carrying an <interfaces> payload is parseable.
+        raw = ('<rpc-reply><data><interfaces><interface><name>Gi1</name>'
+               '</interface></interfaces></data></rpc-reply>')
         hit = CiscoIOSXECodec.probe(raw)
         assert hit is not None
         assert hit[0] >= 50
+
+    def test_ignores_netconf_envelope_without_interfaces(self):
+        """dogfood mesh bb47f21: a NETCONF reply whose payload is NOT
+        OpenConfig <interfaces> (e.g. an IOS-XR <cli> cli-cfg blob) must
+        NOT be claimed — the stub can't parse it, so claiming it routes to
+        a guaranteed 'no <interfaces> element found' parse failure."""
+        bare = '<rpc-reply><data></data></rpc-reply>'
+        assert CiscoIOSXECodec.probe(bare) is None
+        xr_cli = (
+            '<rpc-reply><data>'
+            '<cli xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cli-cfg">'
+            '!! IOS XR Configuration\nhostname r1\n</cli></data></rpc-reply>'
+        )
+        assert CiscoIOSXECodec.probe(xr_cli) is None
 
     def test_ignores_opnsense(self):
         raw = '<opnsense><system/></opnsense>'


### PR DESCRIPTION
## What

Surfaced by the new dogfood mesh harness feeding **real** Batfish/napalm configs through auto-detection: an IOS-XR config delivered as a NETCONF reply — `<rpc-reply><data><cli xmlns="...Cisco-IOS-XR-cli-cfg">!! IOS XR Configuration ...</cli>` — was **confidently mis-detected as `cisco_iosxe`** (the OpenConfig NETCONF stub), then failed parse with `no <interfaces> element found`.

Root cause: `probe()` claimed **any** `<rpc-reply>`/`<data>` envelope at confidence 70, but the stub can only consume an OpenConfig `<interfaces>` payload.

## Fix

Require the `<interfaces>` element in the envelope branch before claiming it. A `<cli>`-payload (or otherwise interface-less) NETCONF reply now returns `None` from the probe, so detection falls through to a better-fit codec instead of a guaranteed parse failure. The OpenConfig-namespace branch (conf 95) and the bare-`<interfaces>`-fragment branch (conf 75) are unchanged — real OpenConfig replies still detect.

Verified: the offending IOS-XR-cli config → `None`; a real OpenConfig reply → 95; an envelope **with** `<interfaces>` → 70; a bare `<cli>` envelope → `None`.

## Tests

`test_detect`: the bare-`<rpc-reply>` case now correctly returns `None` (was asserting the old over-match); adds an IOS-XR-cli-in-NETCONF guard + an envelope-with-`<interfaces>` match. Full `tests/unit` + migration/probe-wiring integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)