### PR TITLE
feat(cisco_iosxe_cli): parse 'ipv6 route' so IPv6 static routes round-trip

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -280,6 +280,17 @@ _STATIC_ROUTE_RE = re.compile(
     r"(\s.*)?$",
     re.IGNORECASE,
 )
+# IPv6 static route: ``ipv6 route [vrf <NAME>] <prefix>/<len> <nh> [tail]``.
+# The destination is already prefix (CIDR) form — no dotted mask, unlike the
+# IPv4 form.  Kept separate so ``ip route`` (v4) and ``ipv6 route`` (v6) never
+# overlap (``ipv6`` != ``ip``).  Same ``(\s.*)?`` trailing-token shape as the
+# v4 RE to avoid the polynomial-ReDoS overlap CodeQL flagged (#128).
+_STATIC_ROUTE_V6_RE = re.compile(
+    r"^ipv6\s+route\s+(?:vrf\s+(\S+)\s+)?"
+    r"([0-9A-Fa-f:]+/\d+)\s+(\S+)"
+    r"(\s.*)?$",
+    re.IGNORECASE,
+)
 # ``ip default-gateway X`` is the L2-switch form of a default route.
 # Common on Catalyst switches that have no routing enabled — the switch
 # itself still needs a gateway for its management SVI.  We map it to the
@@ -1328,6 +1339,43 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
     """
     routes: list[CanonicalStaticRoute] = []
     for line in raw.splitlines():
+        m6 = _STATIC_ROUTE_V6_RE.match(line)
+        if m6:
+            vrf = m6.group(1) or ""
+            dest = m6.group(2)  # already <prefix>/<len> form
+            gw_or_iface = m6.group(3)
+            gateway = ""
+            iface = ""
+            try:
+                ipaddress.IPv6Address(gw_or_iface)
+                gateway = gw_or_iface
+            except ipaddress.AddressValueError:
+                iface = gw_or_iface
+            metric = 0
+            description = ""
+            tail = (m6.group(4) or "").split()
+            t = 0
+            while t < len(tail):
+                tok = tail[t].lower()
+                if tok == "name" and t + 1 < len(tail):
+                    description = tail[t + 1]
+                    t += 2
+                elif tok in ("tag", "track") and t + 1 < len(tail):
+                    t += 2  # keyword + its value — not modelled
+                elif tail[t].isdigit() and metric == 0:
+                    metric = int(tail[t])
+                    t += 1
+                else:
+                    t += 1
+            routes.append(CanonicalStaticRoute(
+                destination=dest,
+                gateway=gateway,
+                interface=iface,
+                vrf=vrf,
+                metric=metric,
+                description=description,
+            ))
+            continue
         m = _STATIC_ROUTE_RE.match(line)
         if m:
             vrf = m.group(1) or ""

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -599,6 +599,35 @@ class TestRender:
         assert "ip route 10.0.0.0 255.0.0.0 192.0.2.1" in out
         assert "ipv6 route 2001:db8:1::/48 fe80::1" in out
 
+    def test_parse_ipv6_static_route(self):
+        # Capstone: the IOS-XE parser now reads ``ipv6 route`` back (render
+        # emitted it since the v6 render fix), so v6 routes round-trip.
+        intent = CiscoIOSXECLICodec().parse(
+            "ipv6 route 2001:db8:1::/48 2001:db8::1\n"
+            "ipv6 route ::/0 2001:db8::9\n"
+        )
+        v6 = sorted((r.destination, r.gateway) for r in intent.static_routes
+                    if ":" in r.destination)
+        assert v6 == [("2001:db8:1::/48", "2001:db8::1"), ("::/0", "2001:db8::9")]
+
+    def test_parse_per_vrf_ipv6_static_route(self):
+        intent = CiscoIOSXECLICodec().parse(
+            "ipv6 route vrf RED 2001:db8:a::/48 2001:db8::9\n"
+        )
+        match = [r for r in intent.static_routes if r.vrf == "RED"]
+        assert match and match[0].destination == "2001:db8:a::/48"
+        assert match[0].gateway == "2001:db8::9"
+
+    def test_ipv6_static_route_round_trip(self):
+        codec = CiscoIOSXECLICodec()
+        out = codec.render(codec.parse("ipv6 route 2001:db8:1::/48 2001:db8::1\n"))
+        assert "ipv6 route 2001:db8:1::/48 2001:db8::1" in out
+        reparsed = codec.parse(out)
+        assert any(
+            r.destination == "2001:db8:1::/48" and r.gateway == "2001:db8::1"
+            for r in reparsed.static_routes
+        )
+
     def test_render_emits_vlan_database_and_svi(self):
         intent = CiscoIOSXECLICodec().parse(
             "vlan 10\n name USERS\n!\n"


### PR DESCRIPTION
## What
Capstone **part 1/3** of the cross-codec IPv6-static-route work. The render side has emitted `ipv6 route <prefix> <nh>` since #251; this re-adds the matching **parse** (`_STATIC_ROUTE_V6_RE` + loop branch, with the optional `vrf <NAME>` qualifier and the same trailing-token handling as the v4 form) so IOS-XE v6 routes round-trip symmetrically.

## Why now (deferred in #251)
The parse surfaces the committed `batfish_cisco_ip_route.txt` fixture's `ipv6 route` lines into **every** target render in the cross-mesh guard. That's now safe — all target renders round-trip v6:
- arista #253, fortigate #252, nxos-render #254, aoscx #255, aoss #256, iosxr-render #257
- junos / mikrotik / vyos already correct
- iosxe-xml / opnsense declare `/routing/static-route` lossy (drop v4 too)

Guard verified green (CODEC_BUG held, no new render-failure pair) **before** commit.

## Next
Capstone parts 2/3 (nxos parse) and 3/3 (iosxr parse) follow — the other two codecs with committed v6-route fixtures.

Full `tests/unit` + cross-mesh guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)