### PR TITLE
docs(changelog): cut [0.4.12] - 2026-07-02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,27 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.4.12] - 2026-07-02
+
+### Added
+
+- **`source_version` is now captured on parse by all 12 codecs** (was
+  3). Each codec's parser records the source device's firmware/OS
+  release into `CanonicalIntent.source_version`: the running-config
+  `version` line (Cisco IOS-XE), the `! device: (…, EOS-4.27.0F)`
+  banner (Arista EOS), `set version` / block-form `version X;` (Junos),
+  the `Created on release #` banner (Aruba AOS-Switch), the
+  `#config-version` header (FortiGate), the `by RouterOS` export header
+  (MikroTik), the trailing `// Release version:` comment (VyOS — not the
+  `vyos-config-version` schema marker), and the OpenConfig
+  `<software-version>` element (Cisco IOS-XE NETCONF). OPNsense records
+  an honest empty string — its `config.xml` carries only a config-schema
+  revision, not the OS release, so conflating them would poison the
+  data. The field is metadata only: render does not echo it and it is
+  excluded from the round-trip and cross-vendor comparators, so
+  behaviour is unchanged — this lays the data groundwork for future
+  version-aware translation.
+
 ### Fixed
 
 - **`arista_eos` auto-detection no longer mis-classifies marker-light EOS


### PR DESCRIPTION
## Release cut: v0.4.12

CHANGELOG-only cut bundling everything merged to `main` since **v0.4.11**. After merge, `v0.4.12` will be tagged (dependent on green CI) to trigger the PyPI + Docker + MSI publish workflows. `setuptools_scm` derives the version from the tag — no version file to bump.

### Contents
- **Added** — `source_version` now captured on parse by all 12 codecs ([#235](https://github.com/netcanon/netcanon/pull/235)). Metadata only (render doesn't echo it; excluded from both comparators), so behaviour is unchanged — data groundwork for future version-aware translation. Regression-checked against an independent Batfish parse: 77.0% clean / 90.4% recognized, no regression.
- **Fixed** — `arista_eos` marker-light EOS detection vs `cisco_iosxe_cli` ([#234](https://github.com/netcanon/netcanon/pull/234)).
- **Fixed** — `mikrotik_routeros` shut VLAN/bridge/loopback silent re-enable ([#233](https://github.com/netcanon/netcanon/pull/233)).

The cross-mesh CI guard ([#231](https://github.com/netcanon/netcanon/pull/231)) is test/tooling infra — intentionally no changelog entry.

### Checks
- Changelog guard green locally (`[0.4.12]` header, descending, dated, `[Unreleased]` anchor retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)