### PR TITLE
feat(cisco_nxos): wire routed sub-interface dot1q (encapsulation dot1q) — GAP-7

### DIFF
--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -134,6 +134,7 @@ class CiscoNXOSCodec(CodecBase):
             # Interfaces — L2 switchport + LAG membership (Phase 2a)
             "/interfaces/interface/switchport-mode",
             "/interfaces/interface/access-vlan",
+            "/interfaces/interface/dot1q-vlan",  # GAP 7: routed-subif `encapsulation dot1q N`
             "/interfaces/interface/trunk-allowed-vlans",
             "/interfaces/interface/trunk-native-vlan",
             "/interfaces/interface/lag-member-of",
@@ -470,17 +471,6 @@ class CiscoNXOSCodec(CodecBase):
             ),
         ],
         unsupported=[
-            UnsupportedPath(
-                path="/interfaces/interface/dot1q-vlan",
-                reason=(
-                    "Routed sub-interface 802.1Q tag (Cisco "
-                    "`encapsulation dot1Q N` / Junos `unit N vlan-id`) is "
-                    "not yet wired for this codec.  Declared unsupported "
-                    "(ship-before-wire, GAP 7) so a routed sub-interface "
-                    "tag is flagged as a drop, not silently mis-rendered "
-                    "as an L2 access-mode VLAN."
-                ),
-            ),
             UnsupportedPath(
                 path="/interfaces/interface/voice-vlan",
                 reason=(

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -120,6 +120,11 @@ _VRF_MEMBER_RE = re.compile(r"^\s+vrf\s+member\s+(\S+)\s*$", re.IGNORECASE)
 # ``no switchport`` is consumed (it marks the port routed) but sets no
 # canonical field — ``switchport_mode=None`` already means "routed".
 _NO_SWITCHPORT_RE = re.compile(r"^\s+no\s+switchport\s*$", re.IGNORECASE)
+#: GAP 7: routed sub-interface 802.1Q tag — NX-OS writes lowercase
+#: ``encapsulation dot1q <vlan>`` (e.g. under ``interface Ethernet1/1.100``).
+_ENCAP_DOT1Q_RE = re.compile(
+    r"^\s+encapsulation\s+dot1q\s+(\d+)\b", re.IGNORECASE,
+)
 _SWITCHPORT_MODE_RE = re.compile(
     r"^\s+switchport\s+mode\s+(\S+)", re.IGNORECASE,
 )
@@ -602,6 +607,7 @@ def _new_iface_scratch(name: str) -> dict:
         "kind": "",
         "switchport_mode": None,
         "access_vlan": None,
+        "dot1q_vlan": None,
         "trunk_allowed": [],
         "trunk_native": None,
         "lag_member_of": None,
@@ -751,6 +757,15 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:  # noqa: C901
             current["fabric_forwarding_anycast"] = True
             return
 
+        # ── GAP 7: routed sub-interface 802.1Q tag ──
+        # ``encapsulation dot1q <vlan>`` on a sub-interface (e.g.
+        # ``interface Ethernet1/1.100``) → dedicated dot1q_vlan, NOT
+        # access_vlan (a routed sub-iface is L3, not an L2 access port).
+        em = _ENCAP_DOT1Q_RE.match(line)
+        if em:
+            current["dot1q_vlan"] = int(em.group(1))
+            return
+
         # ── L2 switchport (Phase 2) ──
         if _NO_SWITCHPORT_RE.match(line):
             # Routed port — leave switchport_mode None (render emits
@@ -864,6 +879,7 @@ def _build_canonical_interface(raw: dict) -> CanonicalInterface:
         kind=kind,
         switchport_mode=raw.get("switchport_mode"),
         access_vlan=raw.get("access_vlan"),
+        dot1q_vlan=raw.get("dot1q_vlan"),  # GAP 7: routed-subif 802.1Q tag
         trunk_allowed_vlans=raw.get("trunk_allowed", []),
         trunk_native_vlan=raw.get("trunk_native"),
         lag_member_of=raw.get("lag_member_of"),

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -374,6 +374,38 @@ def _render_nve(tree: CanonicalIntent) -> list[str]:
     return block
 
 
+def _render_switchport_lines(iface) -> list[str]:
+    """The L2 switchport config lines for an interface (empty for the
+    inherently-L3 kinds: SVI / loopback / mgmt / VTEP / tunnel).
+
+    Extracted from ``_render_interface`` to keep it under the cyclomatic-
+    complexity gate.  Physical, LAG, and unknown cross-vendor names default
+    to L2 on NX-OS, so a routed one gets an explicit ``no switchport``.
+    """
+    kind = _port_names.classify_port_name(iface.name).kind
+    if kind in ("svi", "loopback", "mgmt", "vtep", "tunnel"):
+        return []
+    out: list[str] = []
+    if iface.switchport_mode == "access":
+        if iface.access_vlan is not None:
+            out.append(f"  switchport access vlan {iface.access_vlan}")
+        else:
+            out.append("  switchport mode access")
+    elif iface.switchport_mode == "trunk":
+        out.append("  switchport mode trunk")
+        if iface.trunk_native_vlan is not None:
+            out.append(
+                f"  switchport trunk native vlan {iface.trunk_native_vlan}"
+            )
+        if iface.trunk_allowed_vlans:
+            vlist = _coalesce_vlan_ids(sorted(set(iface.trunk_allowed_vlans)))
+            out.append(f"  switchport trunk allowed vlan {vlist}")
+    elif iface.ipv4_addresses or iface.ipv6_addresses:
+        # Routed physical / LAG port — state the L3 intent explicitly.
+        out.append("  no switchport")
+    return out
+
+
 def _render_interface(iface, lag_mode_by_name: dict) -> list[str]:
     """Render one interface stanza.
 
@@ -395,32 +427,13 @@ def _render_interface(iface, lag_mode_by_name: dict) -> list[str]:
     if iface.mtu is not None:
         block.append(f"  mtu {iface.mtu}")
 
-    kind = _port_names.classify_port_name(iface.name).kind
-    # Switchport applies to L2-capable ports.  Exclude the inherently-L3
-    # kinds (SVI / loopback / mgmt / VTEP / tunnel); everything else —
-    # physical, LAG, and unknown cross-vendor names that default to L2 on
-    # NX-OS — is switchport-eligible.
-    if kind not in ("svi", "loopback", "mgmt", "vtep", "tunnel"):
-        if iface.switchport_mode == "access":
-            if iface.access_vlan is not None:
-                block.append(f"  switchport access vlan {iface.access_vlan}")
-            else:
-                block.append("  switchport mode access")
-        elif iface.switchport_mode == "trunk":
-            block.append("  switchport mode trunk")
-            if iface.trunk_native_vlan is not None:
-                block.append(
-                    f"  switchport trunk native vlan {iface.trunk_native_vlan}"
-                )
-            if iface.trunk_allowed_vlans:
-                vlist = _coalesce_vlan_ids(sorted(set(iface.trunk_allowed_vlans)))
-                block.append(f"  switchport trunk allowed vlan {vlist}")
-        elif iface.ipv4_addresses or iface.ipv6_addresses:
-            # Routed physical / LAG port — state the L3 intent explicitly.
-            block.append("  no switchport")
+    block.extend(_render_switchport_lines(iface))
 
     if iface.vrf:
         block.append(f"  vrf member {iface.vrf}")
+    # GAP 7: routed sub-interface 802.1Q tag (lowercase dot1q on NX-OS).
+    if iface.dot1q_vlan is not None:
+        block.append(f"  encapsulation dot1q {iface.dot1q_vlan}")
     for addr in iface.ipv4_addresses:
         line = f"  ip address {addr.ip}/{addr.prefix_length}"
         if addr.is_secondary:

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -458,6 +458,39 @@ interface Ethernet1/6
 """
 
 
+class TestRoutedSubifDot1q:
+    """GAP 7 wiring: routed sub-interface ``encapsulation dot1q N`` <->
+    CanonicalInterface.dot1q_vlan (NOT access_vlan)."""
+
+    _RAW = (
+        "!Command: show running-config\n"
+        "hostname r1\n"
+        "interface Ethernet1/1.100\n"
+        "  no switchport\n"
+        "  encapsulation dot1q 100\n"
+        "  ip address 10.0.0.1/30\n"
+    )
+
+    def test_parse(self, codec):
+        sub = next(
+            i for i in codec.parse(self._RAW).interfaces
+            if i.name == "Ethernet1/1.100"
+        )
+        assert sub.dot1q_vlan == 100
+        assert sub.access_vlan is None  # NOT the L2 access field
+        assert sub.switchport_mode is None
+
+    def test_round_trip(self, codec):
+        out = codec.render(codec.parse(self._RAW))
+        assert "  encapsulation dot1q 100" in out
+        assert "switchport access vlan" not in out.lower()
+        sub = next(
+            i for i in codec.parse(out).interfaces
+            if i.name == "Ethernet1/1.100"
+        )
+        assert sub.dot1q_vlan == 100
+
+
 class TestPhase2L2:
     @pytest.fixture
     def tree(self, codec):


### PR DESCRIPTION
## What

Second per-codec wire-up of the GAP-7 `dot1q_vlan` surface (after cisco_iosxe_cli [#240](https://github.com/netcanon/netcanon/pull/240)).

- **Parse**: `encapsulation dot1q <vlan>` (lowercase q on NX-OS) on a sub-interface (`interface Ethernet1/1.100`) → `dot1q_vlan` (not `access_vlan`). Added to the already-`C901`-grandfathered `_on_line`.
- **Render**: emit `  encapsulation dot1q <dot1q_vlan>` after `vrf member`, before the routed IP. Extracted the L2 switchport block into `_render_switchport_lines` so `_render_interface` stays under the complexity gate — **no new suppression, ratchet held**.
- **Matrix**: `/interfaces/interface/dot1q-vlan` flipped `unsupported` → `supported`. (cisco_nxos isn't in the ship-before-wire parametrize set, so no `_WIRED_UP_BY_CODEC` entry needed.)

## Verified
Junos routed sub-interface → NX-OS `encapsulation dot1q N` now translates; nxos→nxos round-trips. Parse + round-trip unit tests. Full unit suite + cross-mesh CI guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)