### PR TITLE
fix(security): 4 minor hardening wins from the Fable review (SEC-3/6/10/11)

### DIFF
--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -46,7 +46,14 @@ import logging
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Path,
+    Request,
+)
 from pydantic import SecretStr
 
 # ``get_collector`` is imported here — and only here — to preserve the
@@ -259,7 +266,18 @@ def list_jobs(
     summary="Get a backup job by ID",
 )
 def get_job(
-    job_id: str,
+    job_id: str = Path(
+        ...,
+        # Job ids are `str(uuid.uuid4())`; constrain to the exact UUID shape
+        # so a crafted id (e.g. a URL-encoded `\`, a real path separator on
+        # Windows) can never reach the file-store path join as a traversal /
+        # existence-oracle vector.  Mirrors the FileConfigStore filename
+        # guard on the sibling config routes (SEC-3).
+        pattern=(
+            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+            r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        ),
+    ),
     jobs: BackupJobRegistry = Depends(get_jobs),
 ) -> BackupJob:
     """Return the current state of a backup job.

--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -128,7 +128,10 @@ class MigrationDetectRequest(BaseModel):
     input modes (paste vs. stored-config) on a single endpoint.
     """
 
-    raw_text: str | None = None
+    # Cap the pasted-config body at 10 MB, matching MigrationPlanRequest —
+    # otherwise /detect buffers an unbounded body while /plan is capped
+    # (SEC-10 DoS-surface parity).
+    raw_text: str | None = Field(default=None, max_length=10_000_000)
     source_filename: str | None = None
     min_confidence: int = Field(default=1, ge=0, le=100)
 

--- a/netcanon/migration/canonical/snmp_names.py
+++ b/netcanon/migration/canonical/snmp_names.py
@@ -146,11 +146,14 @@ def translate_snmp_community(
     current_community = ""
     if isinstance(intent, CanonicalIntent) and intent.snmp is not None:
         current_community = intent.snmp.community or ""
+    # The SNMP community is a shared secret — log only its presence, never
+    # its value (CodeQL py/clear-text-logging-sensitive-data), matching the
+    # count-only convention of the three sibling per-pane orchestrators.
     logger.debug(
-        "translate_snmp_community: entry rename_map=%s current=%r",
+        "translate_snmp_community: entry rename_map=%s has_community=%s",
         "None" if rename_map is None
         else f"{len(rename_map)}-entry dict",
-        current_community,
+        bool(current_community),
     )
 
     result = SnmpRenameResult()
@@ -204,17 +207,21 @@ def translate_snmp_community(
     matched = False
     for src, tgt in valid_map.items():
         if src != current:
+            # Do NOT interpolate the parsed community value: these warnings
+            # surface to the operator (SnmpRenameResult.warnings) and land in
+            # logs — the community is a shared secret. Name the source key
+            # (operator-supplied) only.
             result.warnings.append(
                 f"snmp_community_rename: source name {src!r} does not "
-                f"match parsed community {current!r} — rewrite skipped"
+                f"match the parsed community — rewrite skipped"
             )
             continue
         if matched:
             # Defensive — shouldn't happen because src is compared
             # literally and the current community is a single string.
             result.warnings.append(
-                f"snmp_community_rename: multiple entries matched "
-                f"community {current!r}; using first"
+                "snmp_community_rename: multiple entries matched the parsed "
+                "community; using the first"
             )
             continue
         if tgt is None:

--- a/netcanon/services/egress.py
+++ b/netcanon/services/egress.py
@@ -36,19 +36,26 @@ class EgressBlocked(Exception):
 
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    """A target IP is blocked if it is loopback or link-local.
+    """A target IP is blocked if it is loopback, link-local or unspecified.
 
     ``is_link_local`` covers ``169.254.0.0/16`` (and ``fe80::/10``), which
     includes the ``169.254.169.254`` cloud-metadata endpoint.
+
+    ``is_unspecified`` covers ``0.0.0.0`` and ``::`` — on many stacks a
+    connect to the unspecified address routes to loopback, so without this
+    check the allow-list could be bypassed to reach a loopback service.
 
     IPv4-mapped IPv6 literals (``::ffff:127.0.0.1``) parse as IPv6 and would
     otherwise sidestep the IPv4 loopback/link-local checks, so the embedded
     IPv4 address is unwrapped and re-checked.
     """
-    if ip.is_loopback or ip.is_link_local:
+    if ip.is_loopback or ip.is_link_local or ip.is_unspecified:
         return True
     mapped = getattr(ip, "ipv4_mapped", None)
-    return bool(mapped is not None and (mapped.is_loopback or mapped.is_link_local))
+    return bool(
+        mapped is not None
+        and (mapped.is_loopback or mapped.is_link_local or mapped.is_unspecified)
+    )
 
 
 def assert_egress_allowed(host: str) -> None:

--- a/tests/integration/test_backups_api.py
+++ b/tests/integration/test_backups_api.py
@@ -541,12 +541,31 @@ class TestGetJob:
         assert resp.json()["status"] == "completed"
 
     def test_get_nonexistent_job_returns_404(self, client):
-        resp = client.get("/api/v1/backups/nonexistent-id")
+        # A well-formed-but-unknown UUID reaches the handler and 404s.
+        resp = client.get(
+            "/api/v1/backups/00000000-0000-0000-0000-000000000000"
+        )
         assert resp.status_code == 404
 
     def test_404_detail_mentions_job_id(self, client):
-        resp = client.get("/api/v1/backups/missing-id-123")
-        assert "missing-id-123" in resp.json()["detail"]
+        missing = "11111111-2222-3333-4444-555555555555"
+        resp = client.get(f"/api/v1/backups/{missing}")
+        assert missing in resp.json()["detail"]
+
+    def test_malformed_job_id_rejected_422_not_reaching_store(self, client):
+        """SEC-3 (2026-07-03 review): a non-UUID job_id must be rejected by
+        the route's UUID pattern (422) before it can reach the file-store
+        path join as a traversal or existence-oracle vector. (A payload
+        containing an encoded separator decodes to a multi-segment path and
+        never matches the single-segment route at all — also safe.)"""
+        for bad in (
+            "nonexistent-id",
+            "a" * 40,                                   # right-ish length, non-hex
+            "..%5C..%5Cwindows",                        # encoded backslash, single seg
+            "11111111-2222-3333-4444-55555555555",      # 35 hex — one short
+        ):
+            resp = client.get(f"/api/v1/backups/{bad}")
+            assert resp.status_code == 422, (bad, resp.status_code)
 
     def test_job_has_results(self, client):
         job_id = _post_backup(client).json()["id"]

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -1703,6 +1703,15 @@ class TestOpnsenseParamikoShellEchoRescue:
 
 
 class TestDetectEndpoint:
+    def test_detect_oversized_raw_text_rejected_422(self, client):
+        """SEC-10 (2026-07-03 review): /detect must cap raw_text at 10 MB
+        like /plan, so it can't be used to buffer an unbounded body."""
+        resp = client.post(
+            "/api/v1/migration/detect",
+            json={"raw_text": "x" * 10_000_001},
+        )
+        assert resp.status_code == 422
+
     def test_detect_opnsense_xml(self, client):
         resp = client.post(
             "/api/v1/migration/detect",

--- a/tests/unit/migration/test_snmp_names.py
+++ b/tests/unit/migration/test_snmp_names.py
@@ -207,6 +207,18 @@ class TestEdgeCases:
         assert "does not match" in result.warnings[0]
         assert intent.snmp.community == "public"  # unchanged
 
+    def test_community_value_never_appears_in_warnings(self):
+        """SEC-6 (2026-07-03 review): the SNMP community is a shared secret;
+        the operator-visible warnings (and the DEBUG entry log) must name the
+        source rename key but NEVER echo the parsed community value."""
+        intent = _tree_with_snmp(community="S3CRET-COMMUNITY")
+        result = translate_snmp_community(
+            intent, rename_map={"wrong-src": "monitoring-ro"},
+        )
+        assert result.warnings  # a non-match warning fired
+        assert all("S3CRET-COMMUNITY" not in w for w in result.warnings)
+        assert any("wrong-src" in w for w in result.warnings)  # key still named
+
     def test_empty_community_with_override(self):
         """Source has a bare SNMP block with location but no
         community.  Operator's rename map can't match (current

--- a/tests/unit/test_egress.py
+++ b/tests/unit/test_egress.py
@@ -27,6 +27,9 @@ pytestmark = pytest.mark.unit
         "fe80::1",
         "::ffff:127.0.0.1",      # IPv4-mapped IPv6 loopback (bypass guard)
         "::ffff:169.254.169.254",  # IPv4-mapped metadata endpoint
+        "0.0.0.0",               # SEC-11: unspecified — routes to loopback
+        "::",                    # SEC-11: IPv6 unspecified
+        "::ffff:0.0.0.0",        # SEC-11: IPv4-mapped unspecified
     ],
 )
 def test_loopback_and_link_local_are_blocked(host: str) -> None:


### PR DESCRIPTION
## MINOR security batch — SEC-3 / SEC-6 / SEC-10 / SEC-11

Four cheap, low-risk security-minor fixes from the Fable review's MINOR tail, all verify-first reproduced.

| ID | Fix |
|---|---|
| **SEC-3** | `/api/v1/backups/{job_id}` took a bare `str` into the file-store path join (the sibling `FileConfigStore` has a `_FILENAME_RE` + `is_relative_to` guard). `job.id` is a uuid4, so the route param now carries a strict **UUID `pattern=`** — a crafted id (encoded separator, non-hex) **422s** before reaching the store, closing the traversal + existence-oracle. |
| **SEC-6** | The SNMP community (a shared secret) was logged verbatim at DEBUG (`current=%r`) and echoed into two operator-visible rename warnings, while the sibling orchestrators log counts only. Now logs **presence** (`has_community=%s`); warnings name only the operator-supplied source key. |
| **SEC-10** | `MigrationDetectRequest.raw_text` had **no** `max_length` while `/plan` caps at 10 MB — added the same 10 MB cap for DoS-surface parity. |
| **SEC-11** | The egress allow-list blocked loopback/link-local but **not** the unspecified address; `0.0.0.0` / `::` route to loopback on many stacks, bypassing the guard. Now blocked via `is_unspecified` (incl. the IPv4-mapped form). |

### Triaged and NOT fixed (from the same cluster)
- **SEC-8** (CSRF on `/open`) — accepted: off by default, feature-flag-gated, same-machine-only.
- **SEC-12** (known_hosts TOFU race) — **non-issue** (verify-first): the shared file is only ever written under `_KNOWN_HOSTS_LOCK`; `AutoAddPolicy`'s connect-time add is in-memory only.

### Gate
- New tests: egress `0.0.0.0`/`::`/mapped blocked; community value absent from warnings; malformed `job_id` → 422 (well-formed-unknown UUID still 404); oversized `/detect` body → 422.
- **Full `tests/unit` + touched integration files + cross-mesh CI guard green: 5288 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
