### PR TITLE
feat(cisco_iosxr): wire routed sub-interface dot1q onto dot1q_vlan — GAP-7

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -135,6 +135,10 @@ class CiscoIOSXRCodec(CodecBase):
             "/interfaces/interface/ipv6/address/prefix-length",
             # Phase 2 — per-interface VRF membership (bare `vrf <name>`)
             "/interfaces/interface/config/vrf",
+            # GAP 7 — routed sub-interface 802.1Q tag on the interface
+            # (`encapsulation dot1q N`), distinct from the synthesised
+            # VLAN id-list below.
+            "/interfaces/interface/dot1q-vlan",
             # Phase 2 — sub-interface `encapsulation dot1q` → synthesised
             # VLAN id-list (no port membership; name always empty)
             "/vlans/vlan/id",
@@ -292,17 +296,6 @@ class CiscoIOSXRCodec(CodecBase):
             ),
         ],
         unsupported=[
-            UnsupportedPath(
-                path="/interfaces/interface/dot1q-vlan",
-                reason=(
-                    "Routed sub-interface 802.1Q tag (Cisco "
-                    "`encapsulation dot1Q N` / Junos `unit N vlan-id`) is "
-                    "not yet wired for this codec.  Declared unsupported "
-                    "(ship-before-wire, GAP 7) so a routed sub-interface "
-                    "tag is flagged as a drop, not silently mis-rendered "
-                    "as an L2 access-mode VLAN."
-                ),
-            ),
             UnsupportedPath(
                 path="/interfaces/interface/vrrp-groups/group",
                 reason=(

--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -325,6 +325,7 @@ def _new_iface_scratch(name: str) -> dict:
         "ipv6": [],
         "vrf": "",
         "lag_member_of": None,
+        "dot1q_vlan": None,
     }
 
 
@@ -391,6 +392,18 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:
         if vm:
             current["vrf"] = vm.group(1)
             return
+        # GAP 7: routed sub-interface 802.1Q tag.  ``encapsulation dot1q
+        # <vid>`` also feeds _parse_dot1q_vlans (VLAN synthesis for
+        # VLAN-centric targets); here we ALSO record it on the interface's
+        # dedicated dot1q_vlan so the render emits the true tag (not just
+        # when the sub-iface unit number coincides with the tag).
+        em = _ENCAP_DOT1Q_RE.match(line)
+        if em:
+            try:
+                current["dot1q_vlan"] = int(em.group(1))
+            except ValueError:
+                pass
+            return
 
     # Loop skeleton (open on `interface`, close on `!`/dedent, flush at EOF)
     # is the shared codecs/_scanner helper; the vendor regex cascade above
@@ -430,6 +443,7 @@ def _build_canonical_interface(raw: dict) -> CanonicalInterface:
         ],
         vrf=raw.get("vrf", ""),
         lag_member_of=raw.get("lag_member_of"),
+        dot1q_vlan=raw.get("dot1q_vlan"),  # GAP 7: routed-subif 802.1Q tag
     )
 
 

--- a/netcanon/migration/codecs/cisco_iosxr/render.py
+++ b/netcanon/migration/codecs/cisco_iosxr/render.py
@@ -85,10 +85,9 @@ def render_intent(tree: CanonicalIntent) -> str:
         lines.extend(_render_vrf(ri))
 
     # ── Interfaces (XR show-output-ish order) ──
-    vlan_ids = {v.id for v in tree.vlans}
     lag_mode_by_name = {lag.name: lag.mode for lag in tree.lags}
     for iface in _sort_interfaces_iosxr(tree.interfaces):
-        lines.extend(_render_interface(iface, vlan_ids, lag_mode_by_name))
+        lines.extend(_render_interface(iface, lag_mode_by_name))
 
     # ── Static routes (default VRF + per-VRF) ──
     lines.extend(_render_router_static(tree.static_routes))
@@ -245,7 +244,7 @@ def _render_router_static(routes: list) -> list[str]:
     return out
 
 
-def _render_interface(iface, vlan_ids: set, lag_mode_by_name: dict) -> list[str]:
+def _render_interface(iface, lag_mode_by_name: dict) -> list[str]:
     """Render one ``interface <name>`` stanza (``!``-terminated).
 
     IPv4 emits the dotted-mask form (``ipv4 address X Y``); IPv6 emits
@@ -266,10 +265,12 @@ def _render_interface(iface, vlan_ids: set, lag_mode_by_name: dict) -> list[str]
         block.append(f" mtu {iface.mtu}")
     if iface.vrf:
         block.append(f" vrf {iface.vrf}")
-    if "." in iface.name:
-        unit = _subinterface_unit(iface.name)
-        if unit is not None and unit in vlan_ids:
-            block.append(f" encapsulation dot1q {unit}")
+    # GAP 7: routed sub-interface 802.1Q tag.  Emitted directly from the
+    # dedicated dot1q_vlan field (was previously inferred from the
+    # sub-iface unit number matching a synthesised VLAN id, which dropped
+    # the tag whenever unit != tag).
+    if iface.dot1q_vlan is not None:
+        block.append(f" encapsulation dot1q {iface.dot1q_vlan}")
     for addr in iface.ipv4_addresses:
         line = f" ipv4 address {addr.ip} {_prefix_to_mask(addr.prefix_length, vendor='cisco_iosxr')}"
         if addr.is_secondary:
@@ -286,19 +287,6 @@ def _render_interface(iface, vlan_ids: set, lag_mode_by_name: dict) -> list[str]
             block.append(f" bundle id {m.group(1)} mode {mode}")
     block.append("!")
     return block
-
-
-def _subinterface_unit(name: str) -> int | None:
-    """Return the numeric unit suffix of a sub-interface name, or None.
-
-    ``GigabitEthernet0/0/0/1.100`` → ``100``; a name with a non-numeric
-    or absent suffix returns ``None``.
-    """
-    tail = name.rsplit(".", 1)[-1]
-    try:
-        return int(tail)
-    except ValueError:
-        return None
 
 
 #: Interface-kind render order: Loopback → MgmtEth → physical →

--- a/tests/unit/migration/test_cisco_iosxr.py
+++ b/tests/unit/migration/test_cisco_iosxr.py
@@ -311,6 +311,33 @@ class TestParsePhase2:
         assert [v.id for v in intent.vlans] == [100]
         assert intent.vlans[0].name == ""
 
+    def test_dot1q_on_interface_dot1q_vlan_field(self, codec, kitchen_sink):
+        """GAP 7: the tag is now ALSO recorded on the sub-interface's
+        dedicated dot1q_vlan (not only synthesised as a VLAN record)."""
+        sub = next(
+            i for i in codec.parse(kitchen_sink).interfaces
+            if i.name == "GigabitEthernet0/0/0/1.100"
+        )
+        assert sub.dot1q_vlan == 100
+
+    def test_dot1q_tag_differs_from_unit_number(self, codec):
+        """A sub-interface whose unit number differs from its 802.1Q tag
+        renders the TRUE tag (the old unit==vlan_id workaround dropped it)."""
+        raw = (
+            "!! IOS XR Configuration 7.5.2\n"
+            "interface GigabitEthernet0/0/0/1.100\n"
+            " encapsulation dot1q 50\n"
+            " ipv4 address 10.0.0.1 255.255.255.252\n"
+            "!\n"
+        )
+        intent = codec.parse(raw)
+        sub = next(
+            i for i in intent.interfaces
+            if i.name == "GigabitEthernet0/0/0/1.100"
+        )
+        assert sub.dot1q_vlan == 50
+        assert " encapsulation dot1q 50" in codec.render(intent)
+
 
 # ---------------------------------------------------------------------------
 # Round-trip


### PR DESCRIPTION
## What

Fourth per-codec wire-up of the GAP-7 `dot1q_vlan` surface (after iosxe_cli [#240](https://github.com/netcanon/netcanon/pull/240), nxos [#241](https://github.com/netcanon/netcanon/pull/241), arista [#242](https://github.com/netcanon/netcanon/pull/242)).

IOS-XR already parsed `encapsulation dot1q <vid>` — but only into a separate VLAN-synthesis scan (`_parse_dot1q_vlans`), and rendered the tag via a **fragile workaround** that emitted it *only* when the sub-interface unit number equalled a synthesised VLAN id (so a `.100` sub-iface carrying tag `50` silently **dropped** the tag).

- **Parse**: `_parse_interfaces` now also records the tag on the interface's dedicated `dot1q_vlan`. The VLAN synthesis stays — it's the id-list VLAN-centric targets consume.
- **Render**: emit ` encapsulation dot1q <dot1q_vlan>` directly from the field; **removed** the `unit==vlan_id` workaround + the now-dead `vlan_ids` param and `_subinterface_unit` helper.
- **Matrix**: `/interfaces/interface/dot1q-vlan` flipped `unsupported` → `supported`.

## Bonus fix
A sub-interface whose unit number differs from its 802.1Q tag now renders the **true tag** (regression-tested). Round-trip stable on the committed iosxr fixtures (all `unit==tag`).

Full unit suite + cross-mesh CI guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)