### PR TITLE
feat(codecs): capture source_version on parse for the 9 remaining codecs

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -188,6 +188,25 @@ _GLOBAL_VARP_MAC_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+#: EOS release from the ``! device:`` banner, e.g.
+#: ``! device: sw1 (DCS-7280SR, EOS-4.27.0F)`` → ``4.27.0F``.  The banner
+#: is the only place EOS emits its release string; the ``.swi`` boot line
+#: carries an image *filename* (``vEOS-lab.swi``), not a version, so we
+#: anchor on the parenthesised ``EOS-<ver>)`` form to avoid matching it.
+#: Captures the full token (4-segment ``4.21.1.1F`` and ``4.22.4M-2GB``).
+_VERSION_RE = re.compile(r"EOS-([\w.\-]+)\)")
+
+
+def _extract_version(raw: str) -> str:
+    """Return the EOS release string from the ``! device:`` banner.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
+    render path synthesises a fresh banner rather than echoing this, so it
+    is informational.  Returns ``""`` when no banner is present.
+    """
+    m = _VERSION_RE.search(raw)
+    return m.group(1) if m else ""
+
 
 def _vrrp_group_for(
     iface: CanonicalInterface, gid: int, mode: str = "vrrp",
@@ -377,6 +396,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     m = _HOSTNAME_RE.search(raw)
     if m:
         intent.hostname = m.group(1)
+    intent.source_version = _extract_version(raw)
     for dns_m in _DNS_SERVER_RE.finditer(raw):
         intent.dns_servers.append(dns_m.group(1))
     m = _DNS_DOMAIN_RE.search(raw)

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -320,6 +320,24 @@ def _unquote(s: str) -> str:
     return s
 
 
+#: AOS-Switch (ProVision) release from the ``Created on release #`` banner
+#: comment, e.g. ``; JL258A Configuration Editor; Created on release
+#: #WC.16.10.0005`` → ``WC.16.10.0005``.  Rendered templates omit the
+#: release token (``Created via template render``) → honest ``""``.
+_VERSION_RE = re.compile(r"Created on release #(\S+)", re.MULTILINE)
+
+
+def _extract_version(raw: str) -> str:
+    """Return the AOS-Switch release from the config-editor banner comment.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
+    render path does not echo it, so it is informational.  Returns ``""``
+    when no release banner is present.
+    """
+    m = _VERSION_RE.search(raw)
+    return m.group(1) if m else ""
+
+
 def _dest_to_cidr(dest: str) -> str:
     """Accept either ``A.B.C.D/N`` or just ``A.B.C.D``; default /32."""
     if "/" in dest:
@@ -804,6 +822,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         source_vendor="aruba_aoss",
         source_format="cli-aruba-aoss",
     )
+    intent.source_version = _extract_version(raw)
 
     lines = raw.splitlines()
     i = 0

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -136,9 +136,12 @@ _NS_IP = "http://openconfig.net/yang/interfaces/ip"
 #: ``version`` line — so we match the element namespace-agnostically.
 #: Interface-only ``<interfaces>`` fragments carry no system subtree, so
 #: absence is the honest common case (→ ``""``); a full ``get-config``
-#: reply that includes ``<system>`` yields the release.
+#: reply that includes ``<system>`` yields the release.  The element text
+#: is captured with a single greedy ``[^<]+`` (stops at the closing tag)
+#: and stripped in Python — NOT wrapped in ``\s*``, whose overlap with
+#: ``[^<]`` is a polynomial-ReDoS backtracking hazard on hostile input.
 _VERSION_RE = re.compile(
-    r"<(?:[\w.-]+:)?software-version>\s*([^<]+?)\s*</", re.IGNORECASE
+    r"<(?:[\w.-]+:)?software-version>([^<]+)</", re.IGNORECASE
 )
 
 

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -84,6 +84,7 @@ Round-trip invariant (proven in unit tests):
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 from xml.etree import ElementTree as ET
@@ -127,6 +128,29 @@ logger = logging.getLogger(__name__)
 # without having to track which exact prefix the device used.
 _NS_IF = "http://openconfig.net/yang/interfaces"
 _NS_IP = "http://openconfig.net/yang/interfaces/ip"
+
+#: OpenConfig system-state software version, e.g.
+#: ``openconfig-system:system/state/software-version``.  Unlike the CLI
+#: sibling (``cisco_iosxe_cli``), the NETCONF/OpenConfig wire format
+#: carries the release in a ``<software-version>`` element, not a
+#: ``version`` line — so we match the element namespace-agnostically.
+#: Interface-only ``<interfaces>`` fragments carry no system subtree, so
+#: absence is the honest common case (→ ``""``); a full ``get-config``
+#: reply that includes ``<system>`` yields the release.
+_VERSION_RE = re.compile(
+    r"<(?:[\w.-]+:)?software-version>\s*([^<]+?)\s*</", re.IGNORECASE
+)
+
+
+def _extract_version(raw: str) -> str:
+    """Return the IOS-XE release from an OpenConfig ``<software-version>``
+    element, or ``""`` when the payload carries no system subtree.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
+    render path does not echo it, so it is informational.
+    """
+    m = _VERSION_RE.search(raw)
+    return m.group(1).strip() if m else ""
 
 
 @register
@@ -784,6 +808,7 @@ class CiscoIOSXECodec(CodecBase):
             source_vendor="cisco_iosxe",
             source_format="xml-netconf",
         )
+        intent.source_version = _extract_version(raw)
         for idx, iface_el in enumerate(interfaces_el.findall(_q("interface"))):
             raw_iface = _parse_interface(iface_el, idx=idx)
             intent.interfaces.append(_iface_dict_to_canonical(raw_iface))

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -230,6 +230,10 @@ def _infer_type(iface_name: str) -> str:
 
 
 _HOSTNAME_RE = re.compile(r"^hostname\s+(\S+)", re.IGNORECASE | re.MULTILINE)
+#: Running-config ``version 17.9`` header — first token after a column-0
+#: ``version`` keyword is the IOS/IOS-XE release.  Partial/tolerance
+#: captures omit the header, so absence is honest (→ ``""``).
+_VERSION_RE = re.compile(r"^version\s+(\S+)", re.IGNORECASE | re.MULTILINE)
 _VLAN_RE = re.compile(r"^vlan\s+(\d+)", re.IGNORECASE)
 _VLAN_NAME_RE = re.compile(r"^\s+name\s+(.+)", re.IGNORECASE)
 _STATIC_ROUTE_RE = re.compile(
@@ -427,6 +431,7 @@ def parse_intent(raw: str) -> CanonicalIntent:
 
     # System-level fields
     intent.hostname = _extract_hostname(raw)
+    intent.source_version = _extract_version(raw)
 
     # Top-level system services: domain name, DNS resolvers, NTP
     # servers.  Mirrors arista_eos prior art — same wire syntax in the
@@ -536,6 +541,17 @@ def parse_intent(raw: str) -> CanonicalIntent:
 
 def _extract_hostname(raw: str) -> str:
     m = _HOSTNAME_RE.search(raw)
+    return m.group(1) if m else ""
+
+
+def _extract_version(raw: str) -> str:
+    """Return the IOS/IOS-XE release from the running-config ``version`` line.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); render
+    synthesises its own preamble rather than echoing this, so it is
+    informational.  Returns ``""`` for partial captures with no header.
+    """
+    m = _VERSION_RE.search(raw)
     return m.group(1) if m else ""
 
 

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -152,6 +152,22 @@ _CONFIG_HEADER_RE = re.compile(r"^config\s+(.+?)\s*$", re.IGNORECASE)
 _EDIT_HEADER_RE = re.compile(r"^edit\s+(.+?)\s*$", re.IGNORECASE)
 _SET_RE = re.compile(r"^set\s+(\S+)\s*(.*)$", re.IGNORECASE)
 _COMMENT_RE = re.compile(r"^\s*#")
+#: FortiOS release from the ``#config-version`` header, e.g.
+#: ``#config-version=FG100E-7.2.13-FW-build1762-...`` → ``7.2.13``.  The
+#: model token has no fixed length (FGT70G / FGVM64 / FG100E), so the lazy
+#: ``\S+?`` stops at the first hyphen after the model, before the triple.
+_VERSION_RE = re.compile(r"#config-version=\S+?-(\d+\.\d+\.\d+)", re.MULTILINE)
+
+
+def _extract_version(raw: str) -> str:
+    """Return the FortiOS release from the ``#config-version`` header.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
+    render path does not echo it, so it is informational.  Returns ``""``
+    when the header is absent.
+    """
+    m = _VERSION_RE.search(raw)
+    return m.group(1) if m else ""
 
 
 def _tokenize_set(value: str) -> list[str]:
@@ -895,6 +911,7 @@ def parse_intent(raw: str) -> CanonicalIntent:
         source_vendor="fortigate",
         source_format="cli-fortigate",
     )
+    intent.source_version = _extract_version(raw)
 
     blocks = _parse_blocks(raw)
     # Track which top-level paths we saw vs which we dispatched — the

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -154,9 +154,13 @@ _SET_RE = re.compile(r"^set\s+(\S+)\s*(.*)$", re.IGNORECASE)
 _COMMENT_RE = re.compile(r"^\s*#")
 #: FortiOS release from the ``#config-version`` header, e.g.
 #: ``#config-version=FG100E-7.2.13-FW-build1762-...`` → ``7.2.13``.  The
-#: model token has no fixed length (FGT70G / FGVM64 / FG100E), so the lazy
-#: ``\S+?`` stops at the first hyphen after the model, before the triple.
-_VERSION_RE = re.compile(r"#config-version=\S+?-(\d+\.\d+\.\d+)", re.MULTILINE)
+#: model token has no fixed length (FGT70G / FGVM64 / FG100E) but is always
+#: alphanumeric, so ``[A-Za-z0-9]+`` matches it exactly up to the hyphen
+#: delimiter — deliberately NOT ``\S+?`` (whose overlap with the ``-``
+#: delimiter is a polynomial-ReDoS backtracking hazard on hostile input).
+_VERSION_RE = re.compile(
+    r"#config-version=[A-Za-z0-9]+-(\d+\.\d+\.\d+)", re.MULTILINE
+)
 
 
 def _extract_version(raw: str) -> str:

--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -137,6 +137,9 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         source_vendor="juniper_junos",
         source_format="cli-junos-set",
     )
+    # Extract from the ORIGINAL input (``stripped``), not the possibly
+    # block→set-converted ``raw`` — the regex handles either form.
+    intent.source_version = _extract_version(stripped)
 
     # Interface accumulator — Junos set-form spreads interface
     # config across many lines; we collect per-iface state
@@ -826,6 +829,27 @@ def _tokenise_set(payload: str) -> list[str]:
         return shlex.split(payload, posix=True)
     except ValueError:
         return payload.split()
+
+
+#: Junos release string.  Present in BOTH forms as a top-level statement:
+#: set-form ``set version 25.4R1.12`` (``display set``) and block-form
+#: ``version 25.4R1.12;`` — the optional ``set`` prefix + optional trailing
+#: ``;`` make one regex cover both.  ``[\w.\-]+`` excludes the block-form
+#: semicolon.  Extracted from the ORIGINAL input (pre block→set conversion).
+_VERSION_RE = re.compile(
+    r'^(?:set\s+)?version\s+"?([\w.\-]+)"?;?\s*$', re.MULTILINE
+)
+
+
+def _extract_version(raw: str) -> str:
+    """Return the Junos release from the top-level ``version`` statement.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
+    render path does not echo it, so it is informational.  Returns ``""``
+    when the capture carries no version statement.
+    """
+    m = _VERSION_RE.search(raw)
+    return m.group(1) if m else ""
 
 
 # ---------------------------------------------------------------------------

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -96,6 +96,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         source_vendor="mikrotik_routeros",
         source_format="cli-mikrotik",
     )
+    intent.source_version = _extract_version(raw)
 
     # Pre-process: join `\` line continuations.
     joined = _join_continuations(raw)
@@ -222,6 +223,22 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
 
 _SECTION_RE = re.compile(r"^(/[a-zA-Z][a-zA-Z0-9 \-]*)$")
 _COMMENT_RE = re.compile(r"^\s*#")
+#: RouterOS release from the export header comment, e.g.
+#: ``# 2026-04-21 20:35:02 by RouterOS 7.18.2`` → ``7.18.2`` (also matches
+#: the older ``by RouterOS 6.48.6`` form).  Versions are 2-3 dotted
+#: components; ``\d[\w.]*`` captures the whole token.
+_VERSION_RE = re.compile(r"RouterOS\s+(\d[\w.]*)", re.MULTILINE)
+
+
+def _extract_version(raw: str) -> str:
+    """Return the RouterOS release from the export header comment.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
+    render path does not echo it, so it is informational.  Returns ``""``
+    when the header comment is absent.
+    """
+    m = _VERSION_RE.search(raw)
+    return m.group(1) if m else ""
 
 
 def _join_continuations(raw: str) -> str:

--- a/netcanon/migration/codecs/opnsense/parse.py
+++ b/netcanon/migration/codecs/opnsense/parse.py
@@ -202,6 +202,14 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         source_vendor="opnsense",
         source_format="xml-opnsense",
     )
+    # NOTE: source_version is intentionally left empty for OPNsense.
+    # The only version-like element in config.xml is the top-level
+    # ``<version>`` (e.g. ``11.2``), which is the config-SCHEMA revision
+    # (bumped by config migrations), NOT the OPNsense OS/firmware release
+    # (25.x / 24.x — never written to config.xml).  Capturing the schema
+    # rev into source_version would conflate two different axes and poison
+    # any downstream "version as a translation vector" analysis, so we
+    # honestly record nothing rather than a misleading value.
 
     # ----- <system> block -----
     sys_el = root.find("system")

--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -88,6 +88,7 @@ single-device SVD ``vlan-to-vni``, per-VRF static routes (``vrf name
 from __future__ import annotations
 
 import logging
+import re
 
 from ...canonical.intent import (
     CanonicalIntent,
@@ -126,6 +127,27 @@ def _unquote(value: str) -> str:
     if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
         return v[1:-1]
     return v
+
+
+#: VyOS OS release from the trailing ``// Release version:`` comment
+#: block, e.g. ``// Release version: 1.4-rolling-202307070317`` → the
+#: whole token.  This is the ACTUAL firmware version — deliberately NOT
+#: the ``// vyos-config-version: "..."`` line, which is a config-schema
+#: migration marker, not the OS release (matching "Release version"
+#: literally excludes it).
+_VERSION_RE = re.compile(r"//\s+Release\s+version:\s+(\S+)", re.MULTILINE)
+
+
+def _extract_version(raw: str) -> str:
+    """Return the VyOS release from the trailing ``// Release version:``
+    comment.
+
+    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
+    render path does not echo it, so it is informational.  Returns ``""``
+    when the trailing comment block is absent.
+    """
+    m = _VERSION_RE.search(raw)
+    return m.group(1) if m else ""
 
 
 def _split_header(header: str) -> tuple[str, str]:
@@ -304,11 +326,18 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             snippet=raw.lstrip()[:120],
         )
 
+    # Capture the OS release from the trailing "// Release version:"
+    # comment on the ORIGINAL input, before the set→brace conversion (the
+    # trailing comment block is a brace-form artifact and may not survive
+    # conversion).
+    _source_version = _extract_version(raw)
+
     # Accept set-form (`show configuration commands`) by converting it to
     # the equivalent curly-brace text up front; idempotent on brace input.
     raw = _setform_to_brace(raw)
 
     intent = CanonicalIntent(source_vendor="vyos", source_format="cli-vyos")
+    intent.source_version = _source_version
 
     # Per-interface scratch keyed by canonical name (preserves first-seen
     # order via ``iface_order``).

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -39,6 +39,36 @@ class TestParseScalars:
         intent = AristaEOSCodec().parse("hostname sw-edge-01\n")
         assert intent.hostname == "sw-edge-01"
 
+    def test_source_version(self):
+        """EOS release captured from the ``! device:`` banner (metadata)."""
+        raw = (
+            "! device: sw1 (DCS-7280SR-48C6, EOS-4.27.0F)\n"
+            "hostname sw1\n"
+        )
+        intent = AristaEOSCodec().parse(raw)
+        assert intent.source_version == "4.27.0F"
+
+    def test_source_version_four_segment_and_swi_line(self):
+        """Full 4-segment release captured; the ``.swi`` boot line (an image
+        filename, not a version) must NOT be mistaken for the release."""
+        raw = (
+            "! device: r1 (vEOS, EOS-4.23.0.1F)\n"
+            "hostname r1\n"
+            "boot system flash:/vEOS-lab.swi\n"
+        )
+        intent = AristaEOSCodec().parse(raw)
+        assert intent.source_version == "4.23.0.1F"
+
+    def test_source_version_maintenance_suffix(self):
+        raw = "! device: s1 (DCS-7150S-64-CL, EOS-4.22.4M-2GB)\nhostname s1\n"
+        intent = AristaEOSCodec().parse(raw)
+        assert intent.source_version == "4.22.4M-2GB"
+
+    def test_source_version_absent(self):
+        """No banner → honest empty string, not a spurious capture."""
+        intent = AristaEOSCodec().parse("hostname sw1\n")
+        assert intent.source_version == ""
+
     def test_dns_servers(self):
         raw = (
             "hostname sw1\n"

--- a/tests/unit/migration/test_aruba_aoss.py
+++ b/tests/unit/migration/test_aruba_aoss.py
@@ -182,6 +182,20 @@ class TestParse:
         tree = ArubaAOSSCodec().parse(_MIN)
         assert tree.hostname == "test-sw"
 
+    def test_source_version_parsed(self):
+        """AOS-S release captured from the config-editor banner comment."""
+        raw = (
+            "; JL258A Configuration Editor; Created on release #WC.16.10.0005\n"
+            + _MIN
+        )
+        tree = ArubaAOSSCodec().parse(raw)
+        assert tree.source_version == "WC.16.10.0005"
+
+    def test_source_version_absent(self):
+        """No release banner (e.g. a template render) → honest empty."""
+        tree = ArubaAOSSCodec().parse(_MIN)
+        assert tree.source_version == ""
+
     def test_vlan_centric_membership(self):
         """The architecturally interesting test: VLAN carries its own
         port list (what Aruba natively does, what the canonical model

--- a/tests/unit/migration/test_cisco_iosxe.py
+++ b/tests/unit/migration/test_cisco_iosxe.py
@@ -120,6 +120,32 @@ class TestParse:
         tree = CiscoIOSXECodec().parse(_MIN_FRAGMENT)
         assert tree.interfaces[0].enabled is True
 
+    def test_source_version_from_system_state(self):
+        """A get-config reply carrying the OpenConfig system subtree yields
+        the release; the extractor matches ``<software-version>``
+        namespace-agnostically (metadata only)."""
+        xml = (
+            '<?xml version="1.0"?>\n'
+            "<rpc-reply><data>\n"
+            '<system xmlns="http://openconfig.net/yang/system">\n'
+            "  <state><software-version>17.09.04a</software-version></state>\n"
+            "</system>\n"
+            '<interfaces xmlns="http://openconfig.net/yang/interfaces">\n'
+            "  <interface><name>Gi0/0/0</name>"
+            "<config><name>Gi0/0/0</name><enabled>true</enabled></config>"
+            "</interface>\n"
+            "</interfaces>\n"
+            "</data></rpc-reply>\n"
+        )
+        tree = CiscoIOSXECodec().parse(xml)
+        assert tree.source_version == "17.09.04a"
+
+    def test_source_version_absent_on_interface_fragment(self):
+        """An interface-only fragment carries no system subtree — the
+        common case — so source_version is honestly empty."""
+        tree = CiscoIOSXECodec().parse(_MIN_FRAGMENT)
+        assert tree.source_version == ""
+
 
 class TestParseErrors:
     def test_malformed_xml_raises_parse_error(self):

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -93,6 +93,16 @@ class TestR3Fields:
 
 
 class TestParseCLI:
+    def test_source_version(self):
+        """IOS-XE release captured from the running-config ``version`` line."""
+        tree = CiscoIOSXECLICodec().parse("version 17.9\nhostname r1\n")
+        assert tree.source_version == "17.9"
+
+    def test_source_version_absent(self):
+        """Partial capture with no ``version`` header → honest empty string."""
+        tree = CiscoIOSXECLICodec().parse(_MINIMAL_CLI)
+        assert tree.source_version == ""
+
     def test_minimal_cli(self):
         tree = CiscoIOSXECLICodec().parse(_MINIMAL_CLI)
         ifaces = tree.interfaces

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -195,6 +195,29 @@ class TestParse:
         tree = FortiGateCLICodec().parse(_MIN)
         assert tree.hostname == "test-fgt"
 
+    def test_source_version_parsed(self):
+        """FortiOS release captured from the ``#config-version`` header;
+        the variable-length model token is skipped, the triple captured."""
+        raw = (
+            "#config-version=FG100E-7.2.13-FW-build1762-260128:"
+            "opmode=1:vdom=0:user=admin\n"
+            "config system global\n"
+            '    set hostname "fgt1"\n'
+            "end\n"
+        )
+        tree = FortiGateCLICodec().parse(raw)
+        assert tree.source_version == "7.2.13"
+
+    def test_source_version_absent(self):
+        """No ``#config-version`` header → honest empty string."""
+        raw = (
+            "config system global\n"
+            '    set hostname "fgt1"\n'
+            "end\n"
+        )
+        tree = FortiGateCLICodec().parse(raw)
+        assert tree.source_version == ""
+
     def test_interface_with_ip(self):
         tree = FortiGateCLICodec().parse(_MIN)
         port1 = tree.interfaces[0]

--- a/tests/unit/migration/test_juniper_junos.py
+++ b/tests/unit/migration/test_juniper_junos.py
@@ -62,6 +62,38 @@ class TestParseScalars:
         intent = JunosCodec().parse(raw)
         assert intent.hostname == "real-host"
 
+    def test_source_version_set_form(self):
+        """``set version`` (display-set) captured into source_version."""
+        raw = (
+            "set version 25.4R1.12\n"
+            "set system host-name r1\n"
+        )
+        intent = JunosCodec().parse(raw)
+        assert intent.source_version == "25.4R1.12"
+
+    def test_source_version_service_release(self):
+        """Hyphenated service-release token captured whole."""
+        raw = "set version 18.4R1-S1.1\nset system host-name r1\n"
+        intent = JunosCodec().parse(raw)
+        assert intent.source_version == "18.4R1-S1.1"
+
+    def test_source_version_block_form(self):
+        """Block-form ``version X;`` is captured from the original input
+        (before the block→set conversion), trailing semicolon stripped."""
+        raw = (
+            "system {\n"
+            '    host-name r1;\n'
+            "}\n"
+            "version 21.4R3.15;\n"
+        )
+        intent = JunosCodec().parse(raw)
+        assert intent.source_version == "21.4R3.15"
+
+    def test_source_version_absent(self):
+        """No version statement → honest empty string."""
+        intent = JunosCodec().parse("set system host-name r1\n")
+        assert intent.source_version == ""
+
 
 # ---------------------------------------------------------------------------
 # Parse — interfaces

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -91,6 +91,17 @@ class TestParse:
         tree = MikroTikRouterOSCodec().parse(_MIN)
         assert tree.hostname == "router1"
 
+    def test_source_version_parsed(self):
+        """RouterOS release captured from the export header comment."""
+        raw = "# 2026-04-21 20:35:02 by RouterOS 7.18.2\n" + _MIN
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.source_version == "7.18.2"
+
+    def test_source_version_absent(self):
+        """No export header comment → honest empty string."""
+        tree = MikroTikRouterOSCodec().parse(_MIN)
+        assert tree.source_version == ""
+
     def test_parse_single_ethernet_interface(self):
         tree = MikroTikRouterOSCodec().parse(_MIN)
         ifaces = tree.interfaces

--- a/tests/unit/migration/test_opnsense.py
+++ b/tests/unit/migration/test_opnsense.py
@@ -56,6 +56,21 @@ class TestParse:
         assert tree.domain == "example.com"
         assert len(tree.interfaces) == 1
 
+    def test_source_version_not_captured_from_config_schema(self):
+        """The top-level ``<version>`` in config.xml is the config-SCHEMA
+        revision (bumped by migrations), NOT the OPNsense OS release, which
+        is never written to config.xml.  source_version must stay empty
+        rather than conflate the two axes — see the NOTE in parse_intent."""
+        xml = (
+            '<?xml version="1.0"?><opnsense>'
+            "<version>11.2</version>"
+            "<system><hostname>fw01</hostname></system>"
+            "</opnsense>"
+        )
+        tree = OPNsenseCodec().parse(xml)
+        assert tree.hostname == "fw01"
+        assert tree.source_version == ""
+
     def test_system_dnsserver_comma_joined_splits(self):
         """Real configs sometimes cram several resolvers into a single
         ``<dnsserver>`` element (``10.0.1.10, 10.0.1.11``) instead of one

--- a/tests/unit/migration/test_synthetic_aruba_aoss_kitchen_sink.py
+++ b/tests/unit/migration/test_synthetic_aruba_aoss_kitchen_sink.py
@@ -338,7 +338,14 @@ class TestRoundTripStable:
         first = codec.parse(raw)
         rendered = codec.render(first)
         second = codec.parse(rendered)
-        assert first == second, (
+        # source_version is parser-stamped metadata (the "Created on
+        # release #" banner); render doesn't re-emit it, so exclude it
+        # from the same-vendor round-trip — mirrors the generic harness.
+        first_d = first.model_dump()
+        second_d = second.model_dump()
+        first_d.pop("source_version", None)
+        second_d.pop("source_version", None)
+        assert first_d == second_d, (
             "kitchen-sink fixture lost canonical state through "
             "render → parse — a feature is silently asymmetric"
         )

--- a/tests/unit/migration/test_synthetic_fortigate_cli_kitchen_sink.py
+++ b/tests/unit/migration/test_synthetic_fortigate_cli_kitchen_sink.py
@@ -203,4 +203,11 @@ def test_round_trip_stable():
     tree1 = codec.parse(raw)
     emitted = codec.render(tree1)
     tree2 = codec.parse(emitted)
-    assert tree1 == tree2
+    # source_version is parser-stamped metadata (the #config-version
+    # header); render doesn't re-emit it, so exclude it from the
+    # same-vendor round-trip — mirrors the generic harness's _compare.
+    d1 = tree1.model_dump()
+    d2 = tree2.model_dump()
+    d1.pop("source_version", None)
+    d2.pop("source_version", None)
+    assert d1 == d2

--- a/tests/unit/migration/test_vyos.py
+++ b/tests/unit/migration/test_vyos.py
@@ -286,6 +286,20 @@ def test_parse_hostname(codec: VyOSCodec) -> None:
     assert codec.parse(_SAMPLE).hostname == "vyos-sample"
 
 
+def test_source_version_release_comment(codec: VyOSCodec) -> None:
+    """The OS release is captured from the ``// Release version:`` trailer."""
+    raw = _SAMPLE + "// Release version: 1.4-rolling-202307070317\n"
+    assert codec.parse(raw).source_version == "1.4-rolling-202307070317"
+
+
+def test_source_version_ignores_config_schema_version(codec: VyOSCodec) -> None:
+    """``_SAMPLE`` carries ``// vyos-config-version:`` (a config-SCHEMA
+    migration marker) but no ``// Release version:`` — source_version must
+    stay empty, NOT capture the schema version (data-quality: the schema
+    rev is a different axis from the OS release)."""
+    assert codec.parse(_SAMPLE).source_version == ""
+
+
 def test_parse_ethernet_l3(codec: VyOSCodec) -> None:
     intent = codec.parse(_SAMPLE)
     eth0 = next(i for i in intent.interfaces if i.name == "eth0")


### PR DESCRIPTION
## What

Populate `CanonicalIntent.source_version` (firmware/OS release) on **parse** for the 9 codecs that didn't yet — bringing all 12 codecs to parity with the existing `cisco_nxos` / `cisco_iosxr` / `aruba_aoscx` prior art. Each codec gets a module-level `_extract_version` helper + `_VERSION_RE` (mirroring the 3 existing implementations), populated as `intent.source_version = _extract_version(raw)`.

This is the **data-capture** half of the "version as a translation vector" work: it enriches what the live + Batfish mass-migration harness can accumulate per config. **Nothing consumes the field yet** — wiring version into parse/render behaviour is deliberately deferred.

## Why it's round-trip-safe

`source_version` is declared metadata: `render()` never echoes it, and it's already excluded from **both** comparators — the round-trip `_compare` (`test_real_captures`) pops it, and the cross-mesh audit `_AUDITED_FIELDS` (`tools/run_full_mesh`) excludes it. So populating it on 9 more codecs cannot introduce drift.

## Per-codec extraction (honest `""` where the format carries no version)

| codec | source | notes |
|---|---|---|
| `cisco_iosxe_cli` | `version 17.9` line | |
| `arista_eos` | `! device: (…, EOS-4.27.0F)` banner | anchored on closing paren → captures 4-segment `4.21.1.1F` / `4.22.4M-2GB`, dodges the `vEOS-lab.swi` boot-image false positive |
| `juniper_junos` | `set version` / block-form `version X;` | extracted from original input pre block→set conversion; one regex handles both forms |
| `aruba_aoss` | `; … Created on release #WC.16.10.0005` | template-render configs have no banner → `""` |
| `fortigate_cli` | `#config-version=FG100E-7.2.13-…` | lazy model-token skip → captures the triple |
| `mikrotik_routeros` | `# … by RouterOS 7.18.2` header | |
| `vyos` | trailing `// Release version:` comment | deliberately **not** the `// vyos-config-version` config-schema marker |
| `cisco_iosxe` | OpenConfig `<software-version>` element | `""` for interface-only NETCONF fragments |
| `opnsense` | **intentionally empty** | config.xml carries only the config-**schema** `<version>` (e.g. `11.2`), never the OS release — capturing it would conflate two axes and poison the version-as-vector dataset (documented inline) |

## Tests

Per-codec unit tests (positive capture + honest-empty/absent cases; arista also covers the 4-segment + `.swi` cases; junos covers set- and block-form; vyos + opnsense assert the config-schema marker is **not** mistaken for the OS release). Round-trip, synthetic-kitchen-sink, and the cross-mesh CI guard all stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)