### PR TITLE
fix(cisco_nxos): render IPv6 static routes with the 'ipv6 route' keyword

### DIFF
--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -201,14 +201,18 @@ def _is_svi(name: str) -> bool:
 
 
 def _render_static_route(route) -> str:
-    """Render one default-VRF static route as ``ip route DEST/N GW [pref]``.
+    """Render one static route as ``ip route DEST/N GW [pref]`` (or
+    ``ipv6 route`` for an IPv6 destination).
 
     ``destination`` is already CIDR (``X/N``).  Next-hop is the gateway
     IP, or the interface name for a directly-attached next-hop.  A
-    non-zero ``metric`` re-emits as the trailing preference token.
+    non-zero ``metric`` re-emits as the trailing preference token.  NX-OS
+    keys the address family off the keyword: an IPv6 destination must use
+    ``ipv6 route`` (``ip route <v6>`` is invalid and rejected on commit).
     """
     nexthop = route.gateway or route.interface
-    out = f"ip route {route.destination} {nexthop}".rstrip()
+    keyword = "ipv6 route" if ":" in (route.destination or "") else "ip route"
+    out = f"{keyword} {route.destination} {nexthop}".rstrip()
     if route.metric:
         out += f" {route.metric}"
     return out

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -261,6 +261,23 @@ class TestParse:
         # Exactly one instance — no phantom duplicate from the route harvest.
         assert [r.name for r in intent.routing_instances] == ["TENANT"]
 
+    def test_render_ipv6_static_route_uses_ipv6_keyword(self, codec):
+        # NX-OS keys the AF off the keyword: an IPv6 destination must render
+        # ``ipv6 route`` (``ip route <v6>`` is invalid CLI).  Covers both the
+        # default-VRF and per-VRF (vrf context) render paths.
+        intent = CanonicalIntent(hostname="R1", static_routes=[
+            CanonicalStaticRoute(destination="10.0.0.0/8", gateway="192.0.2.1"),
+            CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="2001:db8::1"),
+            CanonicalStaticRoute(
+                destination="2001:db8:a::/48", gateway="2001:db8::9", vrf="TENANT",
+            ),
+        ])
+        out = codec.render(intent)
+        assert "ip route 10.0.0.0/8 192.0.2.1" in out
+        assert "ipv6 route 2001:db8:1::/48 2001:db8::1" in out
+        assert "ipv6 route 2001:db8:a::/48 2001:db8::9" in out  # inside vrf context
+        assert "ip route 2001" not in out  # v6 never on the bare ``ip route``
+
 
 # ---------------------------------------------------------------------------
 # Round-trip


### PR DESCRIPTION
## What
NX-OS keys the static-route address family off the keyword — IPv6 uses `ipv6 route <prefix> <next-hop>`. `_render_static_route` (shared by the default-VRF and per-VRF `vrf context` paths) hardcoded `ip route`, so a v6 destination rendered `ip route <v6>` — invalid CLI a 9k rejects on commit.

## Fix
Branch the keyword on the destination family. Covers both render call sites (default-VRF and inside `vrf context`).

## Render-only (parse deferred to capstone)
Two committed nxos fixtures (`akarneliuk_evpn_vxlan_mcast_leaf_c1l1_nxos939`, `batfish_nxos_n9kv_ebgp_r1`) carry `ipv6 route` lines. Enabling the matching **parse** would surface those v6 routes into every target render in the cross-mesh guard *before* the remaining targets (aoscx/aoss/iosxr) round-trip → guard regression. So parse is deferred to the cross-codec capstone (with `cisco_iosxe_cli` parse), once all targets round-trip. This render change is guard-inert (no committed fixture currently produces a v6 static route in canonical).

## Context
Fourth of the cross-codec IPv6-static-route fixes from the full-corpus Mode-A dogfood mesh — after `cisco_iosxe_cli` #251, `fortigate_cli` #252, `arista_eos` #253.

Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)