### PR TITLE
fix(arista_eos): render/parse IPv6 static routes with the 'ipv6 route' keyword

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -90,6 +90,12 @@ _IP_ROUTE_RE = re.compile(
     r"^ip route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)",
     re.MULTILINE,
 )
+_IPV6_ROUTE_RE = re.compile(
+    # ``ipv6 route 2001:db8::/48 2001:db8::1`` — v6 uses the ``ipv6 route``
+    # keyword with the prefix form (does not overlap ``^ip route``).
+    r"^ipv6 route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)",
+    re.MULTILINE,
+)
 _SNMP_COMMUNITY_RE = re.compile(
     # ``snmp-server community public ro`` / ``... rw``.
     r"^snmp-server community\s+(\S+)\s+(ro|rw)",
@@ -416,6 +422,19 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             continue
         intent.static_routes.append(CanonicalStaticRoute(
             destination=f"{ip}/{prefix}",
+            gateway=next_hop,
+            interface="",
+        ))
+    for route_m in _IPV6_ROUTE_RE.finditer(raw):
+        dest, next_hop = route_m.groups()
+        # Same interface-form skip as the v4 branch: only IP next hops
+        # round-trip cleanly onto the canonical gateway.
+        try:
+            ipaddress.IPv6Address(next_hop)
+        except ipaddress.AddressValueError:
+            continue
+        intent.static_routes.append(CanonicalStaticRoute(
+            destination=dest,
             gateway=next_hop,
             interface="",
         ))

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -932,13 +932,23 @@ def render_intent(tree: Any) -> str:  # noqa: C901
 
     # --- Static routes ---
     if tree.static_routes:
+        has_v4 = has_v6 = False
         for route in tree.static_routes:
-            if route.gateway:
-                out.append(
-                    f"ip route {route.destination} {route.gateway}"
-                )
+            if not route.gateway:
+                continue
+            # EOS keys the address family off the keyword: IPv6 destinations
+            # use ``ipv6 route`` (emitting ``ip route <v6>`` is invalid CLI).
+            if ":" in (route.destination or ""):
+                out.append(f"ipv6 route {route.destination} {route.gateway}")
+                has_v6 = True
+            else:
+                out.append(f"ip route {route.destination} {route.gateway}")
+                has_v4 = True
         out.append("!")
-        out.append("ip routing")
+        if has_v4:
+            out.append("ip routing")
+        if has_v6:
+            out.append("ipv6 unicast-routing")
         out.append("!")
 
     out.append("end")

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -16,6 +16,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalInterface,
     CanonicalIPv4Address,
     CanonicalLocalUser,
+    CanonicalStaticRoute,
     CanonicalVlan,
     CanonicalVRRPGroup,
 )
@@ -112,6 +113,20 @@ class TestParseScalars:
         intent = AristaEOSCodec().parse(raw)
         assert len(intent.static_routes) == 1
         assert intent.static_routes[0].gateway == "10.0.0.1"
+
+    def test_ipv6_static_route_parsed(self):
+        """EOS keys the AF off the keyword: ``ipv6 route <prefix> <nh>``."""
+        raw = (
+            "hostname sw1\n"
+            "ipv6 route 2001:db8:1::/48 2001:db8::1\n"
+            "ipv6 route ::/0 fe80::1\n"
+        )
+        v6 = [r for r in AristaEOSCodec().parse(raw).static_routes
+              if ":" in r.destination]
+        assert sorted((r.destination, r.gateway) for r in v6) == [
+            ("2001:db8:1::/48", "2001:db8::1"),
+            ("::/0", "fe80::1"),
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -487,6 +502,32 @@ class TestRender:
     def test_render_rejects_non_canonical(self):
         with pytest.raises(RenderError):
             AristaEOSCodec().render({"not": "canonical"})
+
+    def test_render_ipv6_static_route_uses_ipv6_keyword(self):
+        # EOS: an IPv6 destination must render with the ``ipv6 route``
+        # keyword (``ip route <v6>`` is invalid CLI) and enable
+        # ``ipv6 unicast-routing``.
+        intent = CanonicalIntent(hostname="sw1", static_routes=[
+            CanonicalStaticRoute(destination="10.0.0.0/8", gateway="192.0.2.1"),
+            CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="2001:db8::1"),
+        ])
+        out = AristaEOSCodec().render(intent)
+        assert "ip route 10.0.0.0/8 192.0.2.1" in out
+        assert "ipv6 route 2001:db8:1::/48 2001:db8::1" in out
+        assert "ipv6 unicast-routing" in out
+        # v6 dest must never appear on the bare ``ip route`` keyword.
+        assert "ip route 2001" not in out
+
+    def test_ipv6_static_route_round_trip(self):
+        intent = CanonicalIntent(hostname="sw1", static_routes=[
+            CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="2001:db8::1"),
+        ])
+        codec = AristaEOSCodec()
+        reparsed = codec.parse(codec.render(intent))
+        assert any(
+            r.destination == "2001:db8:1::/48" and r.gateway == "2001:db8::1"
+            for r in reparsed.static_routes
+        )
 
     def test_render_interface_l3_emits_no_switchport(self):
         intent = CanonicalIntent(


### PR DESCRIPTION
## What
EOS keys the static-route address family off the keyword — IPv6 uses `ipv6 route <prefix> <next-hop>`. The renderer emitted `ip route <v6dest>` for **every** route regardless of family (invalid CLI an EOS device rejects on commit), and the parser's `ip route` regex is IPv4-only, so a v6 route didn't round-trip.

## Fix
- **Render**: branch on destination family — `ipv6 route` + `ipv6 unicast-routing` for v6; `ip route` + `ip routing` for v4 (unchanged, byte-identical).
- **Parse**: add `_IPV6_ROUTE_RE` with the same interface-form-next-hop skip as the v4 branch.

v6 routes now round-trip losslessly (verified `/48`, `::/0`).

## Context
Third of the cross-codec IPv6-static-route fixes from the full-corpus Mode-A dogfood mesh — after `cisco_iosxe_cli` #251 and `fortigate_cli` #252. Remaining: nxos, aruba (aoscx/aoss), iosxr; iosxe-xml/opnsense honesty; then the `cisco_iosxe_cli` parse capstone.

## Ratchet safety
No committed arista fixture uses `ipv6 route`, so the parse-add is inert in the cross-mesh guard until a v6 source targets arista; v4-only renders unchanged. Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)