### PR TITLE
fix(detect): key nxos probe on RANCID/feature/nxapi + generalize RANCID header across probes

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -575,10 +575,37 @@ class CiscoIOSXECLICodec(CodecBase):
             r"|^nv\s+overlay\s+evpn\b"
             r"|^\s+vn-segment\s+\d+"
             r"|^interface\s+lag\s+\d"
-            r"|^\s+vrf\s+attach\b",
+            r"|^\s+vrf\s+attach\b"
+            r"|^nxapi\b",  # NX-API mgmt plane — NX-OS-exclusive
             raw_prefix, re.IGNORECASE | re.MULTILINE,
         ):
             return None
+
+        # GENERAL NX-OS `feature <name>` keyword: IOS-XE has NO `feature`
+        # command at all (see the comment above), so it is NX-OS-exclusive
+        # and we defer.  GUARD: a dotted-decimal mask (`ip address A.B.C.D
+        # M.M.M.M`) is IOS-EXCLUSIVE (NX-OS only writes CIDR `/N`), so a
+        # config carrying BOTH `feature` and a dotted mask is an IOS /
+        # synthetic hybrid — keep it here rather than hand it to the
+        # CIDR-only NX-OS parser.  Without this, marker-light NX-OS
+        # (`feature bgp` BGP snippets, no `!Command` banner) tied
+        # cisco_iosxe_cli at 70/90 on generic IOS-shape markers and lost
+        # the alphabetical tie-break (dogfood detection sweep, 38 configs).
+        if (re.search(r"^feature\s+\S+", raw_prefix,
+                      re.IGNORECASE | re.MULTILINE)
+                and not re.search(
+                    r"^\s+ip\s+address\s+\d+\.\d+\.\d+\.\d+\s+\d+\.\d+\.\d+\.\d+",
+                    raw_prefix, re.IGNORECASE | re.MULTILINE)):
+            return None
+
+        # RANCID / oxidized collection header naming bare ``cisco`` —
+        # IOS / IOS-XE classic, distinct from ``cisco-nx`` / ``cisco-xr``
+        # (which the deferral blocks above already routed to the NX-OS /
+        # XR probes).  ``\s*$`` pins the bare value so ``cisco-nx`` /
+        # ``cisco-xr`` can't match here.  A definitive vendor declaration.
+        if re.search(r"^!\s*RANCID-CONTENT-TYPE:\s*cisco\s*$",
+                     raw_prefix, re.MULTILINE | re.IGNORECASE):
+            return (97, "RANCID-CONTENT-TYPE: cisco header")
 
         # Cisco-specific banners — each unambiguous on its own.  The
         # ``show running-config`` echo is now ONLY a confidence

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -629,6 +629,14 @@ class CiscoIOSXRCodec(CodecBase):
         if re.search(r"^!!\s+IOS XR Configuration", raw_prefix, re.MULTILINE):
             return (98, "IOS XR Configuration banner present")
 
+        # RANCID / oxidized collection header — a definitive vendor
+        # declaration for marker-light XR captures (bare BGP / SSH
+        # snippets lacking the banner and 4-segment ports).  Zero
+        # false-positive (it names XR).
+        if re.search(r"^!\s*RANCID-CONTENT-TYPE:\s*cisco-xr\b",
+                     raw_prefix, re.MULTILINE | re.IGNORECASE):
+            return (97, "RANCID-CONTENT-TYPE: cisco-xr header")
+
         hits = 0
         if re.search(
             r"^interface\s+(?:GigabitEthernet|TenGigE|HundredGigE|FortyGigE|"

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -659,6 +659,12 @@ class CiscoNXOSCodec(CodecBase):
         if re.search(r"^interface\s+nve1\b", raw_prefix,
                      re.MULTILINE | re.IGNORECASE):
             nxos_specific += 1
+        # NX-API management plane (``nxapi http port`` / ``feature nxapi``)
+        # is NX-OS-exclusive and commonly the FIRST management line — it
+        # lands inside the 500-byte probe window even when the `feature`
+        # feature-set lines sit deeper in the config.
+        if re.search(r"^nxapi\b", raw_prefix, re.MULTILINE | re.IGNORECASE):
+            nxos_specific += 1
 
         if "!command: show running-config" in lowered:
             if nxos_specific >= 1:
@@ -670,6 +676,17 @@ class CiscoNXOSCodec(CodecBase):
                          raw_prefix, re.MULTILINE | re.IGNORECASE):
                 return (98, "NX-OS !Command banner + CIDR addressing")
             return (90, "NX-OS !Command banner")
+
+        # RANCID / oxidized collection header — a definitive vendor
+        # declaration (real config repos prepend it), higher-signal than
+        # IOS-lookalike structure.  Without it, marker-light NX-OS (bare
+        # BGP / NTP / SSH snippets carrying only `feature X` or nothing
+        # structural) scored 0-70 here and lost the alphabetical tie to
+        # `cisco_iosxe_cli` (dogfood detection sweep).  Mirrors the
+        # arista_eos RANCID marker; zero false-positive (it names NX-OS).
+        if re.search(r"^!\s*RANCID-CONTENT-TYPE:\s*cisco-nx\b",
+                     raw_prefix, re.MULTILINE | re.IGNORECASE):
+            return (97, "RANCID-CONTENT-TYPE: cisco-nx header")
 
         # No banner — lean on NX-OS-specific markers only.
         if nxos_specific >= 2:

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -439,6 +439,14 @@ class JunosCodec(CodecBase):
         # / banner framing so real captures don't bypass the guard.
         if detect_input_shape(raw_prefix) is not None:
             return None
+        # RANCID / oxidized collection header — the Junos comment char is
+        # ``#`` (with or without a following space).  A definitive vendor
+        # declaration that claims block-form / marker-light captures the
+        # set-form structural markers below don't match (RANCID collects
+        # the hierarchical config; the parser converts block->set-form).
+        if re.search(r"^#\s*RANCID-CONTENT-TYPE:\s*juniper\b",
+                     raw_prefix, re.MULTILINE | re.IGNORECASE):
+            return (97, "RANCID-CONTENT-TYPE: juniper header")
         if re.search(
             r"^set version \d",
             raw_prefix, re.MULTILINE,

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -20,6 +20,7 @@ from netcanon.migration.codecs.base import ParseError, RenderError
 from netcanon.migration.codecs.cisco_iosxe import CiscoIOSXECodec
 from netcanon.migration.codecs.cisco_iosxe_cli import CiscoIOSXECLICodec
 from netcanon.models.migration import MigrationJobStatus
+from netcanon.services.migration_detect import detect_codec
 from netcanon.services.migration_pipeline import run_plan
 
 pytestmark = pytest.mark.unit
@@ -42,6 +43,57 @@ end
 # ---------------------------------------------------------------------------
 # R3 field declarations
 # ---------------------------------------------------------------------------
+
+
+class TestProbeNXOSDeferral:
+    """Detection: the IOS-CLI probe must NOT steal NX-OS captures that
+    carry the NX-OS-exclusive ``feature`` keyword or a RANCID cisco-nx
+    header (dogfood detection label-noise sweep — 38 configs)."""
+
+    def test_feature_keyword_defers_to_nxos(self):
+        """`feature bgp` (IOS-XE has no ``feature`` command) with CIDR
+        addressing and NO dotted mask → the IOS-CLI probe defers, and
+        detection resolves to NX-OS."""
+        raw = (
+            "feature bgp\n"
+            "hostname nxos-bgp-1\n"
+            "interface Ethernet1\n"
+            "  ip address 192.168.1.2/30\n"
+            "router bgp 1\n"
+        )
+        assert CiscoIOSXECLICodec.probe(raw) is None
+        assert detect_codec(raw)[0].codec == "cisco_nxos"
+
+    def test_feature_plus_dotted_mask_stays_ios(self):
+        """A hybrid carrying BOTH ``feature`` and an IOS-EXCLUSIVE dotted
+        mask is not pure NX-OS (the CIDR-only NX-OS parser can't take it),
+        so the IOS-CLI probe keeps it rather than deferring."""
+        raw = (
+            "feature bgp\n"
+            "hostname dc2_sw2\n"
+            "interface loopback100\n"
+            "  ip address 169.254.255.4 255.255.255.255\n"
+        )
+        assert CiscoIOSXECLICodec.probe(raw) is not None
+
+    def test_rancid_cisco_header_detected(self):
+        """Bare ``cisco`` RANCID header (IOS/IOS-XE classic) is claimed;
+        ``cisco-nx`` / ``cisco-xr`` are pinned out by the end-of-line."""
+        raw = (
+            "!RANCID-CONTENT-TYPE: cisco\n"
+            "!\n"
+            "hostname r1\n"
+            "interface GigabitEthernet0/0\n"
+        )
+        result = CiscoIOSXECLICodec.probe(raw)
+        assert result is not None
+        assert result[0] >= 95
+        assert "cisco" in result[1]
+
+    def test_rancid_cisco_nx_not_claimed_as_ios(self):
+        """The bare-``cisco`` match must NOT fire on a ``cisco-nx`` header."""
+        raw = "!RANCID-CONTENT-TYPE: cisco-nx\n!\nhostname nxos_ntp\n"
+        assert detect_codec(raw)[0].codec == "cisco_nxos"
 
 
 class TestR3Fields:

--- a/tests/unit/migration/test_cisco_iosxr.py
+++ b/tests/unit/migration/test_cisco_iosxr.py
@@ -79,6 +79,20 @@ class TestProbe:
         )
         assert codec.probe(raw) == (98, "IOS XR Configuration banner present")
 
+    def test_rancid_cisco_xr_header_detected(self, codec):
+        """RANCID collection header is a definitive XR declaration for
+        marker-light captures lacking the banner + 4-segment ports."""
+        raw = (
+            "!RANCID-CONTENT-TYPE: cisco-xr\n"
+            "!\n"
+            "hostname pe1\n"
+        )
+        result = codec.probe(raw)
+        assert result is not None
+        score, reason = result
+        assert score >= 95
+        assert "cisco-xr" in reason
+
     def test_marker_fallback_without_banner(self, codec):
         """A 4-segment-port + ipv4-address + MgmtEth config without the
         banner still scores high on XR-specific markers."""

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -78,6 +78,36 @@ class TestProbe:
             98, "NX-OS !Command banner + structural markers",
         )
 
+    def test_rancid_cisco_nx_header_detected(self, codec):
+        """RANCID collection header is a definitive NX-OS declaration — a
+        marker-light snippet (no !Command banner, no structural markers)
+        must still be claimed rather than lose the alphabetical tie-break
+        to cisco_iosxe_cli (dogfood detection label-noise sweep)."""
+        raw = (
+            "!RANCID-CONTENT-TYPE: cisco-nx\n"
+            "!\n"
+            "hostname nxos_ntp\n"
+        )
+        result = codec.probe(raw)
+        assert result is not None
+        score, reason = result
+        assert score >= 95
+        assert "cisco-nx" in reason
+
+    def test_nxapi_is_nxos_marker(self, codec):
+        """``nxapi http port`` (NX-API mgmt plane) is NX-OS-exclusive and
+        lands in the 500-byte probe window even when the `feature` lines
+        sit deeper in the config (dogfood detection sweep — leaf2 case)."""
+        raw = (
+            "hostname leaf2\n"
+            "nxapi http port 80\n"
+            "interface Ethernet1/1\n"
+            "  ip address 10.0.0.1/32\n"
+        )
+        result = codec.probe(raw)
+        assert result is not None
+        assert result[0] >= 70
+
     def test_iosxe_classic_banner_rejected(self, codec):
         """IOS-XE classic banners are a hard NOT-NX-OS signal even if a
         stray ``!Command:`` line appears later in a multi-capture paste."""

--- a/tests/unit/migration/test_juniper_junos.py
+++ b/tests/unit/migration/test_juniper_junos.py
@@ -377,6 +377,18 @@ class TestProbe:
         score, _ = result
         assert score >= 85  # 4 markers → strong signal
 
+    def test_rancid_juniper_header_detected(self):
+        """RANCID collection header (Junos comment char ``#``, with or
+        without a space) is a definitive Juniper declaration — claims
+        block-form / marker-light captures the set-form markers miss."""
+        for header in ("# RANCID-CONTENT-TYPE: juniper", "#RANCID-CONTENT-TYPE: juniper"):
+            raw = header + "\nsystem {\n    host-name r1;\n}\n"
+            result = JunosCodec.probe(raw)
+            assert result is not None, header
+            score, reason = result
+            assert score >= 95, header
+            assert "juniper" in reason
+
     def test_non_junos_returns_none(self):
         """Cisco IOS-like text must NOT probe as Junos."""
         raw = (


### PR DESCRIPTION
## What

Follow-up to the arista detection fix ([#234](https://github.com/netcanon/netcanon/pull/234)), from the same dogfood detection label-noise sweep. Fixes NX-OS (and other marker-light) configs mis-detecting as `cisco_iosxe_cli`.

### Root causes
1. **Alphabetical tie-break** — `detect_codec` breaks confidence ties by ascending codec name, so `cisco_iosxe_cli` beats `cisco_nxos`. A marker-light NX-OS config (`feature bgp` BGP snippet, no `!Command` banner) capped `cisco_nxos` at 70 and tied/lost.
2. **`cisco_iosxe_cli` false-positive** on NX-OS content (`interface Ethernet1/1` + CIDR + `feature`) — which its own comment already declares impossible ("IOS-XE has no `feature` command").

### Fixes
- `cisco_iosxe_cli` defers on the **general** `^feature <name>` keyword (was only two specific EVPN feature lines), **guarded by "no dotted-decimal mask"** — a dotted mask is IOS-exclusive, so a `feature`+dotted-mask hybrid stays on IOS-CLI rather than going to the CIDR-only NX-OS parser. Also defers on `nxapi`.
- `cisco_nxos` keys on `!RANCID-CONTENT-TYPE: cisco-nx` (97) and `nxapi` (in the 500-byte window even when `feature` lines sit deeper).
- **Generalizes the RANCID/oxidized collection header** (the #234 arista pattern) across the probes whose header value appears in the corpus and maps to a codec: `cisco-xr`→iosxr, bare `cisco`→iosxe_cli (end-of-line pinned so `cisco-nx`/`cisco-xr` can't match), `juniper`→junos (`#` comment char). `paloalto` has no codec (skipped).

### Verified (verify-first, on the dogfood corpus)
- **RANCID ground-truth agreement: 100%** across all 5 vendors — arista 19/19, cisco 50/50, cisco-nx 12/12, cisco-xr 33/33, juniper 11/11 (125 configs).
- **NX-OS-marker configs mis-detected as `cisco_iosxe_cli`: 38 → 1** — the sole remaining is the intended `feature`+dotted-mask hybrid, correctly kept on IOS-CLI (the CIDR-only NX-OS parser couldn't take it).

### Tests
Per-probe unit tests (RANCID header per vendor; `feature`-defer; hybrid-preserve; `nxapi` marker; bare-`cisco` vs `cisco-nx` disambiguation). Full unit suite + cross-mesh CI guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)