### PR TITLE
fix(codecs): raise ParseError (not raw ValueError) on malformed XML numeric fields — ROB-1

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -1148,7 +1148,17 @@ def _parse_subinterface(el: ET.Element, iface_idx: int = 0) -> dict[str, Any]:
     out: dict[str, Any] = {}
     idx_el = el.find(_q("index"))
     if idx_el is not None and idx_el.text is not None:
-        out["index"] = int(idx_el.text.strip())
+        try:
+            out["index"] = int(idx_el.text.strip())
+        except ValueError as e:
+            raise ParseError(
+                f"cisco_iosxe: non-integer subinterface <index> {idx_el.text!r}",
+                path=(
+                    f"/interfaces/interface[{iface_idx}]"
+                    "/subinterfaces/subinterface/index"
+                ),
+                snippet=(idx_el.text or "")[:120],
+            ) from e
 
     # <ipv4> block — IP augment namespace, but we strip and treat uniformly.
     ipv4_el = None

--- a/netcanon/migration/codecs/opnsense/parse.py
+++ b/netcanon/migration/codecs/opnsense/parse.py
@@ -421,7 +421,14 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         for vlan_el in vlans_el.findall("vlan"):
             tag_el = vlan_el.find("tag")
             if tag_el is not None and tag_el.text:
-                vid = int(tag_el.text.strip())
+                try:
+                    vid = int(tag_el.text.strip())
+                except ValueError as e:
+                    raise ParseError(
+                        f"opnsense: non-integer <tag> {tag_el.text!r}",
+                        path="/vlans/vlan/tag",
+                        snippet=(tag_el.text or "")[:120],
+                    ) from e
                 descr_el = vlan_el.find("descr")
                 intent.vlans.append(CanonicalVlan(
                     id=vid,

--- a/tests/unit/migration/test_cisco_iosxe.py
+++ b/tests/unit/migration/test_cisco_iosxe.py
@@ -321,6 +321,24 @@ class TestParseErrors:
         with pytest.raises(ParseError, match="non-integer prefix-length"):
             CiscoIOSXECodec().parse(raw)
 
+    def test_non_integer_subinterface_index_raises(self):
+        """ROB-1 (2026-07-03 review): a non-numeric ``<subinterface><index>``
+        must surface as a ParseError (→ clean 4xx), not a raw ValueError
+        that escapes the codec boundary and becomes an HTTP 500."""
+        raw = """<?xml version="1.0"?>
+<interfaces xmlns="http://openconfig.net/yang/interfaces">
+  <interface>
+    <name>eth0</name>
+    <subinterfaces>
+      <subinterface>
+        <index>notanumber</index>
+      </subinterface>
+    </subinterfaces>
+  </interface>
+</interfaces>"""
+        with pytest.raises(ParseError, match="non-integer subinterface <index>"):
+            CiscoIOSXECodec().parse(raw)
+
 
 # ---------------------------------------------------------------------------
 # Render + round-trip

--- a/tests/unit/migration/test_opnsense.py
+++ b/tests/unit/migration/test_opnsense.py
@@ -149,6 +149,15 @@ class TestParseErrors:
         with pytest.raises(ParseError, match="non-integer <subnet>"):
             OPNsenseCodec().parse(raw)
 
+    def test_non_integer_vlan_tag_raises(self):
+        """ROB-1 (2026-07-03 review): a non-numeric ``<vlan><tag>`` must
+        surface as a ParseError (→ clean 4xx), not a raw ValueError that
+        escapes the codec boundary and becomes an HTTP 500 on /sanitize."""
+        raw = """<?xml version="1.0"?>
+<opnsense><vlans><vlan><tag>abc</tag><descr>Users</descr></vlan></vlans></opnsense>"""
+        with pytest.raises(ParseError, match="non-integer <tag>"):
+            OPNsenseCodec().parse(raw)
+
 
 class TestParseTolerancePreamble:
     """Defensive: the parse() prefix-trim rescues OPNsense backups


### PR DESCRIPTION
## ROB-1 — malformed XML numeric field → HTTP 500

The **opnsense** and **cisco_iosxe** (XML) parsers coerced two XML fields with a bare `int()` that raises a raw `ValueError` on non-numeric input:

- `opnsense` `<vlans><vlan><tag>abc</tag>` → `ValueError: invalid literal for int()`
- `cisco_iosxe` `<subinterface><index>notanumber</index>` → same

The `CodecBase` class-boundary wrapper only converts pydantic `ValidationError` → `ParseError`, so a raw `ValueError` escaped the codec. Since the API `/sanitize` and `/plan` handlers only catch `ParseError`, that became an **HTTP 500** instead of a clean 4xx.

### Fix

Both sites now wrap the `int()` in `try/except ValueError` → `ParseError` (with a path + bounded snippet), mirroring the sibling guarded sites already present in each file (`opnsense` `<subnet>`, `cisco_iosxe` `mtu` / `prefix-length`). Loud 4xx, not a 500 — and **not** a silent skip (a non-numeric VLAN tag / subinterface index is genuinely malformed input the operator must see). Valid numeric input is unchanged, so no cross-vendor render output moves.

### Verify-first + gate

- Reproduced both raw `ValueError`s (investigator probe), confirmed both now raise `ParseError`, valid input unaffected.
- New tests: `test_non_integer_vlan_tag_raises` (opnsense) + `test_non_integer_subinterface_index_raises` (cisco_iosxe).
- **Full `tests/unit` + cross-mesh CI guard green: 5114 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
