### PR TITLE
fix(cli/api): 5 minor CLI/API-contract cleanups (API-2..6)

### DIFF
--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -324,7 +324,7 @@ def plan_migration_ports(
 
     First concrete per-pane override endpoint.  Establishes the
     pattern that subsequent category endpoints (``/plan/vlans``,
-    ``/plan/snmp``, ``/plan/local_users``, ``/plan/snmpv3_users``)
+    ``/plan/snmp``, ``/plan/local_users``, ``/plan/snmpv3``)
     will follow: each accepts the same :class:`MigrationPlanRequest`
     body and dispatches to :func:`run_plan_with_overrides` with only
     its category's override map populated.

--- a/netcanon/api/routes/sanitize.py
+++ b/netcanon/api/routes/sanitize.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from ... import config as app_config
-from ...migration.codecs.base import ParseError
+from ...migration.codecs.base import ParseError, RenderError
 from ...migration.codecs.registry import list_public_codecs
 from ...tools.sanitize import sanitize_text
 
@@ -83,6 +83,14 @@ async def post_sanitize(
         raise HTTPException(
             status_code=400,
             detail=f"Failed to parse upload as {source_vendor!r}: {e}",
+        ) from e
+    except RenderError as e:
+        # RenderError is a sibling of ParseError (not caught above); a render
+        # failure on the sanitized tree must be a clean 4xx, not an uncaught
+        # 500 (API-3).
+        raise HTTPException(
+            status_code=422,
+            detail=f"Failed to render sanitized {source_vendor!r}: {e}",
         ) from e
 
     if dry_run:

--- a/netcanon/cli.py
+++ b/netcanon/cli.py
@@ -130,7 +130,7 @@ def _cmd_sanitize(args: argparse.Namespace) -> int:
     """``netcanon sanitize`` subcommand handler."""
     # Lazy import — keeps `netcanon --help` fast and avoids loading
     # the migration codec graph for non-sanitize subcommands.
-    from .migration.codecs.base import ParseError
+    from .migration.codecs.base import ParseError, RenderError
     from .tools.sanitize import sanitize_text
 
     try:
@@ -153,6 +153,15 @@ def _cmd_sanitize(args: argparse.Namespace) -> int:
         print(
             f"error: failed to parse {args.input!r} as "
             f"{args.source_vendor!r}: {e}",
+            file=sys.stderr,
+        )
+        return 2
+    except RenderError as e:
+        # ParseError and RenderError are sibling CodecError subclasses, so a
+        # render failure on the sanitized tree isn't caught above — surface it
+        # as a clean CLI error instead of an uncaught traceback (API-3).
+        print(
+            f"error: failed to render sanitized {args.source_vendor!r}: {e}",
             file=sys.stderr,
         )
         return 2

--- a/netcanon/models/migration.py
+++ b/netcanon/models/migration.py
@@ -667,8 +667,14 @@ class MigrationPlanRequest(BaseModel):
     """Optional per-port target-name override map.  When provided, the
     pipeline runs the Tier 2 port-name translator with these entries
     taking precedence over the auto-heuristic.  Used by the Tier 3 UI
-    rename modal.  Backwards-compatible: callers that don't set this
-    get the legacy behaviour (no port-name translation at all).
+    rename modal.
+
+    Note (API-6): omitting this map does NOT disable port-name
+    translation on the ``/plan`` route.  Since v0.3.2 the route defaults
+    an absent map to ``{}`` (auto-translate-by-default), so a request with
+    no ``port_rename_map`` still gets auto port-name translation.  The
+    ``None``-disengages-the-translator behaviour is a property of the
+    lower-level ``run_plan_with_overrides`` function, not the API route.
 
     Entry value semantics:
 

--- a/netcanon/tools/demo.py
+++ b/netcanon/tools/demo.py
@@ -37,6 +37,7 @@ import sys
 from dataclasses import dataclass
 
 from ..migration.codecs.registry import get_codec
+from ..models.migration import MigrationJobStatus
 from ..services.migration_pipeline import run_plan_with_rename
 
 # ---------------------------------------------------------------------------
@@ -271,9 +272,22 @@ def _run_scenario(scenario: Scenario) -> int:
     target = get_codec(scenario.target_codec)
     job = run_plan_with_rename(source, target, scenario.source_text, port_rename_map={})
 
-    if str(job.status).endswith("failed"):
-        _print_section("FAILED")
-        print(f"Error: {job.error}")
+    # API-5: branch on the enum, not the stringified repr. There are THREE
+    # terminal states (completed / partial / failed); the old
+    # ``str(job.status).endswith("failed")`` matched only `failed` and let a
+    # `partial` job (a block-severity validation, or a wrong-codec empty tree)
+    # print the full success flow and exit 0.
+    if job.status != MigrationJobStatus.completed:
+        label = "FAILED" if job.status == MigrationJobStatus.failed else "PARTIAL"
+        _print_section(label)
+        if job.error:
+            print(f"Error: {job.error}")
+        if job.status == MigrationJobStatus.partial:
+            print(
+                "Job did not fully translate (lossy / unsupported surfaces or "
+                "unrecognised input); output is NOT deploy-safe. See the "
+                "validation report."
+            )
         return 1
 
     _print_section(

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -134,6 +134,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from ..migration.canonical.intent import CanonicalIntent
+from ..migration.codecs.base import ParseError
 from ..migration.codecs.registry import get_codec
 
 #: A DNS hostname: dot-separated labels (alnum, internal hyphen, and
@@ -230,6 +231,28 @@ def sanitize_text(
     # to 400 and the CLI reports cleanly.  No per-call pydantic handling
     # needed (this generalised #229's single sanitize-boundary conversion).
     intent = codec.parse(raw)
+
+    # API-4: whole-input-rejection guard.  A permissive ``parse()`` returns an
+    # essentially-empty canonical tree for input it doesn't understand (wrong
+    # source vendor, garbage) — ``sanitize`` would then emit a bare scaffold
+    # with ZERO substitutions, silently discarding a config the operator
+    # believed was redacted.  Mirror the migration pipeline's "recognized zero
+    # surfaces" signal (services.migration_pipeline._input_not_recognized):
+    # non-trivial input that walks to no xpaths is a rejection, surfaced as a
+    # ParseError (which the CLI + /sanitize route already report cleanly)
+    # rather than a misleading empty scaffold.
+    if (
+        raw.strip()
+        and isinstance(intent, CanonicalIntent)
+        and next(iter(codec.iter_xpaths(intent)), None) is None
+    ):
+        raise ParseError(
+            f"input not recognised as {source_codec_name!r} — it parsed to an "
+            "empty configuration (wrong source vendor?); nothing was "
+            "sanitised.",
+            snippet=raw.lstrip()[:120],
+        )
+
     sanitized_intent, substitutions = sanitize_intent(intent)
 
     if dry_run:

--- a/tests/unit/tools/test_demo.py
+++ b/tests/unit/tools/test_demo.py
@@ -48,6 +48,29 @@ class TestDemoModule:
         assert "OUTPUT" in out
         assert "FAILED" not in out
 
+    def test_partial_job_exits_nonzero(self, capsys, monkeypatch):
+        """API-5 (2026-07-03 review): the demo keyed success off the enum's
+        repr suffix (``endswith('failed')``), so a *partial* job printed the
+        full success flow and exited 0. It must now treat only ``completed``
+        as success — a partial job prints a PARTIAL section and returns
+        non-zero."""
+        from types import SimpleNamespace
+
+        import netcanon.tools.demo as demo_mod
+        from netcanon.models.migration import MigrationJobStatus
+
+        monkeypatch.setattr(
+            demo_mod, "run_plan_with_rename",
+            lambda *a, **k: SimpleNamespace(
+                status=MigrationJobStatus.partial, error=None,
+            ),
+        )
+        rc = demo_main(["--pair", "cisco__junos"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "PARTIAL" in out
+        assert "OUTPUT" not in out
+
 
 class TestDemoViaCLI:
     """``netcanon demo …`` must delegate to the same module (the shipped path)."""

--- a/tests/unit/tools/test_sanitize.py
+++ b/tests/unit/tools/test_sanitize.py
@@ -1854,3 +1854,30 @@ class TestOverlayFieldRedaction:
         blob = sanitized.model_dump_json()
         leaked = [t for t in ("65501:100", "239.7.7.7", "9.9.9.9") if t in blob]
         assert not leaked, f"overlay identifiers survived sanitisation: {leaked}"
+
+
+class TestUnrecognizedInputRejected:
+    """API-4 (2026-07-03 review): sanitising input the declared codec can't
+    parse must RAISE (ParseError), not silently emit a bare scaffold with
+    zero substitutions — otherwise an operator believes a config was redacted
+    when its secrets were actually discarded."""
+
+    def test_wrong_source_vendor_raises_parse_error(self):
+        # A Junos set-form config declared as cisco_iosxe_cli parses to an
+        # empty canonical tree (the Cisco CLI parser recognises nothing).
+        junos = (
+            "set system host-name r1\n"
+            "set interfaces ge-0/0/0 unit 0 family inet address 10.0.0.1/24\n"
+        )
+        with pytest.raises(ParseError, match="not recognised"):
+            sanitize_text(junos, "cisco_iosxe_cli", dry_run=True)
+
+    def test_recognised_config_still_sanitises(self):
+        # Negative control: a real Cisco config is recognised and sanitised.
+        cisco = (
+            "hostname R1\n"
+            "interface GigabitEthernet0/0\n"
+            " ip address 8.8.8.8 255.255.255.0\n"
+        )
+        result = sanitize_text(cisco, "cisco_iosxe_cli", dry_run=True)
+        assert result.substitutions  # at least the hostname + public IP


### PR DESCRIPTION
## MINOR CLI/API-contract batch — API-2 / API-3 / API-4 / API-5 / API-6

Five cheap, low-risk CLI/API fixes from the Fable review's MINOR tail, all verify-first reproduced.

| ID | Fix |
|---|---|
| **API-4** | `sanitize_text` had no input-recognition guard: input the declared codec can't parse (wrong source vendor / garbage) parsed to an empty tree and emitted a **bare scaffold with zero substitutions** — silently discarding a config the operator believed was redacted. Now raises `ParseError` (mirroring the pipeline's "recognized zero surfaces" signal). |
| **API-3** | `RenderError` is a **sibling** (not subclass) of `ParseError`, so a render failure on the sanitized tree wasn't caught → uncaught traceback in `netcanon sanitize` and an **HTTP 500** on `POST /sanitize`. Both now catch `RenderError` → clean CLI error (exit 2) / 422. |
| **API-5** | The demo keyed success off the enum repr (`str(job.status).endswith("failed")`), so a **`partial`** job printed the full success flow and exited 0. Now branches on the enum — only `completed` is success; a partial prints a PARTIAL section (not deploy-safe) and returns non-zero. |
| **API-2** | Docstring: the per-pane list named a `/plan/snmpv3_users` route that ships as `/plan/snmpv3`. Corrected. |
| **API-6** | Docstring: `MigrationPlanRequest.port_rename_map` claimed omitting it gives "no port-name translation", but since v0.3.2 the `/plan` route defaults an absent map to `{}` (auto-translate). Clarified. |

**API-7** (force-clears-block semantics) was triaged as a **deferred** design question and not touched.

### Gate
- New tests: wrong-vendor sanitize → `ParseError` (+ negative control); demo partial job → non-zero exit.
- **Full `tests/unit` + sanitize integration + cross-mesh CI guard green: 5143 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
