### PR TITLE
docs(aruba_aoscx): clarify dot1q-vlan is architecturally unsupported (no routed sub-ifs)

### DIFF
--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -434,12 +434,13 @@ class ArubaAOSCXCodec(CodecBase):
             UnsupportedPath(
                 path="/interfaces/interface/dot1q-vlan",
                 reason=(
-                    "Routed sub-interface 802.1Q tag (Cisco "
-                    "`encapsulation dot1Q N` / Junos `unit N vlan-id`) is "
-                    "not yet wired for this codec.  Declared unsupported "
-                    "(ship-before-wire, GAP 7) so a routed sub-interface "
-                    "tag is flagged as a drop, not silently mis-rendered "
-                    "as an L2 access-mode VLAN."
+                    "AOS-CX has NO routed sub-interface construct (no "
+                    "`<parent>.<subid>` naming) — tagged L3 is done via "
+                    "SVIs (`interface vlan N`), not `encapsulation dot1q` "
+                    "sub-interfaces.  So the routed-subif 802.1Q tag (GAP "
+                    "7) is architecturally unsupported here, not merely "
+                    "un-wired: a cross-vendor source's tag is flagged as a "
+                    "drop rather than mis-rendered."
                 ),
             ),
             UnsupportedPath(


### PR DESCRIPTION
## What

Refines the GAP-7 `/interfaces/interface/dot1q-vlan` `UnsupportedPath` reason for AOS-CX. The ship-before-wire boilerplate ([#239](https://github.com/netcanon/netcanon/pull/239)) said "not yet wired", but the per-codec survey confirmed **AOS-CX has no routed sub-interface construct at all** — tagged L3 is done via SVIs (`interface vlan N`), not `encapsulation dot1q` sub-interfaces. So the field is *architecturally* unsupported here, not merely awaiting a wire-up (unlike the Cisco/Arista codecs wired in #240–#243).

Reason-string only; no behaviour change. This completes the GAP-7 per-codec pass: every codec with a native routed-subif dot1q construct is now wired (junos + iosxe_cli + nxos + arista + iosxr), and the ones without (aoss, aoscx, fortigate, mikrotik, opnsense, cisco_iosxe NETCONF) honestly declare it unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)