### PR TITLE
fix(vyos): carry vif 802.1Q tag onto dot1q_vlan so routed sub-ifs cross-render valid — CODEC-2

### DIFF
--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -459,7 +459,17 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         if len(stk) == 2:
             return _touch_iface(arg, typ)
         if len(stk) == 3 and stk[2][0] == "vif" and stk[2][1]:
-            return _touch_iface(f"{arg}.{stk[2][1]}", "ethernet")
+            sc = _touch_iface(f"{arg}.{stk[2][1]}", "ethernet")
+            # A VyOS ``vif <vid>`` IS the 802.1Q tag of a routed
+            # sub-interface.  Record it on ``dot1q_vlan`` so cross-vendor
+            # targets emit a valid encapsulation (e.g. Cisco IOS
+            # ``encapsulation dot1Q <vid>``) instead of a tag-less — and
+            # therefore invalid — sub-interface.  Same-vendor render is
+            # unaffected: it reconstructs ``vif <vid>`` from the ``.<vid>``
+            # name suffix, not from this field.
+            if stk[2][1].isdigit():
+                sc["dot1q_vlan"] = int(stk[2][1])
+            return sc
         return None  # deeper nesting we don't model in v1
 
     for raw_line in raw.splitlines():
@@ -891,4 +901,5 @@ def _build_iface(sc: dict) -> CanonicalInterface:
         dhcp_client_v6=sc.get("dhcp_client_v6", ""),
         lag_member_of=sc.get("lag_member_of"),
         vrf=sc.get("vrf", ""),
+        dot1q_vlan=sc.get("dot1q_vlan"),
     )

--- a/tests/unit/migration/test_vyos.py
+++ b/tests/unit/migration/test_vyos.py
@@ -323,6 +323,32 @@ def test_parse_vif_subinterface(codec: VyOSCodec) -> None:
     assert vif.ipv4_addresses[0].ip == "10.0.100.1"
 
 
+def test_parse_vif_sets_dot1q_vlan(codec: VyOSCodec) -> None:
+    """CODEC-2 (2026-07-03 review): a VyOS ``vif <vid>`` IS the 802.1Q tag
+    of the routed sub-interface, so it must land on ``dot1q_vlan`` — not
+    just be encoded in the ``.<vid>`` name suffix.  Without it, targets
+    that need an explicit encapsulation (Cisco IOS et al.) emit a tag-less,
+    invalid sub-interface with a clean report."""
+    intent = codec.parse(_SAMPLE)
+    vif = next(i for i in intent.interfaces if i.name == "eth1.100")
+    assert vif.dot1q_vlan == 100
+    # The parent carries no tag.
+    parent = next(i for i in intent.interfaces if i.name == "eth1")
+    assert parent.dot1q_vlan is None
+
+
+def test_vif_renders_valid_ios_subinterface(codec: VyOSCodec) -> None:
+    """End-to-end: a VyOS ``vif`` must cross-render to a *valid* Cisco IOS
+    routed sub-interface — i.e. with ``encapsulation dot1Q <vid>``.  This
+    is the deployment-validity payoff of carrying ``dot1q_vlan`` (CODEC-2);
+    a routed IOS sub-interface without an encapsulation is rejected by the
+    device."""
+    intent = codec.parse(_SAMPLE)
+    out = get_codec("cisco_iosxe_cli").render(intent)
+    assert "interface eth1.100" in out
+    assert "encapsulation dot1Q 100" in out
+
+
 def test_parse_loopback_dual_stack(codec: VyOSCodec) -> None:
     lo = next(i for i in codec.parse(_SAMPLE).interfaces if i.name == "lo")
     assert lo.ipv4_addresses[0].ip == "192.0.2.255"


### PR DESCRIPTION
## CODEC-2 — VyOS `vif` must carry its 802.1Q tag onto `dot1q_vlan`

From the 2026-07-03 Fable review. A VyOS `ethernet ethN { vif <vid> { ... } }` block **is** a routed 802.1Q sub-interface, but the parser only encoded the tag in the canonical `ethN.<vid>` name suffix and left `dot1q_vlan` unset.

### Impact (verify-first probe)

```
interfaces { ethernet eth0 { vif 100 { address 10.0.100.1/24 ... } } }
```

Parsed → `eth0.100` with `dot1q_vlan=None`. Rendered to **Cisco IOS-XE CLI**:

```
interface eth0.100
 description tenant-100
 ip address 10.0.100.1 255.255.255.0          ← NO `encapsulation dot1Q 100`
```

A routed IOS sub-interface **without** an encapsulation is rejected by the device — an invalid config emitted with a clean (non-lossy) report.

### Fix

- On the vif branch in `parse_intent`, set `dot1q_vlan = int(<vid>)` and thread it through `_build_iface`.
- **Same-vendor render is byte-identical**: vyos render reconstructs `vif <vid>` from the `.<vid>` name suffix, not from this field, so vyos→vyos round-trip stays stable.
- Cross-vendor targets now receive the tag: vyos→cisco_iosxe_cli emits `encapsulation dot1Q 100`.

### Tests / gate

- `tests/unit/migration/test_vyos.py`: assert the parsed vif carries `dot1q_vlan=100` (parent stays `None`); assert a vyos vif cross-renders to a valid IOS sub-interface with the `encapsulation dot1Q 100` line.
- **Full `tests/unit` + `tests/integration/test_cross_mesh_ci_guard.py` green: 5084 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
