### PR TITLE
fix(walker): VLAN-mount secondary-IP by cardinality not is_secondary flag — MTX-5

### DIFF
--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -212,7 +212,7 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:  # noqa: C901
         # reports severity:ok while the SVI/management IP silently vanishes
         # (the same fail-surfaced principle as the {tagged,untagged}-ports
         # twin above; blind-audit 3ec11f3 T0-2).  Droppers declare it lossy.
-        for addr in vlan.ipv4_addresses:
+        for idx, addr in enumerate(vlan.ipv4_addresses):
             yield "/vlans/vlan/ipv4/address/ip"
             # VLAN-SVI L3 sub-fields — the twin of the interface-mount walk
             # above.  Previously the VLAN-SVI mount yielded ONLY .../ip while
@@ -223,7 +223,14 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:  # noqa: C901
             # (blind-audit f92e97a T0-2).  Walk them (conditionally, mirroring
             # the interface loop) so the loss surfaces; droppers declare them
             # lossy/unsupported per the per-codec capability matrix.
-            if addr.is_secondary:
+            # Cardinality discriminator (MTX-5): mirror the interface-mount
+            # walk (idx > 0 or is_secondary). VLAN-centric sources that don't
+            # model a primary/secondary distinction leave is_secondary False
+            # on every SVI address, so a flag-only gate emitted nothing for a
+            # genuinely multi-address SVI and the dropped secondary rode the
+            # classify() default to "supported" (severity:ok) — the same hole
+            # the interface-mount twin closed at line 96.
+            if idx > 0 or addr.is_secondary:
                 yield "/vlans/vlan/ipv4/address/secondary-ip"
             if addr.virtual_gateway_address:
                 yield "/vlans/vlan/ipv4/address/virtual-gateway-address"

--- a/tests/unit/migration/test_multiaddress_cardinality_walk.py
+++ b/tests/unit/migration/test_multiaddress_cardinality_walk.py
@@ -29,6 +29,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalInterface,
     CanonicalIPv4Address,
     CanonicalIPv6Address,
+    CanonicalVlan,
 )
 from netcanon.migration.canonical.xpath_walker import _walk_canonical
 from netcanon.migration.codecs import (  # noqa: F401  (register codecs)
@@ -94,6 +95,39 @@ class TestCardinalityDiscriminator:
             _intent([_v4("10.0.0.1", sec=True)], [])
         ))
         assert _V4_SEC in paths
+
+
+_VLAN_V4_SEC = "/vlans/vlan/ipv4/address/secondary-ip"
+
+
+class TestVlanMountCardinalityDiscriminator:
+    """MTX-5 (2026-07-03 review): the VLAN/SVI-mount walk must use the same
+    cardinality discriminator as the interface-mount twin — a multi-address
+    SVI whose extra addresses are flagless (is_secondary False) previously
+    walked only ``.../ip`` and rode classify() to a silent ``supported``."""
+
+    @staticmethod
+    def _vlan_intent(v4: list[CanonicalIPv4Address]) -> CanonicalIntent:
+        return CanonicalIntent(
+            hostname="r1",
+            vlans=[CanonicalVlan(id=10, name="SVI", ipv4_addresses=v4)],
+        )
+
+    def test_flagless_multi_svi_ipv4_yields_secondary(self):
+        paths = set(_walk_canonical(
+            self._vlan_intent([_v4("10.0.10.1"), _v4("10.0.99.1")])
+        ))
+        assert _VLAN_V4_SEC in paths
+
+    def test_single_svi_address_does_not_yield_secondary(self):
+        paths = set(_walk_canonical(self._vlan_intent([_v4("10.0.10.1")])))
+        assert _VLAN_V4_SEC not in paths
+
+    def test_explicit_flagged_svi_secondary_still_yields(self):
+        paths = set(_walk_canonical(
+            self._vlan_intent([_v4("10.0.10.1", sec=True)])
+        ))
+        assert _VLAN_V4_SEC in paths
 
 
 class TestEndToEndLossSurfaces:


### PR DESCRIPTION
## MTX-5 — VLAN/SVI-mount secondary-IP silent loss

The interface-mount walk was hardened (audit 276eaeb T0-1) to yield `.../secondary-ip` for every address beyond the first **regardless of `is_secondary`** — because VLAN-centric / Junos / OPNsense sources leave `is_secondary` False on every address. The **VLAN/SVI-mount twin** still gated on `if addr.is_secondary:` only.

So a multi-address SVI whose extra addresses were flagless walked only `.../ip`; the dropped secondary rode `classify()`'s default to **"supported"** and `validate_against` reported `severity: ok` while a subnet's reachability vanished — the exact hole the interface-mount fix closed, left un-mirrored on the twin.

**Fix:** enumerate and gate on `idx > 0 or addr.is_secondary`, matching the interface-mount contract. **Walk-only** — no render output moves, cross-mesh guard unaffected.

**Tests:** VLAN-mount cardinality class mirroring the interface-mount one (flagless multi-SVI yields secondary-ip; single does not; explicit flag still does).

### Deferred from this cluster (triaged, with rationale)
- **MTX-6** (interface-mount `virtual-gateway-mac` undeclared on 9–10 no-anycast codecs) — a **verified** honesty gap (`classify()` is exact-match, so the sibling `virtual-gateway-address` decl doesn't cover it; only Junos parses the per-IRB MAC, no no-anycast renderer emits it). Narrow (Junos-source-only), forced by no test today, 10-file matrix churn → deferred as the "batch opportunistically" tail.
- **CODEC-4** (SNMP community whitespace → bare token) — genuinely **latent** (every parser extracts community via `\S+`, so no real source produces a whitespace community) and not cleanly quotable on VyOS. Deferred.

### Gate
- **Full `tests/unit` + cross-mesh CI guard green: 5132 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
