### PR TITLE
docs(changelog): cut [0.4.11] - 2026-06-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-06-30
+
 ### Fixed
 
 - **`/api/v1/sanitize` (and the `netcanon sanitize` CLI) no longer


### PR DESCRIPTION
Release cut for **v0.4.11**. Bundles the four post-0.4.10 fixes from `[Unreleased]`:

- **#225** — `cisco_iosxe` NETCONF probe no longer over-claims envelopes it can't parse
- **#226** — `cisco_nxos` SNMPv3 `priv` key no longer leaks through the sanitizer
- **#228** — `mikrotik_routeros` bare-address `/32` inference + `opnsense` system-DNS comma-split (dogfood corpus)
- **#229** — `/api/v1/sanitize` returns a clean 400 (not 500) on out-of-range canonical input (live-dogfood finding)

`setuptools_scm` derives the version from the git tag; tagging `v0.4.11` after this merges is the publish trigger (PyPI + Docker + MSI). The changelog guard (`tests/unit/test_changelog.py`) passes: `[0.4.11]` header is dated, unique, and strictly descending under the retained `[Unreleased]` anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)