### PR TITLE
fix(concurrency): CONC-3/5/7 — same-second save clobber, evicted-running-job 404, Fernet keygen race

### DIFF
--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -224,6 +224,21 @@ def create_backup(
         total_devices=len(resolved_request.devices),
     )
     jobs[job.id] = job
+    # Persist the pending job to disk immediately so it survives an LRU
+    # eviction from the in-memory cache during its run.  The runner only
+    # saves on completion (backup_runner terminal save), so without this a
+    # job evicted while still running would disk-miss and poll as a 404
+    # for an active job (CONC-5).  The runner's terminal save later
+    # overwrites this pending snapshot with the final state.
+    try:
+        job_store.save(job)
+    except OSError as exc:
+        # Non-fatal: the job still runs and is saved on completion — we
+        # only lose the mid-run disk fallback for this one.  Don't fail
+        # the request over it.
+        logger.warning(
+            "Could not persist pending job %s at creation: %s", job.id, exc
+        )
     max_workers = getattr(
         request.app.state.settings, "backup_concurrency", MAX_BACKUP_CONCURRENCY
     )

--- a/netcanon/security/credentials.py
+++ b/netcanon/security/credentials.py
@@ -65,6 +65,7 @@ import base64
 import binascii
 import logging
 import os
+import threading
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,11 @@ _ACCOUNT = "master_key"
 _ENV_VAR = "NETCANON_FERNET_KEY"
 _KEY_FILENAME = ".fernet_key"
 _fernet = None  # Fernet instance, initialised lazily on first use
+# Serialises lazy key initialisation so a fresh install (no env key, no
+# keyring, no key file) can't have two threads each generate a *different*
+# key and both persist it — the loser's ciphertext would then fail to
+# decrypt against the surviving key (CONC-7).
+_fernet_lock = threading.Lock()
 
 
 def _data_dir() -> Path:
@@ -243,16 +249,31 @@ def _resolve_key() -> str:
 
 
 def _get_fernet():
-    """Return a Fernet instance, initialising the key on first call."""
+    """Return a Fernet instance, initialising the key on first call.
+
+    Double-checked locking on ``_fernet_lock``: the fast path returns the
+    already-built instance with no lock, and the first-call path
+    serialises so exactly one thread resolves/generates + persists the
+    key.  Without this, two threads racing the very first
+    ``encrypt``/``decrypt`` on a fresh install would each generate and
+    persist a different key (last-writer-wins on the key file); the
+    loser's in-flight ciphertext would later fail to decrypt against the
+    surviving key (CONC-7).
+    """
     global _fernet
     if _fernet is not None:
         return _fernet
 
     from cryptography.fernet import Fernet
 
-    raw = _resolve_key()
-    _fernet = Fernet(raw.encode())
-    return _fernet
+    with _fernet_lock:
+        # Re-check inside the lock — another thread may have initialised
+        # while we were blocked on it.
+        if _fernet is not None:
+            return _fernet
+        raw = _resolve_key()
+        _fernet = Fernet(raw.encode())
+        return _fernet
 
 
 def encrypt(plaintext: str) -> str:

--- a/netcanon/storage/file_store.py
+++ b/netcanon/storage/file_store.py
@@ -61,6 +61,7 @@ import json
 import logging
 import re
 import shutil
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -120,6 +121,11 @@ class FileConfigStore(BaseConfigStore):
         # find no flat files and do nothing.
         self._dir = Path(storage_dir)
         self._dir.mkdir(parents=True, exist_ok=True)
+        # Serialises the collision-resolution → write → rename critical
+        # section in :meth:`save` so two concurrent saves (backup runs
+        # execute on a ThreadPoolExecutor) for the same device+second
+        # can't both claim the same path or share a tmp file (CONC-3).
+        self._save_lock = threading.Lock()
         self._migrate_flat_files()
 
     # ------------------------------------------------------------------
@@ -168,32 +174,39 @@ class FileConfigStore(BaseConfigStore):
         subdir.mkdir(parents=True, exist_ok=True)
         path = subdir / filename
 
-        # Collision safety — append _1, _2, … if the same-second file exists.
-        counter = 0
-        while path.exists():
-            counter += 1
-            filename = f"{stem}_{counter}.{extension}"
-            path = subdir / filename
-            logger.warning(
-                "Filename collision: renamed to %r (counter=%d)", filename, counter
-            )
+        # Collision-resolution → write → rename runs under the store lock
+        # so two concurrent saves for the same device+second can't both
+        # pass the `exists()` check and pick the same path (a TOCTOU that
+        # silently collapses two backups into one), nor race on a shared
+        # `.tmp` (CONC-3).  Saves are small local writes on a cold path
+        # (≤ backup_concurrency at a time), so the serialisation is free.
+        with self._save_lock:
+            # Collision safety — append _1, _2, … if the same-second file exists.
+            counter = 0
+            while path.exists():
+                counter += 1
+                filename = f"{stem}_{counter}.{extension}"
+                path = subdir / filename
+                logger.warning(
+                    "Filename collision: renamed to %r (counter=%d)", filename, counter
+                )
 
-        # Atomic write: write to temp then rename to prevent corruption.
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(content, encoding="utf-8")
-        tmp.replace(path)
-        size = path.stat().st_size
-        logger.info("Saved config %r (%d bytes) → %s", filename, size, subdir)
+            # Atomic write: write to temp then rename to prevent corruption.
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(content, encoding="utf-8")
+            tmp.replace(path)
+            size = path.stat().st_size
+            logger.info("Saved config %r (%d bytes) → %s", filename, size, subdir)
 
-        if device_profile_id is not None:
-            meta_path = subdir / f"{filename}.meta.json"
-            meta_tmp = meta_path.with_suffix(".tmp")
-            meta_tmp.write_text(
-                json.dumps({"device_profile_id": device_profile_id}),
-                encoding="utf-8",
-            )
-            meta_tmp.replace(meta_path)
-            logger.debug("Wrote sidecar metadata %s", meta_path.name)
+            if device_profile_id is not None:
+                meta_path = subdir / f"{filename}.meta.json"
+                meta_tmp = meta_path.with_suffix(".tmp")
+                meta_tmp.write_text(
+                    json.dumps({"device_profile_id": device_profile_id}),
+                    encoding="utf-8",
+                )
+                meta_tmp.replace(meta_path)
+                logger.debug("Wrote sidecar metadata %s", meta_path.name)
 
         return ConfigRecord(
             device_type=device_type,

--- a/tests/integration/test_load_and_memory.py
+++ b/tests/integration/test_load_and_memory.py
@@ -175,6 +175,37 @@ class TestSustainedLoad:
             finally:
                 test_app.state.jobs = original_registry
 
+    def test_running_job_survives_eviction_via_creation_persist(self, test_app):
+        """CONC-5: a job is persisted to disk at creation, so it stays
+        reachable via disk fallback even after an LRU eviction *before*
+        the runner's terminal save — polling an active-but-evicted job
+        returns its state instead of a 404.  The background runner is
+        stubbed out so the creation-time persist is the ONLY disk write,
+        isolating the fix from the runner's on-completion save."""
+        with patch(
+            "netcanon.api.routes.backups.run_backup_job",
+        ), TestClient(test_app) as c:
+            original_registry = _swap_registry(test_app, max_memory_jobs=1)
+            try:
+                first = c.post(
+                    "/api/v1/backups",
+                    json={"devices": [_device_payload(host="10.0.0.1")]},
+                ).json()
+                # On disk immediately — before any runner save (stubbed).
+                assert test_app.state.job_store.load_one(first["id"]) is not None
+                # A second submission evicts the first from the cap-1 cache.
+                c.post(
+                    "/api/v1/backups",
+                    json={"devices": [_device_payload(host="10.0.0.2")]},
+                )
+                assert first["id"] not in list(test_app.state.jobs.keys())
+                # Still reachable via disk fallback — 200, not 404.
+                resp = c.get(f"/api/v1/backups/{first['id']}")
+                assert resp.status_code == 200, resp.text
+                assert resp.json()["id"] == first["id"]
+            finally:
+                test_app.state.jobs = original_registry
+
 
 # ---------------------------------------------------------------------------
 # Concurrency: parallel POSTs against the registry

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -6,6 +6,8 @@ The OS keyring is mocked throughout — no real credential store is touched.
 """
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
 
 import pytest
@@ -420,3 +422,52 @@ class TestFileFallback:
             credentials._fernet = None
             plaintext = "container-deployment-password"
             assert credentials.decrypt(credentials.encrypt(plaintext)) == plaintext
+
+
+class TestFernetInitRace:
+    """CONC-7: concurrent first-call key initialisation must generate
+    exactly one key.  Without the double-checked lock in ``_get_fernet``,
+    N threads racing the very first encrypt/decrypt on a fresh install
+    (no env key, no keyring, no key file) each generate a *different* key
+    and persist it (last-writer-wins on the key file); the losers'
+    ciphertext then fails to decrypt against the surviving key."""
+
+    def test_concurrent_get_fernet_generates_one_key(self, tmp_path, monkeypatch):
+        from cryptography.fernet import Fernet
+        from keyring.errors import NoKeyringError
+
+        from netcanon.security import credentials
+
+        # Fresh install: no env key, keyring unavailable, key file under
+        # a clean tmp dir → resolution deterministically hits the file
+        # tier (a single generate per resolve).
+        monkeypatch.delenv("NETCANON_FERNET_KEY", raising=False)
+        monkeypatch.setenv("NETCANON_DATA_DIR", str(tmp_path))
+        credentials._fernet = None
+
+        n = 16
+        barrier = threading.Barrier(n)
+
+        with (
+            patch("keyring.get_password", side_effect=NoKeyringError("no backend")),
+            patch(
+                "cryptography.fernet.Fernet.generate_key",
+                wraps=Fernet.generate_key,
+            ) as gen_spy,
+        ):
+            def _init():
+                # Release all threads into _get_fernet() simultaneously.
+                barrier.wait(timeout=10)
+                return credentials._get_fernet()
+
+            with ThreadPoolExecutor(max_workers=n) as pool:
+                instances = [
+                    f.result() for f in [pool.submit(_init) for _ in range(n)]
+                ]
+
+        # Exactly one key generated despite N racing first-callers.
+        assert gen_spy.call_count == 1
+        # Every thread received the identical Fernet instance.
+        assert all(inst is instances[0] for inst in instances)
+        # The single key was persisted to the file tier.
+        assert (tmp_path / credentials._KEY_FILENAME).is_file()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -5,6 +5,8 @@ All I/O is directed to pytest's ``tmp_path`` — no network, no shared state.
 """
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -134,6 +136,31 @@ class TestCollisionSafety:
         store.save("Cisco", "1.1.1.1", _ts(), "cfg", "b")
         r3 = store.save("Cisco", "1.1.1.1", _ts(), "cfg", "c")
         assert "_2" in r3.filename
+
+    def test_concurrent_same_second_saves_dont_clobber(self, tmp_path: Path):
+        """CONC-3: N threads saving the same device+second concurrently
+        must produce N distinct files with all N contents intact.  The
+        old non-atomic ``exists()``-loop plus a shared ``.tmp`` was a
+        TOCTOU that could collapse two backups (which run on a
+        ThreadPoolExecutor) into a single clobbered file."""
+        store = FileConfigStore(tmp_path)
+        n = 16
+        barrier = threading.Barrier(n)
+        contents = [f"config-{i}" for i in range(n)]
+
+        def _save(text: str):
+            # Release all threads into save() together to maximise overlap
+            # on the collision-resolution window.
+            barrier.wait(timeout=10)
+            return store.save("Cisco", "1.1.1.1", _ts(), "cfg", text)
+
+        with ThreadPoolExecutor(max_workers=n) as pool:
+            records = [f.result() for f in [pool.submit(_save, c) for c in contents]]
+
+        # One distinct filename per save — nothing overwrote another.
+        assert len({r.filename for r in records}) == n
+        # Every content round-trips off disk — no write was lost.
+        assert {store.get_content(r.filename) for r in records} == set(contents)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second cheap-win batch from the deferred Fable-review tail — three independent concurrency fixes, each mirroring the lock discipline from CONC-1/2/6. No behaviour change to the translation core.

### CONC-3 — `FileConfigStore.save` same-second clobber
The same-second filename was resolved with a non-atomic `exists()`-loop and written through a **shared** `.tmp` (`path.with_suffix(".tmp")`). Two concurrent saves (backups run on a `ThreadPoolExecutor`) for the same device+second could both see the base path free, both pick it, and clobber each other via the shared tmp — collapsing two backups into one file. Added a store `threading.Lock` around the collision-resolution → write → rename critical section (saves are small local writes on a cold path, so serialising them is free).

### CONC-5 — 404 for an evicted-but-running job
The runner only persists a job **on completion** (`backup_runner` terminal save). A job LRU-evicted from the in-memory registry while still running therefore disk-missed → `GET /backups/{id}` returned **404 for an active job**. The create route now persists the `pending` job to disk immediately, so the disk fallback in `__contains__`/`__getitem__` finds an evicted-but-running job; the runner's terminal save later overwrites it with the final state.

### CONC-7 — `_get_fernet` double-keygen race
No lock guarded the lazy key init. On a **fresh install** (no env key / keyring / key file) two threads racing the first encrypt/decrypt each generated a *different* key and persisted it (last-writer-wins on the key file) — the loser's ciphertext then failed to decrypt against the surviving key. Added double-checked locking on a module `_fernet_lock`.

### Tests (all barrier-driven to force real overlap)
- **CONC-3**: 16 threads saving the same device+second → 16 distinct files, every content round-trips off disk (no lost write).
- **CONC-5**: stubbed background runner + cap-1 registry → job persisted at creation is still `200` (not `404`) after eviction.
- **CONC-7**: 16 threads racing `_get_fernet()` → `generate_key` called exactly once, all threads get the identical instance.

Whole `tests/unit` + `test_cross_mesh_ci_guard.py` + backup/schedule/load integration green locally (`--basetemp=D:/nc-pytest-tmp`), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
