### PR TITLE
fix(fortigate_cli): render IPv6 static routes as 'config router static6' instead of crashing

### DIFF
--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -693,6 +693,31 @@ def _apply_router_static(
         ))
 
 
+def _apply_router_static6(
+    block: _ConfigBlock, intent: CanonicalIntent,
+) -> None:
+    """Parse ``config router static6`` (IPv6 static routes).
+
+    Unlike the IPv4 ``config router static`` form, ``set dst`` here is a
+    single ``<prefix>/<len>`` token (no dotted mask), so the destination
+    is used verbatim.
+    """
+    for edit in block.edits:
+        dst = edit.settings.get("dst")
+        if not dst:
+            continue
+        destination = dst[0]  # already in <prefix>/<len> form
+        gateway_tokens = edit.settings.get("gateway") or [""]
+        device_tokens = edit.settings.get("device") or [""]
+        comment_tokens = edit.settings.get("comment") or [""]
+        intent.static_routes.append(CanonicalStaticRoute(
+            destination=destination,
+            gateway=gateway_tokens[0],
+            interface=device_tokens[0],
+            description=comment_tokens[0],
+        ))
+
+
 def _apply_system_admin(
     block: _ConfigBlock, intent: CanonicalIntent,
 ) -> None:
@@ -876,6 +901,7 @@ _DISPATCH: ClassVar[dict[str, object]] = {
     "system ntp": _apply_system_ntp,
     "system interface": _apply_system_interface,
     "router static": _apply_router_static,
+    "router static6": _apply_router_static6,
     "system snmp sysinfo": _apply_snmp_sysinfo,
     "system snmp community": _apply_snmp_community,
     "system snmp user": _apply_snmp_user,

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -939,23 +939,43 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             out.append("    next")
         out.append("end")
 
-    # --- router static ---
-    if tree.static_routes:
-        out.append("config router static")
-        for idx, route in enumerate(tree.static_routes, start=1):
-            out.append(f"    edit {idx}")
+    # --- router static (IPv4) / router static6 (IPv6) ---
+    # FortiOS keeps IPv4 and IPv6 static routes in SEPARATE stanzas:
+    # ``config router static`` uses ``set dst <ip> <mask>`` (dotted mask),
+    # while ``config router static6`` uses ``set dst <prefix>/<len>`` (no
+    # mask).  Forcing a v6 destination through the v4 mask path raised
+    # RenderError on the >32 prefix length.
+    v4_routes = [r for r in tree.static_routes if ":" not in (r.destination or "")]
+    v6_routes = [r for r in tree.static_routes if ":" in (r.destination or "")]
+
+    def _emit_route_body(route: object, v6: bool) -> None:
+        if v6:
+            out.append(f"        set dst {route.destination}")
+        else:
             dst_ip, dst_prefix = _split_cidr(route.destination)
-            dst_mask = _prefix_to_mask(dst_prefix)
-            out.append(f"        set dst {dst_ip} {dst_mask}")
-            if route.gateway:
-                out.append(f"        set gateway {route.gateway}")
-            if route.interface:
-                out.append(f'        set device "{route.interface}"')
-            if route.description:
-                # FortiOS uses ``set comment`` (singular) on
-                # ``config router static`` entries; max 255 chars.
-                # Ref: https://docs.fortinet.com/document/fortigate/7.4.0/cli-reference/522620/config-router-static
-                out.append(f'        set comment "{route.description}"')
+            out.append(f"        set dst {dst_ip} {_prefix_to_mask(dst_prefix)}")
+        if route.gateway:
+            out.append(f"        set gateway {route.gateway}")
+        if route.interface:
+            out.append(f'        set device "{route.interface}"')
+        if route.description:
+            # FortiOS uses ``set comment`` (singular) on static-route
+            # entries; max 255 chars.
+            # Ref: https://docs.fortinet.com/document/fortigate/7.4.0/cli-reference/522620/config-router-static
+            out.append(f'        set comment "{route.description}"')
+
+    if v4_routes:
+        out.append("config router static")
+        for idx, route in enumerate(v4_routes, start=1):
+            out.append(f"    edit {idx}")
+            _emit_route_body(route, v6=False)
+            out.append("    next")
+        out.append("end")
+    if v6_routes:
+        out.append("config router static6")
+        for idx, route in enumerate(v6_routes, start=1):
+            out.append(f"    edit {idx}")
+            _emit_route_body(route, v6=True)
             out.append("    next")
         out.append("end")
 

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -347,6 +347,59 @@ class TestRender:
         assert "set gateway 10.0.0.1" in out
         assert 'set device "port1"' in out
 
+    def test_ipv6_static_route_renders_static6_without_crash(self):
+        # Regression: an IPv6 static route (prefix len > 32) used to be forced
+        # through the IPv4 ``set dst <ip> <mask>`` path and blew up
+        # _prefix_to_mask with ``prefix length 48 out of range``.  FortiOS
+        # keeps v6 routes in a SEPARATE ``config router static6`` stanza with
+        # the prefix (no-mask) form.
+        tree = CanonicalIntent(static_routes=[
+            CanonicalStaticRoute(
+                destination="2001:db8:1::/48",
+                gateway="2001:db8::1",
+                interface="port2",
+            ),
+        ])
+        out = FortiGateCLICodec().render(tree)  # must not raise RenderError
+        assert "config router static6" in out
+        assert "set dst 2001:db8:1::/48" in out
+        assert "set gateway 2001:db8::1" in out
+        assert 'set device "port2"' in out
+        # v6 must NOT leak into the IPv4 stanza / dotted-mask form.
+        assert "config router static\n" not in out  # no bare v4 block here
+
+    def test_ipv4_and_ipv6_static_routes_split_into_static_and_static6(self):
+        tree = CanonicalIntent(static_routes=[
+            CanonicalStaticRoute(destination="10.0.0.0/8", gateway="192.0.2.1"),
+            CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="2001:db8::1"),
+        ])
+        out = FortiGateCLICodec().render(tree)
+        assert "config router static\n" in out
+        assert "set dst 10.0.0.0 255.0.0.0" in out
+        assert "config router static6" in out
+        assert "set dst 2001:db8:1::/48" in out
+
+    def test_ipv6_static_route_round_trip(self):
+        tree = CanonicalIntent(static_routes=[
+            CanonicalStaticRoute(
+                destination="2001:db8:1::/48",
+                gateway="2001:db8::1",
+                interface="port2",
+                description="v6up",
+            ),
+            CanonicalStaticRoute(destination="::/0", gateway="2001:db8::9"),
+        ])
+        codec = FortiGateCLICodec()
+        reparsed = codec.parse(codec.render(tree))
+        got = sorted(
+            (r.destination, r.gateway, r.interface, r.description)
+            for r in reparsed.static_routes
+        )
+        assert got == [
+            ("2001:db8:1::/48", "2001:db8::1", "port2", "v6up"),
+            ("::/0", "2001:db8::9", "", ""),
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Round-trip


### PR DESCRIPTION
## What
The FortiGate static-route renderer forced **every** route through the IPv4 `config router static / set dst <ip> <mask>` path. An IPv6 destination (prefix > 32) blew up `_prefix_to_mask`:

```
RenderError: fortigate_cli: prefix length 48 out of range
```

A hard crash that aborts the entire config render.

## Fix
FortiOS keeps IPv4 and IPv6 static routes in **separate** stanzas. Split `static_routes` by address family:
- v4 → `config router static` (`set dst <ip> <mask>`, unchanged)
- v6 → `config router static6` (`set dst <prefix>/<len>`, no dotted mask)

Add a `router static6` parse handler so v6 routes round-trip symmetrically (render → parse → render lossless, verified for `/48`, `::/0`, with gateway/device/comment).

## Context
Second of the cross-codec IPv6-static-route fixes surfaced by the full-corpus Mode-A dogfood mesh (2026-07-02), after `cisco_iosxe_cli` #251. Remaining: arista/nxos/aruba emit invalid `ip route <v6>`; iosxe-xml/opnsense drop; then the `cisco_iosxe_cli` parse capstone.

## Ratchet safety
No committed fortigate fixture uses `config router static6`, so the parse-add is inert in the cross-mesh guard until a v6 source targets fortigate. Guard green, full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)