### PR TITLE
docs(migration): resolve API-7 — drop the phantom strip_unsupported affordance

### DIFF
--- a/netcanon/migration/codecs/base.py
+++ b/netcanon/migration/codecs/base.py
@@ -313,10 +313,13 @@ class CodecBase(ABC):
         the adapter's supported subset.
 
         Raises:
-            RenderError: When *tree* contains paths the adapter
-                cannot emit.  Callers should have run the
-                ``strip_unsupported`` transform first if the target
-                :class:`ValidationReport` flagged any paths.
+            RenderError: When *tree* contains a construct the adapter
+                cannot render into valid config.  Note most
+                target-unsupported paths are NOT raised here — they are
+                omitted from the output and surfaced as a ``block`` in
+                the :class:`ValidationReport` (a ``partial`` job).
+                ``RenderError`` is reserved for a tree the adapter
+                genuinely cannot serialise.
         """
 
     def iter_xpaths(self, tree: Any) -> Iterable[str]:

--- a/netcanon/models/migration.py
+++ b/netcanon/models/migration.py
@@ -13,12 +13,14 @@ All severity fields use the same three-step convention introduced by
     ok    — safe to proceed, no user action needed
     warn  — proceed with awareness (lossy or partial)
     block — the strongest signal.  In the migration pipeline the render
-            still runs and the job is flagged ``partial`` (the target
-            can't faithfully consume the tree); ``block`` does not abort
-            the run, and ``force`` does NOT clear it — ``force`` only
-            skips the separate cross-device-class guard.  Drop the
-            offending paths with the ``strip_unsupported`` transform to
-            clear a ``block``.
+            still runs and the job is flagged ``partial``: the target
+            can't faithfully consume the tree, so the unsupported paths
+            are simply absent from the rendered output.  ``block`` does
+            not abort the run, and nothing "clears" it — the ``partial``
+            status plus the ``ValidationReport`` are the honest record of
+            what was dropped, which the caller reviews before deploying.
+            (``force`` is unrelated: it only skips the separate
+            cross-device-class guard.)
 """
 
 from __future__ import annotations
@@ -134,9 +136,9 @@ class LossyPath(BaseModel):
         severity: ``warn`` (default) surfaces a warning and the report
             stays ``warn``; ``error`` escalates the report to ``block``,
             which flags the rendered job ``partial``.  Neither aborts the
-            render, and ``force`` does not downgrade a ``block`` (it only
-            skips the cross-device-class guard) — drop the path with the
-            ``strip_unsupported`` transform to avoid it.
+            render, and ``force`` does not downgrade a ``block`` — it only
+            skips the cross-device-class guard.  A ``block`` is the honest
+            "this render is partial" signal, not an error to suppress.
     """
 
     path: str
@@ -149,10 +151,12 @@ class UnsupportedPath(BaseModel):
 
     Presence of any unsupported path in a tree forces the
     ``ValidationReport`` severity to ``block``, which flags the rendered
-    job ``partial`` (the render still runs — the path is simply absent
-    from the output).  ``force`` does NOT clear this (it only skips the
-    cross-device-class guard); apply the ``strip_unsupported`` transform
-    before render to drop the path explicitly and clear the block.
+    job ``partial``: the target adapter simply omits the path from its
+    output (it has no way to emit it).  This is deliberate "declare what
+    you drop" honesty — the ``partial`` status + report tell the caller
+    exactly what was lost.  There is no auto-strip step (and ``force``
+    does not apply — it only skips the cross-device-class guard); the
+    caller reviews the report before deploying.
     """
 
     path: str

--- a/tests/unit/migration/test_pipeline.py
+++ b/tests/unit/migration/test_pipeline.py
@@ -122,6 +122,22 @@ class TestRunPlanFailures:
         assert job.validation.severity == "block"
         assert job.rendered is not None  # still produced for review
 
+    def test_force_does_not_clear_a_validation_block(self):
+        """API-7: ``force`` only skips the cross-device-class guard — it
+        does NOT clear a validation ``block``.  A tree with an unsupported
+        path renders to ``partial`` whether or not ``force`` is set; there
+        is no ``strip_unsupported`` mechanism (the ``partial`` status is
+        the honest record of what the target dropped).  MockCodec→MockCodec
+        share a device class, so the class guard is a no-op and the block
+        comes purely from the unsupported path — isolating the invariant.
+        """
+        raw = json.dumps({"/unsafe/kernel_module": "rootkit.ko"})
+        forced = run_plan(MockCodec(), MockCodec(), raw, force=True)
+        assert forced.status is MigrationJobStatus.partial
+        assert forced.validation is not None
+        assert forced.validation.severity == "block"
+        assert forced.rendered is not None
+
     def test_failed_job_still_has_completed_at(self):
         job = run_plan(MockCodec(), MockCodec(), "not valid json")
         assert job.completed_at is not None


### PR DESCRIPTION
The last design-call item from the Fable-review tail. The finding: `force` "doesn't clear a block" while the docs implied it did — "make force clear the block, **or drop the affordance**."

### Verify-first turned up a deeper issue
The `strip_unsupported` transform the docstrings told callers to run to clear a block **does not exist**. It was referenced in four docstrings (`models/migration.py` ×3 + `codecs/base.py`) with **zero implementation, calls, or UI**. The doc-half fix in #288 unknowingly kept recommending it.

### The behaviour is already correct — so: drop the affordance
`force` only skips the stage-0 cross-device-class guard. A validation `block` renders anyway (the target simply omits the paths it can't emit) and the job is flagged `partial`. **That `partial` status + the `ValidationReport` *are* the mechanism** — netcanon's "declare what you drop" honesty keystone. An auto-strip would only *suppress* that honest signal, so building one would be an anti-feature; the right resolution is the review's own alternative — drop the affordance.

### Changes
- Removed all four `strip_unsupported` references; rewrote the `block` severity / `LossyPath` / `UnsupportedPath` / `render()` docstrings to state the honest, self-consistent behaviour.
- Added `test_force_does_not_clear_a_validation_block` pinning the invariant: `MockCodec→MockCodec` share a device class (class guard is a no-op), so the block comes purely from the unsupported path — `force=True` still yields `partial`/`block`.

**No behaviour change** — the force/block semantics were already right; this makes the docs match reality and kills the vaporware reference. Whole `tests/unit` + cross-mesh guard + migration-API integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
