### PR TITLE
fix(robustness): 4 minor concurrency/robustness edge fixes (CONC-4/6/8/9)

### DIFF
--- a/netcanon/api/routes/configs.py
+++ b/netcanon/api/routes/configs.py
@@ -316,8 +316,17 @@ def diff_configs(
             },
         )
 
-    left_text = storage.get_content(body.left)
-    right_text = storage.get_content(body.right)
+    # CONC-9: a config deleted between the list_configs() snapshot above and
+    # this read is a TOCTOU — surface it as 404 (matching the single-config
+    # routes' FileNotFoundError handling) rather than letting the raw
+    # FileNotFoundError fall through to the global handler as a 500.
+    try:
+        left_text = storage.get_content(body.left)
+        right_text = storage.get_content(body.right)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"Config not found: {exc}"
+        ) from exc
     report = compute_diff(
         left_rec, left_text, right_rec, right_text, force=body.force
     )

--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -145,13 +145,21 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
     from ...models.device import BackupRequest, DeviceCredentials, DeviceTarget
     from ...models.device_profile import DeviceProfile
     from ...services.backup_runner import run_backup_job
+    from ...storage.device_profile_store import DEVICE_PROFILE_REGISTRY_LOCK
 
     schedules = app.state.schedules
     schedule = schedules.get(schedule_id)
     if not schedule or not schedule.enabled:
         return
 
-    device_profiles: dict[str, DeviceProfile] = app.state.device_profiles
+    # Snapshot the shared device-profile registry under its lock (CONC-6):
+    # this coroutine runs on the scheduler/event-loop thread while the
+    # create/update/delete routes mutate the same dict from FastAPI's
+    # threadpool. Iterating the live dict raced a mutation -> "dictionary
+    # changed size during iteration" RuntimeError that silently skipped the
+    # whole scheduled run. The lock is held only for the O(n) copy.
+    with DEVICE_PROFILE_REGISTRY_LOCK:
+        device_profiles: dict[str, DeviceProfile] = dict(app.state.device_profiles)
 
     # Resolve target devices (new-style: profile-based).
     # Build a type_key index for O(n) instead of O(n*m) resolution.

--- a/netcanon/api/routes/ui.py
+++ b/netcanon/api/routes/ui.py
@@ -332,8 +332,16 @@ def diff_page(
             },
         )
 
-    left_text = storage.get_content(left)
-    right_text = storage.get_content(right)
+    # CONC-9: a config deleted between the list_configs() resolution above and
+    # this read is a TOCTOU — raise 404 (rendered as the themed error page by
+    # the StarletteHTTPException handler) instead of a raw FileNotFoundError 500.
+    try:
+        left_text = storage.get_content(left)
+        right_text = storage.get_content(right)
+    except FileNotFoundError as exc:
+        raise StarletteHTTPException(
+            status_code=404, detail=f"Config not found: {exc}"
+        ) from exc
     report: DiffReport = compute_diff(
         left_rec, left_text, right_rec, right_text, force=force
     )

--- a/netcanon/collectors/paramiko_collector.py
+++ b/netcanon/collectors/paramiko_collector.py
@@ -178,19 +178,24 @@ class ParamikoShellCollector(BaseCollector):
             device.port,
             device.credentials.username,
         )
-        client.connect(
-            hostname=device.host,
-            port=device.port,
-            username=device.credentials.username,
-            password=device.credentials.password.get_secret_value(),
-            timeout=_CONNECT_TIMEOUT,
-            look_for_keys=False,
-            allow_agent=False,
-        )
-        # TOFU: persist the (possibly newly-learned) host key for next time.
-        persist_paramiko_host_keys(client, settings)
-
+        # CONC-8: connect + host-key persist live INSIDE the try so the
+        # finally's client.close() also covers a connect/auth failure —
+        # otherwise a failed connect propagated without closing the client,
+        # leaking it (and its socket/Transport) on a repeatedly-unreachable
+        # device.
         try:
+            client.connect(
+                hostname=device.host,
+                port=device.port,
+                username=device.credentials.username,
+                password=device.credentials.password.get_secret_value(),
+                timeout=_CONNECT_TIMEOUT,
+                look_for_keys=False,
+                allow_agent=False,
+            )
+            # TOFU: persist the (possibly newly-learned) host key for next time.
+            persist_paramiko_host_keys(client, settings)
+
             shell = client.invoke_shell(width=220, height=50)
             time.sleep(2)
             initial = self._drain(shell)
@@ -291,6 +296,7 @@ class ParamikoShellCollector(BaseCollector):
                 device.host,
                 exc,
             )
+            client.close()  # CONC-8: don't leak the client on connect failure
             return {}
 
         try:

--- a/netcanon/storage/file_store.py
+++ b/netcanon/storage/file_store.py
@@ -218,7 +218,12 @@ class FileConfigStore(BaseConfigStore):
         """
         records: list[ConfigRecord] = []
         for path in self._dir.rglob("*"):
-            if path.is_file():
+            # Skip half-written atomic-save artifacts: a crash between the
+            # temp write and the rename leaves a `<stem>.tmp` that matches
+            # _FILENAME_RE and would otherwise be listed (and downloadable)
+            # as a real config (CONC-4). Mirrors the sidecar `.meta.json`
+            # handling.
+            if path.is_file() and path.suffix != ".tmp":
                 record = self._parse_filename(path)
                 if record is not None:
                     meta_path = path.parent / f"{path.name}.meta.json"
@@ -311,7 +316,9 @@ class FileConfigStore(BaseConfigStore):
         """
         moved = 0
         for path in list(self._dir.iterdir()):
-            if not path.is_file():
+            if not path.is_file() or path.suffix == ".tmp":
+                # A crash-orphaned `.tmp` matches _FILENAME_RE; don't migrate
+                # it into a subdir as if it were a real config (CONC-4).
                 continue
             m = _FILENAME_RE.match(path.name)
             if not m:

--- a/tests/integration/test_configs_api.py
+++ b/tests/integration/test_configs_api.py
@@ -354,6 +354,22 @@ class TestDiffCompatibility:
         )
         assert resp.status_code == 404
 
+    def test_diff_deleted_mid_read_returns_404_not_500(self, client, monkeypatch):
+        """CONC-9 (2026-07-03 review): a config deleted between the
+        list_configs() resolution and the get_content() read (TOCTOU) must
+        surface as 404, not a raw FileNotFoundError → 500."""
+        a = _seed_config_of_type(client, "Cisco", "10.9.9.1")
+        b = _seed_config_of_type(client, "Cisco", "10.9.9.2")
+
+        def _deleted(filename):
+            raise FileNotFoundError(filename)
+
+        monkeypatch.setattr(client.app.state.storage, "get_content", _deleted)
+        resp = client.post(
+            "/api/v1/configs/diff", json={"left": a, "right": b},
+        )
+        assert resp.status_code == 404
+
 
 class TestDiffEfficiency:
     """blind-audit 276eaeb T0-5: a two-sided diff resolves both records from

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -247,6 +247,20 @@ class TestFileConfigStoreList:
         store = FileConfigStore(tmp_path)
         assert store.list_configs() == []
 
+    def test_list_ignores_orphaned_tmp_files(self, tmp_path: Path):
+        """CONC-4 (2026-07-03 review): a crash between the atomic-save temp
+        write and the rename leaves a `<stem>.tmp` that matches _FILENAME_RE;
+        it must NOT be listed (nor downloadable) as a real config."""
+        store = FileConfigStore(tmp_path)
+        rec = store.save("Cisco", "1.2.3.4", _ts(), "cfg", "real")
+        # Simulate the crash artifact next to the real file.
+        real_path = tmp_path / "Cisco" / "1-2-3-4" / rec.filename
+        orphan = real_path.with_suffix(".tmp")
+        orphan.write_text("half-written", encoding="utf-8")
+        listed = {r.filename for r in store.list_configs()}
+        assert rec.filename in listed
+        assert not any(name.endswith(".tmp") for name in listed)
+
     def test_list_multiple_device_types(self, tmp_path: Path):
         store = FileConfigStore(tmp_path)
         store.save("Cisco", "1.1.1.1", _ts(second=0), "cfg", "cisco")


### PR DESCRIPTION
## MINOR concurrency/robustness batch — CONC-4 / CONC-6 / CONC-8 / CONC-9

Four cheap, low-risk edge-case fixes from the Fable review's MINOR tail, all verify-first reproduced.

| ID | Fix |
|---|---|
| **CONC-6** | The scheduler iterated the shared `device_profiles` dict on the event-loop thread with **no lock**, while create/update/delete routes mutate it from the threadpool (`DEVICE_PROFILE_REGISTRY_LOCK` is held by every mutator but not this reader). A mid-iteration mutation raised *"dictionary changed size during iteration"* and **silently skipped the whole scheduled run**. Now snapshots `dict(device_profiles)` under the lock. |
| **CONC-4** | A crash between the atomic-save temp write and the rename leaves a `<stem>.tmp` that matches `_FILENAME_RE`; `list_configs` (and the flat-file migration) listed it as a real, downloadable config. Now skips `.tmp`. |
| **CONC-8** | The paramiko `connect()` sat **outside** the try/finally in both `collect()` and `probe()`, so a connect/auth failure leaked the `SSHClient` (+ socket) without `client.close()`. Now inside the try / closes on the failure path. |
| **CONC-9** | The two-sided diff (API `POST /configs/diff` + the UI diff_page) read `get_content` after a `list_configs` snapshot with no `FileNotFoundError` catch; a config deleted in that TOCTOU window surfaced as a **500**. Now **404** (themed page on the UI route), matching the single-config routes. |

### Triaged NOT-fixed (deferred — larger / design-call)
CONC-3 (same-second save race → needs a store lock), CONC-5 (LRU-evicted running job 404 → job-lifecycle change), CONC-7 (fresh-install Fernet keygen race → crypto init, wants a considered change + test).

### Gate
- New tests: orphaned `.tmp` excluded from `list_configs`; diff of a deleted-mid-read config → 404 (not 500). CONC-6/CONC-8 covered for non-regression by the existing schedule + paramiko-collector suites (the races aren't deterministically reproducible in a unit test; the fixes are defensive).
- **Full `tests/unit` + touched integration files + cross-mesh CI guard green: 5197 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
