### PR TITLE
fix(cisco_iosxe_cli): render IPv6 static routes as 'ipv6 route' instead of crashing

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -548,7 +548,6 @@ def render_intent(tree: Any) -> str:  # noqa: C901
 
     # --- static routes ---
     for route in tree.static_routes:
-        dest, mask = _cidr_to_dest_mask(route.destination)
         tail = ""
         if route.metric and route.metric > 0:
             tail = f" {route.metric}"
@@ -568,6 +567,17 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         # ``ip route`` keyword and the destination (v0.2.0 — graduated
         # /routing/static-route/vrf from unsupported to supported).
         vrf_prefix = f"vrf {route.vrf} " if route.vrf else ""
+        # IPv6 destinations use the ``ipv6 route`` keyword with the prefix
+        # form (no dotted mask) — forcing them through the IPv4
+        # ``ip route <dest> <mask>`` path raised RenderError on the >32
+        # prefix length.  IOS-XE: ``ipv6 route [vrf X] <prefix>/<len> <nh>``.
+        if ":" in (route.destination or ""):
+            out.append(
+                f"ipv6 route {vrf_prefix}{route.destination} "
+                f"{target}{tail}{name_tail}",
+            )
+            continue
+        dest, mask = _cidr_to_dest_mask(route.destination)
         out.append(f"ip route {vrf_prefix}{dest} {mask} {target}{tail}{name_tail}")
     if tree.static_routes:
         out.append("!")

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -544,6 +544,61 @@ class TestRender:
         assert "ip route 192.168.0.0 255.255.255.0 10.0.0.1" in out
         assert "ip route vrf" not in out
 
+    def test_ipv6_static_route_renders_without_crash(self):
+        # Regression: an IPv6 static route (prefix len > 32) arriving from a
+        # cross-vendor source (e.g. VyOS ``route6``) used to be forced through
+        # the IPv4 ``ip route <dest> <mask>`` path and blew up _prefix_to_mask
+        # with ``prefix length 64 out of range`` — a hard RenderError that
+        # aborted the whole config.  It must now render as the ``ipv6 route``
+        # prefix form (IOS-XE's IPv6 static-route keyword) instead.  Build the
+        # canonical tree directly since the IOS-XE parser does not read v6
+        # routes (its ``ipv6 route`` round-trip is separate follow-up work).
+        from netcanon.migration.canonical.intent import (
+            CanonicalIntent,
+            CanonicalStaticRoute,
+        )
+        intent = CanonicalIntent(hostname="r1", static_routes=[
+            CanonicalStaticRoute(
+                destination="2001:db8:2fe:ffff::/64",
+                gateway="2001:db8:200:102::5",
+            ),
+        ])
+        out = CiscoIOSXECLICodec().render(intent)  # must not raise RenderError
+        assert "ipv6 route 2001:db8:2fe:ffff::/64 2001:db8:200:102::5" in out
+        assert "ip route 2001" not in out  # never the IPv4 keyword/mask form
+
+    def test_ipv6_default_and_vrf_static_routes_render(self):
+        # ``::/0`` default and a per-VRF v6 route both use the ``ipv6 route``
+        # keyword; the VRF qualifier sits between the keyword and the prefix.
+        from netcanon.migration.canonical.intent import (
+            CanonicalIntent,
+            CanonicalStaticRoute,
+        )
+        intent = CanonicalIntent(hostname="r1", static_routes=[
+            CanonicalStaticRoute(destination="::/0", gateway="2001:db8::1"),
+            CanonicalStaticRoute(
+                destination="2001:db8:a::/48", gateway="2001:db8::9", vrf="RED",
+            ),
+        ])
+        out = CiscoIOSXECLICodec().render(intent)
+        assert "ipv6 route ::/0 2001:db8::1" in out
+        assert "ipv6 route vrf RED 2001:db8:a::/48 2001:db8::9" in out
+
+    def test_ipv4_and_ipv6_static_routes_coexist(self):
+        # A mixed v4/v6 route set renders each on the correct keyword — v4
+        # keeps the dotted-mask ``ip route`` form, v6 the ``ipv6 route`` form.
+        from netcanon.migration.canonical.intent import (
+            CanonicalIntent,
+            CanonicalStaticRoute,
+        )
+        intent = CanonicalIntent(hostname="r1", static_routes=[
+            CanonicalStaticRoute(destination="10.0.0.0/8", gateway="192.0.2.1"),
+            CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="fe80::1"),
+        ])
+        out = CiscoIOSXECLICodec().render(intent)
+        assert "ip route 10.0.0.0 255.0.0.0 192.0.2.1" in out
+        assert "ipv6 route 2001:db8:1::/48 fe80::1" in out
+
     def test_render_emits_vlan_database_and_svi(self):
         intent = CiscoIOSXECLICodec().parse(
             "vlan 10\n name USERS\n!\n"


### PR DESCRIPTION
## What
The IOS-XE CLI static-route renderer forced **every** route through the IPv4 `ip route <dest> <mask>` path. An IPv6 destination (prefix length > 32) blew up `_prefix_to_mask`:

```
RenderError: cisco_iosxe_cli: prefix length 64 out of range
```

A hard crash that aborts the **entire** config render — not a signalled drop. IPv6 static routes reach IOS-XE from cross-vendor sources that model them natively (VyOS `route6`, Junos `routing-options static`).

## Fix
Branch on address family in the static-route loop:
- IPv6 dest → `ipv6 route [vrf X] <prefix>/<len> <next-hop>` (IOS-XE prefix form, no dotted mask)
- IPv4 dest → unchanged `ip route <dest> <mask> <next-hop>`

The matrix already declares `/routing/static-route` supported, so this brings the code in line with the declared capability.

## How surfaced
Full-corpus Mode-A dogfood mesh over the expanded 1442-config corpus + the batfish deployability render pass — `vyos → cisco_iosxe_cli` RenderError on real configs (`985adbb80759` prefix `/64`, `dcfa98388f65` prefix `/48`, `3172682dd86c` `::/0`).

## Scope
This PR fixes **only** the surfaced iosxe_cli render crash. The dogfood run showed IPv6 static routes are handled inconsistently across all codecs — a separate cross-codec follow-up:
- **`fortigate_cli` also crashes** (`prefix length 48 out of range`) — needs the `config router static6` form.
- **arista_eos / cisco_nxos / aruba_aoss / aruba_aoscx** emit invalid `ip route <v6dest>` (wrong keyword).
- **cisco_iosxe (xml) / opnsense** silently drop v6 routes.
- IOS-XE parse round-trip of `ipv6 route` (iosxe_cli never sources v6 routes today).

## Ratchet safety
No new render-failure pair; CODEC_BUG held at baseline. Full `tests/unit` + cross-mesh guard green. (The parse-round-trip half was deliberately left out of this PR because it surfaces the above cross-codec crashes into downstream renders — tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)