### PR TITLE
chore(fable-tail): cheap-win batch — SEC-5 drain caps, PKG-4/5 CI hardening, API-7 docs

### DIFF
--- a/.github/workflows/desktop-msi-publish.yml
+++ b/.github/workflows/desktop-msi-publish.yml
@@ -36,11 +36,13 @@ on:
         required: true
         type: string
 
-# Need write access to the Releases API so the action can create the
-# release page + upload the MSI as a release asset.
+# Least-privilege default: at the workflow level only the pytest `test`
+# gate's checkout runs, and it needs no more than read.  The elevated
+# scopes the MSI build needs (Releases-API write + CI-run read) are
+# declared on the `build-msi` job itself so the test gate can't reach
+# them (PKG-4).
 permissions:
-  contents: write
-  actions: read    # read the CI run conclusion for the "require CI success" gate
+  contents: read
 
 # Prevent two simultaneous MSI builds for the same ref from racing
 # the release-upload step.  Within a single ref, we let the second
@@ -94,6 +96,12 @@ jobs:
     name: Build Windows MSI
     needs: [test]
     runs-on: windows-latest
+    # Write access to the Releases API (create the release page + upload
+    # the MSI asset) plus read of the CI run conclusion for the gate
+    # below.  Scoped here so the pytest `test` gate never gets it (PKG-4).
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - name: Checkout (full history for setuptools_scm)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,12 +7,12 @@ on:
       - 'v*.*.*-*'    # rc / alpha / beta pre-release tags
   workflow_dispatch:
 
+# Least-privilege default: at the workflow level only the pytest `test`
+# gate's checkout runs, so read is all it needs.  The registry-push,
+# signing, SARIF-upload and CI-gate scopes are declared on the
+# `build-and-publish` job so the test gate can't reach them (PKG-4).
 permissions:
   contents: read
-  packages: write
-  id-token: write          # cosign keyless signing via Sigstore + GitHub OIDC
-  security-events: write   # Trivy SARIF upload to Code Scanning
-  actions: read            # read the CI run conclusion for the "require CI success" gate
 
 # Serialise release runs for a given ref so a re-pushed tag (or a
 # workflow_dispatch racing the tag push) can't double-build / double-push
@@ -71,8 +71,34 @@ jobs:
     name: Build, push, sign, attest
     needs: [test]
     runs-on: ubuntu-latest
+    # Elevated scopes scoped to the publish job only (PKG-4): push to
+    # GHCR, keyless-sign via OIDC, upload the Trivy SARIF, read the CI
+    # run conclusion for the gate, and read the checkout.
+    permissions:
+      contents: read
+      packages: write          # push image + cosign artifacts to GHCR
+      id-token: write          # cosign keyless signing via Sigstore + GitHub OIDC
+      security-events: write   # Trivy SARIF upload to Code Scanning
+      actions: read            # read the CI run conclusion for the "require CI success" gate
 
     steps:
+      # Refuse to publish from anything but a version tag.  A bare
+      # `workflow_dispatch` selects a git ref in the UI; on a branch ref
+      # `type=semver` emits no versioned tag, but `type=raw,value=latest`
+      # would still move `:latest` onto a `.devN` build — the same
+      # dev-publish footgun as pypi-publish.yml (PKG-5).  Tag pushes
+      # satisfy the guard; a workflow_dispatch rebuild must select a tag.
+      # Uses $GITHUB_REF (a default env var), not a `${{ }}` template, so
+      # there is no injection surface.
+      - name: Refuse a non-tag ref (workflow_dispatch footgun guard)
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
+            echo "::error::Refusing to publish from '${GITHUB_REF}' — the image publish must run from a version tag (refs/tags/v*), not a branch. A branch run would move :latest onto a .devN build."
+            exit 1
+          fi
+          echo "OK: publishing from tag '${GITHUB_REF}'."
+
       - uses: actions/checkout@v7.0.0
         with:
           # Full history so the on-main ancestry guard below can run a

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -70,6 +70,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Refuse to publish from anything but a version tag.  A bare
+      # `workflow_dispatch` selects a git ref in the UI; if that ref is a
+      # branch (e.g. main) rather than a tag, setuptools_scm derives a
+      # `X.Y.Z.devN` version and `no-local-version` (pyproject.toml)
+      # strips the `+g<sha>` local segment PyPI would otherwise reject —
+      # making that accidental dev build a PyPI-legal upload.  The on-main
+      # ancestry check below passes trivially for a branch on main, so it
+      # does NOT catch this.  Tag pushes always satisfy the guard; a
+      # workflow_dispatch backfill must select a tag in the ref picker
+      # (PKG-5).  Uses $GITHUB_REF (a default env var), not a `${{ }}`
+      # template, so there is no injection surface.
+      - name: Refuse a non-tag ref (workflow_dispatch footgun guard)
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
+            echo "::error::Refusing to publish from '${GITHUB_REF}' — the PyPI publish must run from a version tag (refs/tags/v*), not a branch. A workflow_dispatch on a branch would build a .devN version."
+            exit 1
+          fi
+          echo "OK: publishing from tag '${GITHUB_REF}'."
+
       - uses: actions/checkout@v7.0.0
         with:
           # Full history + tags for setuptools_scm to derive the package

--- a/netcanon/collectors/paramiko_collector.py
+++ b/netcanon/collectors/paramiko_collector.py
@@ -59,6 +59,16 @@ _CONNECT_TIMEOUT = 30
 # latency low and the separate-session cost acceptable.
 _PROBE_IDLE_THRESHOLD = 8   # consecutive idle polls (~1.6s)
 _PROBE_MAX_SECONDS = 30
+# Absolute bounds for `_drain` so a device that streams without ever
+# pausing (wedged, or hostile once the connection is trusted) can't
+# hang the worker or exhaust memory.  `_drain` only resets its idle
+# window on new data — without a hard cap that window never expires
+# against a continuous stream (SEC-5).  `_drain` is a best-effort
+# pre-command flush (login banner / OPNsense menu), NOT a config
+# capture, so on hitting a cap it returns what it has rather than
+# failing closed the way `_collect_output` does.
+_DRAIN_MAX_SECONDS = 10      # absolute wall-clock cap; idle-reset can't extend past it
+_DRAIN_MAX_BYTES = 1 << 20   # 1 MiB — banners/menus are tiny; bound a runaway stream
 
 
 _SHELL_PROMPT_RE = re.compile(
@@ -348,20 +358,46 @@ class ParamikoShellCollector(BaseCollector):
     def _drain(self, shell: paramiko.Channel, timeout: float = 0.5) -> str:
         """Read and return all immediately available output, then stop.
 
+        Returns once the channel has been quiet for *timeout* seconds,
+        or on hitting the absolute ``_DRAIN_MAX_SECONDS`` /
+        ``_DRAIN_MAX_BYTES`` cap — whichever comes first.  The idle
+        window resets on new data (so a briefly-chatty device still
+        drains promptly once it settles), but the absolute caps do NOT
+        reset, so a device that streams without pause can no longer keep
+        the loop alive forever or grow the buffer unbounded (SEC-5).
+
+        This is a best-effort pre-command flush (banner / menu text),
+        not a config capture, so hitting a cap returns the truncated
+        buffer rather than raising — unlike :meth:`_collect_output`,
+        which fails closed to avoid persisting a partial backup.
+
         Args:
             shell: Active Paramiko channel.
-            timeout: Maximum seconds to wait for data before returning.
+            timeout: Idle window — seconds of silence before returning.
 
         Returns:
-            All data received within *timeout* seconds, decoded as UTF-8.
+            Data received before the idle window or an absolute cap was
+            hit, decoded as UTF-8.
         """
         buf = ""
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
+        now = time.monotonic()
+        idle_deadline = now + timeout
+        hard_deadline = now + _DRAIN_MAX_SECONDS
+        while True:
+            now = time.monotonic()
+            if now >= idle_deadline or now >= hard_deadline:
+                break
             if shell.recv_ready():
                 chunk = shell.recv(65536).decode("utf-8", errors="replace")
                 buf += chunk
-                deadline = time.monotonic() + timeout  # reset on new data
+                idle_deadline = time.monotonic() + timeout  # reset on new data
+                if len(buf) >= _DRAIN_MAX_BYTES:
+                    logger.warning(
+                        "_drain hit the %d-byte cap (device streaming without "
+                        "pause) — returning truncated pre-command output",
+                        _DRAIN_MAX_BYTES,
+                    )
+                    break
             else:
                 time.sleep(0.05)
         return buf

--- a/netcanon/models/migration.py
+++ b/netcanon/models/migration.py
@@ -12,7 +12,13 @@ All severity fields use the same three-step convention introduced by
 
     ok    — safe to proceed, no user action needed
     warn  — proceed with awareness (lossy or partial)
-    block — stop unless the caller explicitly overrides (force=True)
+    block — the strongest signal.  In the migration pipeline the render
+            still runs and the job is flagged ``partial`` (the target
+            can't faithfully consume the tree); ``block`` does not abort
+            the run, and ``force`` does NOT clear it — ``force`` only
+            skips the separate cross-device-class guard.  Drop the
+            offending paths with the ``strip_unsupported`` transform to
+            clear a ``block``.
 """
 
 from __future__ import annotations
@@ -125,8 +131,12 @@ class LossyPath(BaseModel):
         path: YANG xpath expression (adapter-scoped interpretation — see
             ``CapabilityMatrix.classify``).
         reason: Human-readable explanation of what's lost.
-        severity: ``warn`` (default) lets the migration proceed; ``error``
-            escalates to a block unless ``force=True``.
+        severity: ``warn`` (default) surfaces a warning and the report
+            stays ``warn``; ``error`` escalates the report to ``block``,
+            which flags the rendered job ``partial``.  Neither aborts the
+            render, and ``force`` does not downgrade a ``block`` (it only
+            skips the cross-device-class guard) — drop the path with the
+            ``strip_unsupported`` transform to avoid it.
     """
 
     path: str
@@ -138,9 +148,11 @@ class UnsupportedPath(BaseModel):
     """A YANG path the target adapter cannot emit at all.
 
     Presence of any unsupported path in a tree forces the
-    ``ValidationReport`` severity to ``block``.  The caller may still
-    override with ``force=True``; in that case ``strip_unsupported`` is
-    the natural transform to apply before render.
+    ``ValidationReport`` severity to ``block``, which flags the rendered
+    job ``partial`` (the render still runs — the path is simply absent
+    from the output).  ``force`` does NOT clear this (it only skips the
+    cross-device-class guard); apply the ``strip_unsupported`` transform
+    before render to drop the path explicitly and clear the block.
     """
 
     path: str
@@ -650,7 +662,9 @@ class MigrationPlanRequest(BaseModel):
         raw_text: Inline config text.  Mutually exclusive with
             ``source_filename``.
         source_filename: Name of a stored config to load.
-        force: Skip the device-class guard.  Default ``False``.
+        force: Skip the stage-0 cross-device-class guard.  Does NOT clear
+            a validation ``block`` — unsupported / error-level paths still
+            flag the job ``partial``.  Default ``False``.
     """
 
     source: str

--- a/tests/unit/test_paramiko_collector.py
+++ b/tests/unit/test_paramiko_collector.py
@@ -279,3 +279,65 @@ class TestCollectOutputFailsClosedOnTruncation:
         with pytest.raises(TimeoutError) as exc:
             _collector()._collect_output(_SettlingChannel([]), "silent.example")
         assert "No output received" in str(exc.value)
+
+
+class _ChattyChannel:
+    """Never fully idle but never floods: drips one byte every other
+    poll, so the idle window keeps resetting (idle exit never fires)
+    while the volume stays far below the byte cap.  Exercises the
+    absolute ``_DRAIN_MAX_SECONDS`` wall-clock cap specifically."""
+
+    def __init__(self) -> None:
+        self._ready = True
+
+    def recv_ready(self) -> bool:
+        # Flip each poll: half the polls report idle (→ the else-branch
+        # sleeps, advancing the virtual clock toward the hard cap), the
+        # other half deliver a byte (→ reset the idle window).
+        self._ready = not self._ready
+        return self._ready
+
+    def recv(self, _n: int) -> bytes:
+        return b"."
+
+
+class TestDrainBounded:
+    """SEC-5: ``_drain`` used to reset its idle deadline on every chunk
+    with no absolute ceiling, so a device that streamed without pausing
+    kept the read loop alive forever and grew the buffer unbounded (hung
+    worker + OOM).  It must now terminate on the byte cap (a flood) or
+    the wall-clock cap (a never-settling drip), and — being a best-effort
+    pre-command flush, not a config capture — return what it has rather
+    than raising."""
+
+    @pytest.fixture(autouse=True)
+    def _virtual_time(self, monkeypatch):
+        clock = _VirtualClock()
+        monkeypatch.setattr(
+            paramiko_collector,
+            "time",
+            types.SimpleNamespace(monotonic=clock.monotonic, sleep=clock.sleep),
+        )
+        return clock
+
+    def test_unbounded_flood_hits_byte_cap_and_returns(self, monkeypatch):
+        """An always-ready stream terminates on ``_DRAIN_MAX_BYTES`` and
+        returns a bounded buffer (never hangs / grows without limit)."""
+        monkeypatch.setattr(paramiko_collector, "_DRAIN_MAX_BYTES", 512)
+        out = _collector()._drain(_NeverIdleChannel())
+        # Bounded: the cap plus at most one final over-cap chunk.
+        assert 512 <= len(out) <= 512 + len(b"flood flood flood\n")
+        assert "flood" in out
+
+    def test_never_settling_drip_hits_time_cap_and_returns(self):
+        """A trickle that never goes idle but never floods terminates on
+        the wall-clock cap — NOT the byte cap — and returns its buffer."""
+        out = _collector()._drain(_ChattyChannel())
+        assert 0 < len(out) < paramiko_collector._DRAIN_MAX_BYTES
+
+    def test_settled_stream_returns_promptly(self):
+        """Healthy path preserved: output that arrives then goes quiet
+        drains on the idle window and returns the full buffer."""
+        out = _collector()._drain(_SettlingChannel([b"banner\n", b"prompt> "]))
+        assert "banner" in out
+        assert "prompt>" in out


### PR DESCRIPTION
Opportunistic batch closing the four cheapest items from the deferred tail of the 2026-07-03 Fable review. All low-churn; **no behaviour change to the translation core**.

### SEC-5 — bound `paramiko _drain`
`_drain` reset its idle deadline on every chunk with **no absolute ceiling**, so a device that streamed without pausing kept the read loop alive forever and grew the buffer unbounded (hung worker + OOM). Added `_DRAIN_MAX_SECONDS` (wall-clock) and `_DRAIN_MAX_BYTES` (1 MiB) caps that the idle-reset can no longer extend past. `_drain` is a best-effort pre-command flush (login banner / OPNsense menu), **not** a config capture, so on hitting a cap it returns the truncated buffer rather than failing closed the way `_collect_output` does. New regression tests cover the byte cap (flood), the time cap (never-settling drip) and the healthy idle exit.

### PKG-4 — least-privilege CI permissions
Moved the write scopes off the **workflow** level onto the **publish job** so the pytest `test` gate runs read-only:
- `desktop-msi-publish.yml`: `contents: write` → job-scoped to `build-msi`.
- `docker-publish.yml`: `packages`/`id-token`/`security-events: write` → job-scoped to `build-and-publish`.

Mirrors `pypi-publish.yml`'s already-scoped model (the finding named it as the correct reference).

### PKG-5 — refuse a non-tag `workflow_dispatch` publish
A bare `workflow_dispatch` on a **branch** ref would let `setuptools_scm` build a `X.Y.Z.devN` version that `no-local-version` (pyproject) makes PyPI-legal — and would move docker `:latest` onto that dev build. The on-main ancestry check passes trivially for a branch, so it does not catch this. Added a first-step guard to the pypi `build` and docker `build-and-publish` jobs refusing any ref that isn't `refs/tags/v*`. Tag pushes always satisfy it; a `workflow_dispatch` backfill must select a tag in the ref picker. Uses `$GITHUB_REF` (a default env var), **not** a `${{ }}` template, so there is no injection surface.

### API-7 (doc half) — stop over-promising `force`
Corrected the `LossyPath` / `UnsupportedPath` / module-level docstrings in `models/migration.py` that claimed `force=True` clears a validation `block`. It doesn't: `force` only skips the stage-0 cross-device-class guard; a `block` renders anyway and flags the job `partial`. `strip_unsupported` is the actual mechanism. The behaviour half stays deferred.

### Test plan
- `tests/unit` (whole) + `tests/integration/test_cross_mesh_ci_guard.py` — green locally (`--basetemp=D:/nc-pytest-tmp`).
- `ruff check` clean on the changed Python files.
- All three workflow YAMLs parse; jobs unchanged in shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
