### PR TITLE
fix(codecs): escape " and \ in quoted free-text (fortigate/aoss/mikrotik) — CODEC-1/CODEC-3

### DIFF
--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -72,8 +72,12 @@ logger = logging.getLogger(__name__)
 # Capture the whole remainder (quoted-with-escapes or bare); ``_unquote``
 # strips the outer pair and reverses ``\"`` / ``\\`` escapes.  A prior
 # ``"?([^"\n]+)"?`` form truncated at the first *inner* ``\"`` and so
-# shredded any name/description containing an embedded quote.
-_HOSTNAME_RE = re.compile(r"^hostname\s+(.+)$", re.IGNORECASE)
+# shredded any name/description containing an embedded quote.  The capture
+# starts with ``\S`` (disjoint from the preceding ``\s+``) and carries no
+# ``$`` anchor, so ``\s+`` and ``.`` can never both match a run of spaces
+# under backtracking — avoids the ``py/polynomial-redos`` shape a
+# ``\s+(.+)$`` form would introduce.
+_HOSTNAME_RE = re.compile(r"^hostname\s+(\S.*)", re.IGNORECASE)
 # Capture the quoted community token.  AOS-S: `snmp-server community "public" Operator`
 _SNMP_COMMUNITY_LINE_RE = re.compile(
     r'^snmp-server\s+community\s+"?([^"\s]+)"?', re.IGNORECASE,
@@ -247,7 +251,7 @@ _IFACE_HEADER_RE = re.compile(
     r'^interface\s+("?[A-Za-z0-9][A-Za-z0-9./\-]*"?)\s*$', re.IGNORECASE,
 )
 
-_VLAN_NAME_RE = re.compile(r"^name\s+(.+)$", re.IGNORECASE)
+_VLAN_NAME_RE = re.compile(r"^name\s+(\S.*)", re.IGNORECASE)
 _UNTAGGED_RE = re.compile(r"^(no\s+)?untagged\s+(.+)$", re.IGNORECASE)
 _TAGGED_RE = re.compile(r"^(no\s+)?tagged\s+(.+)$", re.IGNORECASE)
 _IP_ADDR_CIDR_RE = re.compile(
@@ -266,7 +270,7 @@ _IPV6_ADDR_RE = re.compile(
     r"^ipv6\s+address\s+([0-9A-Fa-f:]+)/(\d+)(?:\s+(link-local))?\s*$",
     re.IGNORECASE,
 )
-_IFACE_NAME_RE = re.compile(r"^name\s+(.+)$", re.IGNORECASE)
+_IFACE_NAME_RE = re.compile(r"^name\s+(\S.*)", re.IGNORECASE)
 
 # VRRP grammar — nested inside ``vlan N`` stanzas, with a global
 # ``router vrrp`` enable.

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -69,7 +69,11 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-_HOSTNAME_RE = re.compile(r'^hostname\s+"?([^"\n]+)"?', re.IGNORECASE)
+# Capture the whole remainder (quoted-with-escapes or bare); ``_unquote``
+# strips the outer pair and reverses ``\"`` / ``\\`` escapes.  A prior
+# ``"?([^"\n]+)"?`` form truncated at the first *inner* ``\"`` and so
+# shredded any name/description containing an embedded quote.
+_HOSTNAME_RE = re.compile(r"^hostname\s+(.+)$", re.IGNORECASE)
 # Capture the quoted community token.  AOS-S: `snmp-server community "public" Operator`
 _SNMP_COMMUNITY_LINE_RE = re.compile(
     r'^snmp-server\s+community\s+"?([^"\s]+)"?', re.IGNORECASE,
@@ -243,7 +247,7 @@ _IFACE_HEADER_RE = re.compile(
     r'^interface\s+("?[A-Za-z0-9][A-Za-z0-9./\-]*"?)\s*$', re.IGNORECASE,
 )
 
-_VLAN_NAME_RE = re.compile(r'^name\s+"?([^"\n]+)"?', re.IGNORECASE)
+_VLAN_NAME_RE = re.compile(r"^name\s+(.+)$", re.IGNORECASE)
 _UNTAGGED_RE = re.compile(r"^(no\s+)?untagged\s+(.+)$", re.IGNORECASE)
 _TAGGED_RE = re.compile(r"^(no\s+)?tagged\s+(.+)$", re.IGNORECASE)
 _IP_ADDR_CIDR_RE = re.compile(
@@ -262,7 +266,7 @@ _IPV6_ADDR_RE = re.compile(
     r"^ipv6\s+address\s+([0-9A-Fa-f:]+)/(\d+)(?:\s+(link-local))?\s*$",
     re.IGNORECASE,
 )
-_IFACE_NAME_RE = re.compile(r'^name\s+"?([^"\n]+)"?', re.IGNORECASE)
+_IFACE_NAME_RE = re.compile(r"^name\s+(.+)$", re.IGNORECASE)
 
 # VRRP grammar — nested inside ``vlan N`` stanzas, with a global
 # ``router vrrp`` enable.
@@ -318,11 +322,39 @@ _VRRP_AUTH_PLAINTEXT_RE = re.compile(
 # ---------------------------------------------------------------------------
 
 
+def _unescape(value: str) -> str:
+    """Reverse :func:`~netcanon.migration.codecs.aruba_aoss.render._esc`.
+
+    Single left-to-right pass: a backslash consumes the next character
+    literally (``\\\\`` → ``\\``, ``\\"`` → ``"``), the exact inverse of
+    doubling backslashes then escaping quotes.  A trailing lone backslash
+    is emitted verbatim."""
+    out: list[str] = []
+    i = 0
+    n = len(value)
+    while i < n:
+        c = value[i]
+        if c == "\\" and i + 1 < n:
+            out.append(value[i + 1])
+            i += 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
 def _unquote(s: str) -> str:
-    """Strip surrounding ASCII quotes if present."""
+    """Strip surrounding ASCII quotes and reverse render-side escaping.
+
+    AOS-S free-text values (hostname / vlan name / interface description)
+    are emitted double-quoted with ``\\"`` / ``\\\\`` escapes (see
+    ``render._esc``); this strips the outer pair and reverses those
+    escapes so a value containing a quote or backslash round-trips
+    byte-stable.  A bare (unquoted) value — as some real AOS-S captures
+    emit — is returned stripped, unescaped-as-is."""
     s = s.strip()
-    if s.startswith('"') and s.endswith('"'):
-        return s[1:-1]
+    if len(s) >= 2 and s.startswith('"') and s.endswith('"'):
+        return _unescape(s[1:-1])
     return s
 
 

--- a/netcanon/migration/codecs/aruba_aoss/render.py
+++ b/netcanon/migration/codecs/aruba_aoss/render.py
@@ -116,6 +116,19 @@ _VLAN_ID_DOTTED_RE = re.compile(
 )
 
 
+def _esc(value: str) -> str:
+    """Escape a free-text value for an AOS-Switch ``"..."`` literal.
+
+    AOS-S (ProVision) uses ``\\`` as the in-quote escape introducer — an
+    embedded double-quote must be written ``\\"`` (per HPE's variable-file
+    docs) or the value terminates the literal early.  A literal backslash
+    is doubled first so the pair round-trips.  Reversed on the parse side
+    by :func:`~netcanon.migration.codecs.aruba_aoss.parse._unquote`.
+    Backslash first, then quote (order matters); a no-op for the common
+    quote-free / backslash-free case."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _vlan_iface_id(name: str) -> int | None:
     """Extract a VLAN id encoded in an interface name, if any.
 
@@ -376,7 +389,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
     )
 
     if tree.hostname:
-        lines.append(f'hostname "{tree.hostname}"')
+        lines.append(f'hostname "{_esc(tree.hostname)}"')
 
     # Domain suffix — AOS-S form is ``ip dns domain-name <name>``,
     # verified against Aruba AOS-S 16.10/16.11 Management &
@@ -587,7 +600,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
     for vlan in tree.vlans:
         lines.append(f"vlan {vlan.id}")
         if vlan.name:
-            lines.append(f'   name "{vlan.name}"')
+            lines.append(f'   name "{_esc(vlan.name)}"')
         if vlan.untagged_ports:
             lines.append(
                 f"   untagged {_format_port_list(vlan.untagged_ports)}"
@@ -813,7 +826,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         else:
             lines.append(f"interface {iface.name}")
         if iface.description:
-            lines.append(f'   name "{iface.description}"')
+            lines.append(f'   name "{_esc(iface.description)}"')
         # Skip enable/disable + routing markers on logical
         # interfaces (loopback is always-up, has no routing toggle).
         is_logical = lname.startswith("loopback")

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -82,6 +82,20 @@ _RFC1918_NETWORKS = (
 )
 
 
+def _esc(value: str) -> str:
+    """Escape a free-text value for a FortiOS ``"..."`` literal.
+
+    FortiOS uses ``\\`` as the in-quote escape introducer, so a literal
+    backslash is doubled and an embedded double-quote becomes ``\\"`` —
+    otherwise the value closes the literal early (an operator
+    description like ``Link "A"`` would break the ``edit`` body).  The
+    parse side already unescapes via ``shlex.split(posix=True)``, so this
+    is the render half of a symmetric pair.  Backslash first, then quote
+    (order matters).  A no-op for the common quote-free / backslash-free
+    case, keeping output tidy."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _svi_ip_mask(addr: Any) -> tuple[str, str]:
     """Return ``(ip, dotted-mask)`` for an SVI IPv4 address.
 
@@ -552,7 +566,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             if iface.description:
                 # FortiOS alias caps at 25 chars per spec.
                 alias = iface.description[:25]
-                out.append(f'        set alias "{alias}"')
+                out.append(f'        set alias "{_esc(alias)}"')
             # LAG aggregate marker takes precedence over VLAN.
             lag = lag_by_name.get(iface.name)
             if lag is not None:
@@ -758,9 +772,9 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         out.append("config system snmp sysinfo")
         out.append("    set status enable")
         if tree.snmp.location:
-            out.append(f'    set location "{tree.snmp.location}"')
+            out.append(f'    set location "{_esc(tree.snmp.location)}"')
         if tree.snmp.contact:
-            out.append(f'    set contact-info "{tree.snmp.contact}"')
+            out.append(f'    set contact-info "{_esc(tree.snmp.contact)}"')
         out.append("end")
         # FortiOS nests trap targets inside ``config system snmp
         # community / config hosts`` — there is no top-level "trap
@@ -962,7 +976,7 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             # FortiOS uses ``set comment`` (singular) on static-route
             # entries; max 255 chars.
             # Ref: https://docs.fortinet.com/document/fortigate/7.4.0/cli-reference/522620/config-router-static
-            out.append(f'        set comment "{route.description}"')
+            out.append(f'        set comment "{_esc(route.description)}"')
 
     if v4_routes:
         out.append("config router static")

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -296,7 +296,7 @@ _KV_RE = re.compile(
     ([\w\-]+)             # key
     =
     (                     # value:
-        "[^"]*"           #   double-quoted string, OR
+        "(?:\\.|[^"\\])*"  #  double-quoted string (spans \" / \\ escapes), OR
       | [^\s]+            #   bare token (no spaces)
     )
     """,
@@ -315,10 +315,34 @@ def _parse_kv(line: str) -> dict[str, str]:
     for m in _KV_RE.finditer(line):
         key = m.group(1)
         val = m.group(2)
-        if val.startswith('"') and val.endswith('"'):
-            val = val[1:-1]
+        if len(val) >= 2 and val.startswith('"') and val.endswith('"'):
+            # Strip the surrounding quotes, then reverse the render-side
+            # escaping (``\\`` → ``\``, ``\"`` → ``"``) so a comment /
+            # name containing either character round-trips byte-stable.
+            val = _unescape(val[1:-1])
         pairs[key] = val
     return pairs
+
+
+def _unescape(value: str) -> str:
+    """Reverse :func:`~netcanon.migration.codecs.mikrotik_routeros.render._escape`.
+
+    Single left-to-right pass: a backslash consumes the next character
+    literally (so ``\\\\`` → ``\\`` and ``\\"`` → ``"``), which is the exact
+    inverse of doubling backslashes then escaping quotes.  A trailing lone
+    backslash is emitted verbatim."""
+    out: list[str] = []
+    i = 0
+    n = len(value)
+    while i < n:
+        c = value[i]
+        if c == "\\" and i + 1 < n:
+            out.append(value[i + 1])
+            i += 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
 
 
 _FIND_DEFAULT_NAME_RE = re.compile(r"\[\s*find\s+default-name=(\S+)\s*\]")

--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -879,8 +879,17 @@ def _yes_no(flag: bool) -> str:
 
 
 def _escape(value: str) -> str:
-    """Escape double-quotes in a string for inclusion in ``"..."``."""
-    return value.replace('"', '\\"')
+    """Escape a string for inclusion inside a RouterOS ``"..."`` literal.
+
+    RouterOS treats ``\\`` as the escape introducer inside a quoted
+    string, so a literal backslash must itself be doubled *before*
+    double-quotes are escaped — otherwise ``a\\b`` renders as ``a\\b``
+    where ``\\b`` is read back as a backspace escape, and a value
+    containing ``"`` closes the literal early.  Mirrors the sibling
+    :func:`_quote_if_needed` (which already escapes both) and the
+    parse-side :func:`~netcanon.migration.codecs.mikrotik_routeros.parse._parse_kv`
+    which reverses this.  Backslash first, then quote (order matters)."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _render_vrrp(

--- a/tests/unit/migration/test_freetext_quote_escaping.py
+++ b/tests/unit/migration/test_freetext_quote_escaping.py
@@ -1,0 +1,115 @@
+"""Free-text quote / backslash escaping round-trips (CODEC-1 / CODEC-3).
+
+2026-07-03 Fable review, "hardened path / un-hardened sibling":
+``juniper_junos`` escapes ``"`` and ``\\`` inside its quoted free-text
+fields (``_quote_if_needed``/``_quote_always``) so a description like
+``Link "A"`` renders as valid, round-trip-stable config.  Three siblings
+did not:
+
+* ``fortigate_cli`` — emitted ``set alias "Link "A""`` (the inner quote
+  closes the literal early); the FortiOS ``shlex``-based parser then read
+  it back mangled.  Fixed render-side (``_esc``); parse already unescapes
+  via ``shlex.split(posix=True)``.
+* ``aruba_aoss`` — emitted ``name "Link "A""`` and the ``"?([^"\\n]+)"?``
+  name regex truncated at the first inner quote.  Fixed render-side
+  (``_esc``) + parse-side (widened regex + ``_unquote`` unescape).
+* ``mikrotik_routeros`` — ``_escape`` escaped ``"`` but NOT ``\\``
+  (CODEC-3), and ``_KV_RE`` / ``_parse_kv`` couldn't span an escaped
+  quote.  Fixed both sides.
+
+VyOS is deliberately absent: its config validator rejects an embedded
+double-quote in a value string *even when escaped* (vyos.dev/T1246), so
+the correct fix there is sanitisation, not escaping — tracked separately.
+
+Each device documentedly uses ``\\`` as the in-quote escape introducer
+(Junos ``display set``, FortiOS CLI, RouterOS scripting, AOS-S variable
+files), so the rendered output is deployment-valid, and the matched
+parse-side unescape keeps the netcanon round-trip byte-stable.
+"""
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalInterface,
+    CanonicalVlan,
+)
+from netcanon.migration.codecs.aruba_aoss.codec import ArubaAOSSCodec
+from netcanon.migration.codecs.fortigate_cli.codec import FortiGateCLICodec
+from netcanon.migration.codecs.mikrotik_routeros.codec import (
+    MikroTikRouterOSCodec,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# (codec factory, description-length cap the codec applies, or None)
+_CODECS = [
+    pytest.param(FortiGateCLICodec, 25, id="fortigate_cli"),
+    pytest.param(ArubaAOSSCodec, None, id="aruba_aoss"),
+    pytest.param(MikroTikRouterOSCodec, None, id="mikrotik_routeros"),
+]
+
+# Free-text values that stress the two escape-significant characters.
+_VALUES = [
+    "plain description",
+    'has a "quoted" word',
+    'ends with a quote"',
+    '"starts with a quote',
+    "has a back\\slash",
+    'both a "quote" and a \\ backslash',
+    "trailing backslash\\",
+    "just one quote \"",
+]
+
+
+def _rt_description(codec, desc: str) -> str | None:
+    intent = CanonicalIntent(
+        hostname="sw1",
+        interfaces=[CanonicalInterface(name="eth0", description=desc)],
+    )
+    reparsed = codec.parse(codec.render(intent))
+    return next((i.description for i in reparsed.interfaces), None)
+
+
+class TestFreeTextRoundTrip:
+    @pytest.mark.parametrize("codec_cls, cap", _CODECS)
+    @pytest.mark.parametrize("value", _VALUES)
+    def test_description_round_trips(self, codec_cls, cap, value):
+        expected = value[:cap] if cap is not None else value
+        assert _rt_description(codec_cls(), value) == expected
+
+    @pytest.mark.parametrize("codec_cls, cap", _CODECS)
+    def test_embedded_quote_is_escaped_in_render(self, codec_cls, cap):
+        """The rendered config must escape the inner quote (``\\"``) rather
+        than emit a bare ``"`` that closes the quoted literal early — that
+        is what makes the output valid on a real device."""
+        intent = CanonicalIntent(
+            hostname="sw1",
+            interfaces=[
+                CanonicalInterface(name="eth0", description='say "hi"'),
+            ],
+        )
+        out = codec_cls().render(intent)
+        # The escaped sequence appears; a bare unescaped ``"hi"`` fragment
+        # (quote-word-quote with no preceding backslash) does not.
+        assert '\\"' in out
+        assert 'say "hi"' not in out
+
+
+class TestVlanNameRoundTrip:
+    """aruba_aoss quotes the VLAN *name* free-text field too, and (unlike
+    mikrotik, which stores the human label on ``vlan.description`` and uses
+    the iface name as ``vlan.name`` by design) round-trips it verbatim."""
+
+    def test_aoss_vlan_name_with_quote_round_trips(self):
+        intent = CanonicalIntent(
+            hostname="sw1",
+            vlans=[CanonicalVlan(id=10, name='the "core" vlan')],
+        )
+        out = ArubaAOSSCodec().render(intent)
+        reparsed = ArubaAOSSCodec().parse(out)
+        v10 = next((v for v in reparsed.vlans if v.id == 10), None)
+        assert v10 is not None
+        assert v10.name == 'the "core" vlan'


### PR DESCRIPTION
## CODEC-1 / CODEC-3 — escape `"` and `\` in quoted free-text

From the 2026-07-03 Fable review's headline **"hardened path / un-hardened sibling"** pattern. `juniper_junos` escapes `"` / `\` inside its quoted free-text fields; three siblings quoted free-text without escaping, so an embedded double-quote closed the literal early — invalid on a real device and mangled on re-parse.

### Before (verify-first probe, `description = 'Link "A"\core'`)

| codec | rendered | reparsed | stable |
|---|---|---|---|
| fortigate_cli | `set alias "Link "A"\core"` | `Link A\core` | ❌ |
| aruba_aoss | `name "Link "A"\core"` | `Link` | ❌ |
| mikrotik | `comment="Link \"A\"\core"` | `Link \` | ❌ |
| *juniper_junos (reference)* | `description "Link \"A\"\\core"` | `Link "A"\core` | ✅ |

### Fix

- **fortigate_cli** — render-only (`_esc` on alias / snmp location+contact / static-route comment); parse already unescapes via `shlex.split(posix=True)`.
- **aruba_aoss** — render `_esc` on hostname / vlan name / iface description **+** parse-side: the `"?([^"\n]+)"?` name regexes truncated at the first inner quote, so they now capture the whole remainder and `_unquote` reverses the `\"`/`\\` escapes.
- **mikrotik_routeros (CODEC-3)** — `_escape` escaped `"` but **not** `\` (asymmetric with its own sibling `_quote_if_needed`, which already did both); `_KV_RE` / `_parse_kv` couldn't span an escaped quote. Now `_escape` doubles backslashes first, `_KV_RE` spans `\"`/`\\`, and `_parse_kv` unescapes.

Each NOS documentedly uses `\` as the in-quote escape introducer (Junos `display set`, FortiOS CLI, RouterOS scripting, AOS-S variable files), so the output is **deployment-valid** and the matched parse-side unescape keeps the netcanon round-trip **byte-stable**.

### VyOS deliberately excluded (verify-first)

VyOS's config validator **rejects an embedded double-quote in a value string even when escaped** ([T1246](https://vyos.dev/T1246); [forum](https://forum.vyos.io/t/cannot-use-the-double-quote-character-in-a-value-string-with-dhcp-server-shared-network-parameters/3088)), and its backslash handling is itself buggy ([T1001](https://vyos.dev/T1001)). Emitting `\"` there would still be invalid — the correct fix is **sanitise + declare-lossy**, a different and larger change tracked separately.

### Tests / gate

- New `tests/unit/migration/test_freetext_quote_escaping.py` — parametrised round-trip + render-escaping assertions across the three fixed codecs, plus an aruba VLAN-name case (24+ cases).
- 9-case edge probe (leading/trailing quote, lone/embedded backslash, mixed) passes on all three.
- **Full `tests/unit` + `tests/integration/test_cross_mesh_ci_guard.py` green: 5110 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
