### PR TITLE
chore(pii-guard): gitignore the two PII/unlicensed review dirs + assert they stay untracked

### DIFF
--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -25,10 +25,12 @@ jobs:
       - name: git grep tracked files for leaked identifiers
         run: |
           # Scope: tracked files only.  The review dossier under
-          # docs/codebase-review/ intentionally quotes these values and is
-          # gitignored, so git grep never sees it.  Commit-message /
-          # Co-authored-by trailer hygiene is enforced locally by
-          # scripts/git-hooks/pre-push (see its header for how to enable it).
+          # docs/codebase-review/ intentionally quotes these values; it is
+          # gitignored (see .gitignore) so git grep never sees it, and the
+          # tracked-path assertion below fails closed if it is ever force-
+          # added anyway.  Commit-message / Co-authored-by trailer hygiene is
+          # enforced locally by scripts/git-hooks/pre-push (see its header for
+          # how to enable it).
           #
           # The patterns use regex character classes (`[i]` = a literal
           # `i`, `[\]` = a literal backslash) for two reasons:
@@ -58,3 +60,24 @@ jobs:
             exit 1
           fi
           echo "PII guard: clean — no leaked identifiers in tracked files."
+
+      - name: No PII / unlicensed review directory is tracked
+        run: |
+          # Path-based companion to the content grep above.  Two directories
+          # must NEVER be committed:
+          #   * docs/codebase-review/ — quotes the scrubbed PII verbatim.
+          #   * docs/reviews/2026-06-19-run3-verification/ — third-party
+          #     device configs with no redistributable licence; these match
+          #     NEITHER pattern in the content grep, so only a path check can
+          #     catch them.
+          # .gitignore keeps them out on a normal `git add`; this asserts the
+          # guarantee actually held (a `git add -f`, a stale pre-.gitignore
+          # commit, or a bad merge would slip past the ignore rule).  Fails
+          # closed on any tracked path under either directory.
+          tracked=$(git ls-files -- docs/codebase-review 'docs/reviews/2026-06-19-run3-verification')
+          if [ -n "${tracked}" ]; then
+            echo "::error::A PII / unlicensed review directory is tracked in git (must be gitignored, never committed):"
+            echo "${tracked}"
+            exit 1
+          fi
+          echo "PII-dir guard: clean — no forbidden review directory is tracked."

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,15 @@ _pr-archive-pre-public.md
 # Holds pulled SSH keys, any decrypted secrets, the scratch-VM ledger, and the
 # PVE build/watch/destroy scripts. NEVER commit — contains credentials.
 /local/
+
+# Uncommittable review artifacts — MUST never be tracked (nor reach the sdist).
+#   * docs/codebase-review/ — the 2026-06 codebase-review dossier quotes the
+#     scrubbed personal identifiers (email / operator-machine path) verbatim.
+#   * docs/reviews/2026-06-19-run3-verification/ — holds third-party device
+#     configs used to verify a run that carry no redistributable licence.
+# The pii-guard workflow's content scan only catches the PII strings; the
+# run3-verification configs match no pattern, so ignoring these paths here —
+# plus the tracked-path assertion in .github/workflows/pii-guard.yml — is what
+# actually keeps them out of the tree and the published PyPI source tarball.
+docs/codebase-review/
+docs/reviews/2026-06-19-run3-verification/


### PR DESCRIPTION
## What

Fixes GUARD-1 from the 2026-07-03 review: the two PII/unlicensed review directories were **not actually gitignored**, and the pii-guard workflow's comment falsely claimed one of them was.

- `docs/codebase-review/` — quotes the scrubbed personal identifiers verbatim.
- `docs/reviews/2026-06-19-run3-verification/` — third-party device configs with no redistributable licence.

Both showed as *untracked, not ignored* (`git check-ignore` rc=1). The content-only grep can't protect `run3-verification/` — those configs match **neither** forbidden pattern — so a stray `git add docs/` would commit it clean, and `MANIFEST.in` (which prunes only `tests/`) would ship it in the next PyPI sdist.

## Fix

1. Add both directories to `.gitignore`.
2. Add a **path-based guard step** to `pii-guard.yml` that fails closed if either directory is ever tracked (catches `git add -f`, a stale pre-ignore commit, or a bad merge — what `.gitignore` alone can't).
3. Correct the (now-accurate) "is gitignored" comment to reference both the ignore rule and the new assertion.

## Verified locally

- `git check-ignore` now matches both dirs.
- The new review dir `docs/reviews/2026-07-03-fable-full-review/` is deliberately **not** ignored (it's a legitimate committable artifact).
- The tracked-path guard passes on the current tree.
- `pii-guard.yml` parses as valid YAML; the new step runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
