### PR TITLE
fix(guards): 3 minor test-guard + resource-cap hardening (TEST-2/TEST-5/PERF-4)

### DIFF
--- a/netcanon/migration/target_profiles.py
+++ b/netcanon/migration/target_profiles.py
@@ -386,6 +386,12 @@ _RANGE_RE = re.compile(
     r"^(?P<prefix>.*?)(?P<start>\d+)-(?P<prefix2>.*?)(?P<end>\d+)$"
 )
 
+#: Upper bound on a single ``range:`` shorthand's span, mirroring the
+#: aoss port-range clamp (PERF-1).  A typo'd / hostile operator range like
+#: ``1-1000000`` would otherwise materialise ~1e6 port dicts at boot; refuse
+#: it up front with a clear error.  No real switch has this many ports.
+_MAX_PROFILE_RANGE_SPAN = 4096
+
 
 def _expand_range_entries(ports_raw: list[Any]) -> list[dict[str, Any]]:
     """Expand ``range`` shorthand entries into concrete port records.
@@ -441,6 +447,13 @@ def _expand_range_entries(ports_raw: list[Any]) -> list[dict[str, Any]]:
         if start > end:
             raise ProfileLoadError(
                 f"invalid range {range_str!r}: start {start} > end {end}"
+            )
+        span = end - start + 1
+        if span > _MAX_PROFILE_RANGE_SPAN:
+            raise ProfileLoadError(
+                f"invalid range {range_str!r}: spans {span} entries, "
+                f"exceeds the {_MAX_PROFILE_RANGE_SPAN} cap (PERF-4) — a "
+                f"single profile range that large is almost certainly a typo"
             )
         shared = {k: v for k, v in entry.items() if k != "range"}
         for n in range(start, end + 1):

--- a/tests/integration/test_cross_mesh_ci_guard.py
+++ b/tests/integration/test_cross_mesh_ci_guard.py
@@ -161,6 +161,37 @@ def test_no_new_codec_bug_pairs(mesh_and_recon, baseline):
     )
 
 
+def test_no_pair_codec_bug_count_regressed(mesh_and_recon, baseline):
+    """No EXISTING pair's codec-bug count may exceed its baseline (TEST-2).
+
+    The aggregate-total and pair-membership guards above both miss an
+    intra-corpus shuffle where one pair drops (e.g. 1→0, leaving the set)
+    while another rises (2→3): the total stays equal and no NEW pair
+    appears, so both pass green while a real per-pair regression hides.
+    This pins each pair's count with ``<=`` so a genuine fix (lower count)
+    still passes but a rise is caught."""
+    _, result = mesh_and_recon
+
+    def _by_pair(rows):
+        return {
+            (r["source_codec"], r["target_codec"]): r["codec_bug_count"]
+            for r in rows
+        }
+
+    live = _by_pair(result["pair_codec_bug_counts"])
+    base = _by_pair(baseline["pair_codec_bug_counts"])
+    regressed = {
+        pair: (base[pair], live[pair])
+        for pair in base
+        if live.get(pair, 0) > base[pair]
+    }
+    assert not regressed, (
+        "existing codec-bug pair(s) regressed (baseline→live): "
+        f"{regressed}. A previously-tolerated pair now drifts MORE on the "
+        "committed corpus even though the aggregate total / pair set held."
+    )
+
+
 def test_mesh_cell_count_matches_baseline(mesh_and_recon, baseline):
     """The baseline was computed on a fixed corpus size; if fixtures are
     added/removed the count shifts and the CODEC_BUG baseline must be

--- a/tests/integration/test_load_and_memory.py
+++ b/tests/integration/test_load_and_memory.py
@@ -362,9 +362,20 @@ class TestMemoryBound:
             # buffers.  Cap holds at 10 in memory so the live
             # BackupJob instances are ~50 KB total.  Use 5 MB as
             # a generous ceiling that flags > 10× regressions.
-            assert total_delta < 5_000_000, (
-                f"tracemalloc delta {total_delta} bytes exceeds 5 MB ceiling "
-                "— suggests an allocation regression"
-            )
+            #
+            # TEST-5 (2026-07-03 review): this test is self-described as
+            # best-effort / flaky under CI allocator variance, yet a hard
+            # assert here would — under the suite's ``-x`` addopt — abort the
+            # ENTIRE run on a single spurious flake, masking downstream
+            # failures.  Since the gc.get_objects test above is the PRIMARY
+            # memory guard, treat an over-ceiling delta as a SKIP (visible,
+            # non-aborting) rather than a fatal failure.
+            if total_delta >= 5_000_000:
+                pytest.skip(
+                    f"tracemalloc delta {total_delta} bytes exceeds the 5 MB "
+                    "soft ceiling — allocator-variance flake; the "
+                    "gc.get_objects test is the primary guard. Skipping so a "
+                    "flake can't -x-abort the suite (TEST-5)."
+                )
         finally:
             tracemalloc.stop()

--- a/tests/unit/migration/test_target_profile_loader.py
+++ b/tests/unit/migration/test_target_profile_loader.py
@@ -165,6 +165,29 @@ ports:
   - {range: "10-1", kind: physical}
 """)
 
+    def test_oversized_range_span_rejected(self, tmp_path):
+        """PERF-4 (2026-07-03 review): an absurd range span must be refused
+        at load (mirrors the aoss port-range clamp) rather than materialise
+        ~1e6 port dicts at boot."""
+        with pytest.raises(ProfileLoadError, match="exceeds the .* cap"):
+            self._write(tmp_path, """
+vendor: aruba_aoss
+model: t
+ports:
+  - {range: "1-1000000", kind: physical}
+""")
+
+    def test_large_but_in_cap_range_still_expands(self, tmp_path):
+        """A big-but-plausible range (a real high-density chassis) still
+        loads — the cap only rejects the absurd."""
+        profile = self._write(tmp_path, """
+vendor: aruba_aoss
+model: t
+ports:
+  - {range: "1-4096", kind: physical}
+""")
+        assert len(profile.ports) == 4096
+
 
 class TestProfileWithModulesLoader:
     """YAML loader support for the ``modules:`` key."""


### PR DESCRIPTION
## MINOR test-guard + resource-cap batch — TEST-2 / TEST-5 / PERF-4

Three cheap, low-risk hardening fixes from the Fable review's MINOR tail, all verify-first reproduced.

| ID | Fix |
|---|---|
| **TEST-2** | The cross-mesh fidelity ratchet only checked the aggregate `CODEC_BUG` total and the pair-membership **set**; an intra-corpus shuffle (one pair 1→0 leaving the set, another 2→3) kept the total equal and added no new pair, so both guards passed green while a real per-pair regression hid. Added `test_no_pair_codec_bug_count_regressed` (no existing pair's count may exceed its baseline, `<=`). |
| **TEST-5** | `test_tracemalloc_peak_under_load` is self-described best-effort/flaky, yet a hard `assert < 5MB` would — under the suite's `-x` addopt — abort the **whole run** on one flake. The gc.get_objects test is the primary guard, so an over-ceiling delta now `pytest.skip`s (visible, non-aborting) instead of failing fatally. |
| **PERF-4** | `target_profiles._expand_range_entries` expanded a `range:` shorthand with **no span cap** → a typo'd/hostile `1-1000000` would materialise ~1e6 port dicts at boot. Added `_MAX_PROFILE_RANGE_SPAN=4096` → `ProfileLoadError` (mirrors the shipped PERF-1 aoss clamp); a real high-density chassis (≤4096) still loads. |

### Gate
- Verified: in-cap range expands (`1-48`→48, `1-4096`→4096), over-cap raises `ProfileLoadError`; per-pair cross-mesh guard passes on the corpus; memory test skips (not fails) over the ceiling.
- **Full `tests/unit` + cross-mesh CI guard green: 5136 passed, 81 skipped.** ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
