### PR TITLE
feat(cisco_iosxr): parse 'address-family ipv6 unicast' static routes

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -143,10 +143,16 @@ _ROUTER_STATIC_RE = re.compile(r"^router\s+static\s*$", re.IGNORECASE)
 _AF_IPV4_UNICAST_RE = re.compile(
     r"^address-family\s+ipv4\s+unicast\b", re.IGNORECASE,
 )
+_AF_IPV6_UNICAST_RE = re.compile(
+    r"^address-family\s+ipv6\s+unicast\b", re.IGNORECASE,
+)
 _STATIC_VRF_RE = re.compile(r"^vrf\s+(\S+)", re.IGNORECASE)
-#: A static-route leaf: ``<dest>/<prefix> <token>...`` (CIDR destination).
+#: A static-route leaf: ``<dest>/<prefix> <token>...`` (CIDR destination,
+#: IPv4 or IPv6).  The destination char class covers both dotted-decimal
+#: (``10.0.0.0/8``) and colon-hex (``2001:db8::/32``) prefixes; the address
+#: family is discriminated by the enclosing ``address-family`` block.
 _STATIC_LEAF_RE = re.compile(
-    r"^(\d+\.\d+\.\d+\.\d+/\d+)\s+(.+)$",
+    r"^([0-9A-Fa-f:.]+/\d+)\s+(.+)$",
 )
 
 # ── VRF top-level stanza + route-target blocks (Phase 2) ──
@@ -647,9 +653,9 @@ def _parse_static_leaf(
     iface = ""
     for tok in m.group(2).split():
         try:
-            ipaddress.IPv4Address(tok)
+            ipaddress.ip_address(tok)  # IPv4 or IPv6 next-hop
             gateway = tok
-        except ipaddress.AddressValueError:
+        except ValueError:
             if not iface:
                 iface = tok
     return CanonicalStaticRoute(
@@ -691,7 +697,7 @@ def _parse_router_static(raw: str) -> list[CanonicalStaticRoute]:
             in_block = False
             continue
 
-        if _AF_IPV4_UNICAST_RE.match(stripped):
+        if _AF_IPV4_UNICAST_RE.match(stripped) or _AF_IPV6_UNICAST_RE.match(stripped):
             in_af = True
             continue
         vrfm = _STATIC_VRF_RE.match(stripped)

--- a/tests/unit/migration/test_cisco_iosxr.py
+++ b/tests/unit/migration/test_cisco_iosxr.py
@@ -200,6 +200,34 @@ class TestParse:
         assert by_dest["10.99.0.0/16"].vrf == "CUSTOMER-A"
         assert by_dest["10.99.0.0/16"].gateway == "203.0.113.2"
 
+    def test_parse_ipv6_static_routes_under_ipv6_af(self, codec):
+        # Capstone: routes under ``address-family ipv6 unicast`` (default +
+        # per-VRF) now parse — gateway, interface-only, and per-VRF forms.
+        raw = (
+            "!! IOS XR Configuration\n"
+            "hostname r1\n"
+            "router static\n"
+            " address-family ipv6 unicast\n"
+            "  2001:db8:1::/48 2001:db8::1\n"
+            "  2001:db8:23::2/128 BVI500\n"
+            " !\n"
+            " vrf RED\n"
+            "  address-family ipv6 unicast\n"
+            "   2001:db8:a::/48 2001:db8::9\n"
+            "  !\n"
+            " !\n"
+            "!\n"
+        )
+        by_dest = {r.destination: r for r in codec.parse(raw).static_routes}
+        assert by_dest["2001:db8:1::/48"].gateway == "2001:db8::1"
+        assert by_dest["2001:db8:1::/48"].vrf == ""
+        # Interface-only v6 next-hop (BVI500) → interface, no gateway.
+        assert by_dest["2001:db8:23::2/128"].interface == "BVI500"
+        assert by_dest["2001:db8:23::2/128"].gateway == ""
+        # Per-VRF v6 route tagged with its VRF.
+        assert by_dest["2001:db8:a::/48"].vrf == "RED"
+        assert by_dest["2001:db8:a::/48"].gateway == "2001:db8::9"
+
     def test_non_contiguous_mask_tolerated(self, codec):
         """A malformed mask drops the address rather than crashing the
         whole parse."""


### PR DESCRIPTION
## What
Capstone **part 3/3 (final)** of the cross-codec IPv6-static-route work. The render side filed v6 routes under `address-family ipv6 unicast` since #257; this adds the matching **parse**:
- the static-route state machine opens `in_af` for the ipv6 (as well as ipv4) unicast block,
- the leaf regex accepts a colon-hex CIDR destination,
- the next-hop classifier uses `ipaddress.ip_address` (v4 or v6) — a v6 gateway lands on `gateway`, a bare interface (e.g. `BVI500`) on `interface`.

Covers default-VRF and per-VRF paths; v6 routes round-trip symmetrically (gateway, interface-only, and per-VRF forms verified).

## Why now (deferred in #257)
A committed iosxr fixture (`iosxr_design_cst_pa3_xr752`) carries an interface-form v6 static route (`2001:db8:23:23::2/128 BVI500`) that this parse surfaces into every target render in the cross-mesh guard. Now safe — all target renders round-trip v6. Guard verified green (CODEC_BUG held, no new render-failure pair) **before** commit.

## Completes the sweep
IPv6 static routes now handled correctly across all 12 codecs: fortigate crash (#252), arista/nxos/aruba invalid-output (#253/#254/#255/#256), iosxr AF-misfile (#257 render + this parse), iosxe_cli crash (#251 render + #258 parse); iosxe-xml/opnsense declare `/routing/static-route` lossy; junos/mikrotik/vyos already correct.

Full `tests/unit` + cross-mesh guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)