### PR TITLE
fix(packaging): ship migration/vendors/*.yaml in the wheel (Docker registry was empty)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,16 +361,40 @@ jobs:
           echo "renders (catches packaging-bug class where /health"
           echo "works but Jinja templates are missing from the wheel —"
           echo "the v0.1.0-rc1/rc2 regression that motivated this check)."
-          if curl -fsS -o /dev/null http://127.0.0.1:8000/; then
-            echo "Smoke test passed (health + dashboard render)."
+          if ! curl -fsS -o /dev/null http://127.0.0.1:8000/; then
+            echo "FAIL: /health returned 200 but / did not."
+            echo "Likely cause: a template file (or partial under"
+            echo "templates/_partials/) is missing from the built wheel"
+            echo "— check pyproject.toml [tool.setuptools.package-data]"
+            echo "and confirm every templates/* path the renderer needs"
+            echo "is covered by the glob list."
+            echo "--- container logs ---"
+            docker logs smoke
+            exit 1
+          fi
+          echo "Dashboard renders."
+          echo
+          echo "Now verifying the translator VENDOR REGISTRY actually loaded."
+          echo "The app boots and / renders even with ZERO vendors (empty"
+          echo "dropdown), so a bare 200 check misses the packaging-bug class"
+          echo "where netcanon/migration/vendors/*.yaml is absent from the"
+          echo "git-less wheel (the .dockerignore excludes .git, so"
+          echo "setuptools_scm's file-finder can't backfill them — only the"
+          echo "package-data globs ship). load_vendors() then logs 'Loaded 0"
+          echo "vendor(s)' and the codec<->vendor grouping is dead."
+          adapters=$(curl -fsS http://127.0.0.1:8000/api/v1/migration/adapters)
+          if echo "${adapters}" | grep -qE '"vendor_display_name" *: *"[^"]'; then
+            echo "Smoke test passed (health + dashboard + non-empty vendor registry)."
             exit 0
           fi
-          echo "FAIL: /health returned 200 but / did not."
-          echo "Likely cause: a template file (or partial under"
-          echo "templates/_partials/) is missing from the built wheel"
-          echo "— check pyproject.toml [tool.setuptools.package-data]"
-          echo "and confirm every templates/* path the renderer needs"
-          echo "is covered by the glob list."
+          echo "FAIL: /api/v1/migration/adapters returned no non-empty"
+          echo "vendor_display_name — the vendor registry is EMPTY in the image."
+          echo "Fix: ensure pyproject.toml [tool.setuptools.package-data]"
+          echo "includes the 'migration/vendors/*.yaml' glob (it is NOT pulled"
+          echo "in by the setuptools_scm file-finder in the .git-less Docker"
+          echo "build context)."
+          echo "--- adapters response ---"
+          echo "${adapters}"
           echo "--- container logs ---"
           docker logs smoke
           exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,22 @@ netcanon = [
     # against /health to catch exactly that regression.  `**` recursive
     # globs need setuptools >= 62.3 (we require >= 68).
     "definitions/library/**/*.yaml",
+    # Translator vendor registry (per-vendor `*.yaml`).  These MUST ship in
+    # the wheel: `load_vendors()` scans the packaged
+    # `netcanon/migration/vendors/` dir at startup, and without them the app
+    # degrades to an EMPTY vendor registry ("Loaded 0 vendor(s)") — the
+    # translator core (codec<->vendor grouping, the migrate-page selectors)
+    # is non-functional.  An explicit glob is REQUIRED here: unlike a local
+    # `.git`-present build (where setuptools_scm's VCS file-finder happens to
+    # pull every tracked file into the wheel), the Docker builder excludes
+    # `.git` via .dockerignore and runs `pip wheel .` directly, so the
+    # finder finds nothing and ONLY these package-data globs are honoured.
+    # The MSI freeze is the same git-less case.  `include-package-data` is
+    # intentionally left unset so this list is the single source of truth.
+    # The `docker-build-smoke` CI job asserts a vendor actually loads
+    # (non-empty vendor_display_name on /api/v1/migration/adapters) to catch
+    # this exact regression class.
+    "migration/vendors/*.yaml",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## What

Fixes a shipped-artifact defect surfaced by a full-project review: the **Docker image ships with an empty vendor registry**.

`netcanon/migration/vendors/*.yaml` (the translator's vendor registry) was never in `[tool.setuptools.package-data]`. It only reached the wheel via setuptools_scm's VCS file-finder — which enumerates git-tracked files. The Docker builder **excludes `.git`** (`.dockerignore`) and runs `pip wheel --no-deps .` directly, so the finder finds nothing and only the explicit `package-data` globs ship. Result: the built image boots, `/` renders, but `load_vendors()` logs **"Loaded 0 vendor(s)"** and the codec↔vendor grouping + migrate-page selectors are dead.

- **PyPI is not affected** — `python -m build` routes the wheel through the sdist (which carries the tracked files). Verified: PyPI-path wheel = 12 vendors.
- **Docker / MSI are affected** — both build git-less.

## Fix

1. Add an explicit `"migration/vendors/*.yaml"` package-data glob, with a comment documenting why the setuptools_scm finder can't be relied on in a git-less build (so it can't silently regress).
2. Tighten `docker-build-smoke` to assert a vendor **actually loads** (non-empty `vendor_display_name` on `/api/v1/migration/adapters`) instead of only asserting `/`→200 — the empty-registry page still renders 200, which is how this shipped unnoticed.

## Verification (real artifacts)

| Build context | vendors in wheel |
|---|---|
| with `.git` (worktree / PyPI-sdist path) | 12 ✅ |
| no `.git` (exact Docker builder condition) **before fix** | **0** ❌ |
| no `.git` **after fix** | **12** ✅ |

Unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
