### PR TITLE
fix(cisco_iosxr): extract the release from the 'version =' banner variant

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -313,8 +313,14 @@ def _extract_version(raw: str) -> str:
     Stored as :attr:`CanonicalIntent.source_version` (metadata); the
     render path synthesises a fresh banner so it is informational only.
     """
+    # Two banner forms occur in the wild:
+    #   ``!! IOS XR Configuration 6.3.1``            (older)
+    #   ``!! IOS XR Configuration version = 6.2.1``  (newer; also ``version 7.x``)
+    # Skip the optional ``version [=]`` keyword so the capture is the release
+    # number, not the literal word ``version``.
     m = re.search(
-        r"^!!\s+IOS XR Configuration\s+(\S+)", raw, re.MULTILINE,
+        r"^!!\s+IOS XR Configuration\s+(?:version\s*=?\s*)?(\S+)",
+        raw, re.MULTILINE,
     )
     return m.group(1) if m else ""
 

--- a/tests/unit/migration/test_cisco_iosxr.py
+++ b/tests/unit/migration/test_cisco_iosxr.py
@@ -147,6 +147,16 @@ class TestParse:
         assert intent.source_vendor == "cisco_iosxr"
         assert intent.source_format == "cli-iosxr"
 
+    @pytest.mark.parametrize("banner,expected", [
+        ("!! IOS XR Configuration 6.3.1", "6.3.1"),          # older form
+        ("!! IOS XR Configuration version = 6.2.1", "6.2.1"),  # newer form
+        ("!! IOS XR Configuration version 7.3.2", "7.3.2"),  # keyword, no '='
+    ])
+    def test_source_version_banner_variants(self, codec, banner, expected):
+        # Regression: the newer ``version = <rel>`` banner made the extractor
+        # capture the literal word "version" instead of the release number.
+        assert codec.parse(banner + "\nhostname r1\n").source_version == expected
+
     def test_loopback_ipv4_mask_to_prefix(self, codec, kitchen_sink):
         intent = codec.parse(kitchen_sink)
         lo = next(i for i in intent.interfaces if i.name == "Loopback0")


### PR DESCRIPTION
## What
`_extract_version` matched `!! IOS XR Configuration <token>` and took the first token. The newer banner form
```
!! IOS XR Configuration version = 6.2.1
```
made it capture the literal word **`version`** instead of the release. On the dogfood corpus that was **~53 of 154** iosxr configs storing `source_version="version"` — garbage that inflated apparent coverage (78% → real clean rate ~43%).

## Fix
Skip an optional `version [=]` keyword before the capture, so both banner forms yield the release:
- `!! IOS XR Configuration 6.3.1` → `6.3.1`
- `!! IOS XR Configuration version = 6.2.1` → `6.2.1`
- `!! IOS XR Configuration version 7.3.2` → `7.3.2`

Corpus re-census: iosxr version capture is now **120/154 with clean release strings and zero `version` junk** (top: `6.3.1`, `6.1.2`, `6.2.1`, `6.1.1`, `6.1.3`).

## Context
Surfaced by a version-data-quality census of the dogfood corpus (enriching the version-as-a-translation-vector track). `source_version` is metadata (stripped from fidelity comparisons), so the cross-mesh guard is unaffected — this purely improves the version dataset.

The sibling opnsense/junos candidates were **not** shipped after verifying: OPNsense's `<version>` is the config-schema version (`v9`/`2`), not the OS version — capturing it would pollute the data; junos extraction is already correct (low coverage is version lines being absent, and the lone `aaa` is a batfish fixture literally containing `set version aaa`).

Guard + full `tests/unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)