### PR TITLE
fix(arista_eos): don't let an indented ! comment close the interface stanza

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -678,6 +678,17 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
         line = raw_line.rstrip()
         stripped = line.strip()
         if not stripped or stripped.startswith("!"):
+            # An INDENTED comment (``   ! review: ...``) is a comment WITHIN
+            # the open stanza, NOT an end-of-stanza delimiter.  The render
+            # emits these for un-translatable attributes (e.g. an HSRP group
+            # on an EOS interface, which EOS can't represent), and one can
+            # sit BEFORE a real sub-command line such as ``mtu 2000``.  Only
+            # a column-0 ``!`` is the genuine section delimiter; treating an
+            # indented ``!`` as one silently dropped every sub-command after
+            # it on reparse (``mtu`` / ``no switchport`` / … lost).  Skip the
+            # comment and keep the stanza open.
+            if line.startswith((" ", "\t")) and stripped.startswith("!"):
+                continue
             # End-of-stanza delimiter.  Close whichever is open.
             current_iface = None
             current_vlan = None

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -281,6 +281,45 @@ class TestParseInterfaces:
         assert iface.ipv4_addresses[0].ip == "10.0.0.1"
         assert iface.ipv4_addresses[0].prefix_length == 31
 
+    def test_indented_comment_does_not_close_interface_block(self):
+        """An INDENTED ``! ...`` comment inside an interface block is a
+        comment, not an end-of-stanza delimiter — sub-commands AFTER it must
+        still parse.  Regression: the render emits ``   ! review: ...`` lines
+        for un-translatable attributes (e.g. an HSRP group cross-vendored to
+        EOS), and one sitting before ``mtu 2000`` made arista parse close the
+        stanza early and silently drop the mtu (and everything after it) on
+        reparse.  Only a column-0 ``!`` closes the block."""
+        raw = (
+            "hostname sw1\n"
+            "interface Ethernet0/1\n"
+            "   ! review: vrrp_groups[1].mode='hsrp' has no Arista equivalent\n"
+            "   mtu 2000\n"
+            "   no switchport\n"
+            "   ip address 10.0.0.1/31\n"
+            "!\n"
+        )
+        iface = AristaEOSCodec().parse(raw).interfaces[0]
+        assert iface.name == "Ethernet0/1"
+        assert iface.mtu == 2000
+        assert iface.ipv4_addresses[0].ip == "10.0.0.1"
+
+    def test_column0_bang_still_separates_stanzas(self):
+        """The fix must not break the genuine delimiter: a column-0 ``!``
+        still closes the interface block, so a trailing top-level line does
+        not bleed into the previous interface."""
+        raw = (
+            "hostname sw1\n"
+            "interface Ethernet1\n"
+            "   mtu 1600\n"
+            "!\n"
+            "interface Ethernet2\n"
+            "   mtu 1700\n"
+            "!\n"
+        )
+        intent = AristaEOSCodec().parse(raw)
+        by_name = {i.name: i.mtu for i in intent.interfaces}
+        assert by_name == {"Ethernet1": 1600, "Ethernet2": 1700}
+
     def test_interface_loopback(self):
         raw = (
             "hostname sw1\n"


### PR DESCRIPTION
## What

An indented `! ...` comment inside an arista interface/vlan block was treated as an **end-of-stanza delimiter**, so every sub-command *after* it (`mtu`, `no switchport`, `ip address`, …) was silently dropped on reparse.

## Why it matters

The render emits `   ! review: ...` lines for un-translatable attributes — e.g. an HSRP group cross-vendored to EOS (which EOS can't represent). One routinely lands **before** a real attribute line, so the attribute vanished on round-trip:

```
interface Ethernet0/1
   ! review: vrrp_groups[1].mode='hsrp' has no Arista EOS equivalent
   mtu 2000          ← dropped on reparse (mtu is declared SUPPORTED → silent loss)
!
```

It also affects any real EOS config that carries an in-block comment.

## Verify-first

Surfaced by the dogfood mesh (`cisco_nxos → arista_eos` dropped a non-default `mtu 2000` and SVI `9216` jumbo). Confirmed the differentiator is the preceding comment:

| input | reparsed mtu |
|---|---|
| `mtu 2000` (no comment) | 2000 ✓ |
| `! review` **before** `mtu 2000` | None ✗ (pre-fix) → 2000 ✓ (post-fix) |
| `! review` **after** `mtu 2000` | 2000 ✓ |

## Fix

Only a **column-0** `!` closes the stanza; an **indented** `!` is skipped as a comment with the stanza kept open. Minimal, scalar, no name/materialization interaction.

## Verification

- New regression tests: in-block comment preserves subsequent attributes; column-0 `!` still separates stanzas.
- Full `tests/unit` + `test_cross_mesh_ci_guard.py` green — **no CODEC_BUG ratchet change** (the fix makes data survive without touching the comparator's name-stability model). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)