### PR TITLE
feat(cisco_iosxe_cli): wire routed sub-interface dot1q (encapsulation dot1Q) — GAP-7

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -119,6 +119,7 @@ class CiscoIOSXECLICodec(CodecBase):
             "/interfaces/interface/ipv6/address/prefix-length",  # GAP-EVPN-3
             "/interfaces/interface/dhcp-client-v6",          # IPv6 DHCPv6 / SLAAC
             "/interfaces/interface/tunnel-type",             # GRE / IPIP / IPSEC / VXLAN discriminator
+            "/interfaces/interface/dot1q-vlan",              # GAP 7: routed-subif `encapsulation dot1Q N`
             # ``switchport voice vlan <N>`` — parsed (_SWITCHPORT_VOICE_RE)
             # and rendered, so it fully round-trips same-vendor (blind-audit
             # 65f9c01 #11; targets that can't carry it declare it unsupported).
@@ -317,17 +318,6 @@ class CiscoIOSXECLICodec(CodecBase):
             ),
         ],
         unsupported=[
-            UnsupportedPath(
-                path="/interfaces/interface/dot1q-vlan",
-                reason=(
-                    "Routed sub-interface 802.1Q tag (Cisco "
-                    "`encapsulation dot1Q N` / Junos `unit N vlan-id`) is "
-                    "not yet wired for this codec.  Declared unsupported "
-                    "(ship-before-wire, GAP 7) so a routed sub-interface "
-                    "tag is flagged as a drop, not silently mis-rendered "
-                    "as an L2 access-mode VLAN."
-                ),
-            ),
             # ── Tier-1 surfaces this codec drops on render — declared so the
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -201,6 +201,38 @@ _FABRIC_AG_MODE_RE = re.compile(
     r"^\s+fabric\s+forwarding\s+mode\s+anycast-gateway\s*$",
     re.IGNORECASE,
 )
+#: GAP 7: routed sub-interface 802.1Q tag, ``encapsulation dot1Q <vlan>``
+#: (IOS-XE writes a capital Q; ``re.IGNORECASE`` tolerates lowercase).
+#: The optional trailing ``native`` keyword is not modelled here.
+_ENCAP_DOT1Q_RE = re.compile(
+    r"^\s+encapsulation\s+dot1q\s+(\d+)\b", re.IGNORECASE,
+)
+
+
+def _parse_iface_l3_markers(line: str, current: dict[str, Any]) -> bool:
+    """Consume a routed-interface L3 marker line into *current*; return
+    ``True`` if the line was handled.
+
+    Two markers live here (extracted from ``_on_line`` to keep it under
+    the cyclomatic-complexity gate):
+
+    * ``fabric forwarding mode anycast-gateway`` — SD-Access per-SVI
+      marker.  Sets a flag; at stanza-close (``_build_canonical_interface``)
+      every primary IPv4 address gets ``virtual_gateway_address = ip`` to
+      mirror the NX-OS / IOS-XE SD-Access shape (the primary IP IS the
+      anycast IP).
+    * ``encapsulation dot1Q <vlan>`` (GAP 7) — the 802.1Q tag on a routed
+      sub-interface (e.g. ``GigabitEthernet0/1.100``).  Stored on the
+      dedicated ``dot1q_vlan`` field, NOT access_vlan (an L2 concept).
+    """
+    if _FABRIC_AG_MODE_RE.match(line):
+        current["fabric_forwarding_anycast"] = True
+        return True
+    em = _ENCAP_DOT1Q_RE.match(line)
+    if em:
+        current["dot1q_vlan"] = int(em.group(1))
+        return True
+    return False
 
 
 #: Interface-name prefix → IANA ifType hint.
@@ -883,15 +915,10 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:  # noqa: C901
         if _dispatch_vrrp_line(line, current):
             return
 
-        # ── SD-Access anycast-gateway per-SVI discriminator ──
-        # ``fabric forwarding mode anycast-gateway`` marks the SVI's
-        # primary IP as the anycast gateway.  We set the flag here; at
-        # stanza-close time (``_build_canonical_interface``) every
-        # primary IPv4 address gets ``virtual_gateway_address = ip`` to
-        # mirror the NX-OS / IOS-XE SD-Access shape (the primary IP IS
-        # the anycast IP).
-        if _FABRIC_AG_MODE_RE.match(line):
-            current["fabric_forwarding_anycast"] = True
+        # Routed-interface L3 markers: SD-Access anycast-gateway mode +
+        # the GAP-7 sub-interface 802.1Q tag.  Extracted to a helper to
+        # keep _on_line under the cyclomatic-complexity gate.
+        if _parse_iface_l3_markers(line, current):
             return
 
     # Loop skeleton (open on `interface`, close on `!`-comment / dedent,
@@ -1095,6 +1122,7 @@ def _build_canonical_interface(raw: dict[str, Any]) -> CanonicalInterface:
         ],
         switchport_mode=switchport_mode,
         access_vlan=raw.get("access_vlan"),
+        dot1q_vlan=raw.get("dot1q_vlan"),  # GAP 7: routed-subif 802.1Q tag
         voice_vlan=raw.get("voice_vlan"),
         trunk_allowed_vlans=raw.get("trunk_allowed", []),
         trunk_native_vlan=raw.get("trunk_native"),

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -295,6 +295,11 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         # — ``ip address ip-address mask [secondary [vrf vrf-name]]``.
         # Round-trips with the parse-side companion that drops the
         # ``secondary`` token before storing in the canonical list.
+        # GAP 7: routed sub-interface 802.1Q tag.  Emitted before the IP
+        # so the tag precedes the routed address (IOS-XE convention).
+        # Capital Q matches Cisco's canonical style.
+        if iface.dot1q_vlan is not None:
+            body.append(f" encapsulation dot1Q {iface.dot1q_vlan}")
         for idx, addr in enumerate(iface.ipv4_addresses):
             mask = _prefix_to_mask(addr.prefix_length, vendor="cisco_iosxe_cli")
             suffix = " secondary" if idx > 0 else ""

--- a/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
+++ b/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
@@ -341,6 +341,8 @@ class TestShipBeforeWireUnsupportedDeclarations:
             "/interfaces/interface/ipv4/address/virtual-gateway-address",
             "/anycast-gateway-mac",
             "/routing/static-route/vrf",
+            # GAP 7 — routed sub-interface `encapsulation dot1Q N`.
+            "/interfaces/interface/dot1q-vlan",
         },
         # NETCONF stub — every path still ``unsupported`` (the
         # codec's matrix declares every canonical surface unsupported

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -96,6 +96,56 @@ class TestProbeNXOSDeferral:
         assert detect_codec(raw)[0].codec == "cisco_nxos"
 
 
+class TestRoutedSubifDot1q:
+    """GAP 7 wiring: routed sub-interface ``encapsulation dot1Q N`` <->
+    CanonicalInterface.dot1q_vlan (NOT access_vlan)."""
+
+    def test_parse_encapsulation_dot1q(self):
+        raw = (
+            "interface GigabitEthernet0/1.100\n"
+            " encapsulation dot1Q 100\n"
+            " ip address 192.168.100.1 255.255.255.0\n"
+            "!\n"
+        )
+        sub = next(
+            i for i in CiscoIOSXECLICodec().parse(raw).interfaces
+            if i.name == "GigabitEthernet0/1.100"
+        )
+        assert sub.dot1q_vlan == 100
+        assert sub.access_vlan is None  # NOT the L2 access field
+        assert sub.switchport_mode is None
+
+    def test_round_trip(self):
+        raw = (
+            "interface GigabitEthernet0/1.100\n"
+            " encapsulation dot1Q 100\n"
+            " ip address 192.168.100.1 255.255.255.0\n"
+            "!\n"
+        )
+        codec = CiscoIOSXECLICodec()
+        out = codec.render(codec.parse(raw))
+        assert " encapsulation dot1Q 100" in out
+        assert "switchport access vlan" not in out.lower()
+        sub = next(
+            i for i in codec.parse(out).interfaces
+            if i.name == "GigabitEthernet0/1.100"
+        )
+        assert sub.dot1q_vlan == 100
+
+    def test_junos_routed_subif_translates_to_encapsulation(self):
+        """End-to-end: a Junos routed sub-interface tag now renders as
+        IOS-XE ``encapsulation dot1Q`` (was dropped before this wiring)."""
+        from netcanon.migration.codecs.juniper_junos import JunosCodec
+        jraw = (
+            "set interfaces ge-0/0/0 unit 100 vlan-id 100\n"
+            "set interfaces ge-0/0/0 unit 100 family inet "
+            "address 10.0.0.1/30\n"
+        )
+        out = CiscoIOSXECLICodec().render(JunosCodec().parse(jraw))
+        assert " encapsulation dot1Q 100" in out
+        assert "switchport access vlan" not in out.lower()
+
+
 class TestR3Fields:
     def test_direction_is_bidirectional(self):
         # The codec was originally parse_only; render path was added


### PR DESCRIPTION
## What

First per-codec wire-up of the GAP-7 `dot1q_vlan` surface ([#239](https://github.com/netcanon/netcanon/pull/239) landed the schema + junos source + ship-before-wire `unsupported` everywhere else).

- **Parse**: `encapsulation dot1Q <vlan>` on a sub-interface (`interface GigabitEthernet0/1.100`) → `CanonicalInterface.dot1q_vlan` (not `access_vlan`). The anycast-mode + dot1q markers were extracted into a `_parse_iface_l3_markers` helper so `_on_line` stays under the cyclomatic-complexity gate — **no new `C901` suppression, the complexity ratchet held**.
- **Render**: emit ` encapsulation dot1Q <dot1q_vlan>` (capital Q, Cisco style) before the routed IP.
- **Matrix**: `/interfaces/interface/dot1q-vlan` flipped `unsupported` → `supported`; graduated in the ship-before-wire `_WIRED_UP_BY_CODEC`.

## Effect

The original GAP-7 inversion is now **fully round-tripped**: a Junos routed sub-interface tag translates to IOS-XE `encapsulation dot1Q N` (after #239 it was an honest *drop*; now it lands correctly). The real fixture `cml_basic_forwarding_iosv_r1_ospf.txt` (`Gi0/1.100` / `encapsulation dot1Q 100`) now captures the tag on parse.

## Tests

Parse + round-trip + junos→iosxe_cli end-to-end. Full unit suite + cross-mesh CI guard green (no `CODEC_BUG` regression from iosxe_cli now capturing the tag on its committed fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)