### PR TITLE
fix(schedules): lock the registry + don't resurrect a schedule deleted mid-run

### DIFF
--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -25,7 +25,10 @@ from ...models.schedule import (
     ScheduleCreate,
 )
 from ...storage.job_store import FileJobStore
-from ...storage.schedule_store import FileScheduleStore
+from ...storage.schedule_store import (
+    SCHEDULE_REGISTRY_LOCK,
+    FileScheduleStore,
+)
 from ..deps import get_schedule_store, get_scheduler, get_schedules
 
 logger = logging.getLogger(__name__)
@@ -262,15 +265,27 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
         getattr(app.state, "device_profile_store", None),
     )
 
-    schedule.last_run_at = datetime.now(UTC)
-    schedule.last_job_id = job.id
-
-    # Refresh next_run_at from the live scheduler
-    ap_job = app.state.scheduler.get_job(schedule_id)
-    if ap_job and ap_job.next_run_time:
-        schedule.next_run_at = ap_job.next_run_time
-
-    app.state.schedule_store.save(schedule)
+    # A minutes-long backup ran above; the operator may have deleted this
+    # schedule in the meantime.  Re-check existence under the registry lock
+    # before persisting — otherwise this post-run save rewrites the deleted
+    # schedule's JSON and resurrects it on the next startup reload (the delete
+    # route removed it from both the registry and disk).
+    with SCHEDULE_REGISTRY_LOCK:
+        if schedule_id not in schedules:
+            logger.info(
+                "Schedule '%s' (id=%s) was removed during its run; skipping "
+                "the post-run save so it is not resurrected on disk.",
+                schedule.name,
+                schedule_id[:8],
+            )
+            return
+        schedule.last_run_at = datetime.now(UTC)
+        schedule.last_job_id = job.id
+        # Refresh next_run_at from the live scheduler
+        ap_job = app.state.scheduler.get_job(schedule_id)
+        if ap_job and ap_job.next_run_time:
+            schedule.next_run_at = ap_job.next_run_time
+        app.state.schedule_store.save(schedule)
 
 
 # ---------------------------------------------------------------------------
@@ -304,22 +319,26 @@ def create_schedule(
     scheduler=Depends(get_scheduler),
 ) -> BackupSchedule:
     """Create a new recurring backup schedule and register it immediately."""
-    if len(schedules) >= 200:
-        raise HTTPException(
-            status_code=409,
-            detail="Maximum schedule limit reached (200). Delete unused schedules first.",
-        )
-    schedule = BackupSchedule(**body.model_dump())
-    schedules[schedule.id] = schedule
-    schedule_store.save(schedule)
-
-    register_schedule_job(scheduler, schedule, request.app)
-
-    # Capture the first calculated next_run_at
-    ap_job = scheduler.get_job(schedule.id)
-    if ap_job and ap_job.next_run_time:
-        schedule.next_run_at = ap_job.next_run_time
+    # Lock the cap-check + insert + persist as one critical section so the
+    # 200-limit can't be raced past and the save can't collide with a
+    # concurrent delete/toggle (shared registry + shared on-disk store).
+    with SCHEDULE_REGISTRY_LOCK:
+        if len(schedules) >= 200:
+            raise HTTPException(
+                status_code=409,
+                detail="Maximum schedule limit reached (200). Delete unused schedules first.",
+            )
+        schedule = BackupSchedule(**body.model_dump())
+        schedules[schedule.id] = schedule
         schedule_store.save(schedule)
+
+        register_schedule_job(scheduler, schedule, request.app)
+
+        # Capture the first calculated next_run_at
+        ap_job = scheduler.get_job(schedule.id)
+        if ap_job and ap_job.next_run_time:
+            schedule.next_run_at = ap_job.next_run_time
+            schedule_store.save(schedule)
 
     logger.info(
         "Created schedule '%s' (every %d min, id=%s)",
@@ -342,14 +361,19 @@ def delete_schedule(
     scheduler=Depends(get_scheduler),
 ) -> None:
     """Delete a schedule and remove its APScheduler job."""
-    if schedule_id not in schedules:
-        raise HTTPException(
-            status_code=404, detail=f"Schedule not found: {schedule_id!r}"
-        )
-    del schedules[schedule_id]
-    schedule_store.delete(schedule_id)
-    if scheduler.get_job(schedule_id):
-        scheduler.remove_job(schedule_id)
+    # Lock the whole remove (registry + disk + APScheduler job) so it is
+    # atomic w.r.t. a schedule-triggered run's post-completion save — the
+    # save re-checks membership under this same lock, so a delete that wins
+    # the lock keeps the schedule deleted (no resurrection).
+    with SCHEDULE_REGISTRY_LOCK:
+        if schedule_id not in schedules:
+            raise HTTPException(
+                status_code=404, detail=f"Schedule not found: {schedule_id!r}"
+            )
+        del schedules[schedule_id]
+        schedule_store.delete(schedule_id)
+        if scheduler.get_job(schedule_id):
+            scheduler.remove_job(schedule_id)
     logger.info("Deleted schedule %s", schedule_id)
 
 
@@ -366,24 +390,27 @@ def toggle_schedule(
     scheduler=Depends(get_scheduler),
 ) -> BackupSchedule:
     """Flip ``enabled`` on a schedule; registers or removes the APScheduler job."""
-    if schedule_id not in schedules:
-        raise HTTPException(
-            status_code=404, detail=f"Schedule not found: {schedule_id!r}"
-        )
-    schedule = schedules[schedule_id]
-    schedule.enabled = not schedule.enabled
+    # Lock the read-modify-(register|remove)-persist as one critical section
+    # (shared registry + APScheduler + on-disk store), matching create/delete.
+    with SCHEDULE_REGISTRY_LOCK:
+        if schedule_id not in schedules:
+            raise HTTPException(
+                status_code=404, detail=f"Schedule not found: {schedule_id!r}"
+            )
+        schedule = schedules[schedule_id]
+        schedule.enabled = not schedule.enabled
 
-    if schedule.enabled:
-        register_schedule_job(scheduler, schedule, request.app)
-        ap_job = scheduler.get_job(schedule_id)
-        if ap_job and ap_job.next_run_time:
-            schedule.next_run_at = ap_job.next_run_time
-    else:
-        if scheduler.get_job(schedule_id):
-            scheduler.remove_job(schedule_id)
-        schedule.next_run_at = None
+        if schedule.enabled:
+            register_schedule_job(scheduler, schedule, request.app)
+            ap_job = scheduler.get_job(schedule_id)
+            if ap_job and ap_job.next_run_time:
+                schedule.next_run_at = ap_job.next_run_time
+        else:
+            if scheduler.get_job(schedule_id):
+                scheduler.remove_job(schedule_id)
+            schedule.next_run_at = None
 
-    schedule_store.save(schedule)
+        schedule_store.save(schedule)
     logger.info(
         "Schedule '%s' %s", schedule.name, "enabled" if schedule.enabled else "disabled"
     )

--- a/netcanon/storage/schedule_store.py
+++ b/netcanon/storage/schedule_store.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from pathlib import Path
 
 from ..models.schedule import BackupSchedule
@@ -25,6 +26,21 @@ from ..security.credentials import encrypt
 from ..security.migration import migrate_credential_fields, scrub_exc_for_log
 
 logger = logging.getLogger(__name__)
+
+#: Guards cross-thread access to the in-memory schedule registry
+#: (``app.state.schedules``) **together with** its on-disk store — the
+#: schedule-side counterpart of ``DEVICE_PROFILE_REGISTRY_LOCK``.  A
+#: schedule-triggered backup coroutine runs for minutes on the APScheduler
+#: event loop, then persists ``last_run_at`` / ``next_run_at``; meanwhile a
+#: route handler (create / delete / toggle) runs in FastAPI's threadpool.
+#: Without serialisation, a delete that lands DURING a run is undone by the
+#: run's post-completion ``save`` — the schedule is rewritten to disk and
+#: resurrected on the next startup reload.  Hold this lock around every
+#: registry read-modify-write-persist (and delete) critical section.  Only
+#: ever held for the brief dict-mutation + APScheduler call + file-write —
+#: never across an ``await`` or the backup itself — so it cannot deadlock or
+#: stall the event loop.
+SCHEDULE_REGISTRY_LOCK = threading.Lock()
 
 
 class FileScheduleStore:

--- a/tests/integration/test_schedules_api.py
+++ b/tests/integration/test_schedules_api.py
@@ -249,3 +249,85 @@ class TestToggleSchedule:
     def test_toggle_nonexistent_id_returns_404(self, client):
         resp = client.post("/api/v1/schedules/nonexistent-id/toggle")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# CONC-2: delete-during-run must not resurrect the schedule
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleDeleteResurrection:
+    """A schedule deleted DURING its run must not be resurrected by the run's
+    post-completion ``save`` (2026-07-03 review, CONC-2).
+
+    ``_run_scheduled_backup_inner`` captures the schedule, awaits a
+    minutes-long ``run_backup_job``, then persists ``last_run_at`` /
+    ``next_run_at``.  If the operator deletes the schedule in that window, the
+    (formerly unconditional) save rewrote the deleted JSON and resurrected it
+    on the next startup reload.  The fix re-checks membership under
+    ``SCHEDULE_REGISTRY_LOCK`` before saving.
+
+    The run is driven directly (not via APScheduler) with ``run_backup_job``
+    monkeypatched, so the delete lands deterministically mid-run.
+    """
+
+    @staticmethod
+    def _cisco_profile(app):
+        from netcanon.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(
+            name="sw", type_key="Cisco", host="10.0.0.1", port=22,
+            username="admin", password="pw",
+        )
+        # A resolvable target so the coroutine reaches run_backup_job + the
+        # post-run save (an empty target set short-circuits before both).
+        app.state.device_profiles[profile.id] = profile
+        return profile
+
+    async def test_delete_during_run_is_not_resurrected(
+        self, client, monkeypatch,
+    ):
+        from pathlib import Path
+
+        from netcanon.api.routes.schedules import _run_scheduled_backup_inner
+        from netcanon.services import backup_runner
+
+        app = client.app
+        self._cisco_profile(app)
+        sid = _create_schedule(client)["id"]
+        store_dir = Path(app.state.schedule_store._dir)
+        assert (store_dir / f"{sid}.json").exists()
+
+        # The awaited backup simulates the operator deleting the schedule
+        # mid-run (registry + disk), exactly as the delete route does.
+        def _delete_mid_run(*args, **kwargs):
+            app.state.schedules.pop(sid, None)
+            app.state.schedule_store.delete(sid)
+
+        monkeypatch.setattr(backup_runner, "run_backup_job", _delete_mid_run)
+        await _run_scheduled_backup_inner(sid, app)
+
+        assert sid not in app.state.schedules
+        assert not (store_dir / f"{sid}.json").exists(), (
+            "deleted schedule was resurrected on disk by the post-run save"
+        )
+
+    async def test_normal_run_still_persists(self, client, monkeypatch):
+        """Negative control: when NOT deleted, the post-run save still runs."""
+        from pathlib import Path
+
+        from netcanon.api.routes.schedules import _run_scheduled_backup_inner
+        from netcanon.services import backup_runner
+
+        app = client.app
+        self._cisco_profile(app)
+        sid = _create_schedule(client)["id"]
+
+        monkeypatch.setattr(
+            backup_runner, "run_backup_job", lambda *a, **k: None,
+        )
+        await _run_scheduled_backup_inner(sid, app)
+
+        assert sid in app.state.schedules
+        assert app.state.schedules[sid].last_run_at is not None
+        assert (Path(app.state.schedule_store._dir) / f"{sid}.json").exists()


### PR DESCRIPTION
## What

Tier-1 CONC-2 from the 2026-07-03 review — the sibling of CONC-1, on the schedule side.

`_run_scheduled_backup_inner` captured the schedule, awaited a minutes-long `run_backup_job`, then **unconditionally** saved `last_run_at` / `next_run_at`. If the operator deleted the schedule during that window (the delete route removes it from the registry **and** disk), the post-run save rewrote the deleted JSON — **resurrecting** the schedule on the next startup reload. The schedule store also had **no cross-thread lock** (the profile store got `DEVICE_PROFILE_REGISTRY_LOCK` in the #10 fix; schedules never did), so create/delete/toggle raced the event-loop-thread save.

## Fix

- `SCHEDULE_REGISTRY_LOCK` (`threading.Lock`) in `schedule_store.py` — the schedule-side counterpart of `DEVICE_PROFILE_REGISTRY_LOCK`.
- **Post-run save** re-checks `schedule_id in schedules` under the lock; if it was removed during the run, log and skip the save (no resurrection).
- **create / delete / toggle** hold the lock across their read-modify-(register|remove)-persist critical section — atomic w.r.t. the post-run save, and closing the check-then-insert 200-cap race + the shared-`.tmp` save collision (saves are now serialised). Held only for brief in-memory + APScheduler + file-write ops — never across an `await` or the backup.

## Test

`TestScheduleDeleteResurrection` — drives the run directly with `run_backup_job` monkeypatched to delete the schedule mid-run (deterministic), asserts no `{id}.json` remains; plus a negative control (an undeleted run still persists `last_run_at` + the file).

Gate: full `tests/unit` + `tests/integration` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
