### PR TITLE
fix(codecs): convert parse-time ValidationError to ParseError at the CodecBase boundary

### DIFF
--- a/netcanon/migration/codecs/base.py
+++ b/netcanon/migration/codecs/base.py
@@ -25,9 +25,12 @@ registry; instances are stateless unless documented otherwise.
 
 from __future__ import annotations
 
+import functools
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+from pydantic import ValidationError
 
 from ...models.migration import CapabilityMatrix
 
@@ -80,6 +83,33 @@ class RenderError(CodecError):
     ) -> None:
         super().__init__(message)
         self.yang_path = yang_path
+
+
+def _validation_error_as_parse_error(
+    codec_name: str, exc: ValidationError
+) -> ParseError:
+    """Convert a pydantic :class:`ValidationError` into a :class:`ParseError`.
+
+    A codec's ``parse`` builds :class:`CanonicalIntent` models from the
+    input.  When a *parsed* value violates a canonical field constraint —
+    an HSRP group-id above ``group_id``'s ``le``, a VLAN id above 4094, an
+    IPv4 prefix length above 32, a VRRP priority above 254, … — pydantic
+    raises a raw ``ValidationError``.  That is unrepresentable-as-canonical
+    INPUT, not a server fault, so every codec boundary surfaces it as the
+    documented ``ParseError`` (see :meth:`CodecBase.parse`).  This keeps the
+    contract uniform: HTTP routes return 400 instead of leaking a 500, the
+    CLI reports a clean message instead of a pydantic traceback, and the
+    sanitize / migrate services need no per-call ``ValidationError`` handling
+    (the fix generalised from #229's single sanitize-boundary conversion).
+    """
+    errs = exc.errors()
+    loc = ".".join(str(x) for x in errs[0]["loc"]) if errs else None
+    detail = f"{loc}: {errs[0]['msg']}" if errs else str(exc)
+    return ParseError(
+        f"{codec_name}: input could not be represented as a valid "
+        f"canonical config ({detail})",
+        path=loc,
+    )
 
 
 #: Canonical catalogue of adapter input formats.  Short strings so they
@@ -220,6 +250,38 @@ class CodecBase(ABC):
     #: is tracked as follow-up work and will clear the declarations
     #: from the affected codec classes when shipped.
     unsupported_rename_categories: ClassVar[frozenset[str]] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Wrap each subclass's ``parse`` at the class boundary so a pydantic
+        ``ValidationError`` raised while building a canonical model surfaces
+        as the documented :class:`ParseError` — never leaking to callers.
+
+        This is the SINGLE uniform boundary that enforces ``parse``'s
+        ``Raises: ParseError`` contract across every codec and every caller
+        (the migrate pipeline, the cross-vendor mesh, sanitize, the CLI,
+        tests) without each codec repeating a ``try/except ValidationError``.
+        See :func:`_validation_error_as_parse_error` for the rationale.
+
+        Applied only to a subclass that DEFINES ``parse`` in its own body
+        (inherited implementations are already wrapped on the class that
+        defined them), and idempotent — re-decorating a class (e.g. under an
+        ``importlib`` reload) never double-wraps.
+        """
+        super().__init_subclass__(**kwargs)
+        raw_parse = cls.__dict__.get("parse")
+        if raw_parse is None or getattr(raw_parse, "_nc_parse_wrapped", False):
+            return
+
+        @functools.wraps(raw_parse)
+        def _wrapped_parse(self: CodecBase, raw: str) -> Any:
+            try:
+                return raw_parse(self, raw)
+            except ValidationError as exc:
+                codec_name = getattr(self, "name", None) or cls.__name__
+                raise _validation_error_as_parse_error(codec_name, exc) from exc
+
+        _wrapped_parse._nc_parse_wrapped = True  # type: ignore[attr-defined]
+        cls.parse = _wrapped_parse  # type: ignore[assignment]
 
     @property
     @abstractmethod

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -133,10 +133,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from pydantic import ValidationError
-
 from ..migration.canonical.intent import CanonicalIntent
-from ..migration.codecs.base import ParseError
 from ..migration.codecs.registry import get_codec
 
 #: A DNS hostname: dot-separated labels (alnum, internal hyphen, and
@@ -225,26 +222,14 @@ def sanitize_text(
             f"Unknown source codec: {source_codec_name!r}. "
             f"See netcanon.migration.codecs.registry.list_codecs()."
         ) from e
-    try:
-        intent = codec.parse(raw)
-    except ValidationError as e:
-        # The input parsed structurally but produced a canonical model that
-        # violates a field constraint (e.g. an HSRP group-id above the
-        # 0-4095 HSRPv2 range that CanonicalVRRPGroup.group_id enforces).
-        # That's
-        # unparseable-as-canonical INPUT, not a server fault — surface it as
-        # a ParseError so callers honour the documented contract: the HTTP
-        # route returns 400 instead of leaking a 500, and the CLI reports it
-        # cleanly rather than dumping a pydantic traceback.
-        errs = e.errors()
-        detail = (
-            f"{'.'.join(str(x) for x in errs[0]['loc'])}: {errs[0]['msg']}"
-            if errs else str(e)
-        )
-        raise ParseError(
-            f"{source_codec_name}: input could not be represented as a "
-            f"valid canonical config ({detail})"
-        ) from e
+    # ``codec.parse`` converts any canonical-model ValidationError into a
+    # ParseError at the CodecBase boundary (base._validation_error_as_parse_
+    # error) — so an out-of-range parsed value (e.g. an HSRP group-id above
+    # CanonicalVRRPGroup.group_id's ceiling, a VLAN id > 4094) already
+    # surfaces here as the documented ParseError, which the HTTP route maps
+    # to 400 and the CLI reports cleanly.  No per-call pydantic handling
+    # needed (this generalised #229's single sanitize-boundary conversion).
+    intent = codec.parse(raw)
     sanitized_intent, substitutions = sanitize_intent(intent)
 
     if dry_run:

--- a/tests/unit/migration/test_parse_validation_boundary.py
+++ b/tests/unit/migration/test_parse_validation_boundary.py
@@ -1,0 +1,186 @@
+"""Guard: no codec ``parse()`` leaks a raw pydantic ``ValidationError``.
+
+A codec builds :class:`CanonicalIntent` models from parsed input.  When a
+*parsed* value violates a field constraint — a VLAN id > 4094, an IPv4
+prefix length > 32, a VRRP priority > 254, an HSRP group-id out of range —
+pydantic raises a raw ``ValidationError``.  Left unhandled that leaks out of
+``parse``: the HTTP routes 500, the CLI dumps a pydantic traceback.
+
+``CodecBase.__init_subclass__`` wraps every codec's ``parse`` at the class
+boundary so such a failure surfaces as the documented :class:`ParseError`
+instead — one uniform boundary that generalises #229's single
+sanitize-boundary conversion to *every* codec and *every* caller (pipeline,
+mesh, sanitize, CLI, tests).
+
+These tests lock the boundary in two ways:
+
+* generically — a synthetic ``CodecBase`` subclass whose ``parse`` builds an
+  out-of-range model must raise ``ParseError`` (proves the wrap applies to
+  ANY subclass, not just the vendors probed below), and
+* through real parse paths — vendor inputs that were verified to raise a raw
+  ``ValidationError`` before the wrap must now raise ``ParseError``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from netcanon.migration.canonical.intent import CanonicalIntent, CanonicalVlan
+from netcanon.migration.codecs.base import CodecBase, ParseError
+from netcanon.migration.codecs.registry import get_codec
+from netcanon.models.migration import CapabilityMatrix
+
+pytestmark = pytest.mark.unit
+
+
+# Real vendor parse paths that construct an OUT-OF-RANGE canonical value.
+# Each was verified to raise a raw pydantic ValidationError BEFORE the
+# boundary wrap (repro 2026-07); the boundary must turn every one into a
+# ParseError whose message names the offending canonical field.
+# (codec, label, raw, expected loc-fragment in the message)
+_OUT_OF_RANGE_INPUTS = [
+    ("cisco_nxos", "vlan-id-gt-4094",
+     "hostname n\nvlan 5000\n  name X\n", "id"),
+    ("cisco_nxos", "ipv4-prefix-gt-32",
+     "hostname n\ninterface Vlan10\n  ip address 10.0.0.1/33\n", "prefix_length"),
+    ("cisco_nxos", "hsrp-priority-gt-254",
+     "hostname n\ninterface Vlan10\n  hsrp 10\n    priority 300\n", "priority"),
+    ("cisco_iosxe_cli", "vlan-id-gt-4094",
+     "hostname n\nvlan 5000\n name X\n", "id"),
+    ("cisco_iosxe_cli", "vrrp-priority-gt-254",
+     "hostname n\ninterface Vlan10\n vrrp 10 priority 300\n vrrp 10 ip 10.0.0.1\n",
+     "priority"),
+    ("arista_eos", "vlan-id-gt-4094",
+     "hostname n\nvlan 5000\n   name X\n", "id"),
+]
+
+
+@pytest.mark.parametrize(
+    "codec_name,label,raw,loc",
+    _OUT_OF_RANGE_INPUTS,
+    ids=[f"{c}-{lab}" for c, lab, *_ in _OUT_OF_RANGE_INPUTS],
+)
+def test_out_of_range_parse_raises_parse_error(codec_name, label, raw, loc):
+    """A vendor parse path that builds an out-of-range model surfaces a
+    ``ParseError`` — never a raw pydantic ``ValidationError``.
+
+    ``pytest.raises(ParseError)`` also fails if a ``ValidationError`` leaks
+    (it is not a ``ParseError`` subclass), so this asserts the conversion.
+    """
+    codec = get_codec(codec_name)
+    with pytest.raises(ParseError) as excinfo:
+        codec.parse(raw)
+    msg = str(excinfo.value)
+    assert "could not be represented" in msg
+    assert codec_name in msg
+    assert loc in msg
+    # The originating ValidationError is chained for debuggability.
+    assert excinfo.value.__cause__ is not None
+
+
+# ---------------------------------------------------------------------------
+# Synthetic subclasses — prove the boundary is generic (applies to ANY codec)
+# and transparent (passes valid input + pre-raised ParseErrors through).
+# Defining a CodecBase subclass does NOT register it (registration is the
+# explicit @register decorator), so these are inert throwaways.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingCodec(CodecBase):
+    """parse() builds an out-of-range model (VLAN id 9999 > le=4094)."""
+
+    name = "raising_boundary_test_codec"
+
+    @property
+    def capabilities(self) -> CapabilityMatrix:
+        return CapabilityMatrix(adapter=self.name)
+
+    def parse(self, raw: str) -> CanonicalIntent:
+        return CanonicalIntent(vlans=[CanonicalVlan(id=9999)])
+
+    def render(self, tree: Any) -> str:
+        return ""
+
+
+class _PassthroughParseErrorCodec(CodecBase):
+    """parse() raises ParseError directly — must pass through unaltered."""
+
+    name = "passthrough_boundary_test_codec"
+
+    @property
+    def capabilities(self) -> CapabilityMatrix:
+        return CapabilityMatrix(adapter=self.name)
+
+    def parse(self, raw: str) -> CanonicalIntent:
+        raise ParseError("original boom", path="ifaces/0", snippet="line 1")
+
+    def render(self, tree: Any) -> str:
+        return ""
+
+
+class _ValidInputCodec(CodecBase):
+    """parse() returns a valid model — the wrap must be transparent."""
+
+    name = "valid_boundary_test_codec"
+
+    @property
+    def capabilities(self) -> CapabilityMatrix:
+        return CapabilityMatrix(adapter=self.name)
+
+    def parse(self, raw: str) -> CanonicalIntent:
+        return CanonicalIntent(hostname="host-1", vlans=[CanonicalVlan(id=10)])
+
+    def render(self, tree: Any) -> str:
+        return ""
+
+
+def test_boundary_wraps_arbitrary_subclass():
+    """The __init_subclass__ wrap fires for ANY CodecBase subclass, not just
+    the shipped vendors — an out-of-range model becomes a named ParseError."""
+    with pytest.raises(ParseError) as excinfo:
+        _RaisingCodec().parse("anything")
+    msg = str(excinfo.value)
+    assert "raising_boundary_test_codec" in msg
+    assert "could not be represented" in msg
+    assert "id" in msg
+
+
+def test_boundary_passes_parse_error_through_unaltered():
+    """A ParseError raised by parse() is not re-wrapped — message, path and
+    snippet survive so the caller keeps the codec's own diagnostics."""
+    with pytest.raises(ParseError) as excinfo:
+        _PassthroughParseErrorCodec().parse("x")
+    assert str(excinfo.value) == "original boom"
+    assert excinfo.value.path == "ifaces/0"
+    assert excinfo.value.snippet == "line 1"
+
+
+def test_boundary_transparent_for_valid_input():
+    """Valid input round-trips through the wrap with no behaviour change."""
+    intent = _ValidInputCodec().parse("x")
+    assert intent.hostname == "host-1"
+    assert intent.vlans[0].id == 10
+
+
+def test_every_registered_codec_parse_is_wrapped():
+    """Structural guard: every shipped codec's own ``parse`` carries the
+    boundary marker, so a future codec that forgets it can't slip through
+    (the wrap is applied by __init_subclass__, not opt-in per codec)."""
+    from netcanon.migration.codecs.registry import list_codecs
+
+    unwrapped = []
+    for name in list_codecs():
+        codec = get_codec(name)
+        parse_fn = type(codec).__dict__.get("parse")
+        # Only codecs that define their OWN parse need the marker; any that
+        # inherit it are covered on the class that defined it.
+        if parse_fn is not None and not getattr(
+            parse_fn, "_nc_parse_wrapped", False
+        ):
+            unwrapped.append(name)
+    assert not unwrapped, (
+        f"codec parse() not wrapped by the ValidationError boundary: "
+        f"{unwrapped}"
+    )


### PR DESCRIPTION
## What

Generalises #229 (which converted a pydantic `ValidationError` → `ParseError` at the **single** `sanitize_text` boundary) into a **uniform guard on every codec**.

`CodecBase.__init_subclass__` now wraps each subclass's `parse()` so that a `ValidationError` raised while building a `CanonicalIntent` model surfaces as the documented `ParseError` instead of leaking to the caller. One boundary covers every caller: the migrate pipeline, the cross-vendor mesh, `sanitize`, the CLI, and tests — no codec has to repeat a `try/except ValidationError`.

## Why

A codec's `parse()` builds canonical models from parsed input. When a parsed value violates a field constraint, pydantic raises a raw `ValidationError`. Left unhandled that leaks: the HTTP routes 500, the CLI dumps a pydantic traceback. #229 fixed one instance (HSRP group-id via sanitize); the same shape existed across other codecs and other constraints.

**Verify-first** — confirmed real leaks through actual parse paths *before* the fix, and that they now raise `ParseError`:

| codec | input | pre-fix | post-fix |
|---|---|---|---|
| `cisco_nxos` | `vlan 5000` (id > 4094) | raw `ValidationError` | `ParseError` |
| `cisco_nxos` | SVI `ip address .../33` (prefix > 32) | raw `ValidationError` | `ParseError` |
| `cisco_nxos` | `hsrp 10 / priority 300` (> 254) | raw `ValidationError` | `ParseError` |
| `cisco_iosxe_cli` | `vlan 5000`, `vrrp 10 priority 300` | raw `ValidationError` | `ParseError` |
| `arista_eos` | `vlan 5000` | raw `ValidationError` | `ParseError` |

## Scope note (deliberately excluded)

The audit also surfaced three **legitimate** HSRP values currently rejected by the VRRP-centric bounds — HSRP `priority 255`, `priority 0`, and group `0`. Those are a *data-capture* question, not a leak, and widening `priority`/`group_id` collides with intentional, tested semantics (opnsense CARP `advskew = 254 - priority`; fortigate/aruba_aoss `owner`→254 clamp; explicit `test_canonical_vrrp_anycast_schema.py` assertions that `priority=0`/`255` must raise). Left as a separate follow-up decision. The boundary here makes all of them **safe** either way (clean `ParseError`, never a 500).

## Changes

- `codecs/base.py` — `__init_subclass__` wrap + `_validation_error_as_parse_error()` helper (idempotent; only wraps a subclass that defines its own `parse`; chains the original error via `from`).
- `tools/sanitize.py` — drops the now-redundant per-call `ValidationError` handling (the boundary owns it); message contract preserved.
- `tests/unit/migration/test_parse_validation_boundary.py` — parametrized guard across real codecs + synthetic subclasses (generic wrap, `ParseError` pass-through, valid-input transparency) + a structural check that every registered codec's own `parse()` carries the boundary marker.

## Verification

- Full `tests/unit` + `tests/integration/test_cross_mesh_ci_guard.py` green (mesh baseline unchanged — the guard keys on counts/buckets, not error strings, and no committed fixture reparse-crashes).
- `tests/unit/tools/test_sanitize.py` + `tests/integration/test_sanitize_api.py` green (400-not-500 contract intact).
- Ruff clean; complexity ratchet unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)