### PR TITLE
fix(aruba_aoscx): render/parse IPv6 static routes with the 'ipv6 route' keyword

### DIFF
--- a/netcanon/migration/codecs/aruba_aoscx/parse.py
+++ b/netcanon/migration/codecs/aruba_aoscx/parse.py
@@ -267,6 +267,12 @@ _STATIC_ROUTE_RE = re.compile(
     r"^ip\s+route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)(?:\s+(\d+))?",
     re.IGNORECASE,
 )
+#: ``ipv6 route <prefix>/<len> <nh> [<dist>]`` — the IPv6 form uses the
+#: ``ipv6 route`` keyword (does not overlap ``^ip route``).
+_STATIC_ROUTE_V6_RE = re.compile(
+    r"^ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)(?:\s+(\d+))?",
+    re.IGNORECASE,
+)
 
 #: ``interface vlan <N>`` SVI name (post-capture; the canonical name is
 #: the space-separated ``vlan N``).
@@ -875,6 +881,24 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
     """
     routes: list[CanonicalStaticRoute] = []
     for line in raw.splitlines():
+        m6 = _STATIC_ROUTE_V6_RE.match(line)
+        if m6:
+            dest, gw_or_iface, metric_str = m6.groups()
+            metric = int(metric_str) if metric_str else 0
+            gateway = ""
+            iface = ""
+            try:
+                ipaddress.IPv6Address(gw_or_iface)
+                gateway = gw_or_iface
+            except ipaddress.AddressValueError:
+                iface = gw_or_iface
+            routes.append(CanonicalStaticRoute(
+                destination=dest,  # already <prefix>/<len>
+                gateway=gateway,
+                interface=iface,
+                metric=metric,
+            ))
+            continue
         m = _STATIC_ROUTE_RE.match(line)
         if not m:
             continue

--- a/netcanon/migration/codecs/aruba_aoscx/render.py
+++ b/netcanon/migration/codecs/aruba_aoscx/render.py
@@ -217,15 +217,18 @@ def _render_snmp(snmp) -> list[str]:
 
 
 def _render_static_route(route) -> str:
-    """Render one default-VRF static route as ``ip route DEST/N GW [dist]``.
+    """Render one default-VRF static route as ``ip route DEST/N GW [dist]``
+    (or ``ipv6 route`` for an IPv6 destination).
 
     ``destination`` is already CIDR (``X/N``).  Next-hop is the gateway
     IP, or the interface name for a directly-attached next-hop.  A
     non-zero ``metric`` re-emits as the trailing administrative-distance
-    token.
+    token.  AOS-CX keys the address family off the keyword: an IPv6
+    destination uses ``ipv6 route`` (``ip route <v6>`` is invalid CLI).
     """
     nexthop = route.gateway or route.interface
-    out = f"ip route {route.destination} {nexthop}".rstrip()
+    keyword = "ipv6 route" if ":" in (route.destination or "") else "ip route"
+    out = f"{keyword} {route.destination} {nexthop}".rstrip()
     if route.metric:
         out += f" {route.metric}"
     return out

--- a/tests/unit/migration/test_aruba_aoscx.py
+++ b/tests/unit/migration/test_aruba_aoscx.py
@@ -201,6 +201,28 @@ def test_parse_static_route(codec: ArubaAOSCXCodec) -> None:
     assert route.gateway == "198.51.100.2"
 
 
+def test_ipv6_static_route_render_and_round_trip(codec: ArubaAOSCXCodec) -> None:
+    # AOS-CX keys the AF off the keyword: an IPv6 destination must render
+    # ``ipv6 route`` (``ip route <v6>`` is invalid CLI) and round-trip.
+    from netcanon.migration.canonical.intent import (
+        CanonicalIntent,
+        CanonicalStaticRoute,
+    )
+    intent = CanonicalIntent(hostname="r1", static_routes=[
+        CanonicalStaticRoute(destination="10.0.0.0/8", gateway="192.0.2.1"),
+        CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="2001:db8::1"),
+    ])
+    out = codec.render(intent)
+    assert "ip route 10.0.0.0/8 192.0.2.1" in out
+    assert "ipv6 route 2001:db8:1::/48 2001:db8::1" in out
+    assert "ip route 2001" not in out  # v6 never on the bare ``ip route``
+    reparsed = codec.parse(out)
+    assert any(
+        r.destination == "2001:db8:1::/48" and r.gateway == "2001:db8::1"
+        for r in reparsed.static_routes
+    )
+
+
 # ---------------------------------------------------------------------------
 # Multi-token interface names + stanza interception
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
AOS-CX keys the static-route address family off the keyword — IPv6 uses `ipv6 route <prefix> <next-hop>`. The renderer emitted `ip route <v6dest>` for every route (invalid CLI rejected on commit), and the `ip route` parse regex is IPv4-only, so v6 routes didn't round-trip.

## Fix
- **Render**: branch the keyword on destination family.
- **Parse**: add `_STATIC_ROUTE_V6_RE` with the same IP-vs-interface next-hop split as the v4 form.

v6 routes round-trip losslessly (verified `/48`).

## Context
Fifth of the cross-codec IPv6-static-route fixes from the full-corpus Mode-A dogfood mesh — after #251 (iosxe_cli), #252 (fortigate), #253 (arista), #254 (nxos render). Remaining: aoss, iosxr, then the nxos+iosxe_cli parse capstone.

## Ratchet safety
No committed aoscx fixture uses `ipv6 route`, so the parse-add is inert in the cross-mesh guard; v4-only renders byte-identical. Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)