### PR TITLE
fix(mikrotik): shut VLAN/bridge/loopback interface no longer silently re-enables (negation-semantics dogfood)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mikrotik_routeros` no longer silently re-enables a shut interface**
+  (surfaced by the dogfood negation-semantics sweep). A source interface
+  administratively down (`enabled=False`) rendered to RouterOS as a VLAN
+  SVI, bridge, or loopback dropped the `disabled=yes` attribute — only the
+  physical-ethernet path emitted it — so RouterOS defaulted the interface
+  up and the shutdown silently INVERTED on reparse (a shut interface came
+  back up). The vlan/bridge/loopback `add` paths now emit `disabled=yes`
+  when the interface is disabled, and the bridge parser reads `disabled=`
+  so a shut loopback round-trips too. Was 10 real shut→up inversions on
+  the aruba_aoscx / cisco_iosxr → mikrotik pairs; the lone remaining case
+  (iosxr→aruba_aoss loopback) is a genuine AOS-S platform limitation
+  (loopbacks are always-up), not a defect.
+
 ## [0.4.11] - 2026-06-30
 
 ### Fixed

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -483,6 +483,11 @@ def _parse_interface_bridge(
         )
         if "comment" in kv:
             iface.description = kv["comment"]
+        # Admin-state — a bridge/loopback added with ``disabled=yes`` is
+        # shut; mirror the ethernet/vlan handlers so a disabled loopback
+        # round-trips instead of silently coming back up.
+        if "disabled" in kv:
+            iface.enabled = kv["disabled"].lower() == "no"
 
 
 def _parse_interface_bonding(

--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -279,6 +279,8 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             if iface.description:
                 parts.append(f'comment="{_escape(iface.description)}"')
             parts.append(f"name={_quote_if_needed(iface.name)}")
+            if not iface.enabled:
+                parts.append("disabled=yes")
             lines.append(" ".join(parts))
             emitted_bridge_names.add(iface.name)
         # Loopback interfaces — same /interface bridge section,
@@ -296,6 +298,8 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             if iface.description:
                 parts.append(f'comment="{_escape(iface.description)}"')
             parts.append(f"name={_quote_if_needed(iface.name)}")
+            if not iface.enabled:
+                parts.append("disabled=yes")
             lines.append(" ".join(parts))
             emitted_bridge_names.add(iface.name)
         # The synthetic add is idempotent — track which bridge
@@ -433,6 +437,11 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             parts.append(f"interface={_quote_if_needed(vlan_parent_name)}")
             parts.append(f"name={_quote_if_needed(iface.name)}")
             parts.append(f"vlan-id={vid}")
+            # Admin-state: a shut VLAN SVI must carry disabled=yes, else
+            # RouterOS defaults it up and the shutdown silently inverts on
+            # reparse (the ethernet path above already emits this).
+            if not iface.enabled:
+                parts.append("disabled=yes")
             lines.append(" ".join(parts))
             rendered_vlan_ids.add(vid)
         # VLANs defined in intent.vlans but without a matching

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -242,6 +242,33 @@ class TestParseErrors:
 
 
 class TestRender:
+    def test_shut_vlan_svi_and_loopback_round_trip_disabled(self):
+        """A shut (enabled=False) VLAN SVI or loopback MUST render
+        ``disabled=yes`` and round-trip as disabled.  Otherwise RouterOS
+        defaults the interface up and the admin-down state silently INVERTS
+        on reparse — a dangerous shut-becomes-up translation surfaced by the
+        dogfood negation-semantics sweep (was 10 real inversions on the
+        aruba_aoscx/cisco_iosxr -> mikrotik pairs).  The ethernet path
+        already emitted disabled=; the vlan/bridge/loopback add-paths did not.
+        """
+        tree = CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(
+                    name="vlan100", interface_type="ianaift:l3ipvlan",
+                    enabled=False),
+                CanonicalInterface(
+                    name="lo0", interface_type="ianaift:softwareLoopback",
+                    enabled=False),
+            ],
+            vlans=[CanonicalVlan(id=100, name="vlan100")],
+        )
+        text = MikroTikRouterOSCodec().render(tree)
+        assert text.count("disabled=yes") >= 2, text
+        rt = MikroTikRouterOSCodec().parse(text)
+        by_name = {i.name: i for i in rt.interfaces}
+        assert by_name["vlan100"].enabled is False
+        assert by_name["lo0"].enabled is False
+
     def test_render_deterministic(self):
         tree = MikroTikRouterOSCodec().parse(_MIN)
         a = MikroTikRouterOSCodec().render(tree)


### PR DESCRIPTION
## What

The dogfood **negation-semantics** sweep (blind-spot #5 — *does an explicitly negated/disabled state survive translation, or silently invert to the default?*) found **10 real shut→up inversions** on the `aruba_aoscx` / `cisco_iosxr` → `mikrotik_routeros` pairs: a source interface that is administratively **down** (`enabled=False`) came back **up** after translation.

## Root cause

The mikrotik render emitted `disabled=` only on the **physical-ethernet** `set [ find … ]` path. Interfaces created via the `add`-form paths — **VLAN SVIs** (`/interface vlan`), **bridges**, and **loopbacks** (`/interface bridge`) — dropped the attribute. So a shut interface rendered *without* `disabled=yes`, RouterOS defaulted it up, and the shutdown **silently inverted** on reparse. mikrotik declares `/interfaces/interface/config/enabled` as **supported**, so this was a declared-supported × observed-dropped silent loss — and worse, a semantic inversion (a translator quietly bringing a down interface up).

## Fix

- Render: the vlan/bridge/loopback `add`-paths now append `disabled=yes` when the interface is disabled (matching the ethernet path).
- Parse: the VLAN parser already read `disabled=`; the **bridge parser did not**, so a shut loopback (rendered as an empty bridge) now round-trips — added the `disabled=` read to `_parse_interface_bridge`.

**Negation sweep result: 11 → 1 inversion.** The lone remaining case (`cisco_iosxr → aruba_aoss` loopback) is a genuine **AOS-S platform limitation** (loopbacks are always-up; the aoss render deliberately omits the enable/disable toggle), verified against the render code — **not a defect**.

## Testing
- New regression test: a shut VLAN SVI + loopback render `disabled=yes` and round-trip `enabled=False`.
- Full `tests/unit/migration` + `tests/integration` green, incl. the cross-mesh CI guard (#231 baseline held — no CODEC_BUG/cell-count regression), round-trip stability, and the mikrotik kitchen-sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)