### PR TITLE
fix(aruba_aoss): clamp port-range expansion to prevent an OOM DoS

### DIFF
--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -466,12 +466,14 @@ def _expand_port_range(lo: str, hi: str) -> list[str]:
         # Implausible span — refuse to materialise (DoS clamp).  Keep the two
         # endpoints as literal port names; a real AOS-S range never exceeds a
         # few hundred ports, so this only ever fires on malformed / hostile
-        # input, and we log it rather than silently dropping coverage.
+        # input, and we log it rather than silently dropping coverage.  Log
+        # only the derived span + cap (integers) — NOT the raw ``lo``/``hi``
+        # tokens, which are parsed config values (CodeQL clear-text-logging).
         logger.warning(
-            "aruba_aoss: refusing to expand implausible port range %s-%s "
-            "(span %d > %d); keeping the endpoints as literal port names "
-            "instead of materialising the range.",
-            lo, hi, num_hi - num_lo + 1, _MAX_PORT_RANGE_SPAN,
+            "aruba_aoss: refusing to expand an implausible port range "
+            "(span %d > cap %d); keeping the two endpoints as literal port "
+            "names instead of materialising the range.",
+            num_hi - num_lo + 1, _MAX_PORT_RANGE_SPAN,
         )
         return [lo, hi]
     return [f"{prefix_lo}{n}" for n in range(num_lo, num_hi + 1)]

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -368,6 +368,16 @@ _AOS_PORT_SHAPE_RE = re.compile(
     r"^(?:[Tt]rk\d+|\d+(?:/[A-Za-z]?\d+)?|[A-Za-z]\d+)$",
 )
 
+#: DoS clamp on port-range expansion.  A fully-stacked AOS-S chassis tops out
+#: at ~10 stack members x 48 ports ~= 500 ports, so 1024 is generous headroom
+#: for any real device.  Without it, ``_expand_port_range`` materialises
+#: ``range(lo, hi + 1)`` unbounded and the ``_AOS_PORT_SHAPE_RE`` gate accepts
+#: an unbounded ``\d+`` endpoint — so a ~20-byte ``tagged 1-999999999`` in a
+#: VLAN stanza would allocate ~1e9 strings and OOM the worker.  Reachable from
+#: ``POST /plan`` and blind to the 10 MB raw_text cap (amplification, not raw
+#: size).
+_MAX_PORT_RANGE_SPAN = 1024
+
 
 def _parse_port_list(text: str) -> list[str]:
     """Expand AOS-S port-list syntax into individual port names.
@@ -451,6 +461,18 @@ def _expand_port_range(lo: str, hi: str) -> list[str]:
     prefix_lo, num_lo = m_lo.group(1), int(m_lo.group(2))
     prefix_hi, num_hi = m_hi.group(1), int(m_hi.group(2))
     if prefix_lo != prefix_hi or num_hi < num_lo:
+        return [lo, hi]
+    if num_hi - num_lo > _MAX_PORT_RANGE_SPAN:
+        # Implausible span — refuse to materialise (DoS clamp).  Keep the two
+        # endpoints as literal port names; a real AOS-S range never exceeds a
+        # few hundred ports, so this only ever fires on malformed / hostile
+        # input, and we log it rather than silently dropping coverage.
+        logger.warning(
+            "aruba_aoss: refusing to expand implausible port range %s-%s "
+            "(span %d > %d); keeping the endpoints as literal port names "
+            "instead of materialising the range.",
+            lo, hi, num_hi - num_lo + 1, _MAX_PORT_RANGE_SPAN,
+        )
         return [lo, hi]
     return [f"{prefix_lo}{n}" for n in range(num_lo, num_hi + 1)]
 

--- a/tests/unit/migration/codecs/aruba_aoss/test_foreign_port_names_round_trip.py
+++ b/tests/unit/migration/codecs/aruba_aoss/test_foreign_port_names_round_trip.py
@@ -100,6 +100,27 @@ class TestParseDoesNotShredForeignPortNames:
         # Real wire form from cross-vendor ksator_qfx5100 round-trip.
         assert _parse_port_list("xe-0/0/2,1/1") == ["xe-0/0/2", "1/1"]
 
+    def test_implausible_range_is_clamped_not_materialised(self):
+        """PERF-1 (2026-07-03 review): an absurd port-range span must NOT be
+        expanded — the ``_AOS_PORT_SHAPE_RE`` gate accepts an unbounded
+        ``\\d+`` endpoint, so ``tagged 1-999999999`` (reachable via POST
+        /plan) would otherwise allocate ~1e9 strings and OOM the worker.
+
+        The clamp keeps the two endpoints as literal port names and returns
+        near-instantly instead of materialising the range.
+        """
+        import time
+
+        start = time.perf_counter()
+        result = _parse_port_list("1-999999999")
+        elapsed = time.perf_counter() - start
+        assert result == ["1", "999999999"], result
+        assert elapsed < 1.0, f"clamp did not short-circuit ({elapsed:.2f}s)"
+        # A range just past the cap is also clamped (endpoints only).
+        assert _parse_port_list("1-5000") == ["1", "5000"]
+        # A plausible in-cap range still expands fully.
+        assert _parse_port_list("1-10") == [str(n) for n in range(1, 11)]
+
 
 # ---------------------------------------------------------------------------
 # 2. Foreign-vendor port-name format-side


### PR DESCRIPTION
## What

Tier-1 PERF-1 from the 2026-07-03 review: `aruba_aoss` port-range expansion was an **OOM DoS**.

`_expand_port_range` materialised `range(lo, hi + 1)` with no upper bound, and the `_AOS_PORT_SHAPE_RE` gate accepts an unbounded `\d+` endpoint. A ~20-byte `tagged 1-999999999` in a VLAN stanza expanded to ~1e9 strings and OOM'd the worker — **reachable from `POST /plan`**, and the 10 MB `raw_text` cap doesn't help (amplification, not raw size).

**Reproduced** (verify-first): `_expand_port_range("1", "200000")` → 200000 strings; extrapolates to ~1e9 for the 9-digit endpoint.

## Fix

- `_MAX_PORT_RANGE_SPAN = 1024` — generous headroom over a fully-stacked AOS-S chassis (~10 members × 48 ≈ 500 ports).
- A span beyond the cap is refused: the two endpoints are kept as **literal port names** (no crash, no *silent* coverage drop) and a `WARNING` is logged. Real ranges (`1-24`, `1/1-1/48`, `A1-A4`) are far under the cap and expand unchanged.

## Test

`test_implausible_range_is_clamped_not_materialised`: `1-999999999` returns the two endpoints in <1s (clamped), a just-past-cap range is clamped, and an in-cap range still expands fully.

Gate: full `tests/unit` + `tests/integration/test_cross_mesh_ci_guard.py` green (real fixtures are all far under the cap, so the cross-mesh round-trip is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
