### PR TITLE
fix(migration): de-freeze ship-before-wire roster (list_public_codecs) + close 2 anycast-mac gaps — MTX-3

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -371,6 +371,16 @@ class CiscoIOSXRCodec(CodecBase):
                     "stage 3)."
                 ),
             ),
+            UnsupportedPath(
+                path="/anycast-gateway-mac",
+                reason=(
+                    "Companion to the anycast virtual-gateway entries above: "
+                    "IOS-XR has no VARP / distributed-anycast-gateway grammar, "
+                    "so the chassis-wide anycast-gateway MAC is dropped on "
+                    "render. Previously undeclared (classify() fail-opened to "
+                    "supported) — Fable review MTX-3."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01) — this codec has no
             #    Cisco-style access/trunk port model, so the per-port VLAN
             #    membership the walker yields is dropped on render.  Declared

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -457,6 +457,16 @@ class VyOSCodec(CodecBase):
                     "drops on render (silent-loss guard, Bucket-C stage 3)."
                 ),
             ),
+            UnsupportedPath(
+                path="/anycast-gateway-mac",
+                reason=(
+                    "Companion to the anycast virtual-gateway entries above: "
+                    "VyOS has no VARP / distributed-anycast-gateway grammar, "
+                    "so the chassis-wide anycast-gateway MAC is dropped on "
+                    "render. Previously undeclared (classify() fail-opened to "
+                    "supported) — Fable review MTX-3."
+                ),
+            ),
             # ── L2 switchport surface (ENG-01) — this codec has no
             #    Cisco-style access/trunk port model, so the per-port VLAN
             #    membership the walker yields is dropped on render.  Declared

--- a/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
+++ b/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+import netcanon.migration  # noqa: F401  (side-effect: populate codec registry)
 from netcanon.migration.canonical.intent import (
     CanonicalIntent,
     CanonicalInterface,
@@ -29,8 +30,18 @@ from netcanon.migration.canonical.intent import (
     CanonicalStaticRoute,
     CanonicalVRRPGroup,
 )
+from netcanon.migration.codecs.registry import list_public_codecs
 
 pytestmark = pytest.mark.unit
+
+#: Ship-before-wire invariant roster — derived from the codec registry so a
+#: newly-added codec is checked automatically instead of being silently
+#: skipped.  A frozen 8-of-12 literal list previously let the 4 newest codecs
+#: (aruba_aoscx / cisco_iosxr / cisco_nxos / vyos) evade the invariant (Fable
+#: review MTX-3).  ``list_public_codecs`` already excludes the hidden ``mock``
+#: reference codec.  The ``import netcanon.migration`` above triggers the
+#: pkgutil auto-discovery that populates the registry at collection time.
+_SHIP_BEFORE_WIRE_ROSTER = sorted(list_public_codecs())
 
 
 # ---------------------------------------------------------------------------
@@ -400,34 +411,44 @@ class TestShipBeforeWireUnsupportedDeclarations:
         "opnsense": {
             "/interfaces/interface/vrrp-groups/group",
         },
+        # The four newest codecs — previously omitted from the frozen
+        # roster (Fable review MTX-3), so their graduations were never
+        # invariant-checked.  Entries below reflect each matrix's ACTUAL
+        # graduated (supported / lossy) paths, verified against the
+        # explicit capability lists.
+        # AOS-CX: VARP active-gateway (ipv4 anycast VIP + the chassis MAC)
+        # graduated; VRRP / IPv6-anycast / per-VRF static / routed
+        # sub-interface stay unsupported.
+        "aruba_aoscx": {
+            "/interfaces/interface/ipv4/address/virtual-gateway-address",
+            "/anycast-gateway-mac",
+        },
+        # IOS-XR: per-VRF static routes + routed sub-interface dot1q
+        # graduated (v0.1.5 GAP-7); VRRP / anycast stay unsupported.
+        "cisco_iosxr": {
+            "/routing/static-route/vrf",
+            "/interfaces/interface/dot1q-vlan",
+        },
+        # NX-OS: HSRP (VRRP-group lossy) + DAG anycast (ipv4 VARP lossy,
+        # chassis anycast-gateway-mac supported) + per-VRF static +
+        # routed sub-interface dot1q all graduated; only IPv6 anycast
+        # stays unsupported.
+        "cisco_nxos": {
+            "/interfaces/interface/vrrp-groups/group",
+            "/interfaces/interface/ipv4/address/virtual-gateway-address",
+            "/anycast-gateway-mac",
+            "/routing/static-route/vrf",
+            "/interfaces/interface/dot1q-vlan",
+        },
+        # VyOS: none of the six graduated yet — every new path stays
+        # unsupported (ship-before-wire).
+        "vyos": set(),
     }
 
-    @pytest.mark.parametrize(
-        "codec_name",
-        [
-            "cisco_iosxe_cli",
-            "cisco_iosxe",
-            "juniper_junos",
-            "arista_eos",
-            "aruba_aoss",
-            "fortigate_cli",
-            "mikrotik_routeros",
-            "opnsense",
-        ],
-    )
+    @pytest.mark.parametrize("codec_name", _SHIP_BEFORE_WIRE_ROSTER)
     def test_codec_declares_new_paths_unsupported(self, codec_name):
-        # Side-effect import to populate the registry — uses the same
-        # mechanism as test_real_captures.py.
-        from netcanon.migration.codecs import (  # noqa: F401
-            arista_eos,
-            aruba_aoss,
-            cisco_iosxe,
-            cisco_iosxe_cli,
-            fortigate_cli,
-            juniper_junos,
-            mikrotik_routeros,
-            opnsense,
-        )
+        # Registry is populated at import time (see the module-level
+        # ``import netcanon.migration`` + ``_SHIP_BEFORE_WIRE_ROSTER``).
         from netcanon.migration.codecs.registry import get_codec
 
         codec = get_codec(codec_name)
@@ -469,3 +490,17 @@ class TestShipBeforeWireUnsupportedDeclarations:
                 f"{path!r} to "
                 f"_WIRED_UP_BY_CODEC[{codec_name!r}]."
             )
+
+    def test_roster_covers_every_public_codec(self):
+        """The invariant roster MUST equal the live public-codec registry —
+        guards against silently re-freezing it to a literal list (the
+        MTX-3 regression, where 4 of 12 codecs went unchecked).  A new
+        codec added to the registry is then auto-included here, and the
+        hidden ``mock`` codec must never leak into the roster."""
+        assert set(_SHIP_BEFORE_WIRE_ROSTER) == set(list_public_codecs())
+        assert "mock" not in _SHIP_BEFORE_WIRE_ROSTER
+        # Every rostered codec has an explicit wire-up entry (even if an
+        # empty set) OR relies on the ``.get(..., set())`` default; assert
+        # the map has no stale entry for a codec no longer in the registry.
+        stale = set(self._WIRED_UP_BY_CODEC) - set(_SHIP_BEFORE_WIRE_ROSTER)
+        assert not stale, f"_WIRED_UP_BY_CODEC has stale codec(s): {stale}"


### PR DESCRIPTION
## MTX-3 — a frozen invariant roster that skipped 4 of 12 codecs

`TestShipBeforeWireUnsupportedDeclarations` (the two-sided guard that every codec either declares a new canonical surface `unsupported` **or** lists it in `_WIRED_UP_BY_CODEC` as graduated) parametrized over a **hardcoded 8-codec list**. The 4 newest codecs — `aruba_aoscx`, `cisco_iosxr`, `cisco_nxos`, `vyos` — were silently never checked. Flagged by **both** the test-quality and schema-matrix review agents.

### Fix

- **De-freeze:** the roster now derives from `registry.list_public_codecs()` (12 codecs; the hidden `mock` codec is already excluded). A module-level `import netcanon.migration` triggers auto-discovery at collection time. New guard `test_roster_covers_every_public_codec` asserts `roster == list_public_codecs()`, `mock` absent, and no stale wire-up entries — so it can't re-freeze to a literal.
- **Wire-up map:** added `_WIRED_UP_BY_CODEC` entries for the 4 codecs, values verified against each matrix's **explicit** supported/lossy lists (probe):
  - `aruba_aoscx` → ipv4 virtual-gateway-address, anycast-gateway-mac
  - `cisco_iosxr` → static-route/vrf, dot1q-vlan
  - `cisco_nxos` → vrrp-groups/group, ipv4 virtual-gateway-address, anycast-gateway-mac, static-route/vrf, dot1q-vlan
  - `vyos` → (none graduated)

### 2 genuine honesty gaps surfaced (and fixed here)

Wiring the codecs revealed that **`cisco_iosxr` and `vyos` declared `/anycast-gateway-mac` in *none* of supported/lossy/unsupported** → `classify()` fail-opened to supported for a surface neither can render. Both now declare it **`unsupported`** (neither has VARP / distributed-anycast-gateway grammar), matching their sibling anycast `virtual-gateway-address` entries. These were **not** papered over with fake wire-up entries — declaring the drop is the honest fix the invariant exists to force.

### Gate

- Invariant now runs over **all 12** public codecs (was 8) and passes; roster guard passes.
- **Full `tests/unit` + cross-mesh CI guard green: 5117 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
