### PR TITLE
fix(arista_eos): strip legacy 'forwarding' keyword from interface vrf parse

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -1222,9 +1222,17 @@ def _apply_iface_subcommand(  # noqa: C901
     if line.startswith("vrf ") and not line.startswith((
         "vrf instance", "vrf definition",
     )):
-        parts = line.split(None, 1)
-        if len(parts) >= 2:
-            iface.vrf = parts[1].strip()
+        parts = line.split()
+        # EOS interface VRF assignment has two syntaxes: modern ``vrf <name>``
+        # and legacy ``vrf forwarding <name>``.  Strip the optional
+        # ``forwarding`` keyword so the canonical VRF name is ``<name>`` (not
+        # ``forwarding <name>``) — otherwise every target renders a bogus
+        # space-bearing VRF name.  A bare ``vrf forwarding`` (no trailing
+        # token) is the modern form of a VRF literally named ``forwarding``.
+        if len(parts) >= 3 and parts[1] == "forwarding":
+            iface.vrf = parts[2]
+        elif len(parts) >= 2:
+            iface.vrf = parts[1]
         return
     # --- Classic VRRP (Wave B) -------------------------------------
     # Arista EOS multi-line VRRP grammar, both modern (``ipv4`` /

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -320,6 +320,42 @@ class TestParseInterfaces:
         by_name = {i.name: i.mtu for i in intent.interfaces}
         assert by_name == {"Ethernet1": 1600, "Ethernet2": 1700}
 
+    def test_interface_vrf_forwarding_legacy_keyword_stripped(self):
+        """EOS accepts two interface-VRF syntaxes: modern ``vrf <name>`` and
+        legacy ``vrf forwarding <name>``.  The parser must strip the optional
+        ``forwarding`` keyword so the canonical VRF name is ``mgmt`` — not
+        ``forwarding mgmt`` (which would render a bogus space-bearing VRF on
+        every target, e.g. a Junos routing-instance called ``forwarding mgmt``).
+        """
+        raw = (
+            "hostname sw1\n"
+            "interface Ethernet1\n"
+            "   no switchport\n"
+            "   vrf forwarding mgmt\n"
+            "   ip address 10.0.0.1/31\n"
+            "!\n"
+        )
+        iface = AristaEOSCodec().parse(raw).interfaces[0]
+        assert iface.vrf == "mgmt"
+
+    def test_interface_vrf_modern_form_unchanged(self):
+        """The modern ``vrf <name>`` form (and a VRF literally named
+        ``forwarding``) must still parse to the bare name."""
+        raw = (
+            "hostname sw1\n"
+            "interface Ethernet1\n"
+            "   no switchport\n"
+            "   vrf BLUE\n"
+            "!\n"
+            "interface Ethernet2\n"
+            "   no switchport\n"
+            "   vrf forwarding\n"
+            "!\n"
+        )
+        by_name = {i.name: i.vrf for i in AristaEOSCodec().parse(raw).interfaces}
+        assert by_name["Ethernet1"] == "BLUE"
+        assert by_name["Ethernet2"] == "forwarding"
+
     def test_interface_loopback(self):
         raw = (
             "hostname sw1\n"


### PR DESCRIPTION
## What
EOS accepts two interface-VRF syntaxes: modern `vrf <name>` and legacy `vrf forwarding <name>`. The arista parser split on the first space only, so `vrf forwarding mgmt` was captured as the VRF name **`forwarding mgmt`** instead of `mgmt`.

That corrupted name then rendered on every target — e.g. a Junos routing-instance literally named `forwarding mgmt` (invalid, silently dropped), or `vrf forwarding forwarding mgmt` back to IOS.

## Fix
Strip the optional `forwarding` keyword in the interface-vrf parse:
- `vrf forwarding mgmt` → `mgmt`
- `vrf BLUE` → `BLUE` (modern form unchanged)
- `vrf forwarding` (no trailing token) → `forwarding` (modern form of a VRF literally named `forwarding`)

## How surfaced
Full-corpus Mode-A dogfood mesh over the expanded 1442-config corpus — `arista_eos → juniper_junos interfaces[].vrf` silent-loss. The batfish `arista_interface` / `arista_vrf` fixtures use the legacy `vrf forwarding` syntax.

## Ratchet safety
No committed **arista** fixture uses interface-level `vrf forwarding` (only cisco fixtures do, and the cisco parser already handles it). The cross-mesh CI guard is unaffected — verified green (CODEC_BUG held). Full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)