### PR TITLE
fix(security): strip inline device credentials from schedule API responses

### DIFF
--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -19,7 +19,11 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ...models.backup import BackupJob, JobStatus
-from ...models.schedule import BackupSchedule, ScheduleCreate
+from ...models.schedule import (
+    BackupSchedule,
+    BackupSchedulePublic,
+    ScheduleCreate,
+)
 from ...storage.job_store import FileJobStore
 from ...storage.schedule_store import FileScheduleStore
 from ..deps import get_schedule_store, get_scheduler, get_schedules
@@ -276,7 +280,7 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
 
 @router.get(
     "/",
-    response_model=list[BackupSchedule],
+    response_model=list[BackupSchedulePublic],
     summary="List all backup schedules",
 )
 def list_schedules(
@@ -289,7 +293,7 @@ def list_schedules(
 @router.post(
     "/",
     status_code=201,
-    response_model=BackupSchedule,
+    response_model=BackupSchedulePublic,
     summary="Create a backup schedule",
 )
 def create_schedule(
@@ -351,7 +355,7 @@ def delete_schedule(
 
 @router.post(
     "/{schedule_id}/toggle",
-    response_model=BackupSchedule,
+    response_model=BackupSchedulePublic,
     summary="Enable or disable a schedule",
 )
 def toggle_schedule(

--- a/netcanon/models/schedule.py
+++ b/netcanon/models/schedule.py
@@ -101,3 +101,47 @@ class ScheduleCreate(BaseModel):
                 "At least one of target_type_keys or target_device_ids must be non-empty"
             )
         return self
+
+
+class ScheduleDevicePublic(BaseModel):
+    """Read-side view of :class:`ScheduleDevice` with credentials removed.
+
+    The legacy inline ``devices`` list stores per-device ``password`` /
+    ``enable_password`` (plaintext in memory, encrypted at rest, decrypted on
+    load for backup use).  Every schedule API response serialises through
+    :class:`BackupSchedulePublic`, whose ``devices`` use THIS model — so those
+    credentials are *write-only* over the API: they never appear in any GET /
+    POST / toggle response.  A guard test
+    (``tests/unit/test_backup_schedule_public.py``) pins the field set to
+    ``ScheduleDevice``'s minus ``{password, enable_password}`` so a new
+    ``ScheduleDevice`` field cannot silently fail to surface (or a credential
+    field leak back in).
+    """
+
+    type_key: str
+    host: str
+    port: int
+    username: str
+
+
+class BackupSchedulePublic(BaseModel):
+    """Read-side view of :class:`BackupSchedule`.
+
+    Identical field set to :class:`BackupSchedule`, but the inline ``devices``
+    carry no credentials (:class:`ScheduleDevicePublic`).  Used as the
+    ``response_model`` for the list / create / toggle schedule routes so inline
+    device credentials never cross the API boundary — the same write-only
+    paradigm as :class:`netcanon.models.device_profile.DeviceProfilePublic`.
+    """
+
+    id: str
+    name: str
+    enabled: bool
+    interval_minutes: int
+    devices: list[ScheduleDevicePublic] = []
+    target_type_keys: list[str] = []
+    target_device_ids: list[str] = []
+    created_at: datetime
+    last_run_at: datetime | None = None
+    next_run_at: datetime | None = None
+    last_job_id: str | None = None

--- a/tests/integration/test_schedules_api.py
+++ b/tests/integration/test_schedules_api.py
@@ -80,6 +80,40 @@ class TestListSchedules:
         timestamps = [item["created_at"] for item in items]
         assert timestamps == sorted(timestamps, reverse=True)
 
+    def test_get_omits_legacy_inline_device_credentials(self, client):
+        """SEC-1 (2026-07-03 review): a legacy inline-device schedule must
+        not echo the device password / enable_password over the read API.
+
+        Inline devices can't be created via ``POST`` (``ScheduleCreate``
+        accepts only target lists), so inject one straight into the registry
+        the route reads — the same shape a pre-profile schedule loads from
+        disk — and assert the serialised response is credential-free.
+        """
+        from netcanon.models.schedule import BackupSchedule, ScheduleDevice
+
+        sched = BackupSchedule(
+            name="legacy inline",
+            interval_minutes=60,
+            devices=[
+                ScheduleDevice(
+                    type_key="Cisco", host="10.0.0.1", port=22,
+                    username="admin", password="PLAINTEXT-PW-XYZ",
+                    enable_password="ENABLE-PW-XYZ",
+                )
+            ],
+        )
+        client.app.state.schedules[sched.id] = sched
+
+        resp = client.get("/api/v1/schedules/")
+        assert resp.status_code == 200
+        # Neither secret may appear anywhere in the serialised response.
+        assert "PLAINTEXT-PW-XYZ" not in resp.text
+        assert "ENABLE-PW-XYZ" not in resp.text
+        item = next(s for s in resp.json() if s["id"] == sched.id)
+        assert item["devices"][0]["username"] == "admin"  # non-secret survives
+        assert "password" not in item["devices"][0]
+        assert "enable_password" not in item["devices"][0]
+
 
 # ---------------------------------------------------------------------------
 # POST /api/v1/schedules/

--- a/tests/unit/test_backup_schedule_public.py
+++ b/tests/unit/test_backup_schedule_public.py
@@ -1,0 +1,80 @@
+"""Guard: ``BackupSchedulePublic`` / ``ScheduleDevicePublic`` are the
+read-side views that strip inline device credentials from schedule API
+responses (2026-07-03 review finding SEC-1).
+
+``GET /api/v1/schedules/`` (and create / toggle) previously serialised the
+full ``BackupSchedule``, echoing the legacy inline ``devices[].password`` /
+``enable_password`` in plaintext.  The routes now serialise through
+``BackupSchedulePublic``, whose ``devices`` use ``ScheduleDevicePublic``.
+
+Like the ``DeviceProfilePublic`` guard, these public models list their fields
+explicitly, so this two-sided invariant catches drift in both directions:
+
+  * a new ``ScheduleDevice`` / ``BackupSchedule`` field not mirrored, and
+  * a credential field leaking back into a public model.
+"""
+from __future__ import annotations
+
+import pytest
+
+from netcanon.models.schedule import (
+    BackupSchedule,
+    BackupSchedulePublic,
+    ScheduleDevice,
+    ScheduleDevicePublic,
+)
+
+pytestmark = pytest.mark.unit
+
+_CRED_FIELDS = {"password", "enable_password"}
+
+
+def test_schedule_device_public_is_device_minus_credentials() -> None:
+    full = set(ScheduleDevice.model_fields)
+    public = set(ScheduleDevicePublic.model_fields)
+    assert public == full - _CRED_FIELDS, (
+        "ScheduleDevicePublic field set drifted from ScheduleDevice minus "
+        f"credentials. Missing: {(full - _CRED_FIELDS) - public}; "
+        f"unexpected: {public - (full - _CRED_FIELDS)}"
+    )
+
+
+def test_schedule_device_public_omits_both_credential_fields() -> None:
+    assert _CRED_FIELDS.isdisjoint(ScheduleDevicePublic.model_fields)
+
+
+def test_backup_schedule_public_has_same_field_names_as_full() -> None:
+    """Only the inner ``devices`` type differs — the field NAME set must match
+    so no schedule metadata silently disappears from the read API."""
+    assert set(BackupSchedulePublic.model_fields) == set(
+        BackupSchedule.model_fields
+    )
+
+
+def test_public_dump_from_schedule_with_inline_device_has_no_credentials() -> None:
+    """Even constructed from a full schedule carrying an inline device with
+    credentials, the serialised dict is clean."""
+    schedule = BackupSchedule(
+        name="legacy inline",
+        interval_minutes=60,
+        devices=[
+            ScheduleDevice(
+                type_key="Cisco",
+                host="10.0.0.1",
+                port=22,
+                username="admin",
+                password="hunter2",
+                enable_password="enable-secret",
+            )
+        ],
+    )
+    public = BackupSchedulePublic.model_validate(schedule.model_dump())
+    dumped = public.model_dump()
+    assert "hunter2" not in str(dumped)
+    assert "enable-secret" not in str(dumped)
+    dev = dumped["devices"][0]
+    assert "password" not in dev
+    assert "enable_password" not in dev
+    # Non-secret device fields still round-trip.
+    assert dev["host"] == "10.0.0.1"
+    assert dev["username"] == "admin"


### PR DESCRIPTION
## What

Tier-1 SEC-1 from the 2026-07-03 review: `GET /api/v1/schedules/` (plus create + toggle) serialised the full `BackupSchedule`, so a **legacy inline-device schedule echoed `devices[].password` / `enable_password` in plaintext** over the read API. The `DeviceProfilePublic` write-only paradigm was never extended to the schedule sibling.

Reachable for pre-profile schedules that carry an inline `devices` list (new schedules reference profile IDs and carry no inline creds).

## Fix

- `ScheduleDevicePublic` (= `ScheduleDevice` minus `{password, enable_password}`) and `BackupSchedulePublic` (same field names as `BackupSchedule`, `devices` typed as `ScheduleDevicePublic`) — mirroring `DeviceProfilePublic`.
- The list / create / toggle routes serialise through `BackupSchedulePublic`, so device credentials are write-only over the API.

## Tests

- `tests/unit/test_backup_schedule_public.py`: two-sided field-set guards (public == full − credentials; no cred field leaks back) + a `model_dump` test built from an inline-device schedule.
- `tests/integration/test_schedules_api.py`: injects a legacy inline-device schedule into the registry and asserts `GET`'s serialised response is credential-free (the on-disk shape `POST` can't create, since `ScheduleCreate` accepts only target lists).

Gate: full `tests/unit` + `tests/integration/test_cross_mesh_ci_guard.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
