### PR TITLE
fix(mikrotik_routeros): quote free-form name=/interface= values with spaces

### DIFF
--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -329,7 +329,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             parts.append(
                 f"mode={_CANONICAL_MODE_TO_ROUTEROS_BONDING.get(lag.mode, '802.3ad')}"
             )
-            parts.append(f"name={lag.name}")
+            parts.append(f"name={_quote_if_needed(lag.name)}")
             lines.append(" ".join(parts))
         lines.append("")
 
@@ -487,7 +487,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         lines.append("/ip address")
         for ip, prefix, iface_name in ip_rows:
             lines.append(
-                f"add address={ip}/{prefix} interface={iface_name}"
+                f"add address={ip}/{prefix} interface={_quote_if_needed(iface_name)}"
             )
         lines.append("")
 
@@ -501,7 +501,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         lines.append("/ipv6 address")
         for ip, prefix, iface_name in ip6_rows:
             lines.append(
-                f"add address={ip}/{prefix} interface={iface_name}"
+                f"add address={ip}/{prefix} interface={_quote_if_needed(iface_name)}"
             )
         lines.append("")
 

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -19,6 +19,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalInterface,
     CanonicalIPv4Address,
     CanonicalIPv6Address,
+    CanonicalLAG,
     CanonicalStaticRoute,
     CanonicalVlan,
     CanonicalVRRPGroup,
@@ -367,6 +368,42 @@ class TestRender:
         )
         out = MikroTikRouterOSCodec().render(tree)
         assert "name=vlan10 vlan-id=10" in out
+
+    def test_kv_values_with_spaces_are_quoted(self):
+        # Defensive: bonding ``name=`` and ``/ip|/ipv6 address interface=``
+        # take free-form names.  A cross-vendor verbatim name with a space
+        # (aruba ``lag 1`` / ``loopback 0``) must be quoted or RouterOS's
+        # key=value grammar truncates it at the first space on re-parse.
+        tree = CanonicalIntent(
+            interfaces=[CanonicalInterface(
+                name="loopback 0",
+                ipv4_addresses=[CanonicalIPv4Address(ip="192.168.1.1", prefix_length=32)],
+                ipv6_addresses=[CanonicalIPv6Address(ip="2001:db8::1", prefix_length=128)],
+            )],
+            lags=[CanonicalLAG(name="lag 1", members=["1/1/1", "1/1/2"])],
+        )
+        codec = MikroTikRouterOSCodec()
+        out = codec.render(tree)
+        assert 'name="lag 1"' in out
+        assert 'interface="loopback 0"' in out          # /ip address
+        assert out.count('interface="loopback 0"') == 2  # + /ipv6 address
+        reparsed = codec.parse(out)
+        assert [lag.name for lag in reparsed.lags] == ["lag 1"]
+        lo = next(i for i in reparsed.interfaces if i.name == "loopback 0")
+        assert [a.ip for a in lo.ipv4_addresses] == ["192.168.1.1"]
+
+    def test_kv_space_free_values_stay_unquoted(self):
+        # No-op for the common case — space-free identifiers render bare.
+        tree = CanonicalIntent(
+            interfaces=[CanonicalInterface(
+                name="ether1",
+                ipv4_addresses=[CanonicalIPv4Address(ip="10.0.0.1", prefix_length=24)],
+            )],
+            lags=[CanonicalLAG(name="bond1", members=["ether2"])],
+        )
+        out = MikroTikRouterOSCodec().render(tree)
+        assert "name=bond1" in out
+        assert "interface=ether1" in out
 
 
 class TestRoundTrip:


### PR DESCRIPTION
## What
Three RouterOS `key=value` render sites emitted the value **bare** while every peer site wraps it in `_quote_if_needed`:
- bonding `name={lag.name}`
- `/ip address … interface={iface_name}`
- `/ipv6 address … interface={iface_name}`

RouterOS's `key=value` grammar (and netcanon's `_KV_RE` bare-token rule) truncates an unquoted value at the first space, so a cross-vendor verbatim name carrying a space (aruba `lag 1`, `loopback 0`) was silently cut — the LAG name truncated to `lag`, and the loopback's IPv4/IPv6 addresses re-attached to a phantom `loopback` interface, dropping them from the real one.

## Fix
Wrap all three in `_quote_if_needed` — a **no-op for space-free identifiers**, so the common case and same-vendor round-trips are byte-identical. Verified: `name="lag 1"` / `interface="loopback 0"` now round-trip (v4+v6 preserved); `name=bond1` / `interface=ether1` stay unquoted.

## Framing
Defensive hardening, **not** a product-path bug: the user-facing pipeline's port-name layer already rewrites such names space-free before render (`lag 1`→`bond1`, `loopback 0`→`lo`). This closes a bare-render inconsistency (3 sites out of ~9 were missing the quoting) surfaced (and correctly *refuted as a product bug*) by the residual dogfood-mesh triage.

## Ratchet safety
Quoting only ever *preserves more data* — it never renames interfaces — so the name-stability cross-mesh guard cannot regress. Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)