### PR TITLE
fix(nxos): SNMPv3 priv key leaked through the sanitizer (dogfood mesh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **`cisco_nxos` SNMPv3 `priv` key no longer leaks through the
+  sanitizer** (surfaced by the dogfood mesh harness on real napalm
+  NX-OS captures). The USM parser assumed `priv <cipher> <key>` (two
+  tokens), but NX-OS just as often emits the bare `priv <key>` form
+  (default DES, no explicit cipher). The greedy regex then captured
+  the real priv key as the "cipher" -- landing it in the un-sanitized
+  `priv_protocol` field -- and the trailing `localizedkey` keyword as
+  the key. `netcanon sanitize` therefore re-emitted the privacy key
+  verbatim. The cipher is now matched against an enumerated token set
+  (`aes-128`/`aes-192`/`aes-256`/`des`/`3des`) so the bare form parses
+  the key into the redacted `priv_passphrase`; render emits `priv`
+  whenever a passphrase is set, so the default-DES form also
+  round-trips faithfully instead of dropping the key.
+
 - **`cisco_iosxe` (NETCONF) auto-detection no longer over-claims NETCONF
   envelopes it can't parse** (surfaced by the dogfood mesh harness on
   real configs). The `probe()` matched any `<rpc-reply>`/`<data>` envelope,

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -178,15 +178,24 @@ _SNMP_HOST_RE = re.compile(
 )
 # NX-OS SNMPv3 USM user:
 #   snmp-server user <name> [<group>] auth <proto> <key>
-#       [priv <proto> <key>] [localized[V2]key] [engineID <id>]
+#       [priv [<cipher>] <key>] [localized[V2]key] [engineID <id>]
 # Keys are 0x-prefixed localized digests on the wire — preserved
-# verbatim.  ``priv`` is optional (auth-no-priv users); ``localizedV2key``
-# (NX-OS 10.x digest) is detected but not modelled — render always emits
-# the older ``localizedkey`` form (declared lossy).
+# verbatim.  ``priv`` is optional (auth-no-priv users); the privacy
+# CIPHER inside ``priv`` is ALSO optional — NX-OS emits ``priv <cipher>
+# <key>`` (e.g. ``priv aes-128 0x…``) when a cipher is configured but the
+# bare ``priv <key>`` form (default DES, no explicit cipher) just as
+# often.  The cipher must therefore match an enumerated token set
+# (``aes-128``/``aes-192``/``aes-256``/``des``/``3des``); a greedy
+# ``(\S+)\s+(\S+)`` instead swallowed the priv KEY as the "cipher" and
+# the trailing ``localizedkey`` keyword as the "key", landing the real
+# priv key in the un-sanitized ``priv_protocol`` field — an SNMPv3
+# priv-key disclosure through the sanitizer (dogfood mesh, napalm NX-OS
+# captures).  ``localizedV2key`` (NX-OS 10.x digest) is detected but not
+# modelled — render always emits the older ``localizedkey`` form (lossy).
 _SNMP_V3_USER_RE = re.compile(
     r"^snmp-server\s+user\s+(\S+)(?:\s+(\S+))?"
     r"\s+auth\s+(md5|sha|sha224|sha256|sha384|sha512)\s+(\S+)"
-    r"(?:\s+priv\s+(\S+)\s+(\S+))?"
+    r"(?:\s+priv\s+(?:(aes-128|aes-192|aes-256|3des|des)\s+)?(\S+))?"
     r"(?:\s+localized(V2)?key)?"
     r"(?:\s+engineID\s+(\S+))?\s*$",
     re.IGNORECASE | re.MULTILINE,

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -259,11 +259,20 @@ def _render_snmp(snmp) -> list[str]:
             line += f" {user.group}"
         if user.auth_protocol:
             line += f" auth {user.auth_protocol} {user.auth_passphrase}"
-            if user.priv_protocol:
-                priv = _CANON_TO_NXOS_PRIV.get(
-                    user.priv_protocol, user.priv_protocol,
-                )
-                line += f" priv {priv} {user.priv_passphrase}"
+            # Emit ``priv`` whenever a privacy passphrase is set — gating on
+            # ``priv_protocol`` instead would DROP the key for the bare
+            # ``priv <key>`` (default-DES, no explicit cipher) form, whose
+            # canonical ``priv_protocol`` is empty.  The cipher token is
+            # emitted only when present (``priv aes-128 <key>``); absent it
+            # round-trips the default-DES form (``priv <key>``).
+            if user.priv_passphrase:
+                if user.priv_protocol:
+                    priv = _CANON_TO_NXOS_PRIV.get(
+                        user.priv_protocol, user.priv_protocol,
+                    )
+                    line += f" priv {priv} {user.priv_passphrase}"
+                else:
+                    line += f" priv {user.priv_passphrase}"
             line += " localizedkey"
         if user.engine_id:
             line += f" engineID {user.engine_id}"

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -589,6 +589,63 @@ class TestPhase2bSNMPUsers:
 
 
 # ---------------------------------------------------------------------------
+# Phase 2b regression — SNMPv3 ``priv <key>`` (default-DES, no explicit
+# cipher).  The dogfood mesh (napalm NX-OS captures) caught the sanitizer
+# leaking the priv key here: the parse regex assumed ``priv <cipher> <key>``
+# (two tokens), so the bare ``priv <key> localizedkey`` form swallowed the
+# real key as the "cipher" (un-sanitized ``priv_protocol``) and the
+# ``localizedkey`` keyword as the "key".
+# ---------------------------------------------------------------------------
+
+
+_SNMP_V3_PRIV_NOCIPHER_CONFIG = """\
+!Command: show running-config
+hostname AAA
+snmp-server user pyclass network-admin auth md5 0xd1e3bf70 priv 0xd1e3bf70 localizedkey
+snmp-server user admin auth md5 0x9e902c38 priv 0x9e902c38 localizedkey engineID 128:0:0:9:3:0:12:41
+"""
+
+
+class TestSNMPv3PrivNoCipherKeyLeak:
+    @pytest.fixture
+    def tree(self, codec):
+        return codec.parse(_SNMP_V3_PRIV_NOCIPHER_CONFIG)
+
+    def test_priv_key_lands_in_passphrase_not_protocol(self, tree):
+        """The bare ``priv <key>`` form has NO cipher, so the key must land
+        in ``priv_passphrase`` (sanitized) with an empty ``priv_protocol`` —
+        NOT the reverse, which leaked the key through the un-sanitized
+        protocol field."""
+        pyclass = next(u for u in tree.snmp.v3_users if u.name == "pyclass")
+        assert pyclass.priv_protocol == ""        # default DES, no cipher token
+        assert pyclass.priv_passphrase == "0xd1e3bf70"
+        assert pyclass.auth_passphrase == "0xd1e3bf70"
+
+    def test_default_des_priv_round_trips_faithfully(self, codec, tree):
+        rendered = codec.render(tree)
+        assert (
+            "snmp-server user pyclass network-admin auth md5 "
+            "0xd1e3bf70 priv 0xd1e3bf70 localizedkey" in rendered
+        )
+        # priv survives a parse->render->parse cycle (was dropped when render
+        # gated the priv segment on the now-empty priv_protocol).
+        assert codec.parse(rendered).snmp.model_dump() == tree.snmp.model_dump()
+
+    def test_sanitizer_does_not_leak_priv_key(self, codec, tree):
+        """Security regression: the original priv/auth key MUST NOT survive
+        verbatim into the sanitized output (dogfood mesh residual-secret
+        sweep finding)."""
+        from netcanon.tools.sanitize import sanitize_intent
+
+        sanitized, _subs = sanitize_intent(tree)
+        out = codec.render(sanitized)
+        for secret in ("0xd1e3bf70", "0x9e902c38"):
+            assert secret not in out, f"sanitizer leaked SNMPv3 key {secret!r}"
+        # the redaction placeholders ARE present (priv actually rendered).
+        assert "priv REDACTED-PRIV-1 localizedkey" in out
+
+
+# ---------------------------------------------------------------------------
 # Phase 2c — HSRP (CanonicalVRRPGroup mode="hsrp")
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The dogfood mesh harness's new **Tier-B residual-secret sweep** caught the `netcanon sanitize` path leaking SNMPv3 privacy keys on real NX-OS configs (8 audit-consistency leaks, all `snmpv3-auth`/`snmpv3-priv`, across 2 napalm NX-OS captures). Verify-first reproduced the exact leak before any fix.

### Root cause (two bugs, one chain)

NX-OS emits SNMPv3 USM users two ways:
- `priv aes-128 0x…` — explicit cipher + key (2 tokens)
- `priv 0x… localizedkey` — **bare key, default DES, no cipher** (1 token)

The parse regex assumed the 2-token form (`priv\s+(\S+)\s+(\S+)`), so the bare form swallowed the **real priv key** as the "cipher" — landing it in `priv_protocol`, which the sanitizer does **not** redact — and the trailing `localizedkey` keyword as the passphrase. Render then re-emitted the un-sanitized `priv_protocol` verbatim:

```
# raw:        snmp-server user pyclass ... priv 0xd1e3bf70 localizedkey
# sanitized (BEFORE):  ... auth md5 REDACTED-AUTH-1 priv 0xd1e3bf70 REDACTED-PRIV-1 localizedkey   ← key leaks
# sanitized (AFTER):   ... auth md5 REDACTED-AUTH-1 priv REDACTED-PRIV-1 localizedkey               ← clean
```

### Fix

- **parse**: cipher matched against an enumerated set (`aes-128`/`aes-192`/`aes-256`/`des`/`3des`); the bare `priv <key>` form now parses the key into the redacted `priv_passphrase` with empty `priv_protocol`. Explicit-cipher form unchanged.
- **render**: emit `priv` whenever a passphrase is set (not gated on `priv_protocol`), so the default-DES form round-trips faithfully (`priv <key> localizedkey`) instead of dropping the key.

### Tests

Existing explicit-cipher + auth-no-priv assertions unchanged. New `TestSNMPv3PrivNoCipherKeyLeak` covers: bare-priv parse lands the key in the sanitized field, faithful parse→render→parse round-trip, and the no-leak sanitize regression. NX-OS has no cross-vendor expectation YAMLs → no phase4 reclassification.

Full `tests/unit` + `tests/integration` green locally; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)