### PR TITLE
fix(aruba_aoss): render/parse IPv6 static routes with the 'ipv6 route' keyword

### DIFF
--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -127,6 +127,12 @@ _IP_ROUTE_RE = re.compile(
     r"\s+(\d+\.\d+\.\d+\.\d+)\s*$",
     re.IGNORECASE,
 )
+_IPV6_ROUTE_RE = re.compile(
+    # ``ipv6 route <prefix>/<len> <next-hop>`` — the IPv6 form (does not
+    # overlap ``^ip route``; ``ipv6`` != ``ip``).
+    r"^ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)\s*$",
+    re.IGNORECASE,
+)
 _VLAN_HEADER_RE = re.compile(r"^vlan\s+(\d+)\s*$", re.IGNORECASE)
 # ``trunk <port-list> <name> <type>`` — AOS-S link-aggregation form.
 # Examples:
@@ -952,6 +958,15 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             intent.static_routes.append(CanonicalStaticRoute(
                 destination="0.0.0.0/0",
                 gateway=gw.group(1),
+            ))
+            i += 1
+            continue
+
+        rt6 = _IPV6_ROUTE_RE.match(stripped_line)
+        if rt6:
+            intent.static_routes.append(CanonicalStaticRoute(
+                destination=rt6.group(1),  # already <prefix>/<len>
+                gateway=rt6.group(2),
             ))
             i += 1
             continue

--- a/netcanon/migration/codecs/aruba_aoss/render.py
+++ b/netcanon/migration/codecs/aruba_aoss/render.py
@@ -841,10 +841,15 @@ def render_intent(tree: Any) -> str:  # noqa: C901
                     )
         lines.append("   exit")
 
-    # Static routes.  Default route (0.0.0.0/0) becomes
-    # ``ip default-gateway`` per AOS-S convention.
+    # Static routes.  IPv4 default route (0.0.0.0/0) becomes
+    # ``ip default-gateway`` per AOS-S convention; IPv6 destinations use the
+    # ``ipv6 route`` keyword (AOS-S has no ``ipv6 default-gateway`` form, so
+    # a v6 default is just ``ipv6 route ::/0 <gw>``).  Emitting ``ip route``
+    # for a v6 destination is invalid CLI.
     for route in tree.static_routes:
-        if route.destination in ("0.0.0.0/0", "default"):
+        if ":" in (route.destination or ""):
+            lines.append(f"ipv6 route {route.destination} {route.gateway}")
+        elif route.destination in ("0.0.0.0/0", "default"):
             lines.append(f"ip default-gateway {route.gateway}")
         else:
             lines.append(

--- a/tests/unit/migration/test_aruba_aoss.py
+++ b/tests/unit/migration/test_aruba_aoss.py
@@ -273,6 +273,25 @@ class TestParse:
         tree = ArubaAOSSCodec().parse(raw)
         assert tree.vlans[0].ipv4_addresses[0].prefix_length == 24
 
+    def test_ipv6_static_route_render_and_round_trip(self):
+        # AOS-S keys the AF off the keyword: v6 destinations use ``ipv6
+        # route`` (no ``ipv6 default-gateway`` form — a v6 default is just
+        # ``ipv6 route ::/0 <gw>``).  Emitting ``ip route <v6>`` is invalid.
+        intent = CanonicalIntent(hostname="sw", static_routes=[
+            CanonicalStaticRoute(destination="0.0.0.0/0", gateway="192.0.2.254"),
+            CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="2001:db8::1"),
+            CanonicalStaticRoute(destination="::/0", gateway="2001:db8::9"),
+        ])
+        out = ArubaAOSSCodec().render(intent)
+        assert "ip default-gateway 192.0.2.254" in out
+        assert "ipv6 route 2001:db8:1::/48 2001:db8::1" in out
+        assert "ipv6 route ::/0 2001:db8::9" in out
+        assert "ip route 2001" not in out  # v6 never on the bare ``ip route``
+        reparsed = ArubaAOSSCodec().parse(out)
+        v6 = sorted((r.destination, r.gateway) for r in reparsed.static_routes
+                    if ":" in r.destination)
+        assert v6 == [("2001:db8:1::/48", "2001:db8::1"), ("::/0", "2001:db8::9")]
+
     def test_comment_character_is_semicolon(self):
         """Lines starting with ';' must be ignored (AOS-S doesn't use '!')."""
         raw = '; a banner comment\nhostname "survived"\n'


### PR DESCRIPTION
## What
AOS-S keys the static-route address family off the keyword. The renderer special-cased the IPv4 default (`ip default-gateway`) and otherwise emitted `ip route <dest> <gw>` — so an IPv6 destination rendered `ip route <v6>` (invalid), and a v6 default hit the same path. AOS-S has no `ipv6 default-gateway` form: a v6 default is just `ipv6 route ::/0 <gw>`.

## Fix
- **Render**: branch the keyword on destination family (v4 keeps the default-gateway special-case).
- **Parse**: add `_IPV6_ROUTE_RE`.

v6 routes round-trip losslessly (verified `/48` + `::/0`, alongside the v4 default-gateway).

## Context
Sixth of the cross-codec IPv6-static-route fixes from the full-corpus Mode-A dogfood mesh — after #251/#252/#253/#254/#255. Remaining: iosxr, then the nxos+iosxe_cli parse capstone.

## Ratchet safety
No committed aoss fixture uses `ipv6 route`; parse-add inert, v4 renders byte-identical. Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)