### PR TITLE
fix(security): scrub decrypted credentials from store corrupt-file error logs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -189,8 +189,13 @@ Restore the original key (or re-enter the credential) to recover; see the
 
 `DeviceProfile`, `ScheduleDevice`, and all other model objects always hold
 **plaintext** credential strings in memory.  Encryption is a storage-layer
-concern only.  Credential fields are **never logged** (verified by
-`tests/unit/test_logging_config.py`).
+concern only.  Credential fields are **never logged**: the store loaders
+decrypt credentials in memory *before* validating, so a validation failure
+could otherwise surface the freshly-decrypted secret through a pydantic
+`ValidationError`'s captured input.  Both loaders route their error path
+through `scrub_exc_for_log`, which formats a `ValidationError` from its field
+locations + error types only (never the input value).  Verified by
+`tests/unit/test_credential_log_redaction.py`.
 
 ### Backup artifacts are stored in plaintext (deliberate; use an encrypted volume)
 

--- a/netcanon/security/migration.py
+++ b/netcanon/security/migration.py
@@ -10,9 +10,40 @@ from __future__ import annotations
 
 import logging
 
+from pydantic import ValidationError
+
 from .credentials import CredentialDecryptError, decrypt_field
 
 logger = logging.getLogger(__name__)
+
+
+def scrub_exc_for_log(exc: BaseException) -> str:
+    """Render *exc* for a log line without echoing decrypted secrets.
+
+    The storage loaders call :func:`migrate_credential_fields` — which
+    decrypts ``password`` / ``enable_password`` into the in-memory dict —
+    BEFORE ``model_validate``.  If validation then fails, the resulting
+    pydantic :class:`ValidationError` carries the offending input in
+    ``.errors()[*]["input"]``; for a model-level error (e.g. a missing
+    required field) that input is the whole decrypted dict, credentials
+    included.  Whether the secret reaches the log is purely a function of how
+    the error is stringified: ``str(exc)`` on pydantic 2.13 happens NOT to
+    render the input, but ``exc.errors()`` does, and the supported range
+    (``pydantic>=2.0.0,<3``) includes older 2.x versions whose ``str`` did.
+    Rather than depend on that, format a ``ValidationError`` from
+    ``errors(include_input=False)`` — field locations + error types only,
+    never the input value.  Any other exception (JSON / OS errors) carries no
+    plaintext — the on-disk credential is still ciphertext at that point — so
+    it passes through ``str`` unchanged.
+    """
+    if isinstance(exc, ValidationError):
+        errs = exc.errors(include_input=False, include_url=False)
+        summary = "; ".join(
+            f"{'.'.join(str(p) for p in e['loc']) or '<root>'}: {e['type']}"
+            for e in errs
+        )
+        return f"{len(errs)} validation error(s) [{summary}]"
+    return str(exc)
 
 
 def migrate_credential_fields(

--- a/netcanon/storage/device_profile_store.py
+++ b/netcanon/storage/device_profile_store.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from ..models.device_profile import DeviceProfile
 from ..security.credentials import encrypt
-from ..security.migration import migrate_credential_fields
+from ..security.migration import migrate_credential_fields, scrub_exc_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -118,8 +118,12 @@ class FileDeviceProfileStore:
 
                 profiles[p.id] = p
             except Exception as exc:
+                # scrub_exc_for_log: migrate_credential_fields decrypted the
+                # credential into `data` above, so a ValidationError here can
+                # carry the plaintext in its input — never log that.
                 logger.error(
-                    "CORRUPT FILE SKIPPED: %s — %s", path.name, exc
+                    "CORRUPT FILE SKIPPED: %s — %s",
+                    path.name, scrub_exc_for_log(exc),
                 )
         logger.info("Loaded %d device profile(s)", len(profiles))
         return profiles

--- a/netcanon/storage/schedule_store.py
+++ b/netcanon/storage/schedule_store.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from ..models.schedule import BackupSchedule
 from ..security.credentials import encrypt
-from ..security.migration import migrate_credential_fields
+from ..security.migration import migrate_credential_fields, scrub_exc_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -108,8 +108,12 @@ class FileScheduleStore:
                     path.name, exc,
                 )
             except Exception as exc:
+                # scrub_exc_for_log: the per-device credential is decrypted
+                # into `dev` above, so a ValidationError here can carry the
+                # plaintext in its input — never log that.
                 logger.error(
-                    "CORRUPT FILE SKIPPED: %s — %s", path.name, exc
+                    "CORRUPT FILE SKIPPED: %s — %s",
+                    path.name, scrub_exc_for_log(exc),
                 )
         logger.info("Loaded %d schedule(s)", len(schedules))
         return schedules

--- a/tests/unit/test_credential_log_redaction.py
+++ b/tests/unit/test_credential_log_redaction.py
@@ -1,0 +1,106 @@
+"""
+Regression tests for SEC-2 / SEC-7 (2026-07-03 review): the storage loaders
+decrypt credentials into an in-memory dict *before* ``model_validate``, so a
+subsequent pydantic ``ValidationError`` captures the freshly-decrypted secret
+in its per-error ``input``.  ``scrub_exc_for_log`` must format such an error
+without echoing that input, and both stores must route their corrupt-file
+error path through it.
+
+NOTE (verify-first): on the currently-resolved pydantic (2.13) ``str(exc)``
+does not render the captured input, so the *default* log line already happens
+not to leak.  But ``exc.errors()`` DOES carry it, and the supported range
+(``pydantic>=2.0.0,<3``) admits older 2.x versions whose ``str`` rendered it —
+so this is defence-in-depth at a decrypt-then-log site, guaranteed independent
+of the pydantic version / formatting path.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from netcanon.models.device_profile import DeviceProfile
+from netcanon.security.migration import scrub_exc_for_log
+from netcanon.storage.device_profile_store import FileDeviceProfileStore
+
+pytestmark = pytest.mark.unit
+
+_SECRET = "PLAINTEXT-SECRET-DO-NOT-LOG"
+
+
+def _validation_error_carrying(secret: str) -> ValidationError:
+    """A ValidationError whose captured input holds *secret*.
+
+    A missing required field makes pydantic capture the whole input dict as
+    that error's ``input`` — the model-level case the store hits after
+    decrypting credentials into the dict.
+    """
+    class _M(BaseModel):
+        name: str
+        password: str
+
+    try:
+        _M.model_validate({"password": secret})  # 'name' missing
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected a ValidationError")  # pragma: no cover
+
+
+class TestScrubExcForLog:
+    def test_secret_is_present_in_the_raw_error_object(self):
+        """Premise: the exposure is real — the error object carries the
+        secret in its errors()[*]['input'] (version-independent)."""
+        exc = _validation_error_carrying(_SECRET)
+        assert any(_SECRET in str(e.get("input")) for e in exc.errors())
+
+    def test_scrubbed_form_drops_the_input_but_keeps_locations(self):
+        exc = _validation_error_carrying(_SECRET)
+        scrubbed = scrub_exc_for_log(exc)
+        assert _SECRET not in scrubbed
+        assert "name" in scrubbed          # field location preserved
+        assert "missing" in scrubbed       # error type preserved
+        assert "validation error(s)" in scrubbed
+
+    def test_non_validation_error_passes_through_unchanged(self):
+        exc = ValueError("plain boom")
+        assert scrub_exc_for_log(exc) == "plain boom"
+
+
+class TestDeviceProfileStoreDoesNotLogDecryptedCreds:
+    def test_corrupt_file_error_log_omits_decrypted_credential(
+        self, tmp_path: Path, caplog
+    ):
+        store = FileDeviceProfileStore(tmp_path)
+        p = DeviceProfile(
+            name="sw", type_key="Cisco", host="10.0.0.1", port=22,
+            username="admin", password=_SECRET, enable_password="ENABLE-XYZ",
+        )
+        store.save(p)  # writes the credential ENCRYPTED to disk
+
+        # Sanity: the on-disk file must not contain the plaintext.
+        jf = tmp_path / f"{p.id}.json"
+        assert _SECRET not in jf.read_text(encoding="utf-8")
+
+        # Corrupt the file so model_validate fails AFTER the loader has
+        # decrypted the credential back into the in-memory dict: drop a
+        # required field + supply a bad port.
+        data = json.loads(jf.read_text(encoding="utf-8"))
+        data.pop("name", None)
+        data["port"] = "not-an-int"
+        jf.write_text(json.dumps(data), encoding="utf-8")
+
+        with caplog.at_level(logging.ERROR):
+            loaded = store.load_all()
+
+        assert p.id not in loaded  # the corrupt profile is skipped, not loaded
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        # The decrypted credential must never reach the log.
+        assert _SECRET not in log_text
+        assert "ENABLE-XYZ" not in log_text
+        # And the error path went through the scrubber (its distinctive
+        # "validation error(s) [" form, not pydantic's default str).
+        assert "CORRUPT FILE SKIPPED" in log_text
+        assert "validation error(s) [" in log_text


### PR DESCRIPTION
## What

Tier-1 SEC-2 + SEC-7 from the 2026-07-03 review — **shipped as honest defence-in-depth after a verify-first pass reclassified the finding.**

Both store loaders decrypt `password` / `enable_password` into the in-memory dict (`migrate_credential_fields`) **before** `model_validate`. Their corrupt-file handler logged the raw exception; a pydantic `ValidationError` at that point captures the offending input (for a model-level error, the whole decrypted dict), so the plaintext credential sits one formatting/version change away from the log.

## Verify-first result (important)

The **active leak does not reproduce on the resolved pydantic (2.13)** — its `str(ValidationError)` doesn't render the captured input. I drove the real store to confirm: the log line is `CORRUPT FILE SKIPPED: <id>.json — 2 validation errors for DeviceProfile`, no secret. The review's verifier over-claimed a live leak.

**But the exposure is real and latent:** `exc.errors()` *does* carry the decrypted input (probe-confirmed), and the dependency range `pydantic>=2.0.0,<3` admits older 2.x versions whose `str` rendered it. So this hardens the two decrypt-then-log sites to be safe regardless of pydantic version / formatting path — not a fix for a leak observable on the pin.

## Change

- `scrub_exc_for_log` in `security/migration.py` (shared module both stores already import): a `ValidationError` → `errors(include_input=False)` summary (field locations + error types, never the input); any other exception → `str` unchanged.
- Both stores' generic `except` route through it.
- `SECURITY.md`: the "credentials never logged" claim is true and now robustly enforced — corrected its citation (it pointed at `test_logging_config.py`, which asserts nothing about credentials) to the new test, and named the mechanism.
- `tests/unit/test_credential_log_redaction.py`: version-independent proof (the raw error object carries the secret; the scrubbed form drops it, keeping loc+type) + an end-to-end device-store test (corrupt-file log omits the decrypted credential, routes through the scrubber).

Gate: full `tests/unit` + `tests/integration/test_cross_mesh_ci_guard.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
