### PR TITLE
fix(sanitize): return 400 not 500 on out-of-range canonical input (live-dogfood finding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **`/api/v1/sanitize` (and the `netcanon sanitize` CLI) no longer
+  returns 500 on input that yields an out-of-range canonical value**
+  (surfaced by the dogfood mesh harness driving the LIVE endpoint). A
+  config that parses structurally but maps to a field outside its
+  canonical constraint -- e.g. an NX-OS `hsrp 301` group-id exceeding
+  the VRRP 0-255 range that `CanonicalVRRPGroup.group_id` enforces --
+  made the codec's `parse()` raise a pydantic `ValidationError` (not the
+  contract's `ParseError`), which escaped the route's `except ParseError`
+  and surfaced as a 500. `sanitize_text` now converts a parse-time
+  `ValidationError` into a `ParseError`, so the endpoint returns a clean
+  400 and the CLI reports it instead of dumping a traceback. (The
+  `/migration/plan` path already degraded to a failed job, not a 500.)
+
 - **`mikrotik_routeros` no longer aborts a whole config over a bare
   host address** (surfaced by the dogfood mesh harness on real
   RouterOS `.rsc` exports). `/ip address` rows for loopbacks and VRRP

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -133,7 +133,10 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from pydantic import ValidationError
+
 from ..migration.canonical.intent import CanonicalIntent
+from ..migration.codecs.base import ParseError
 from ..migration.codecs.registry import get_codec
 
 #: A DNS hostname: dot-separated labels (alnum, internal hyphen, and
@@ -222,7 +225,25 @@ def sanitize_text(
             f"Unknown source codec: {source_codec_name!r}. "
             f"See netcanon.migration.codecs.registry.list_codecs()."
         ) from e
-    intent = codec.parse(raw)
+    try:
+        intent = codec.parse(raw)
+    except ValidationError as e:
+        # The input parsed structurally but produced a canonical model that
+        # violates a field constraint (e.g. an NX-OS HSRP group-id > the
+        # VRRP 0-255 range mapped onto CanonicalVRRPGroup.group_id).  That's
+        # unparseable-as-canonical INPUT, not a server fault — surface it as
+        # a ParseError so callers honour the documented contract: the HTTP
+        # route returns 400 instead of leaking a 500, and the CLI reports it
+        # cleanly rather than dumping a pydantic traceback.
+        errs = e.errors()
+        detail = (
+            f"{'.'.join(str(x) for x in errs[0]['loc'])}: {errs[0]['msg']}"
+            if errs else str(e)
+        )
+        raise ParseError(
+            f"{source_codec_name}: input could not be represented as a "
+            f"valid canonical config ({detail})"
+        ) from e
     sanitized_intent, substitutions = sanitize_intent(intent)
 
     if dry_run:

--- a/tests/integration/test_sanitize_api.py
+++ b/tests/integration/test_sanitize_api.py
@@ -130,6 +130,27 @@ class TestSanitizeEndpointErrors:
         )
         assert response.status_code == 422
 
+    def test_out_of_range_input_returns_400_not_500(self, client):
+        """Input that parses structurally but yields an out-of-range
+        canonical value (NX-OS HSRP group-id 301 > the VRRP 0-255 range)
+        must return a clean 400, not a 500 leaking a pydantic
+        ValidationError.  Surfaced by the live /sanitize dogfood."""
+        raw = (
+            b"feature hsrp\n"
+            b"interface Vlan10\n"
+            b"  no shutdown\n"
+            b"  ip address 10.0.0.2/24\n"
+            b"  hsrp 301\n"
+            b"    ip 10.0.0.1\n"
+        )
+        response = client.post(
+            "/api/v1/sanitize",
+            data={"source_vendor": "cisco_nxos"},
+            files={"config": ("tor.cfg", raw, "text/plain")},
+        )
+        assert response.status_code == 400
+        assert "parse" in response.json()["detail"].lower()
+
 
 class TestSanitizeEndpointConsistency:
     """The HTTP endpoint must produce the same result as direct

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -42,6 +42,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalVRRPGroup,
     CanonicalVxlan,
 )
+from netcanon.migration.codecs.base import ParseError
 from netcanon.tools.sanitize import (
     SanitizationResult,
     Substitution,
@@ -715,6 +716,24 @@ class TestSanitizeTextEndToEnd:
     def test_unknown_codec_raises(self):
         with pytest.raises(ValueError, match="[Uu]nknown source codec"):
             sanitize_text("", "no_such_codec")
+
+    def test_out_of_range_input_raises_parse_error_not_validation_error(self):
+        # An NX-OS HSRP group-id of 301 exceeds the VRRP 0-255 range that
+        # CanonicalVRRPGroup.group_id enforces, so parse constructs an
+        # invalid model and pydantic raises ValidationError.  sanitize_text
+        # must convert that to a ParseError (contract) so the HTTP route
+        # returns a clean 400 rather than leaking a 500.  (Surfaced by the
+        # live /sanitize dogfood on a real NX-OS capture.)
+        raw = (
+            "feature hsrp\n"
+            "interface Vlan10\n"
+            "  no shutdown\n"
+            "  ip address 10.0.0.2/24\n"
+            "  hsrp 301\n"
+            "    ip 10.0.0.1\n"
+        )
+        with pytest.raises(ParseError, match="could not be represented"):
+            sanitize_text(raw, "cisco_nxos")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The **live `/sanitize` dogfood** (Mode-B over real HTTP, 767 corpus configs) surfaced one HTTP **500**: an NX-OS capture with `hsrp 301` — a group-id above the VRRP `0-255` range that `CanonicalVRRPGroup.group_id` enforces.

The codec's `parse()` constructed an invalid canonical model → pydantic raised a `ValidationError` (**not** the `parse()` contract's `ParseError`) → it escaped the route's `except ParseError` → FastAPI returned a **500**.

## Fix

`sanitize_text` now catches a parse-time `ValidationError` and re-raises it as `ParseError` with a concise message:

```
cisco_nxos: input could not be represented as a valid canonical config (group_id: Input should be less than or equal to 255)
```

The route's existing `ParseError` handler then returns a clean **400**, and the CLI reports it instead of dumping a pydantic traceback — honoring the documented `parse()` contract at the shared service boundary. (`/migration/plan` already degraded these to a failed job, not a 500.)

This is the **robustness half** of the finding. The **model half** — whether to widen `group_id` to represent NX-OS HSRPv2 groups (0-4095) rather than reject them — is a canonical-model decision tracked separately (Track-2); HSRP→VRRP is already declared lossy.

## Dogfood leak-guard result (for the record)
The same run confirmed the sanitize endpoint is **100% residual-clean** — 0 independent-scan leaks, 0 audit-consistency leaks over 767 configs (4,722 substitutions applied, p50 2.1ms). #227's leak-guard holds on the live HTTP deployment path.

## Testing
- Unit: `sanitize_text` raises `ParseError` (not `ValidationError`) on `hsrp 301`.
- Integration: `POST /api/v1/sanitize` returns **400** (not 500) for the same input.
- Full `tests/unit` + `tests/integration` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)