### PR TITLE
fix(mikrotik_routeros): derive VLAN tag from the record, not the interface-name digits

### DIFF
--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -1019,15 +1019,21 @@ def _routeros_auth_kv(authentication: str) -> list[str]:
 
 
 def _vlan_id_for(name: str, vlans: list[CanonicalVlan]) -> int | None:
-    """Find the VLAN id for an interface name.
+    """Find the 802.1Q tag for a VLAN interface name.
 
-    Matches on either a ``vlanN`` convention (id parsed from name) or
-    an entry in ``vlans`` whose ``name`` equals the interface name.
+    Prefer the canonical VLAN record whose ``name`` matches the interface —
+    its ``id`` is the authoritative tag.  Fall back to the ``vlanN``
+    name-digit convention only when no record matches (i.e. the tag equals
+    the name suffix).  Consulting the record FIRST is required because an
+    interface's name digits can differ from its tag (e.g. ``name=vlan202``
+    carrying ``vlan-id=20``); the old name-first order rendered the wrong
+    tag (202) AND, by poisoning the rendered-id dedup set, emitted a phantom
+    duplicate for the real tag.
     """
-    m = re.match(r"^vlan(\d+)$", name, re.IGNORECASE)
-    if m:
-        return int(m.group(1))
     for v in vlans:
         if v.name == name:
             return v.id
+    m = re.match(r"^vlan(\d+)$", name, re.IGNORECASE)
+    if m:
+        return int(m.group(1))
     return None

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -342,6 +342,32 @@ class TestRender:
         assert 'name=vlan10' in out
         assert 'vlan-id=10' in out
 
+    def test_vlan_id_from_record_when_name_digits_differ_from_tag(self):
+        # Regression: a VLAN interface whose NAME digits differ from its
+        # 802.1Q tag (name=vlan202 carrying tag 20) must render the tag from
+        # the canonical VLAN record, not the name suffix.  The old name-first
+        # order rendered vlan-id=202 AND emitted a phantom duplicate vlan20.
+        tree = CanonicalIntent(
+            interfaces=[CanonicalInterface(name="vlan202")],
+            vlans=[CanonicalVlan(id=20, name="vlan202")],
+        )
+        codec = MikroTikRouterOSCodec()
+        out = codec.render(tree)
+        vlan_lines = [ln for ln in out.splitlines() if "vlan-id=" in ln]
+        assert vlan_lines == ["add interface=bridge1 name=vlan202 vlan-id=20"]
+        # No phantom duplicate — exactly one VLAN survives, with the right id.
+        reparsed = codec.parse(out)
+        assert sorted(v.id for v in reparsed.vlans) == [20]
+
+    def test_vlan_id_matching_name_and_tag_unchanged(self):
+        # The common ``vlanN`` convention (name digits == tag) is unaffected.
+        tree = CanonicalIntent(
+            interfaces=[CanonicalInterface(name="vlan10")],
+            vlans=[CanonicalVlan(id=10, name="vlan10")],
+        )
+        out = MikroTikRouterOSCodec().render(tree)
+        assert "name=vlan10 vlan-id=10" in out
+
 
 class TestRoundTrip:
     """parse(render(tree)) == tree for every tree in the supported subset."""


### PR DESCRIPTION
## What
`_vlan_id_for` matched the `vlanN` name-digit convention **before** consulting the canonical VLAN record, so a VLAN interface whose name digits differ from its 802.1Q tag rendered the **wrong `vlan-id`**. The wrong id then poisoned the rendered-id dedup set, so the second render loop *also* emitted a phantom duplicate for the real tag.

Example (`mikrotik → mikrotik` round-trip): source
```
add interface=ether4 name=vlan202 vlan-id=20
```
→ `CanonicalVlan(id=20, name='vlan202')` → rendered `vlan-id=202` **and** a spurious `name=vlan20 vlan-id=20`. `/vlans/vlan/id` is declared supported, so this is genuine data corruption (id 20 → 202 + fabricated VLAN).

## Fix
Consult the canonical VLAN record (match by name) **first** — its `id` is the authoritative tag — and fall back to the `vlanN` name-digit regex only when no record matches. Behaviour-neutral for the common `vlanN`==tag convention and for name-only SVIs (e.g. `gn-mgmt`).

Verified: bug case now renders `name=vlan202 vlan-id=20` with no duplicate; common + named-SVI cases unchanged.

## How surfaced
Residual dogfood-mesh triage (2026-07-02), adversarially confirmed (`still_real_bug=true`). The sibling finding — unquoted `name=`/`interface=` values truncating on a space — was **refuted** as a bare-mesh port-name artifact the orchestrator's port-name layer already eliminates in the product path (`lag 1`→`bond1`, `loopback 0`→`lo`), so it's left alone.

## Ratchet safety
No committed mikrotik fixture carries a name/tag mismatch, so the cross-mesh guard is unaffected. Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)