### PR TITLE
test(mesh): committed CI guard for the cross-vendor fidelity/honesty baseline

### DIFF
--- a/tests/integration/test_cross_mesh_ci_guard.py
+++ b/tests/integration/test_cross_mesh_ci_guard.py
@@ -1,0 +1,175 @@
+"""CI guard: the cross-vendor mesh fidelity + honesty baseline.
+
+Runs the full committed-fixture mesh (``tools/run_full_mesh``) and the
+Phase-4 reconciliation (``tools/run_phase4_reconciliation``) IN-PROCESS
+and asserts the fidelity/honesty properties don't regress against the
+committed baseline (``tests/fixtures/real/_phase4_runs/latest.json``):
+
+* reparse of a codec's OWN render never crashes (an absolute invariant —
+  the exact class of regression #229 was, but locked in across every
+  committed fixture × target pair rather than one endpoint),
+* render failures stay within a documented allowlist (a new render crash
+  on the committed corpus is a codec regression),
+* the reconciled high-severity ``CODEC_BUG`` count doesn't exceed the
+  baseline (the confusion-matrix fidelity ratchet), and
+* no NEW codec-bug ``(source, target)`` pair appears.
+
+This turns the manual ``python tools/run_full_mesh.py`` +
+``run_phase4_reconciliation.py`` dogfood loop into a permanent CI
+invariant.  When a codec bug is legitimately fixed (``CODEC_BUG`` drops)
+or the fixture corpus changes, regenerate ``latest.json`` to ratchet the
+baseline (``python tools/run_phase4_reconciliation.py`` writes a fresh
+run; copy its aggregate into ``latest.json``).
+
+Runtime: the mesh is ~1200 cells / ~7s in-process — heavier than a unit
+test, hence ``integration``.  It writes NO timestamped JSON (calls the
+in-memory ``run_full_mesh()`` directly, not the CLI ``main``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BASELINE_PATH = (
+    _REPO_ROOT / "tests" / "fixtures" / "real" / "_phase4_runs" / "latest.json"
+)
+
+# Render failures EXPECTED on the committed corpus: the vyos synthetic
+# kitchen-sink carries constructs cisco_iosxe_cli / fortigate_cli have no
+# render path for.  Any render failure OUTSIDE this set is a regression.
+# (source_codec, target_codec)
+_ALLOWED_RENDER_FAILURES = {
+    ("vyos", "cisco_iosxe_cli"),
+    ("vyos", "fortigate_cli"),
+}
+
+
+def _load_tool(mod_name: str, rel_path: str):
+    """Import a ``tools/*.py`` runner without making ``tools/`` a package
+    (mirrors the pattern in tests/unit/audit)."""
+    path = _REPO_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mesh_and_recon(tmp_path_factory):
+    """Run the mesh + reconciliation ONCE for the whole module."""
+    rfm = _load_tool("run_full_mesh_ciguard", "tools/run_full_mesh.py")
+    recon = _load_tool(
+        "run_phase4_reconciliation_ciguard", "tools/run_phase4_reconciliation.py"
+    )
+    mesh = rfm.run_full_mesh()
+    # run_reconciliation reads a mesh JSON off disk; hand it an in-repo-free
+    # tmp path (the robust relative_to fallback handles the display path).
+    mesh_json = tmp_path_factory.mktemp("ciguard") / "mesh.json"
+    mesh_json.write_text(json.dumps(mesh), encoding="utf-8")
+    result = recon.run_reconciliation(mesh_json)
+    return mesh, result
+
+
+@pytest.fixture(scope="module")
+def baseline():
+    return json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+def _fixture_name(cell: dict) -> str:
+    return Path(cell["fixture"]).name
+
+
+def test_reparse_of_own_render_never_crashes(mesh_and_recon):
+    """Every cell whose render succeeded must reparse without crashing —
+    ``roundtrip_parse_status`` is only ever ``ok`` or ``skipped`` (skipped
+    tracks the render failures).  A codec that emits config its own parser
+    can't read (e.g. an out-of-range value, the #229 class) turns this red."""
+    mesh, _ = mesh_and_recon
+    crashed = [
+        c for c in mesh["cells"]
+        if c["roundtrip_parse_status"] not in ("ok", "skipped")
+    ]
+    assert not crashed, (
+        "reparse of the codec's own render crashed for:\n"
+        + "\n".join(
+            f"  {c['source_codec']} -> {c['target_codec']} "
+            f"[{_fixture_name(c)}]: {c['roundtrip_parse_status']}"
+            for c in crashed[:15]
+        )
+    )
+
+
+def test_render_failures_within_allowlist(mesh_and_recon):
+    """Render failures on the committed corpus stay within the documented
+    allowlist; a new (source, target) render crash is a codec regression."""
+    mesh, _ = mesh_and_recon
+    failing = {
+        (c["source_codec"], c["target_codec"])
+        for c in mesh["cells"]
+        if c["render_status"] != "ok"
+    }
+    new = failing - _ALLOWED_RENDER_FAILURES
+    assert not new, (
+        f"new render failure(s) beyond the allowlist: {sorted(new)}. "
+        "If intentional, add to _ALLOWED_RENDER_FAILURES with a reason; "
+        "otherwise it's a codec render regression."
+    )
+
+
+def test_codec_bug_count_within_baseline(mesh_and_recon, baseline):
+    """The reconciled high-severity CODEC_BUG count must not exceed the
+    committed baseline.  Uses ``<=`` so a legitimate FIX (fewer bugs)
+    passes — ratchet latest.json down when that happens."""
+    _, result = mesh_and_recon
+    live = result["aggregate"]["CODEC_BUG"]
+    base = baseline["aggregate"]["CODEC_BUG"]
+    assert live <= base, (
+        f"cross-vendor CODEC_BUG count regressed: live={live} > baseline={base}.\n"
+        f"live pairs: {result['pair_codec_bug_counts']}\n"
+        "A previously-good field now drifts on the committed corpus — "
+        "investigate the new pair before re-baselining."
+    )
+
+
+def test_no_new_codec_bug_pairs(mesh_and_recon, baseline):
+    """No NEW codec-bug (source, target) pair appears vs the baseline —
+    catches a regression even if the total count is coincidentally equal."""
+    _, result = mesh_and_recon
+    live_pairs = {
+        (p["source_codec"], p["target_codec"])
+        for p in result["pair_codec_bug_counts"]
+    }
+    base_pairs = {
+        (p["source_codec"], p["target_codec"])
+        for p in baseline["pair_codec_bug_counts"]
+    }
+    new = live_pairs - base_pairs
+    assert not new, (
+        f"new codec-bug pair(s) not in the baseline: {sorted(new)}. "
+        "A previously-clean codec pair now produces a high-severity "
+        "fidelity drift on the committed corpus."
+    )
+
+
+def test_mesh_cell_count_matches_baseline(mesh_and_recon, baseline):
+    """The baseline was computed on a fixed corpus size; if fixtures are
+    added/removed the count shifts and the CODEC_BUG baseline must be
+    regenerated alongside — this makes that coupling explicit rather than
+    letting a silently-shrunk corpus weaken the ratchet."""
+    mesh, _ = mesh_and_recon
+    assert mesh["cells_total"] == baseline["cells_total"], (
+        f"mesh cell count {mesh['cells_total']} != baseline "
+        f"{baseline['cells_total']}. Adding/removing a fixture (or a codec) "
+        "changes this — regenerate tests/fixtures/real/_phase4_runs/latest.json "
+        "(python tools/run_phase4_reconciliation.py) and commit it."
+    )

--- a/tools/run_phase4_reconciliation.py
+++ b/tools/run_phase4_reconciliation.py
@@ -1018,7 +1018,15 @@ def run_reconciliation(mesh_json_path: Path) -> dict[str, Any]:
 
     return {
         "started_utc": started,
-        "mesh_json": mesh_json_path.relative_to(_REPO_ROOT).as_posix(),
+        # Display path only.  A mesh JSON handed in from outside the repo
+        # tree (e.g. a pytest tmp_path when a CI guard reconciles an
+        # in-memory mesh) isn't relative to _REPO_ROOT — fall back to the
+        # bare filename rather than letting relative_to() raise.
+        "mesh_json": (
+            mesh_json_path.relative_to(_REPO_ROOT).as_posix()
+            if mesh_json_path.is_relative_to(_REPO_ROOT)
+            else mesh_json_path.name
+        ),
         "mesh_run_started_utc": mesh.get("started_utc"),
         "cells_total": len(cells_out),
         "expectation_yamls_loaded": len(expectations),


### PR DESCRIPTION
## What

Turns the manual dogfood loop (`tools/run_full_mesh.py` + `tools/run_phase4_reconciliation.py`) into a **permanent CI invariant**. A new integration test runs the full committed-fixture mesh (~1224 cells, ~7s) in-process and asserts, against the tracked baseline `tests/fixtures/real/_phase4_runs/latest.json`:

- **reparse of a codec's OWN render never crashes** — an absolute invariant (`roundtrip_parse_status` ∈ {ok, skipped}). This is the #229 `ValidationError`-on-parse class, but locked in across *every* committed fixture × target pair rather than one endpoint.
- **render failures stay within a documented allowlist** — currently only `vyos` kitchen-sink → `cisco_iosxe_cli` / `fortigate_cli`. A new render crash is a codec regression.
- **reconciled high-severity `CODEC_BUG` ≤ baseline (5)** — the confusion-matrix fidelity ratchet. `≤` so a legitimate fix passes; regenerate `latest.json` to ratchet down.
- **no NEW codec-bug `(source, target)` pair** vs baseline.
- **mesh cell count == baseline** — forces re-baselining `latest.json` when the corpus changes, so a silently-shrunk corpus can't weaken the ratchet.

## Why

The tracked baseline (`latest.json`, CODEC_BUG=5) existed, but **nothing in CI compared live mesh results against it** — a regression that broke a fixture round-trip or raised CODEC_BUG wouldn't turn CI red. This closes that gap on the already-committed, licensed corpus (no fixture licensing/PII concerns).

## Tool robustness (1 line)

`run_reconciliation`'s `mesh_json` display-path now falls back to the bare filename when the mesh JSON is outside the repo tree (a pytest `tmp_path`), instead of letting `relative_to()` raise. This is what lets the guard reconcile an **in-memory** mesh without writing a timestamped JSON into the gitignored, disk-filling run dirs.

## Testing
- New `tests/integration/test_cross_mesh_ci_guard.py` — 5 passing (8.5s).
- Existing `tests/unit/audit` green (relative_to change safe).
- No CHANGELOG entry (test + internal-tool robustness, not user-facing — same convention as the #227 test-only PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)