### PR TITLE
fix(parse): mikrotik bare-address /32 inference + opnsense DNS comma-split (dogfood corpus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,28 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **`mikrotik_routeros` no longer aborts a whole config over a bare
+  host address** (surfaced by the dogfood mesh harness on real
+  RouterOS `.rsc` exports). `/ip address` rows for loopbacks and VRRP
+  VIPs are commonly written `address=X ... network=X` with no CIDR
+  mask; the parser raised `ParseError: address 'X' missing CIDR
+  prefix` and dropped the entire device. A host whose network base
+  equals the host itself is only consistent with a `/32`, so the
+  parser now infers `/32` for a prefix-less address instead of failing
+  (20 real corpus configs went from hard-fail to clean parse). An
+  address carrying an explicit but non-numeric prefix (`X/bogus`)
+  still raises.
+
+- **`opnsense` splits comma-joined system DNS servers** (surfaced by
+  the dogfood mesh harness on real `config.xml`). A `<system>` config
+  that crams several resolvers into one element
+  (`<dnsserver>10.0.1.10, 10.0.1.11</dnsserver>`) was parsed as a
+  single bogus DNS entry, which then rendered as one malformed
+  name-server downstream (`ip name-server 10.0.1.10, 10.0.1.11`,
+  reparsing to `10.0.1.10,`). System `<dnsserver>` values are now
+  split on commas so each resolver becomes its own canonical entry,
+  matching the existing per-DHCP-zone handling.
+
 - **`cisco_nxos` SNMPv3 `priv` key no longer leaks through the
   sanitizer** (surfaced by the dogfood mesh harness on real napalm
   NX-OS captures). The USM parser assumed `priv <cipher> <key>` (two

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -803,21 +803,27 @@ def _parse_ip_address(
         iface_name = kv.get("interface")
         if not addr or not iface_name:
             continue
-        if "/" not in addr:
-            raise ParseError(
-                f"mikrotik_routeros: address {addr!r} missing CIDR prefix",
-                path=f"/ip address/{iface_name}",
-                snippet=line[:120],
-            )
-        ip_str, prefix_str = addr.split("/", 1)
-        try:
-            prefix_len = int(prefix_str)
-        except ValueError as e:
-            raise ParseError(
-                f"mikrotik_routeros: invalid CIDR prefix {prefix_str!r}",
-                path=f"/ip address/{iface_name}",
-                snippet=line[:120],
-            ) from e
+        if "/" in addr:
+            ip_str, prefix_str = addr.split("/", 1)
+            try:
+                prefix_len = int(prefix_str)
+            except ValueError as e:
+                raise ParseError(
+                    f"mikrotik_routeros: invalid CIDR prefix {prefix_str!r}",
+                    path=f"/ip address/{iface_name}",
+                    snippet=line[:120],
+                ) from e
+        else:
+            # No CIDR prefix on the address.  Real-world RouterOS configs
+            # (loopbacks, VRRP VIPs, rows authored/exported without the mask)
+            # commonly write ``address=X ... network=X`` — a host whose network
+            # base equals the host itself, which is only consistent with a /32.
+            # Infer /32 rather than aborting the entire config: it's the
+            # faithful reading of ``address==network`` and the safe, non-
+            # over-claiming default when the mask is simply absent.  Observed
+            # across the dogfood corpus on lo/loopback0/vrrpN host rows.
+            ip_str = addr
+            prefix_len = 32
         # Route VIP rows to the VRRP scratch — don't materialise a
         # phantom CanonicalInterface for ``vrrpN`` pseudo-names.
         if vrrp_scratch is not None and iface_name in vrrp_scratch:

--- a/netcanon/migration/codecs/opnsense/parse.py
+++ b/netcanon/migration/codecs/opnsense/parse.py
@@ -221,7 +221,16 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         # https://docs.opnsense.org/manual/settings_general.html.
         for dns_el in sys_el.findall("dnsserver"):
             if dns_el.text and dns_el.text.strip():
-                intent.dns_servers.append(dns_el.text.strip())
+                # Normally one IP per element, but real-world configs
+                # occasionally cram several into a single element
+                # (``<dnsserver>10.0.1.10, 10.0.1.11</dnsserver>``).  Split
+                # on commas so each resolver becomes its own canonical entry —
+                # otherwise the whole "10.0.1.10, 10.0.1.11" string renders as
+                # a single bogus name-server downstream.  Mirrors the
+                # per-DHCP-zone comma handling further below.
+                intent.dns_servers.extend(
+                    s.strip() for s in dns_el.text.split(",") if s.strip()
+                )
         # Local users — <system>/<user> entries.  OPNsense stores
         # users at the same level as <hostname>, each with name,
         # descr, password (bcrypt $2y$), uid, and an optional

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -212,13 +212,20 @@ class TestParseErrors:
         with pytest.raises(ParseError, match="looks like JSON"):
             MikroTikRouterOSCodec().parse('{"key": "value"}')
 
-    def test_ip_address_missing_prefix_raises(self):
+    def test_ip_address_missing_prefix_infers_host_32(self):
+        # Real RouterOS configs write bare host addresses (loopbacks, VRRP
+        # VIPs) as ``address=X ... network=X`` with no CIDR mask.  A host
+        # equal to its own network base is only consistent with /32, so we
+        # infer /32 rather than aborting the whole config.
         raw = (
             "/ip address\n"
-            "add address=10.0.0.2 interface=ether1\n"
+            "add address=10.0.0.2 interface=ether1 network=10.0.0.2\n"
         )
-        with pytest.raises(ParseError, match="missing CIDR prefix"):
-            MikroTikRouterOSCodec().parse(raw)
+        tree = MikroTikRouterOSCodec().parse(raw)
+        iface = next(i for i in tree.interfaces if i.name == "ether1")
+        assert len(iface.ipv4_addresses) == 1
+        assert iface.ipv4_addresses[0].ip == "10.0.0.2"
+        assert iface.ipv4_addresses[0].prefix_length == 32
 
     def test_ip_address_bogus_prefix_raises(self):
         raw = (

--- a/tests/unit/migration/test_opnsense.py
+++ b/tests/unit/migration/test_opnsense.py
@@ -56,6 +56,22 @@ class TestParse:
         assert tree.domain == "example.com"
         assert len(tree.interfaces) == 1
 
+    def test_system_dnsserver_comma_joined_splits(self):
+        """Real configs sometimes cram several resolvers into a single
+        ``<dnsserver>`` element (``10.0.1.10, 10.0.1.11``) instead of one
+        element per IP.  Each must become its own canonical entry, else the
+        whole comma-joined string renders as one bogus name-server (e.g.
+        ``ip name-server 10.0.1.10, 10.0.1.11`` → reparses to ``10.0.1.10,``).
+        """
+        xml = (
+            '<?xml version="1.0"?><opnsense><system>'
+            "<hostname>fw01</hostname>"
+            "<dnsserver>10.0.1.10, 10.0.1.11</dnsserver>"
+            "</system></opnsense>"
+        )
+        tree = OPNsenseCodec().parse(xml)
+        assert tree.dns_servers == ["10.0.1.10", "10.0.1.11"]
+
     def test_zone_interfaces_flatten_to_list(self):
         """OPNsense's native XML has <wan>, <lan>, <opt1> keyed by role,
         each carrying a ``<if>`` child that names the underlying physical


### PR DESCRIPTION
## What

Two parse-robustness gaps surfaced by the **dogfood mesh harness** (1098 real-world configs), triaged verify-first — both are genuine, low-risk, single-root-cause fixes.

### 1. `mikrotik_routeros` — bare host address `/32` inference
Real RouterOS `.rsc` exports write loopback / VRRP-VIP addresses as `address=X ... network=X` with **no CIDR mask**. The parser raised `ParseError: address 'X' missing CIDR prefix` and dropped the **entire device** — 220 mesh cells across ~20 distinct real configs.

A host whose network base equals the host itself is only consistent with `/32`, so we now infer `/32` for a prefix-less address instead of aborting. An address with an explicit but non-numeric prefix (`X/bogus`) still raises.

**Result:** mikrotik corpus parse rate `20 hard-fails → 0`.

### 2. `opnsense` — comma-joined system DNS servers
A `<system>` config that crams several resolvers into one element:
```xml
<dnsserver>10.0.1.10, 10.0.1.11</dnsserver>
```
…was kept as a single bogus `dns_servers` entry, which then rendered as one malformed name-server downstream (`ip name-server 10.0.1.10, 10.0.1.11`, reparsing to `10.0.1.10,` with a trailing comma). System `<dnsserver>` values are now split on commas so each resolver is its own canonical entry — mirroring the existing per-DHCP-zone handling in the same parser.

## Triage note (verify-first)
This closes the two real findings from the new-blood corpus triage. The remaining opnsense "codec-bug" cells were confirmed **non-bugs**: `.j2`/`.tftpl` template files with unrendered `{{ }}` / `${ }` placeholders (correctly rejected as non-config input), VLAN-count *growth* from legitimate target-side VLAN materialization (not data loss), and default-MTU suppression. Those are corpus-hygiene / expectation-YAML-accuracy items, not codec defects.

## Testing
- Updated `test_mikrotik_routeros`: missing-prefix now asserts `/32` inference (+ real `address==network` host case).
- Added `test_opnsense::test_system_dnsserver_comma_joined_splits`.
- Reproduced both fixes on the real corpus configs that were failing.
- Full `tests/unit/migration` + `tests/integration` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)