### PR TITLE
feat(canonical): widen FHRP priority/group_id to the full HSRP union (preserve legit values)

### DIFF
--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -547,12 +547,11 @@ class CanonicalVRRPGroup(BaseModel):
 
     Attributes:
         group_id: FHRP group number.  Required.  VRRP VRID and CARP VHID
-            are 1-255, but HSRPv2 (``mode="hsrp"``) extends to 4095, so the
-            field bound is the union (1-4095).  A VRRP / CARP source never
-            emits a group > 255, so the wider ceiling only ever admits a
-            legitimate HSRPv2 group — it does not need per-mode validation.
-            (Lower bound stays 1: VRRP/CARP require it; HSRP group 0 is a
-            valid but unhandled edge, out of scope here.)
+            are 1-255, but HSRP (``mode="hsrp"``) runs 0-4095 (group 0 is
+            valid; HSRPv2 extends the ceiling to 4095), so the field bound is
+            the union (0-4095).  A VRRP / CARP source never emits a group
+            outside 1-255, so the wider range only ever admits a legitimate
+            HSRP group — it needs no per-mode validation.
         mode: Wire-protocol discriminator.  String literal (not enum)
             so codecs can extend it without a schema change.  Known
             values: ``"vrrp"`` (default — IETF VRRPv2 / VRRPv3),
@@ -575,8 +574,13 @@ class CanonicalVRRPGroup(BaseModel):
             group on parse and hoists back to top-level on render.
             Empty string = vendor-default (``00:00:5E:00:01:<VRID>``
             for IETF VRRP; ``00:00:0C:07:AC:<group>`` for HSRP).
-        priority: VRRP priority (1-254).  Higher wins the election.
-            Vendor default is 100.
+        priority: FHRP priority (0-255 — the VRRP/HSRP/GLBP union).
+            Higher wins the election; vendor default is 100.  VRRP itself
+            configures 1-254 (255 = the auto-assigned address owner, 0 = the
+            master-release sentinel), but HSRP / GLBP permit the full 0-255
+            as an operator-set value, so the canonical bound is the union.
+            A VRRP/CARP codec with no native representation for 255/0 maps
+            it (e.g. AOS-S ``owner`` <-> 255) or clamps on render.
         preempt: Whether a higher-priority router preempts the
             current master.  Vendor defaults vary (Cisco: true,
             Junos: false); the canonical default mirrors the most
@@ -605,12 +609,12 @@ class CanonicalVRRPGroup(BaseModel):
     ``docs/v0.2.0-planning/``.)
     """
 
-    group_id: int = Field(ge=1, le=4095)
+    group_id: int = Field(ge=0, le=4095)
     mode: str = "vrrp"  # "vrrp" | "hsrp" | "carp"
     virtual_ips: list[str] = Field(default_factory=list)
     virtual_ipv6s: list[str] = Field(default_factory=list)
     virtual_mac: str = ""
-    priority: int = Field(default=100, ge=1, le=254)
+    priority: int = Field(default=100, ge=0, le=255)
     preempt: bool = True
     advertisement_interval: int = 1
     authentication: str = ""

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -595,8 +595,8 @@ def _parse_vrrp_group_stanza(
 
     Body grammar (AOS-S 16.10 "Basic configuration process" CLI ref):
 
-      * ``owner``                   — VIP owner → ``priority = 254``
-        (canonical ceiling; 255 reserved-but-unrepresentable)
+      * ``owner``                   — VIP owner → ``priority = 255``
+        (RFC 5798 address-owner priority; now representable)
       * ``backup``                  — explicit backup role (no field)
       * ``virtual-ip-address X``    — append to ``virtual_ips``
         (legacy ``X <mask>`` two-token form tolerated; mask dropped)
@@ -643,17 +643,15 @@ def _parse_vrrp_group_stanza(
             continue
 
         # ``owner`` declares this switch the VIP owner — VRRP reserves
-        # priority 255 for the owner (RFC 5798 §6.1).  The canonical
-        # ``priority`` field caps at 254 (255 is intentionally
-        # unrepresentable — the owner role isn't a first-class canonical
-        # concept), so we map ``owner`` to the canonical ceiling 254:
-        # this preserves the "this switch is the highest-priority
-        # master" intent for cross-vendor render rather than silently
-        # dropping to the default 100.  ``backup`` is the complementary
-        # explicit role with no priority implication — consume it
-        # (priority stays whatever ``priority N`` set, or the default).
+        # priority 255 for the owner (RFC 5798 §6.1).  ``CanonicalVRRPGroup.
+        # priority`` now spans the full 0-255 union, so ``owner`` maps to its
+        # true value 255 (was clamped to 254 while 255 was unrepresentable);
+        # render inverts it back to ``owner`` so the role round-trips.
+        # ``backup`` is the complementary explicit role with no priority
+        # implication — consume it (priority stays whatever ``priority N``
+        # set, or the default).
         if stripped.lower() == "owner":
-            group.priority = 254
+            group.priority = 255
             i += 1
             continue
         if stripped.lower() == "backup":

--- a/netcanon/migration/codecs/aruba_aoss/render.py
+++ b/netcanon/migration/codecs/aruba_aoss/render.py
@@ -670,7 +670,13 @@ def render_intent(tree: Any) -> str:  # noqa: C901
                             f"virtual-ip-address per vrid; secondary "
                             f"{extra} dropped"
                         )
-                if group.priority != 100:
+                if group.priority == 255:
+                    # AOS-S has no ``priority 255`` line — priority 255 IS
+                    # the RFC 5798 address-owner role, expressed via the
+                    # ``owner`` keyword.  Inverse of the parse mapping, so a
+                    # native ``owner`` config round-trips to ``owner``.
+                    lines.append("      owner")
+                elif group.priority != 100:
                     lines.append(f"      priority {group.priority}")
                 if group.preempt:
                     lines.append("      preempt")

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -477,14 +477,13 @@ def _apply_system_interface(  # noqa: C901
                         priority = int(priority_tokens[0])
                     except ValueError:
                         pass
-                # FortiOS permits VRRP priority 1-255; 255 is the
-                # address-owner sentinel that ``CanonicalVRRPGroup.priority``
-                # caps at 254 (``le=254`` — 255 is RFC-reserved /
-                # unrepresentable).  Clamp into [1, 254] so a legitimate
-                # ``set priority 255`` master config does NOT raise a raw
-                # pydantic ValidationError (a 500-class parse crash) —
-                # mirrors the aruba_aoss ``owner`` -> 254 mapping.
-                priority = max(1, min(priority, 254))
+                # FortiOS permits VRRP priority 1-255 (255 = the
+                # address-owner master).  ``CanonicalVRRPGroup.priority`` now
+                # spans the full 0-255 FHRP union, so a legitimate ``set
+                # priority 255`` is preserved verbatim and round-trips.  The
+                # [1, 255] clamp only guards against a malformed out-of-range
+                # value (FortiOS never writes one) rather than raising.
+                priority = max(1, min(priority, 255))
                 preempt_tokens = vrrp_edit.settings.get("preempt")
                 # FortiOS default for preempt is ``enable`` when the knob
                 # is absent — matches the canonical default (``True``).

--- a/tests/unit/migration/test_aruba_aoss.py
+++ b/tests/unit/migration/test_aruba_aoss.py
@@ -1039,10 +1039,10 @@ class TestVRRPGroups:
         assert len(svi.vrrp_groups) == 1
         g = svi.vrrp_groups[0]
         assert g.group_id == 1
-        # ``owner`` → canonical priority ceiling 254 (model caps at 254;
-        # 255 reserved-but-unrepresentable).  Legacy ``<ip> <mask>`` VIP
+        # ``owner`` → the RFC 5798 address-owner priority 255 (now
+        # representable; was clamped to 254).  Legacy ``<ip> <mask>`` VIP
         # keeps the bare IP (mask dropped, not carried on the canonical).
-        assert g.priority == 254
+        assert g.priority == 255
         assert g.virtual_ips == ["10.40.0.1"]
 
     def test_parse_legacy_ip_vrrp_vrid_still_accepted(self):
@@ -1062,12 +1062,12 @@ class TestVRRPGroups:
         svi = next(i for i in tree.interfaces if i.name == "Vlan9")
         assert svi.vrrp_groups[0].group_id == 9
 
-    def test_owner_maps_to_max_priority_254_and_round_trips(self):
-        """``owner`` parses to the canonical priority ceiling 254 (255
-        is unrepresentable).  Render emits ``priority 254`` (AOS-S
-        accepts an explicit priority; the canonical can't distinguish a
-        254-from-owner from an explicit 254), which re-parses to 254 —
-        round-trip stable."""
+    def test_owner_maps_to_priority_255_and_round_trips(self):
+        """``owner`` parses to the RFC 5798 address-owner priority 255, and
+        render inverts it back to the ``owner`` keyword (AOS-S has no
+        ``priority 255`` line) — so the owner role round-trips to ``owner``,
+        not to a lossy ``priority 254`` as it did while 255 was
+        unrepresentable."""
         raw = (
             "router vrrp\n"
             "vlan 7\n"
@@ -1082,12 +1082,13 @@ class TestVRRPGroups:
         codec = ArubaAOSSCodec()
         tree = codec.parse(raw)
         svi = next(i for i in tree.interfaces if i.name == "Vlan7")
-        assert svi.vrrp_groups[0].priority == 254
+        assert svi.vrrp_groups[0].priority == 255
         out = codec.render(tree)
-        assert "      priority 254" in out
+        assert "      owner" in out
+        assert "priority 255" not in out
         reparsed = codec.parse(out)
         svi2 = next(i for i in reparsed.interfaces if i.name == "Vlan7")
-        assert svi2.vrrp_groups[0].priority == 254
+        assert svi2.vrrp_groups[0].priority == 255
 
     # ----------------------------- Capabilities -----------------------------
 

--- a/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
+++ b/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
@@ -93,8 +93,9 @@ class TestCanonicalVRRPGroupValidation:
     """Schema enforces VRID and priority ranges per RFC 5798."""
 
     def test_group_id_lower_bound(self):
+        # HSRP group 0 is valid, so 0 is accepted; -1 is the first invalid.
         with pytest.raises(ValidationError):
-            CanonicalVRRPGroup(group_id=0)
+            CanonicalVRRPGroup(group_id=-1)
 
     def test_group_id_upper_bound(self):
         # HSRPv2 (mode="hsrp") groups run 0-4095; the field ceiling is the
@@ -103,24 +104,30 @@ class TestCanonicalVRRPGroupValidation:
             CanonicalVRRPGroup(group_id=4096)
 
     def test_group_id_boundary_ok(self):
+        CanonicalVRRPGroup(group_id=0, mode="hsrp")  # HSRP group 0
         CanonicalVRRPGroup(group_id=1)
         CanonicalVRRPGroup(group_id=255)  # VRRP VRID max
         CanonicalVRRPGroup(group_id=301, mode="hsrp")  # HSRPv2 > 255
         CanonicalVRRPGroup(group_id=4095, mode="hsrp")  # HSRPv2 max
 
     def test_priority_lower_bound(self):
+        # HSRP / GLBP permit priority 0, so 0 is accepted; -1 is first invalid.
         with pytest.raises(ValidationError):
-            CanonicalVRRPGroup(group_id=10, priority=0)
+            CanonicalVRRPGroup(group_id=10, priority=-1)
 
     def test_priority_upper_bound(self):
-        """255 is the reserved "address owner" value per RFC 5798 — we
-        cap at 254 to keep the canonical model declaratively safe."""
+        """The field spans the 0-255 FHRP union — HSRP / GLBP configure the
+        full range, and VRRP's 255 (the RFC 5798 address owner) is now
+        representable (e.g. AOS-S ``owner`` <-> 255).  256 is the first
+        out-of-range value."""
         with pytest.raises(ValidationError):
-            CanonicalVRRPGroup(group_id=10, priority=255)
+            CanonicalVRRPGroup(group_id=10, priority=256)
 
     def test_priority_boundary_ok(self):
+        CanonicalVRRPGroup(group_id=10, priority=0)    # HSRP / GLBP min
         CanonicalVRRPGroup(group_id=10, priority=1)
         CanonicalVRRPGroup(group_id=10, priority=254)
+        CanonicalVRRPGroup(group_id=10, priority=255)  # VRRP owner / HSRP max
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -807,6 +807,41 @@ class TestPhase2cHSRP:
         )
         assert reparsed.vrrp_groups[0].group_id == 301
 
+    def test_hsrp_union_edge_values_parse_and_round_trip(self, codec):
+        """HSRP legitimately uses group 0 (HSRPv1 default) and priority 0-255
+        (255 = highest); the VRRP-centric bounds (group_id ge=1, priority
+        1-254) rejected all three, which the CodecBase boundary turns into a
+        ParseError.  The `group_id` ge=0 / `priority` 0-255 union widening
+        lets them parse + round-trip instead of being dropped."""
+        raw = (
+            "!Command: show running-config\n"
+            "hostname FHRP\n"
+            "feature hsrp\n"
+            "interface Vlan40\n"
+            "  no shutdown\n"
+            "  ip address 10.40.40.2/24\n"
+            "  hsrp 0\n"          # HSRPv1 group 0
+            "    priority 255\n"  # HSRP max priority
+            "    ip 10.40.40.1\n"
+            "interface Vlan41\n"
+            "  no shutdown\n"
+            "  ip address 10.40.41.2/24\n"
+            "  hsrp 5\n"
+            "    priority 0\n"    # HSRP min priority
+            "    ip 10.40.41.1\n"
+        )
+        tree = codec.parse(raw)  # must NOT raise
+        g40 = next(i for i in tree.interfaces if i.name == "Vlan40").vrrp_groups[0]
+        assert (g40.group_id, g40.priority) == (0, 255)
+        g41 = next(i for i in tree.interfaces if i.name == "Vlan41").vrrp_groups[0]
+        assert (g41.group_id, g41.priority) == (5, 0)
+        # Round-trip: the edge values survive render + reparse.
+        reparsed = codec.parse(codec.render(tree))
+        r40 = next(i for i in reparsed.interfaces if i.name == "Vlan40").vrrp_groups[0]
+        r41 = next(i for i in reparsed.interfaces if i.name == "Vlan41").vrrp_groups[0]
+        assert (r40.group_id, r40.priority) == (0, 255)
+        assert (r41.group_id, r41.priority) == (5, 0)
+
     def test_vrrp_groups_declared_lossy(self, codec):
         # FHRP normalises to HSRP on NX-OS render → the mode discriminator
         # is lossy cross-vendor.

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -660,12 +660,12 @@ end
         assert group.preempt is True
         assert group.advertisement_interval == 1
 
-    def test_priority_255_master_clamped_not_crash(self):
+    def test_priority_255_master_preserved(self):
         """A legitimate FortiOS VRRP master (``set priority 255`` — the
-        address-owner sentinel; FortiOS permits 1-255) must parse without
-        raising.  ``CanonicalVRRPGroup.priority`` caps at 254 (``le=254``),
-        so the parser clamps 255 -> 254 rather than letting pydantic raise
-        a 500-class ValidationError."""
+        address-owner value; FortiOS permits 1-255) parses without raising
+        AND is preserved verbatim: ``CanonicalVRRPGroup.priority`` now spans
+        the full 0-255 FHRP union, so 255 is no longer clamped down to 254
+        (it round-trips)."""
         raw = """\
 config system interface
     edit "vlan20"
@@ -682,7 +682,7 @@ end
 """
         tree = FortiGateCLICodec().parse(raw)  # must NOT raise
         iface = next(i for i in tree.interfaces if i.name == "vlan20")
-        assert iface.vrrp_groups[0].priority == 254
+        assert iface.vrrp_groups[0].priority == 255
 
     def test_preempt_disable_maps_to_false(self):
         raw = """\


### PR DESCRIPTION
## What

Widens `CanonicalVRRPGroup` bounds to the FHRP union so **legitimate HSRP values are represented, not rejected**:
- `priority`: `ge=1, le=254` → **`ge=0, le=255`**
- `group_id`: `ge=1, le=4095` → **`ge=0, le=4095`**

## Why

The follow-up flagged during #246's audit. The VRRP-centric bounds rejected three values that are **valid HSRP** (verified through real `cisco_nxos` parse paths):

| value | validity | pre-#246 | post-#246 | this PR |
|---|---|---|---|---|
| HSRP group `0` | HSRPv1 default group | raw `ValidationError` (500) | `ParseError` (dropped) | **parses + round-trips** |
| HSRP `priority 0` | valid (lowest) | raw `ValidationError` | `ParseError` | **parses + round-trips** |
| HSRP `priority 255` | valid (highest; = VRRP address owner) | raw `ValidationError` | `ParseError` | **parses + round-trips** |

#246 made these *safe* (clean `ParseError` instead of a 500); this PR makes them *representable* — the data-capture goal. It extends #238 (which widened `group_id`'s ceiling to 4095 for HSRPv2) to the lower bound + `priority`.

## Codec ripple, made consistent with the wider model

- **fortigate** parse no longer clamps a legit `set priority 255` down to 254 — it round-trips verbatim. The `[1,255]` clamp stays only as a malformed-value guard.
- **aruba_aoss** maps `owner` ↔ priority **255** (RFC 5798 address owner) symmetrically now that 255 is representable: parse `owner`→255, render 255→`owner`. The owner role now round-trips to `owner` instead of the lossy `priority 254` it produced while 255 was unrepresentable (AOS-S has no `priority 255` line).
- **opnsense** (CARP `advskew = 254 - priority`) already floor/ceils advskew to `[0,254]` and only processes `carp` mode — **no change needed**.

## Verification

- **Verify-first**: reproduced that nxos parses `hsrp 0` / `priority 0` / `priority 255` post-widening (all were raw `ValidationError` → `ParseError` before).
- **No committed fixture** carries a VRRP `owner`, group `0`, or priority `0/255` (the one `priority 255` match is `member 1 priority 255`, a stacking line, not VRRP) → the **cross-mesh baseline is unchanged**.
- Full `tests/unit` + `test_cross_mesh_ci_guard.py` green; ruff clean; complexity ratchet unaffected (aoss `render_intent` is grandfathered).
- Tests: schema boundaries moved to the new first-invalid values (`-1` / `256` / `4096`); a new nxos real-parse round-trip for the three edges; fortigate + aruba_aoss owner-mapping tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)