### PR TITLE
fix(migrate-ui): show the suggested vendor name, not "undefined", in the parse-failure banner

### DIFF
--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -1369,9 +1369,14 @@
     // No suggestion when the top candidate matches what the operator
     // already picked — they have a different (real) problem.
     if (top.codec === planBody.source) return;
-    var suggestedAdapter = adapterEntry(top.codec);
-    var suggestedLabel = suggestedAdapter
-      ? (suggestedAdapter.vendor_display_name || suggestedAdapter.name)
+    // Resolve the display label from the adapters list the same way as the
+    // top-of-page vendor hint (see the adapters.find calls above).  NB:
+    // adapterEntry() returns {codec, label, desc, …} with NO
+    // vendor_display_name / name keys, so reading those off it rendered a
+    // literal "undefined" in both the banner and the retry button.
+    var suggestedRow = adapters.find(function(x) { return x.name === top.codec; });
+    var suggestedLabel = suggestedRow
+      ? (suggestedRow.vendor_display_name || suggestedRow.name)
       : top.codec;
     // Append the suggestion to the existing red banner.  Inline append
     // keeps the parse-error context visible above the suggestion — the

--- a/tests/e2e/test_migrate_page.py
+++ b/tests/e2e/test_migrate_page.py
@@ -215,6 +215,48 @@ class TestMigrateSubmitFlow:
         severity = mig.banner_severity_class()
         assert severity in ("info", "block")
 
+    def test_parse_failure_suggestion_shows_real_vendor_not_undefined(
+        self, page: Page, base_url: str
+    ):
+        """Regression (2026-07-03 review, UX-1): the parse-failure "Did you
+        mean:" recovery banner + retry button must render the suggested
+        vendor's display name, not a literal "undefined".
+
+        The enrichment read ``.vendor_display_name`` / ``.name`` off
+        ``adapterEntry()``, which returns ``{codec, label, …}`` and has
+        neither key — so both the banner and the "Switch source to … and
+        retry" button showed the word "undefined".
+
+        Deterministic trigger: pick the XML netconf codec (cisco_iosxe) but
+        paste IOS CLI text.  Parse fails (malformed XML) and ``/detect``
+        confidently identifies cisco_iosxe_cli (≠ the selected source), so
+        the async suggestion enrichment fires.  cisco_iosxe_cli's vendor
+        record is "Cisco IOS-XE".
+        """
+        page.goto("/migrate")
+        mig = MigratePage(page)
+        page.wait_for_function(
+            """() => document.querySelector(
+                '[data-testid="migrate-source-select"]'
+            ).options.length > 0"""
+        )
+        mig.pick_source("cisco_iosxe")
+        mig.pick_target("cisco_iosxe")
+        mig.fill_raw(
+            "hostname r1\n!\ninterface GigabitEthernet1/0/1\n"
+            " ip address 10.0.0.1 255.255.255.0\n!\nrouter ospf 1\n!\n"
+        )
+        mig.submit_and_wait()
+        expect(mig.status_summary).to_contain_text("failed")
+        # The suggestion button is appended after the async /detect call.
+        suggest_btn = page.locator(
+            '[data-testid="migrate-parse-failure-detect-suggest"]'
+        )
+        expect(suggest_btn).to_be_visible()
+        btn_text = suggest_btn.text_content() or ""
+        assert "undefined" not in btn_text, btn_text
+        assert "Cisco IOS-XE" in btn_text, btn_text
+
     def test_validation_block_still_shows_result(
         self, page: Page, base_url: str
     ):


### PR DESCRIPTION
## What

Fixes UX-1 from the 2026-07-03 review: the migrate page's parse-failure recovery banner rendered a literal **"undefined"**.

When a translation parse fails, the page fetches `/detect` and, if a confident candidate differs from the selected source, appends a *"Did you mean: <vendor>"* banner plus a *"Switch source to <vendor> and retry"* button. Both read `.vendor_display_name` / `.name` off `adapterEntry(top.codec)` — but `adapterEntry` returns `{codec, label, desc, sample, ext, inputFormat}` and has **neither** key. Result: `"Did you mean: undefined"` and `"Switch source to undefined and retry"`.

## Fix

Resolve the label from the `adapters` list via `adapters.find(...)`, exactly as the top-of-page vendor hint and the vendor-id→display-name helper already do (migrate.html:1146-1147, 1714-1715). Yields the real display name (e.g. **"Cisco IOS-XE"**).

## Test

New e2e (`tests/e2e/test_migrate_page.py`): deterministic trigger — select the `cisco_iosxe` (XML netconf) codec but paste IOS CLI text → parse fails (malformed XML) and `/detect` confidently identifies `cisco_iosxe_cli` (≠ source), so the enrichment fires. Asserts the suggestion button shows `"Cisco IOS-XE"` and never `"undefined"`.

Verified locally against a real Chromium: the new test and the full `test_migrate_page.py` e2e file both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
