### PR TITLE
fix(cisco_iosxr): file IPv6 static routes under 'address-family ipv6 unicast'

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxr/render.py
+++ b/netcanon/migration/codecs/cisco_iosxr/render.py
@@ -227,18 +227,28 @@ def _render_router_static(routes: list) -> list[str]:
     if not default_routes and not vrf_routes:
         return []
 
+    def _emit_afs(rs: list, indent: str) -> list[str]:
+        """Emit ``address-family {ipv4,ipv6} unicast`` sub-blocks.  IOS-XR
+        files a route under the AF matching its destination — a v6 prefix
+        under ``address-family ipv4 unicast`` is invalid CLI."""
+        blk: list[str] = []
+        for af, family in (("ipv4", False), ("ipv6", True)):
+            af_routes = [
+                r for r in rs if (":" in (r.destination or "")) == family
+            ]
+            if not af_routes:
+                continue
+            blk.append(f"{indent}address-family {af} unicast")
+            for r in af_routes:
+                blk.append(f"{indent} {_static_route_line(r)}")
+            blk.append(f"{indent}!")
+        return blk
+
     out = ["router static"]
-    if default_routes:
-        out.append(" address-family ipv4 unicast")
-        for r in default_routes:
-            out.append(f"  {_static_route_line(r)}")
-        out.append(" !")
+    out.extend(_emit_afs(default_routes, " "))
     for vrf_name, vroutes in vrf_routes.items():
         out.append(f" vrf {vrf_name}")
-        out.append("  address-family ipv4 unicast")
-        for r in vroutes:
-            out.append(f"   {_static_route_line(r)}")
-        out.append("  !")
+        out.extend(_emit_afs(vroutes, "  "))
         out.append(" !")
     out.append("!")
     return out

--- a/tests/unit/migration/test_cisco_iosxr.py
+++ b/tests/unit/migration/test_cisco_iosxr.py
@@ -34,6 +34,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalIntent,
     CanonicalInterface,
     CanonicalIPv4Address,
+    CanonicalStaticRoute,
 )
 from netcanon.migration.canonical.port_names import PortIdentity
 from netcanon.migration.codecs.cisco_iosxe_cli import CiscoIOSXECLICodec
@@ -380,6 +381,26 @@ class TestRoundTrip:
         assert "router static" in out
         assert "  192.0.2.0/24 Null0" in out
         assert out.rstrip().endswith("end")
+
+    def test_render_ipv6_static_route_under_ipv6_af(self, codec):
+        # IOS-XR files a static route under the address-family matching its
+        # destination.  A v6 prefix must sit under ``address-family ipv6
+        # unicast`` — not ``ipv4 unicast`` (invalid CLI, and the bug the
+        # dogfood mesh surfaced).  Covers default + per-VRF.
+        intent = CanonicalIntent(hostname="r1", static_routes=[
+            CanonicalStaticRoute(destination="10.0.0.0/8", gateway="192.0.2.1"),
+            CanonicalStaticRoute(destination="2001:db8:1::/48", gateway="2001:db8::1"),
+            CanonicalStaticRoute(
+                destination="2001:db8:a::/48", gateway="2001:db8::9", vrf="RED",
+            ),
+        ])
+        out = codec.render(intent)
+        assert " address-family ipv4 unicast\n  10.0.0.0/8 192.0.2.1" in out
+        assert " address-family ipv6 unicast\n  2001:db8:1::/48 2001:db8::1" in out
+        # The per-VRF v6 route nests under vrf RED / ipv6 unicast.
+        assert "  address-family ipv6 unicast\n   2001:db8:a::/48 2001:db8::9" in out
+        # A v6 prefix must never appear under the ipv4 AF block.
+        assert "ipv4 unicast\n  2001" not in out
 
     def test_render_emits_phase2_grammar(self, codec, kitchen_sink):
         out = codec.render(codec.parse(kitchen_sink))


### PR DESCRIPTION
## What
`_render_router_static` emitted **every** route under `address-family ipv4 unicast`, so an IPv6 destination landed in the v4 AF block:

```
router static
 address-family ipv4 unicast
  10.0.0.0/8 192.0.2.1
  2001:db8:1::/48 2001:db8::1   ← invalid: v6 in the v4 AF
```

IOS-XR requires v6 prefixes under `address-family ipv6 unicast`.

## Fix
Split routes by destination family into per-AF sub-blocks, for both the default-VRF and per-VRF (`vrf <name>`) paths. v4-only output is byte-identical.

## Render-only (parse deferred to capstone)
A committed iosxr fixture (`iosxr_design_cst_pa3_xr752`) carries a v6 static route (`2001:db8:23:23::2/128 BVI500`). Enabling the matching `address-family ipv6 unicast` **parse** would surface it into every target render in the cross-mesh guard before the capstone lands → guard regression. Parse is deferred to the capstone (with nxos + iosxe_cli parse). Render change is guard-inert.

## Context
Seventh of the cross-codec IPv6-static-route fixes from the full-corpus Mode-A dogfood mesh — after #251/#252/#253/#254/#255/#256. Next: the parse capstone (nxos + iosxe_cli + iosxr).

Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)