### PR TITLE
feat(arista_eos): wire routed sub-interface dot1q (encapsulation dot1q vlan) — GAP-7

### DIFF
--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -116,6 +116,7 @@ class AristaEOSCodec(CodecBase):
             "/interfaces/interface/dhcp-client-v6",          # IPv6 DHCPv6 / SLAAC
             "/interfaces/interface/tunnel-type",             # GRE / IPIP / IPSEC / VXLAN discriminator
             "/interfaces/interface/config/vrf",   # GAP 6
+            "/interfaces/interface/dot1q-vlan",   # GAP 7: routed-subif `encapsulation dot1q vlan N`
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             "/routing/static-route",
@@ -318,17 +319,6 @@ class AristaEOSCodec(CodecBase):
             ),
         ],
         unsupported=[
-            UnsupportedPath(
-                path="/interfaces/interface/dot1q-vlan",
-                reason=(
-                    "Routed sub-interface 802.1Q tag (Cisco "
-                    "`encapsulation dot1Q N` / Junos `unit N vlan-id`) is "
-                    "not yet wired for this codec.  Declared unsupported "
-                    "(ship-before-wire, GAP 7) so a routed sub-interface "
-                    "tag is flagged as a drop, not silently mis-rendered "
-                    "as an L2 access-mode VLAN."
-                ),
-            ),
             UnsupportedPath(
                 path="/interfaces/interface/voice-vlan",
                 reason=(

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -1141,6 +1141,17 @@ def _apply_iface_subcommand(  # noqa: C901
             except ValueError:
                 pass
         return
+    # GAP 7: routed sub-interface 802.1Q tag.  EOS writes
+    # ``encapsulation dot1q vlan N`` (the ``vlan`` keyword is required —
+    # verified vs an independent Batfish parse); ``split()[-1]`` also
+    # tolerates a bare ``encapsulation dot1q N``.  Stored on the dedicated
+    # dot1q_vlan field, NOT access_vlan (a routed sub-iface is L3).
+    if line.startswith("encapsulation dot1q "):
+        try:
+            iface.dot1q_vlan = int(line.split()[-1])
+        except ValueError:
+            pass
+        return
     # ``switchport mode access`` / ``switchport access vlan N`` /
     # ``switchport trunk allowed vlan L`` — parse-and-record.
     if line.startswith("switchport access vlan "):

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -511,6 +511,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             or not iface.enabled
             or iface.switchport_mode is not None
             or iface.access_vlan is not None
+            or iface.dot1q_vlan is not None  # GAP 7: routed-subif tag
             or bool(iface.trunk_allowed_vlans)
             or bool(iface.lag_member_of)
             # Wave B: VRRP groups on a routed SVI / port count as
@@ -538,11 +539,20 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         if iface.description:
             out.append(f"   description {iface.description}")
         # L3 flip needed when we emit an IP address on a port that
-        # doesn't already indicate L3 (Ethernet<N> physical).
-        if iface.ipv4_addresses and iface.name.lower().startswith(
-            "ethernet"
-        ):
+        # doesn't already indicate L3 (Ethernet<N> physical).  A routed
+        # sub-interface (name contains ``.``) is inherently L3 on EOS and
+        # takes NO ``no switchport`` — it carries ``encapsulation dot1q``
+        # instead (Batfish rejects ``no switchport`` on a sub-interface).
+        if (iface.ipv4_addresses
+                and iface.name.lower().startswith("ethernet")
+                and "." not in iface.name):
             out.append("   no switchport")
+        # GAP 7: routed sub-interface 802.1Q tag.  The EOS form REQUIRES
+        # the ``vlan`` keyword (``encapsulation dot1q vlan N``) — the bare
+        # ``dot1q N`` form is rejected by EOS (verified vs an independent
+        # Batfish parse).
+        if iface.dot1q_vlan is not None:
+            out.append(f"   encapsulation dot1q vlan {iface.dot1q_vlan}")
         # GAP 6: per-interface VRF membership.  Must emit BEFORE
         # ``ip address`` so EOS correctly binds the IP into the
         # VRF's routing table.

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -227,6 +227,41 @@ class TestParseUsers:
 # ---------------------------------------------------------------------------
 
 
+class TestRoutedSubifDot1q:
+    """GAP 7 wiring: routed sub-interface ``encapsulation dot1q vlan N``
+    <-> CanonicalInterface.dot1q_vlan.  The ``vlan`` keyword is required
+    on EOS (bare ``dot1q N`` is rejected — Batfish-verified)."""
+
+    _RAW = (
+        "hostname r1\n"
+        "interface Ethernet1.100\n"
+        "   encapsulation dot1q vlan 100\n"
+        "   ip address 10.0.0.1/30\n"
+        "!\n"
+    )
+
+    def test_parse(self):
+        sub = next(
+            i for i in AristaEOSCodec().parse(self._RAW).interfaces
+            if i.name == "Ethernet1.100"
+        )
+        assert sub.dot1q_vlan == 100
+        assert sub.access_vlan is None  # NOT the L2 access field
+
+    def test_round_trip_emits_vlan_keyword(self):
+        codec = AristaEOSCodec()
+        out = codec.render(codec.parse(self._RAW))
+        # EOS form REQUIRES the ``vlan`` keyword.
+        assert "   encapsulation dot1q vlan 100" in out
+        # A sub-interface is inherently L3 on EOS — no ``no switchport``.
+        assert "no switchport" not in out
+        sub = next(
+            i for i in codec.parse(out).interfaces
+            if i.name == "Ethernet1.100"
+        )
+        assert sub.dot1q_vlan == 100
+
+
 class TestParseInterfaces:
     def test_interface_ethernet_l3(self):
         raw = (

--- a/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
+++ b/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
@@ -371,6 +371,8 @@ class TestShipBeforeWireUnsupportedDeclarations:
             "/interfaces/interface/ipv4/address/virtual-gateway-address",
             "/interfaces/interface/ipv6/address/virtual-gateway-address",
             "/anycast-gateway-mac",
+            # GAP 7 — routed sub-interface `encapsulation dot1q vlan N`.
+            "/interfaces/interface/dot1q-vlan",
         },
         # Wave B — see commit feat(aruba_aoss): wire VRRP groups.
         # AOS-S has no native anycast grammar; those paths stay


### PR DESCRIPTION
## What

Third per-codec wire-up of the GAP-7 `dot1q_vlan` surface (after cisco_iosxe_cli [#240](https://github.com/netcanon/netcanon/pull/240), cisco_nxos [#241](https://github.com/netcanon/netcanon/pull/241)).

- **Parse**: `encapsulation dot1q vlan N` on a sub-interface (`interface Ethernet1.100`) → `dot1q_vlan` (not `access_vlan`). Tolerant of a bare `encapsulation dot1q N` on input.
- **Render**: emit `   encapsulation dot1q vlan <dot1q_vlan>`; a routed sub-interface (name contains `.`) skips the `no switchport` line (EOS sub-interfaces are inherently L3).
- **Matrix**: `/interfaces/interface/dot1q-vlan` flipped `unsupported` → `supported`; graduated in the ship-before-wire `_WIRED_UP_BY_CODEC`.

## Grammar verified against an independent parser

The arista survey couldn't confirm the EOS form and no fixture exercises it, so I settled it against a live **Batfish EOS parse**:
- `encapsulation dot1q 100` → **PARTIALLY_UNRECOGNIZED**
- `encapsulation dot1q vlan 100` → **PASSED**

So the `vlan` keyword is **required** — the render emits exactly the Batfish-clean shape.

## Tests
Parse + round-trip (asserts the `vlan` keyword and no `no switchport` on the sub-interface). Full unit suite + cross-mesh CI guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)