### PR TITLE
fix(api): /plan auto-translates ports even when only a non-port override is posted

### DIFF
--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -259,10 +259,20 @@ def plan_migration(
         # SNMP overrides posted in the same body.
         job = run_plan_with_overrides(
             source, target, raw_text,
+            # Default to {} (auto port-name translation ENGAGED) whenever the
+            # caller didn't pass an explicit port_rename_map — matching the
+            # bare-request else branch and the v0.3.2 auto-translate-by-default
+            # contract.  Passing None here DISENGAGES the translator entirely
+            # (see run_plan_with_overrides: `if port_rename_map is not None`),
+            # so a request carrying only a non-port override (e.g. a
+            # vlan_rename_map) would otherwise silently render verbatim
+            # source-vendor interface names — the API-1 trap from the
+            # 2026-07-03 review.  target_profile no longer gates this: auto
+            # translation is the default for every non-port-map request.
             port_rename_map=(
                 body.port_rename_map
                 if body.port_rename_map is not None
-                else ({} if body.target_profile is not None else None)
+                else {}
             ),
             vlan_rename_map=body.vlan_rename_map,
             local_user_rename_map=body.local_user_rename_map,

--- a/netcanon/services/migration_pipeline.py
+++ b/netcanon/services/migration_pipeline.py
@@ -423,11 +423,14 @@ def run_plan_with_overrides(  # noqa: C901
         target: Target codec.
         raw_text: Source-vendor config text.
         port_rename_map: Optional source-name → target-name override
-            map.  Entries win over the auto-heuristic.  Empty / None
-            = fully auto.  Set to ``{}`` (rather than None) to opt
-            into the rename-aware pipeline with no explicit overrides
-            — this is what the UI sends when the operator has
-            selected a target profile but not yet customised any row.
+            map.  Entries win over the auto-heuristic.  ``{}`` engages
+            the auto-heuristic with no explicit overrides (what the UI
+            sends when the operator opened a rename pane but customised
+            nothing, and what ``POST /plan`` passes by default so a plain
+            translation renders native target-vendor names).  ``None``
+            does NOT run the port-name translator at all — verbatim
+            source names, the legacy :func:`run_plan` behaviour (see the
+            ``if port_rename_map is not None`` guard below).
         vlan_rename_map: Optional source_vlan_id → target_vlan_id
             override map.  Same None-vs-{} sentinel semantics as
             ``port_rename_map``.  Entries with ``None`` values drop

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -415,6 +415,46 @@ class TestPlanEndpoint:
         assert resp.status_code == 200
         assert resp.json()["status"] == "completed"
 
+    def test_non_port_override_still_auto_translates_ports(self, client):
+        """Regression (2026-07-03 review, API-1): a request carrying only a
+        NON-port override map (here ``vlan_rename_map``) must NOT disengage
+        the port-name auto-translation.
+
+        The ``/plan`` override branch used to pass ``port_rename_map=None``
+        unless a ``target_profile`` was also present, while a bare ``/plan``
+        passed ``{}``.  ``None`` turns the translator OFF, so merely opening
+        the VLAN pane (or posting any non-port override) silently reverted
+        interface names to verbatim source-vendor form — contradicting the
+        v0.3.2 auto-translate-by-default contract.  cisco_iosxe_cli →
+        juniper_junos renames ``GigabitEthernet1/0/1`` → ``ge-1/0/1``, so the
+        regression is visible in both ``port_renames`` and the rendered text.
+        """
+        iosxe_cli = (
+            "hostname r1\n"
+            "!\n"
+            "interface GigabitEthernet1/0/1\n"
+            " ip address 10.0.0.1 255.255.255.0\n"
+            "!\n"
+        )
+        base = {
+            "source": "cisco_iosxe_cli",
+            "target": "juniper_junos",
+            "raw_text": iosxe_cli,
+        }
+        bare = client.post("/api/v1/migration/plan", json=base).json()
+        # A bare /plan auto-translates the port name (Gi… → ge-…).
+        assert bare["port_renames"] == {"GigabitEthernet1/0/1": "ge-1/0/1"}
+
+        with_vlan = client.post(
+            "/api/v1/migration/plan",
+            json={**base, "vlan_rename_map": {}},
+        ).json()
+        # Adding a vlan-only override must engage the SAME auto-translation,
+        # not disengage it — identical port_renames, translated render.
+        assert with_vlan["port_renames"] == bare["port_renames"]
+        assert "GigabitEthernet1/0/1" not in (with_vlan["rendered"] or "")
+        assert "ge-1/0/1" in (with_vlan["rendered"] or "")
+
 
 class TestPlanPortsEndpoint:
     """``POST /api/v1/migration/plan/ports`` — first per-pane override


### PR DESCRIPTION
## What

Fixes API-1 from the 2026-07-03 full-project review: `POST /plan` silently disengaged port-name translation when the body carried only a **non-port** override map.

`request_has_overrides_or_profile()` routes any body with a `vlan_rename_map` (or other non-port override) into the override branch, which passed `port_rename_map=None` unless a `target_profile` was also present. `None` means "don't run the port-name translator at all" (`if port_rename_map is not None` in `run_plan_with_overrides`), so a request that merely renamed a VLAN rendered **verbatim source-vendor interface names** — e.g. `GigabitEthernet1/0/1` straight into a Junos config — with no warning. The bare `else` branch already does the right thing by passing `{}`. The web UI was immune only because its rename-apply JS always includes a port map.

## Fix

- Default `port_rename_map` to `{}` (auto-translate engaged) whenever the caller sent no explicit map — dropping the `target_profile` gate so auto-translation is the default for every non-port-map request.
- Correct the `run_plan_with_overrides` docstring, which claimed *"Empty / None = fully auto"* — wrong, and part of what made this trap easy to write. `None` = translator off; `{}` = auto-heuristic engaged.
- Add an integration regression test.

## Reproduction (probe, cisco_iosxe_cli → juniper_junos)

| `port_rename_map` | `port_renames` | rendered |
|---|---|---|
| `None` (old override-branch value) | `{}` | verbatim `GigabitEthernet1/0/1` |
| `{}` (fix / bare-branch value) | `{"GigabitEthernet1/0/1": "ge-1/0/1"}` | translated `ge-1/0/1` |

Gate green: `tests/unit` + `tests/integration/test_migration_api.py` + `tests/integration/test_cross_mesh_ci_guard.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
