### PR TITLE
fix(vyos): sanitise embedded double-quotes in free-text so config stays valid — CODEC-1 carve-out

### DIFF
--- a/netcanon/migration/codecs/vyos/render.py
+++ b/netcanon/migration/codecs/vyos/render.py
@@ -36,9 +36,12 @@ Grammar notes that shape the output (see
 
 from __future__ import annotations
 
+import logging
 import re
 
 from ...canonical.intent import CanonicalIntent
+
+logger = logging.getLogger(__name__)
 
 #: Stamped into the ``// vyos-config-version`` trailer.  Cosmetic — the
 #: parser skips the trailer entirely (the probe only substring-matches
@@ -103,7 +106,37 @@ def render_intent(tree: CanonicalIntent) -> str:
 
 
 def _q(value: str) -> str:
-    """Double-quote a leaf value (VyOS 1.4+ ``show configuration`` style)."""
+    """Double-quote a leaf value (VyOS 1.4+ ``show configuration`` style).
+
+    VyOS is the odd codec out on embedded double-quotes.  Every other
+    quoted-free-text codec (``juniper_junos`` / ``fortigate_cli`` /
+    ``aruba_aoss`` / ``mikrotik_routeros``) *escapes* an inner ``"`` as
+    ``\\"`` — but VyOS's config parser **rejects an embedded double-quote in
+    a value string even when backslash-escaped** (vyos.dev/T1246), and its
+    backslash handling is itself buggy (T1001).  So escaping here would still
+    produce a config the device refuses to load.
+
+    Instead we **sanitise**: an embedded ``"`` is replaced with an apostrophe
+    (an ordinary character inside a VyOS value) so the rendered leaf is valid
+    on-device.  This is a genuine — but rare — alteration of cross-vendor
+    free-text: an operator can't normally type an embedded double-quote into
+    a VyOS description, so this only bites a description / snmp
+    contact-or-location / vrf value carried in from another vendor.  Because
+    ``validate_against`` classifies per-*path* (value-blind), a matrix
+    ``LossyPath`` on ``description`` would warn on every description — the
+    common no-quote case included — so the honest, value-specific signal is a
+    log line emitted only when a substitution actually happens.  Structured
+    values (IP / prefix) never contain a quote, so this is a no-op for them.
+    """
+    if '"' in value:
+        logger.warning(
+            "vyos render: replaced %d embedded double-quote(s) with "
+            "apostrophes in a free-text value — VyOS rejects embedded "
+            "quotes in value strings even when escaped (vyos.dev/T1246); "
+            "the value's punctuation was altered to keep the config valid.",
+            value.count('"'),
+        )
+        value = value.replace('"', "'")
     return f'"{value}"'
 
 

--- a/tests/unit/migration/test_vyos.py
+++ b/tests/unit/migration/test_vyos.py
@@ -808,6 +808,73 @@ def test_render_vif_nested_under_parent(codec: VyOSCodec) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Free-text quote sanitisation (CODEC-1 VyOS carve-out)
+# ---------------------------------------------------------------------------
+
+
+class TestFreeTextQuoteSanitise:
+    """VyOS rejects an embedded double-quote in a value string even when
+    backslash-escaped (vyos.dev/T1246), so — unlike the escape-codecs — the
+    vyos renderer SANITISES an embedded ``"`` to an apostrophe to keep the
+    config valid on-device.  These tests assert deployment-VALIDITY of the
+    rendered text (the number of ``"`` on the leaf line is exactly the
+    wrapping pair), NOT a parse(render())==tree round-trip — the lenient
+    ``_unquote`` would pass the round-trip even with the bug present.
+    """
+
+    @staticmethod
+    def _leaf(out: str, key: str) -> str:
+        return next(ln for ln in out.splitlines() if ln.strip().startswith(key))
+
+    def test_interface_description_quote_is_sanitised(self, codec):
+        from netcanon.migration.canonical.intent import (
+            CanonicalIntent,
+            CanonicalInterface,
+        )
+        intent = CanonicalIntent(
+            hostname="r1",
+            interfaces=[
+                CanonicalInterface(name="eth0", description='link to "core"'),
+            ],
+        )
+        line = self._leaf(codec.render(intent), "description")
+        # Exactly the wrapping pair — no embedded (value-breaking) quote.
+        assert line.count('"') == 2, line
+        assert "'core'" in line          # sanitised to apostrophes
+        assert 'description "' in line
+
+    def test_snmp_contact_and_location_quotes_sanitised(self, codec):
+        from netcanon.migration.canonical.intent import (
+            CanonicalIntent,
+            CanonicalSNMP,
+        )
+        intent = CanonicalIntent(
+            hostname="r1",
+            snmp=CanonicalSNMP(
+                contact='the "netops" team',
+                location='rack "A"',
+            ),
+        )
+        out = codec.render(intent)
+        assert self._leaf(out, "contact").count('"') == 2
+        assert self._leaf(out, "location").count('"') == 2
+
+    def test_plain_description_is_untouched(self, codec):
+        from netcanon.migration.canonical.intent import (
+            CanonicalIntent,
+            CanonicalInterface,
+        )
+        intent = CanonicalIntent(
+            hostname="r1",
+            interfaces=[
+                CanonicalInterface(name="eth0", description="plain uplink"),
+            ],
+        )
+        line = self._leaf(codec.render(intent), "description")
+        assert line.strip() == 'description "plain uplink"'
+
+
+# ---------------------------------------------------------------------------
 # Capability matrix
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## VyOS free-text quote sanitise — the CODEC-1 carve-out

[#275](https://github.com/netcanon/netcanon/pull/275) fixed free-text quote handling for four codecs by **escaping** `"`→`\"`, but deliberately **excluded VyOS**: VyOS's config parser rejects an embedded double-quote in a value string *even when backslash-escaped* ([T1246](https://vyos.dev/T1246)), and its backslash handling is itself buggy ([T1001](https://vyos.dev/T1001)) — escaping would still emit an un-loadable config.

### Bug

`_q` wrapped values in `"…"` with no sanitisation, so a cross-vendor free-text value carrying an embedded `"` rendered as invalid VyOS: `description "link to "core""`. netcanon's lenient `_unquote` (strips only the outer pair) **masked** it — the internal round-trip stayed byte-stable while the emitted config was un-loadable on-device.

### Fix

`_q` (the single free-text chokepoint — covers description / snmp contact+location / vrf at once) now replaces an embedded `"` with an apostrophe, an ordinary character inside a VyOS value. Structured values (IP/prefix) never contain a quote → no-op.

### Why not a matrix `LossyPath`?

`classify_tree` records **one lossy entry per occurrence**, so declaring `description` lossy would warn on *every* description (the common no-quote case) → alert fatigue. The substitution is instead surfaced **value-specifically** via a `logger.warning` emitted **only when a quote is actually replaced** — logging the **count**, never the value (CodeQL-safe, per the codec-parse logging gotcha).

### Verify / gate

- `link to "core"` → `description "link to 'core'"` (exactly the wrapping pair; on-device-valid). Plain description untouched. Log fires only on substitution.
- Tests assert deployment-**validity** (quote count on the leaf line), not the lenient round-trip.
- **Full `tests/unit` + cross-mesh CI guard green: 5115 passed, 81 skipped.** ruff clean.

**NB:** exact VyOS acceptance was reasoned from T1246 + docs, not device-validated (the dogfood VM lab is parked); the sanitise is conservative (removes only the one value-breaking character).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
