### PR TITLE
fix(model): widen CanonicalVRRPGroup.group_id 255->4095 for NX-OS HSRPv2 groups

### DIFF
--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -533,7 +533,13 @@ class CanonicalVRRPGroup(BaseModel):
       wire-protocol-distinct from IETF VRRP).
 
     Attributes:
-        group_id: VRRP VRID (1-255) or CARP VHID (1-255).  Required.
+        group_id: FHRP group number.  Required.  VRRP VRID and CARP VHID
+            are 1-255, but HSRPv2 (``mode="hsrp"``) extends to 4095, so the
+            field bound is the union (1-4095).  A VRRP / CARP source never
+            emits a group > 255, so the wider ceiling only ever admits a
+            legitimate HSRPv2 group — it does not need per-mode validation.
+            (Lower bound stays 1: VRRP/CARP require it; HSRP group 0 is a
+            valid but unhandled edge, out of scope here.)
         mode: Wire-protocol discriminator.  String literal (not enum)
             so codecs can extend it without a schema change.  Known
             values: ``"vrrp"`` (default — IETF VRRPv2 / VRRPv3),
@@ -586,7 +592,7 @@ class CanonicalVRRPGroup(BaseModel):
     ``docs/v0.2.0-planning/``.)
     """
 
-    group_id: int = Field(ge=1, le=255)
+    group_id: int = Field(ge=1, le=4095)
     mode: str = "vrrp"  # "vrrp" | "hsrp" | "carp"
     virtual_ips: list[str] = Field(default_factory=list)
     virtual_ipv6s: list[str] = Field(default_factory=list)

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -229,8 +229,9 @@ def sanitize_text(
         intent = codec.parse(raw)
     except ValidationError as e:
         # The input parsed structurally but produced a canonical model that
-        # violates a field constraint (e.g. an NX-OS HSRP group-id > the
-        # VRRP 0-255 range mapped onto CanonicalVRRPGroup.group_id).  That's
+        # violates a field constraint (e.g. an HSRP group-id above the
+        # 0-4095 HSRPv2 range that CanonicalVRRPGroup.group_id enforces).
+        # That's
         # unparseable-as-canonical INPUT, not a server fault — surface it as
         # a ParseError so callers honour the documented contract: the HTTP
         # route returns 400 instead of leaking a 500, and the CLI reports it

--- a/tests/integration/test_sanitize_api.py
+++ b/tests/integration/test_sanitize_api.py
@@ -132,15 +132,16 @@ class TestSanitizeEndpointErrors:
 
     def test_out_of_range_input_returns_400_not_500(self, client):
         """Input that parses structurally but yields an out-of-range
-        canonical value (NX-OS HSRP group-id 301 > the VRRP 0-255 range)
-        must return a clean 400, not a 500 leaking a pydantic
-        ValidationError.  Surfaced by the live /sanitize dogfood."""
+        canonical value (NX-OS HSRP group-id 5000 > the 0-4095 HSRPv2
+        range) must return a clean 400, not a 500 leaking a pydantic
+        ValidationError.  Surfaced by the live /sanitize dogfood on
+        `hsrp 301`, which now parses since the ceiling widened to 4095."""
         raw = (
             b"feature hsrp\n"
             b"interface Vlan10\n"
             b"  no shutdown\n"
             b"  ip address 10.0.0.2/24\n"
-            b"  hsrp 301\n"
+            b"  hsrp 5000\n"
             b"    ip 10.0.0.1\n"
         )
         response = client.post(

--- a/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
+++ b/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
@@ -97,12 +97,16 @@ class TestCanonicalVRRPGroupValidation:
             CanonicalVRRPGroup(group_id=0)
 
     def test_group_id_upper_bound(self):
+        # HSRPv2 (mode="hsrp") groups run 0-4095; the field ceiling is the
+        # VRRP/HSRP union (4095), so 4096 is the first out-of-range value.
         with pytest.raises(ValidationError):
-            CanonicalVRRPGroup(group_id=256)
+            CanonicalVRRPGroup(group_id=4096)
 
     def test_group_id_boundary_ok(self):
         CanonicalVRRPGroup(group_id=1)
-        CanonicalVRRPGroup(group_id=255)
+        CanonicalVRRPGroup(group_id=255)  # VRRP VRID max
+        CanonicalVRRPGroup(group_id=301, mode="hsrp")  # HSRPv2 > 255
+        CanonicalVRRPGroup(group_id=4095, mode="hsrp")  # HSRPv2 max
 
     def test_priority_lower_bound(self):
         with pytest.raises(ValidationError):

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -748,6 +748,32 @@ class TestPhase2cHSRP:
             }
         assert groups(tree) == groups(codec.parse(rendered))
 
+    def test_hsrpv2_group_above_255_parses_and_round_trips(self, codec):
+        """NX-OS HSRPv2 groups run 0-4095; a group > 255 (`hsrp 301`) must
+        parse + represent, not raise a ValidationError.  Was rejected by
+        the old `group_id` le=255 constraint (the class that produced the
+        #229 sanitize 500); the ceiling is now 4095."""
+        raw = (
+            "!Command: show running-config\n"
+            "hostname FHRP\n"
+            "feature hsrp\n"
+            "interface Vlan30\n"
+            "  no shutdown\n"
+            "  ip address 10.30.30.2/24\n"
+            "  hsrp 301\n"
+            "    ip 10.30.30.1\n"
+        )
+        tree = codec.parse(raw)
+        g = next(i for i in tree.interfaces if i.name == "Vlan30").vrrp_groups[0]
+        assert g.group_id == 301
+        assert g.mode == "hsrp"
+        rendered = codec.render(tree)
+        assert "  hsrp 301" in rendered
+        reparsed = next(
+            i for i in codec.parse(rendered).interfaces if i.name == "Vlan30"
+        )
+        assert reparsed.vrrp_groups[0].group_id == 301
+
     def test_vrrp_groups_declared_lossy(self, codec):
         # FHRP normalises to HSRP on NX-OS render → the mode discriminator
         # is lossy cross-vendor.

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -718,18 +718,20 @@ class TestSanitizeTextEndToEnd:
             sanitize_text("", "no_such_codec")
 
     def test_out_of_range_input_raises_parse_error_not_validation_error(self):
-        # An NX-OS HSRP group-id of 301 exceeds the VRRP 0-255 range that
-        # CanonicalVRRPGroup.group_id enforces, so parse constructs an
+        # An NX-OS HSRP group-id of 5000 exceeds the 0-4095 HSRPv2 range
+        # that CanonicalVRRPGroup.group_id enforces, so parse constructs an
         # invalid model and pydantic raises ValidationError.  sanitize_text
         # must convert that to a ParseError (contract) so the HTTP route
-        # returns a clean 400 rather than leaking a 500.  (Surfaced by the
-        # live /sanitize dogfood on a real NX-OS capture.)
+        # returns a clean 400 rather than leaking a 500.  (The guard was
+        # first surfaced by the live /sanitize dogfood on `hsrp 301`, which
+        # now parses since the group_id ceiling widened 255->4095; 5000
+        # keeps a genuinely out-of-range value under test.)
         raw = (
             "feature hsrp\n"
             "interface Vlan10\n"
             "  no shutdown\n"
             "  ip address 10.0.0.2/24\n"
-            "  hsrp 301\n"
+            "  hsrp 5000\n"
             "    ip 10.0.0.1\n"
         )
         with pytest.raises(ParseError, match="could not be represented"):


### PR DESCRIPTION
## What

Closes the canonical-model half deferred from [#229](https://github.com/netcanon/netcanon/pull/229). `CanonicalVRRPGroup` is the shared FHRP surface (VRRP / HSRP / CARP via `mode`), but `group_id` was bounded `le=255` — the VRRP VRID / CARP VHID range. **HSRPv2 groups run 0–4095**, so an NX-OS `hsrp 301` parsed structurally then raised a pydantic `ValidationError` constructing the model — the exact class that produced the #229 sanitize 500 (which #229 patched at the service boundary but left the model unable to *represent* the group).

## Fix
- `group_id` ceiling widened to the VRRP/HSRP union: `le=255` → **`le=4095`**.
- A VRRP/CARP source never emits a group > 255, so the wider bound only ever admits a legitimate HSRPv2 group — no per-mode validator needed (permissive canonical intermediate; nothing clamps `group_id`, and the NX-OS renderer already passes it through verbatim). Lower bound stays 1 (HSRP group 0 is a valid but unhandled edge, noted out-of-scope).

## Tests
- NX-OS `hsrp 301` now parses (`group_id=301, mode=hsrp`) and round-trips through render.
- Schema boundary test: `4096` is the first out-of-range value; `301`/`4095` OK.
- The #229 sanitize regression guards move from `hsrp 301` (now valid) to `hsrp 5000` (still > 4095), so **"out-of-range → ParseError/400, not 500"** stays under test at the correct boundary.

Full unit suite + cross-mesh CI guard + sanitize integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)