### PR TITLE
fix(arista): detect marker-light EOS via .swi boot image + RANCID header (detection label-noise dogfood)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **`arista_eos` auto-detection no longer mis-classifies marker-light EOS
+  configs as `cisco_iosxe_cli`** (surfaced by the dogfood detection
+  label-noise sweep). Real EOS configs whose only vendor tell was a `.swi`
+  boot image or a `!RANCID-CONTENT-TYPE: arista` collection header — with no
+  `! device: … EOS-` banner — scored 0 on the Arista probe and fell through
+  to the generic IOS-CLI codec (batfish `eos_mlag` / `arista-originator` /
+  `arista_dhcp_relay` were detected as `cisco_iosxe_cli` at margin 70-90).
+  The probe now recognises the Arista-unique `.swi` boot image (Cisco boots
+  `.bin`) and the `RANCID-CONTENT-TYPE` header. Corpus detection agreement
+  vs batfish's own filename labels rose 81% → 94%.
+
 - **`mikrotik_routeros` no longer silently re-enables a shut interface**
   (surfaced by the dogfood negation-semantics sweep). A source interface
   administratively down (`enabled=False`) rendered to RouterOS as a VLAN

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -462,6 +462,25 @@ class AristaEOSCodec(CodecBase):
             return None
         if re.search(r"^!\s*device:.*EOS-", raw_prefix, re.MULTILINE):
             return (98, "Arista EOS '! device: ... EOS-' banner present")
+        # EOS software image: the ``.swi`` (SWitch Image) extension on a
+        # ``boot system`` line is Arista-unique (Cisco boots ``.bin``), and
+        # real captures carry it even without the ``! device:`` banner.
+        # Tolerate a leading ``! `` (the boot line is often a header comment).
+        # Without this, marker-light EOS configs (mlag/BGP topologies) fell
+        # through to cisco_iosxe_cli — surfaced by the dogfood detection
+        # label-noise sweep (batfish eos_mlag / arista-originator detected as
+        # cisco_iosxe_cli at margin 70-90).
+        if re.search(r"^!?\s*boot system\b.*\.swi\b", raw_prefix, re.MULTILINE):
+            return (95, "Arista EOS boot image (.swi)")
+        # RANCID / oxidized collection header — an explicit, operator-tool
+        # vendor declaration (real config repos carry it).  Zero false-positive
+        # (it names the vendor) and higher-signal than IOS-lookalike content,
+        # so marker-light EOS (dhcp-relay / interface / misc feature snippets)
+        # stops falling through to cisco_iosxe_cli.  Same dogfood label-noise
+        # finding as the .swi marker above.
+        if re.search(r"^!\s*RANCID-CONTENT-TYPE:\s*arista\b",
+                     raw_prefix, re.MULTILINE | re.IGNORECASE):
+            return (97, "RANCID-CONTENT-TYPE: arista header")
         hits = 0
         if re.search(r"^daemon TerminAttr", raw_prefix, re.MULTILINE):
             hits += 1

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -954,6 +954,37 @@ class TestProbe:
         score, _ = result
         assert score >= 90  # 3+ markers
 
+    def test_swi_boot_image_signal(self):
+        # A `.swi` boot image is Arista-unique (Cisco boots `.bin`); marker-
+        # light EOS with this line (but no `! device:` banner) must not fall
+        # through to cisco_iosxe_cli.  Dogfood detection label-noise finding
+        # (batfish eos_mlag was detected as cisco_iosxe_cli @margin 90).
+        raw = (
+            "! boot system flash:/EOS-4.19.1F.swi\n"
+            "!\n"
+            "hostname eos_mlag\n"
+            "interface Port-Channel1\n"
+        )
+        result = AristaEOSCodec.probe(raw)
+        assert result is not None
+        score, reason = result
+        assert score >= 95
+        assert ".swi" in reason
+
+    def test_rancid_content_type_header_signal(self):
+        # RANCID/oxidized collection header — explicit vendor declaration.
+        raw = (
+            "!RANCID-CONTENT-TYPE: arista\n"
+            "!\n"
+            "hostname arista_dhcp_relay\n"
+            "ip dhcp relay always-on\n"
+        )
+        result = AristaEOSCodec.probe(raw)
+        assert result is not None
+        score, reason = result
+        assert score >= 95
+        assert "RANCID" in reason
+
     def test_no_signal_returns_none(self):
         raw = "hostname router1\ninterface GigabitEthernet0/0\n"
         # Cisco-ish grammar — Arista probe shouldn't claim it.


### PR DESCRIPTION
## What

The dogfood **detection label-noise** sweep (cross-checking `detect_codec` vs batfish's own filename labels) found genuinely-Arista EOS configs detected as `cisco_iosxe_cli` — some *confidently* (margin 70-90).

Root cause: the arista probe's strong signal was the `! device: … EOS-` banner, but marker-light EOS configs whose only vendor tell was a **`.swi` boot image** or a **`!RANCID-CONTENT-TYPE: arista`** collection header scored 0 on the arista probe and fell through to the generic IOS-CLI codec. Verified as real EOS (`mlag`, `trunk group`, prefix-length addressing, `.swi` image): `eos_mlag`, `arista-originator`, `arista_dhcp_relay`.

## Fix

The arista probe now recognises two Arista-unique signals:
- the **`.swi`** (SWitch Image) boot line — Cisco boots `.bin` — at confidence 95;
- the **`!RANCID-CONTENT-TYPE: arista`** collection header at 97.

Both are zero-false-positive (a full-corpus scan confirms no `.swi`-boot config detects as non-arista). Corpus detection agreement vs batfish's independent filename labels rose **81% → 94%**.

## Follow-up (characterized, not in this PR)

The 4 remaining disagreements are NX-OS BGP snippets tied at margin 0 with `cisco_iosxe_cli`, carrying `feature bgp` / `vrf context` / `!RANCID-CONTENT-TYPE: cisco-nx` markers the nxos probe doesn't key on — same fix pattern, distinct codec, its own scoped pass. (Also worth generalising `RANCID-CONTENT-TYPE` across all probes.)

## Testing
- Regression tests: `.swi` boot image + RANCID header each yield a ≥95 Arista signal.
- Full `tests/unit/migration` + `tests/integration` green, incl. the cross-mesh CI guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)