### PR TITLE
fix(codecs): declare /vxlan-vnis/udp-port lossy on nxos + aoscx — MTX-1/2

### DIFF
--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -429,6 +429,19 @@ class ArubaAOSCXCodec(CodecBase):
                 ),
                 severity="warn",
             ),
+            LossyPath(
+                path="/vxlan-vnis/udp-port",
+                reason=(
+                    "Render emits the `interface vxlan 1` VTEP + per-VNI "
+                    "`vni`/`vlan` bindings but no UDP-port override, so a "
+                    "non-default VXLAN UDP port (e.g. the legacy 8472) is "
+                    "dropped on render and re-parses as the IANA default "
+                    "4789.  The VLAN↔VNI binding survives; only the custom "
+                    "port is lost.  Previously undeclared (classify() "
+                    "fail-opened to supported) — Fable review MTX-2."
+                ),
+                severity="warn",
+            ),
         ],
         unsupported=[
             UnsupportedPath(

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -169,7 +169,6 @@ class CiscoNXOSCodec(CodecBase):
             # VXLAN-EVPN (Phase 4) — L2 VLAN↔VNI + VTEP + L3VNI
             "/vxlan-vnis/vni",
             "/vxlan-vnis/source-interface",
-            "/vxlan-vnis/udp-port",
             "/vxlan-vnis/mcast-group",
             "/vxlan-vnis/flood-list",
             "/routing-instances/instance/l3-vni",
@@ -181,6 +180,20 @@ class CiscoNXOSCodec(CodecBase):
             "/anycast-gateway-mac",
         ],
         lossy=[
+            LossyPath(
+                path="/vxlan-vnis/udp-port",
+                reason=(
+                    "The NX-OS NVE render emits the VTEP source-interface + "
+                    "per-VNI `member vni` bindings but no `vxlan udp-port` "
+                    "override, so a non-default VXLAN UDP port (e.g. the "
+                    "legacy 8472) is dropped on render and re-parses as the "
+                    "IANA default 4789. The VNI binding survives; only the "
+                    "custom port is lost. Declared lossy so validate_against "
+                    "surfaces the drop instead of reporting severity:ok "
+                    "(was mis-declared supported — Fable review MTX-1)."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/routing-instances/instance/instance-type",
                 reason=(

--- a/tests/unit/migration/test_aruba_aoscx.py
+++ b/tests/unit/migration/test_aruba_aoscx.py
@@ -334,6 +334,33 @@ def test_render_vxlan_omits_non_ip_source(codec: ArubaAOSCXCodec) -> None:
     assert "source ip" not in out
 
 
+def test_non_default_udp_port_drops_on_render(codec: ArubaAOSCXCodec) -> None:
+    """MTX-2 (Fable review): the AOS-CX VTEP render emits no UDP-port
+    override, so a non-default VXLAN UDP port is dropped and re-parses as
+    the IANA default 4789 — the behaviour the ``/vxlan-vnis/udp-port``
+    lossy declaration describes.  Documented so a future change can't flip
+    the matrix back to (implicit) supported without preserving the port."""
+    from netcanon.migration.canonical.intent import (
+        CanonicalIntent,
+        CanonicalVxlan,
+    )
+    intent = CanonicalIntent(
+        hostname="leaf",
+        vxlan_vnis=[
+            CanonicalVxlan(
+                vlan_id=10, vni=10010, udp_port=8472,
+                source_interface="10.0.0.1",
+            ),
+        ],
+    )
+    out = codec.render(intent)
+    assert "8472" not in out
+    assert "udp-port" not in out
+    reparsed = codec.parse(out)
+    v = next(v for v in reparsed.vxlan_vnis if v.vni == 10010)
+    assert v.udp_port == 4789  # non-default silently normalised (lossy)
+
+
 def test_interface_l3_addressing(codec: ArubaAOSCXCodec) -> None:
     intent = codec.parse(_SAMPLE)
     by_name = {i.name: i for i in intent.interfaces}
@@ -630,6 +657,10 @@ def test_matrix_supported(codec: ArubaAOSCXCodec, path: str) -> None:
     "/snmp/v3-user/priv-passphrase",
     "/snmp/v3-user/group",
     "/vxlan-vnis/source-interface",
+    # Fable review MTX-2: the VTEP render emits no UDP-port override, so a
+    # non-default VXLAN UDP port drops on render (re-parses as 4789). Was
+    # undeclared (classify() fail-opened to supported).
+    "/vxlan-vnis/udp-port",
 ])
 def test_matrix_lossy(codec: ArubaAOSCXCodec, path: str) -> None:
     assert codec.capabilities.classify(path) == "lossy"

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -1263,6 +1263,30 @@ class TestPhase4VXLAN:
         assert "  member vni 10030" in out
         assert "    mcast-group 239.1.1.30" in out
 
+    def test_non_default_udp_port_drops_on_render(self, codec):
+        # MTX-1 (Fable review): a non-default VXLAN UDP port is not emitted
+        # (no `vxlan udp-port` line) and re-parses as the IANA default 4789.
+        # This is the behaviour the `/vxlan-vnis/udp-port` lossy declaration
+        # describes; the render-drop is documented here so a future "fix"
+        # can't quietly flip the matrix back to supported without preserving
+        # the port.
+        tree = CanonicalIntent(
+            hostname="X",
+            vlans=[CanonicalVlan(id=40, name="P")],
+            vxlan_vnis=[
+                CanonicalVxlan(
+                    vlan_id=40, vni=10040, udp_port=8472,
+                    source_interface="loopback0",
+                ),
+            ],
+        )
+        out = codec.render(tree)
+        assert "8472" not in out
+        assert "udp-port" not in out
+        reparsed = codec.parse(out)
+        v = next(v for v in reparsed.vxlan_vnis if v.vni == 10040)
+        assert v.udp_port == 4789  # non-default silently normalised (lossy)
+
     def test_mcast_group_parse_inline(self, codec):
         # Regression (gap-hunt): the inline ``member vni N mcast-group X``
         # form was never harvested — a matrix-`supported` surface lost
@@ -1353,7 +1377,6 @@ interface nve1
         caps = codec.capabilities
         for path in [
             "/vxlan-vnis/source-interface",
-            "/vxlan-vnis/udp-port",
             "/vxlan-vnis/mcast-group",
             "/vxlan-vnis/flood-list",
             "/routing-instances/instance/l3-vni",
@@ -1363,6 +1386,10 @@ interface nve1
         # evpn-type5 is lossy (modelled via the l3_vni VRF binding).
         assert caps.classify("/vxlan-vnis/vni") == "lossy"
         assert caps.classify("/evpn-type5-routes/route") == "lossy"
+        # udp-port: the NVE render emits no `vxlan udp-port` override, so a
+        # non-default port drops on render (re-parses as 4789). Declared
+        # lossy (was mis-declared supported — Fable review MTX-1).
+        assert caps.classify("/vxlan-vnis/udp-port") == "lossy"
         # IPv4 DAG anycast graduated; only the IPv6 companion is deferred.
         assert caps.classify("/anycast-gateway-mac") == "supported"
         # Demoted supported -> lossy (Bucket-C stage 3): DAG round-trips only


### PR DESCRIPTION
## MTX-1 / MTX-2 — silent VXLAN UDP-port drop with a clean report

`cisco_nxos` declared `/vxlan-vnis/udp-port` **supported**; `aruba_aoscx` declared it **nowhere** (so `classify()` fail-opened to implicit supported). Yet neither renders a `vxlan udp-port` override — so a non-default VXLAN UDP port (e.g. the legacy 8472) is dropped on render and re-parses as the IANA default 4789, while `validate_against` reported `severity: ok`. That's the inverse of netcanon's "declared-lossy is honest" paradigm: a silent normalization presented as lossless.

### Verify-first (investigator probe, reconfirmed)

```
cisco_nxos : render(udp_port=8472) → reparse 4789 ; classify(/vxlan-vnis/udp-port) = supported  (BEFORE)
aruba_aoscx: render(udp_port=8472) → reparse 4789 ; classify(/vxlan-vnis/udp-port) = supported  (BEFORE, implicit)
```

### Fix

Both now declare `/vxlan-vnis/udp-port` as `LossyPath(severity="warn")`, matching the sibling always-present-but-dropped VXLAN surfaces already declared lossy on each codec (`source-interface` / `mcast-group` / `flood-list`). **Matrix-only** — no render/parse code moves, so cross-vendor output is byte-unchanged and the cross-mesh guard is unaffected.

**Alternatives considered & rejected:** (a) actually rendering the port override — would change cross-mesh output and neither parser recovers it anyway; (b) guarding the shared xpath-walker to yield udp-port only when non-default — correct in principle (a prior review flagged the unconditional yield) but disproportionate here: it touches all 12 codecs + many `cross_vendor_expectations` fixtures. Tracked as a separate walker concern.

### Gate

- `classify(/vxlan-vnis/udp-port) == "lossy"` now for both; render-drop regressions assert 8472 is absent and reparses as 4789.
- nxos `test_phase4_matrix_graduated` updated (udp-port moved supported→lossy).
- **Full `tests/unit` + cross-mesh CI guard green: 5115 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
