### PR TITLE
docs: fix matrix/capability drift + missing dependency notices (2026-07-03 review)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ exercises a translation we don't currently test.
    `tests/unit/migration/`.
 6. Run the cross-mesh audit
    (`python tools/run_full_mesh.py --matrix`) and commit the
-   regenerated `tests/fixtures/real/PHASE4_RECONCILIATION.md`.
+   regenerated `tests/fixtures/real/CROSS_MESH_RESULTS.md`.
 
 If the fixture surfaces a `CODEC_BUG` cell, that's the goal — we want
 to know.  Open an issue with the bug report template and reference the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -231,13 +231,18 @@ Credentials are **not embedded in HTML**.
 
 - **Dashboard (`index.html`)** — the Saved Device `<select>` options include
   only non-sensitive fields (`type_key`, `host`, `port`, `username`).
-  Passwords are fetched via `GET /api/v1/devices/{id}` when a profile is
-  selected; the API call is over localhost HTTP.
 
 - **Devices page (`devices.html`)** — the `data-profile` DOM attribute
   contains only non-sensitive fields (id, name, type_key, host, port,
-  notes, created_at).  `runDeviceBackup()` fetches the full profile from
-  the API before submitting a backup job.
+  notes, created_at).
+
+The browser **never receives the credential.** Every device-profile API
+response is serialised through the write-only `DeviceProfilePublic` model,
+which omits the password / enable-password fields entirely — so
+`GET /api/v1/devices/{id}` returns no secret.  A backup is launched by
+submitting the profile **id**; the server then resolves and decrypts the
+credential from encrypted storage server-side (`backup_runner`), so the
+plaintext secret never crosses the network to the client.
 
 ---
 

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -85,6 +85,13 @@ Licenses below were read from the components' own installed package metadata.
 * python-multipart  — Apache-2.0     — Andrew Dunham and contributors — https://github.com/Kludex/python-multipart
 * python-dotenv     — BSD-3-Clause   — Saurabh Kumar and contributors — https://github.com/theskumar/python-dotenv
 * six               — MIT            — Benjamin Peterson — https://github.com/benjaminp/six
+* pydantic-settings — MIT            — Pydantic Services Inc. and contributors — https://github.com/pydantic/pydantic-settings
+* aiofiles          — Apache-2.0     — Tin Tvrtković and contributors — https://github.com/Tinche/aiofiles
+* APScheduler       — MIT            — Alex Grönholm — https://github.com/agronholm/apscheduler
+* tzlocal           — MIT            — Lennart Regebro and contributors — https://github.com/regebro/tzlocal
+* rich              — MIT            — Will McGugan / Textualize, Inc. — https://github.com/Textualize/rich
+* Pygments          — BSD-2-Clause   — the Pygments team — https://pygments.org
+* ruamel.yaml       — MIT            — Anthon van der Neut — https://pypi.org/project/ruamel.yaml/
 
 Notes
 -----

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -92,7 +92,7 @@ names the canonical surface, not a blanket guarantee.
 * `dns_servers`, `ntp_servers`, `syslog_servers`, `timezone`
 * `interfaces[].vrrp_groups` (v0.2.0 Wave B — classic FHRP
   redundancy, mode discriminator `vrrp` / `hsrp` / `carp`) — wired
-  across all seven bidirectional codecs.  See
+  across the bidirectional codecs.  See
   [`v0.2.0-planning/01-vrrp-canonical/`](v0.2.0-planning/01-vrrp-canonical/)
   for the design rationale and the
   [Cross-vendor L3-redundancy grammar reference](#cross-vendor-l3-redundancy-grammar-reference)
@@ -254,7 +254,7 @@ output.
 
 | Path | Class | Reason |
 |---|---|---|
-| `/interfaces/interface/vrrp-groups/group` | Supported (Wave B) | Parses + renders a global `router vrrp` enable + `vrrp vrid <N> / owner\|priority / virtual-ip-address <Y> / preempt / enable` inside `vlan N` stanzas (AOS-S binds VRRP to the SVI's VLAN, not the L3 interface). The `vrrp vrid` header carries **no** `ip` prefix per the AOS-S 16.10 CLI reference; the legacy `ip vrrp vrid` form is still accepted on parse. `owner` maps to the canonical priority ceiling 254 (255 unrepresentable). |
+| `/interfaces/interface/vrrp-groups/group` | Supported (Wave B) | Parses + renders a global `router vrrp` enable + `vrrp vrid <N> / owner\|priority / virtual-ip-address <Y> / preempt / enable` inside `vlan N` stanzas (AOS-S binds VRRP to the SVI's VLAN, not the L3 interface). The `vrrp vrid` header carries **no** `ip` prefix per the AOS-S 16.10 CLI reference; the legacy `ip vrrp vrid` form is still accepted on parse. `owner` maps to the canonical priority 255 (the RFC 5798 address-owner value — the full 0-255 range is now representable, and render inverts 255 back to `owner`). |
 | `/interfaces/interface/vrrp-groups/group/virtual-ips` | Lossy (Wave B) | AOS-S `virtual-ip-address` accepts only ONE address per vrid; cross-vendor migration from Cisco IOS-XE secondaries or Junos `virtual-address [ list ]` drops the tail with a review comment. |
 | `/interfaces/interface/ipv4/address/virtual-gateway-address` | Unsupported | AOS-S has no anycast-gateway grammar (campus L2/L3 codec). |
 | `/interfaces/interface/ipv6/address/virtual-gateway-address` | Unsupported | Same as IPv4 — no native anycast grammar. |
@@ -275,7 +275,7 @@ output.
 | `/interfaces/interface/ipv6/address/virtual-gateway-mac` | Supported (Wave C) | `virtual-gateway-v6-mac M`. |
 | `/routing/static-route/vrf` | Supported (v0.2.0) | `set routing-instances <NAME> routing-options static route <dest> next-hop <gw>` harvests onto `CanonicalStaticRoute.vrf` and renders back out (the routing-instances dispatcher now descends into `routing-options static`).  Top-level `set routing-options static route` lines round-trip with `vrf=""`.  next-hop form only — `discard` / `reject` blackhole routes and the explicit `rib <name>` form (e.g. IPv6 `inet6.0`) are not modelled, same as the global table; a VRF implied solely by a static route does not materialise an empty routing-instance. |
 | `/anycast-gateway-mac` | Unsupported | Junos has no chassis-wide anycast-gateway MAC; per-IRB-unit overrides live on `CanonicalIPv4Address.virtual_gateway_mac` (the `virtual-gateway-v4-mac` / `-v6-mac` grammar) and round-trip through the supported per-address surface instead.  Cross-vendor migration from a source carrying a system-wide MAC (Arista, NX-OS) must distribute the value across every IRB unit's per-address MAC on the receiving Junos side. |
-| `/interfaces/interface/subinterfaces/subinterface` | Lossy | Unit 0 collapses into the parent; units 1+ materialise as distinct `<parent>.<unit>` interfaces, but per-unit VLAN tagging (`unit N vlan-id 100`) parses-and-ignores pending a canonical tagged-subinterface model. |
+| `/interfaces/interface/subinterfaces/subinterface` | Lossy | Unit 0 collapses into the parent; units 1+ materialise as distinct `<parent>.<unit>` interfaces, and per-unit 802.1Q tagging (`unit N vlan-id`) is captured on `/interfaces/interface/dot1q-vlan` (GAP 7 — round-trips). Per-unit subinterface attributes beyond the address + 802.1Q tag remain unmodelled. |
 | `/groups` | Lossy | Apply-groups inheritance is wired for the dispatch surface (system / login / interfaces / protocols / SNMP / routing-options / routing-instances / vlans); group bodies for unsupported surfaces (policy-options, firewall filters, RADIUS server options) parse-and-ignore. |
 | `/evpn-type5-routes/route` | Lossy | Per-prefix records lossy-by-default — VRF-property model uses `CanonicalRoutingInstance.l3_vni`; explicit per-prefix lists not populated by any codec today. |
 | `/routing/bgp` | Unsupported | BGP / IS-IS / OSPF / MPLS stanzas parse-and-ignore in v1; Junos routing-options grammar warrants a dedicated follow-up. |
@@ -548,8 +548,11 @@ The rename modal (Tier-3 rename) shows an amber banner on a pane
 when the active target codec declares that pane's category in
 `unsupported_rename_categories`.  Today only the
 `cisco_iosxe` (NETCONF) and `opnsense` codecs declare anything —
-both list `"snmpv3"` because their SNMPv3 paths are unsupported in
-the codec's render layer.  The banner prevents the ghost-success
+both list `"snmpv3"` (their SNMPv3 render paths are unsupported), and
+`cisco_iosxe` additionally lists `"ports"` (its port-name translation
+is an inherited no-op stub, so a port-rename pane against it warns
+up-front rather than emitting N per-port warnings).  The banner
+prevents the ghost-success
 bug where rename overrides apply to canonical but vanish from
 rendered output.
 

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -268,10 +268,11 @@ class JunosCodec(CodecBase):
                     "— most Junos interfaces have exactly one unit).  "
                     "GAP 4 materialises units 1+ as distinct "
                     "CanonicalInterface entries named "
-                    "``<parent>.<unit>``; per-unit VLAN tagging "
-                    "(``unit N vlan-id 100``) still parses-and-"
-                    "ignores pending a canonical tagged-subinterface "
-                    "model."
+                    "``<parent>.<unit>``, and GAP 7 captures the "
+                    "per-unit 802.1Q tag (``unit N vlan-id``) on "
+                    "``/interfaces/interface/dot1q-vlan`` (round-trips). "
+                    "Per-unit subinterface attributes beyond the address "
+                    "+ 802.1Q tag remain unmodelled."
                 ),
                 severity="warn",
             ),

--- a/tools/gen_requirements_lock.sh
+++ b/tools/gen_requirements_lock.sh
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 # Keep this digest in lock-step with the FROM lines in Dockerfile.
-BASE="python:3.14.5-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb"
+BASE="python:3.14.6-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT


### PR DESCRIPTION
## What

Batched documentation-honesty fixes from the 2026-07-03 review's Tier-0 list. Each was **verified against the live code/tooling** before editing (netcanon's no-overclaiming ethic).

| ID | File | Fix |
|---|---|---|
| DOC-1 | `juniper_junos/codec.py`, `CAPABILITIES.md` | junos `unit N vlan-id` no longer "parses-and-ignores" — GAP 7 ships `/…/dot1q-vlan` as **supported** and it round-trips (probe: `ge-0/0/0.100` → `dot1q_vlan=100` → re-rendered). Reworded to the real behaviour + genuine residual lossiness. |
| DOC-6 | `CAPABILITIES.md` | "all **seven** bidirectional codecs" → "the bidirectional codecs" (12-codec registry; the per-vendor table is authoritative). |
| DOC-3 | `CAPABILITIES.md` | AOS-S VRRP: "priority ceiling 254 (255 unrepresentable)" is stale — the canonical range is 0-255 and `owner` maps to **255** (`aruba_aoss/parse.py`). |
| DOC-5 | `CAPABILITIES.md` | `cisco_iosxe` declares `{"snmpv3", "ports"}`, not just `"snmpv3"` — documented the `"ports"` stub. |
| DOC-2 | `SECURITY.md` | "Credential Exposure" described a `GET /api/v1/devices/{id}` password fetch; the API serialises through the write-only `DeviceProfilePublic` (no secret returned) and resolves creds server-side from the profile id. Documented the (stronger) actual behaviour. |
| DOC-4 | `CONTRIBUTING.md` | `run_full_mesh.py --matrix` regenerates `CROSS_MESH_RESULTS.md`, not `PHASE4_RECONCILIATION.md`. |
| PKG-2 | `gen_requirements_lock.sh` | `BASE` digest `3.14.5` → `3.14.6-slim-bookworm` to match the Dockerfile, per the file's own "keep in lock-step" comment. |
| LIC-1 | `THIRD-PARTY-NOTICES.txt` | Add the 7 permissive deps the MSI redistributes but the file omitted — pydantic-settings, aiofiles, APScheduler, tzlocal (direct) + rich, Pygments, ruamel.yaml (transitive); **all confirmed present in `requirements.lock`**. |

## Not included

**SEC-7** (SECURITY.md's *"credentials never logged (verified by test_logging_config.py)"*) is intentionally deferred to the **SEC-2** fix — the claim is false until the `ValidationError.input_value` log leak is fixed, and the cited test asserts no such thing. Fixing the leak + adding the real assertion + the claim will land together.

Gate: full `tests/unit` + `tests/integration/test_cross_mesh_ci_guard.py` green (the one code touch is a junos LossyPath reason string — not asserted by any test, guard-inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
