### PR TITLE
fix(mikrotik): union-parse RouterOS 6/7 NTP client forms

### DIFF
--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -148,6 +148,8 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             _parse_system_dns(lines, intent)
         elif section == "/system ntp client":
             _parse_system_ntp(lines, intent)
+        elif section == "/system ntp client servers":
+            _parse_system_ntp_client_servers(lines, intent)
         elif section == "/interface ethernet":
             _parse_interface_ethernet(lines, iface_by_name)
         elif section == "/interface vlan":
@@ -373,14 +375,71 @@ def _parse_system_dns(lines: list[str], intent: CanonicalIntent) -> None:
                 ]
 
 
+# RouterOS "no server configured" markers: an empty string (``servers=""``,
+# ``server-dns-names=""``) and the ``0.0.0.0`` unset sentinel RouterOS 6
+# writes into ``primary-ntp``/``secondary-ntp`` when a slot is unconfigured.
+_NTP_UNSET_TOKENS = frozenset({"", "0.0.0.0"})
+
+
+def _add_ntp_servers(intent: CanonicalIntent, candidates: list[str]) -> None:
+    """Union NTP server tokens onto ``intent.ntp_servers``.
+
+    Order-preserving and de-duplicated, skipping empty / ``0.0.0.0``
+    unset sentinels.  Shared by both NTP handlers so the RouterOS 6
+    (``primary-ntp=``/``secondary-ntp=``/``server-dns-names=``), the
+    RouterOS 7 inline (``servers=A,B``) and the RouterOS 7 subsection
+    (``/system ntp client servers``) forms all merge into one list.
+    """
+    servers = list(intent.ntp_servers)
+    seen = set(servers)
+    for raw in candidates:
+        token = raw.strip()
+        if token in _NTP_UNSET_TOKENS or token in seen:
+            continue
+        seen.add(token)
+        servers.append(token)
+    intent.ntp_servers = servers
+
+
 def _parse_system_ntp(lines: list[str], intent: CanonicalIntent) -> None:
+    """Parse the ``/system ntp client`` ``set`` line across RouterOS versions.
+
+    RouterOS 7 uses ``servers=A,B`` (a comma list); RouterOS 6 uses
+    ``primary-ntp=A`` / ``secondary-ntp=B`` (IP literals) plus
+    ``server-dns-names=`` (a comma list of hostnames).  Union every form
+    so a v6 export no longer silently loses its NTP servers.
+    """
     for line in lines:
-        if line.startswith("set"):
-            kv = _parse_kv(line)
-            if "servers" in kv:
-                intent.ntp_servers = [
-                    s.strip() for s in kv["servers"].split(",") if s.strip()
-                ]
+        if not line.startswith("set"):
+            continue
+        kv = _parse_kv(line)
+        candidates: list[str] = []
+        if "servers" in kv:                            # RouterOS 7 inline
+            candidates.extend(kv["servers"].split(","))
+        for key in ("primary-ntp", "secondary-ntp"):   # RouterOS 6 IP literals
+            if key in kv:
+                candidates.append(kv[key])
+        if "server-dns-names" in kv:                   # RouterOS 6 hostnames
+            candidates.extend(kv["server-dns-names"].split(","))
+        _add_ntp_servers(intent, candidates)
+
+
+def _parse_system_ntp_client_servers(
+    lines: list[str], intent: CanonicalIntent
+) -> None:
+    """Parse the RouterOS 7 ``/system ntp client servers`` subsection.
+
+    RouterOS 7 moved NTP servers out of the ``set`` line into a dedicated
+    subsection of ``add address=X`` rows (each an IP literal or a
+    hostname).  Merge them into ``intent.ntp_servers`` alongside anything
+    the ``set`` line already produced.
+    """
+    for line in lines:
+        if not line.startswith("add"):
+            continue
+        kv = _parse_kv(line)
+        if "address" in kv:
+            _add_ntp_servers(intent, [kv["address"]])
 
 
 def _parse_interface_ethernet(

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -211,6 +211,95 @@ class TestParse:
         assert vlan_iface.ipv4_addresses[0].prefix_length == 24
 
 
+class TestNtpVersionForms:
+    """``/system ntp client`` grammar differs by RouterOS major version.
+
+    RouterOS 7 writes ``servers=A,B`` (or a ``/system ntp client servers``
+    subsection); RouterOS 6 writes ``primary-ntp=``/``secondary-ntp=`` +
+    ``server-dns-names=``.  Parse must union every form — a version-agnostic
+    fidelity fix: v6 and v7-subsection exports previously dropped all NTP
+    servers silently.
+    """
+
+    def test_v7_inline_servers(self):
+        raw = "/system ntp client\nset enabled=yes servers=10.0.0.1,10.0.0.2\n"
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.ntp_servers == ["10.0.0.1", "10.0.0.2"]
+
+    def test_v6_primary_secondary(self):
+        raw = (
+            "/system ntp client\n"
+            "set enabled=yes primary-ntp=10.0.0.1 secondary-ntp=10.0.0.2\n"
+        )
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.ntp_servers == ["10.0.0.1", "10.0.0.2"]
+
+    def test_v6_duplicate_primary_secondary_dedups(self):
+        # A real export (routeros_diff_verbose_export.rsc) repeats the same
+        # IP in both slots — order-preserving dedup yields a single entry.
+        raw = (
+            "/system ntp client\n"
+            "set enabled=yes primary-ntp=10.200.0.15 secondary-ntp=10.200.0.15"
+            ' server-dns-names=""\n'
+        )
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.ntp_servers == ["10.200.0.15"]
+
+    def test_v6_server_dns_names(self):
+        raw = (
+            "/system ntp client\n"
+            "set enabled=yes server-dns-names=time.google.com,pool.ntp.org\n"
+        )
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.ntp_servers == ["time.google.com", "pool.ntp.org"]
+
+    def test_v7_subsection_add_address(self):
+        raw = (
+            "/system ntp client\n"
+            "set enabled=yes\n"
+            "/system ntp client servers\n"
+            "add address=time.google.com\n"
+            "add address=10.0.0.9\n"
+        )
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.ntp_servers == ["time.google.com", "10.0.0.9"]
+
+    def test_unset_sentinels_skipped(self):
+        # servers="" (v7) and 0.0.0.0 (v6 unconfigured slot) are not servers.
+        raw = (
+            "/system ntp client\n"
+            'set enabled=no servers="" primary-ntp=0.0.0.0 secondary-ntp=0.0.0.0'
+            ' server-dns-names=""\n'
+        )
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.ntp_servers == []
+
+    @pytest.mark.parametrize(
+        "fixture,expected",
+        [
+            ("routeros_diff_verbose_export.rsc", ["10.200.0.15"]),
+            ("taqavi_initial_provisioning.rsc", ["time.google.com"]),
+        ],
+    )
+    def test_real_fixtures_no_longer_drop_ntp(self, fixture, expected):
+        raw = (
+            Path(__file__).resolve().parents[2]
+            / "fixtures" / "real" / "mikrotik" / fixture
+        ).read_text(encoding="utf-8")
+        tree = MikroTikRouterOSCodec().parse(raw)
+        assert tree.ntp_servers == expected
+
+    def test_v6_ntp_round_trips(self):
+        raw = (
+            "/system ntp client\n"
+            "set enabled=yes primary-ntp=10.0.0.1 secondary-ntp=10.0.0.2\n"
+        )
+        codec = MikroTikRouterOSCodec()
+        tree = codec.parse(raw)
+        reparsed = codec.parse(codec.render(tree))
+        assert reparsed.ntp_servers == tree.ntp_servers == ["10.0.0.1", "10.0.0.2"]
+
+
 class TestParseErrors:
     def test_empty_input_raises(self):
         with pytest.raises(ParseError, match="empty input"):


### PR DESCRIPTION
## What

The MikroTik parser read only the RouterOS **7 inline** NTP form (`set ... servers=A,B`). It silently dropped NTP servers written in either of the other two real-world forms:

- **RouterOS 6:** `set ... primary-ntp=A secondary-ntp=B server-dns-names=...`
- **RouterOS 7 subsection:** `/system ntp client servers` + `add address=X` rows

## Why it's a bug (reproduced)

Two committed real fixtures parsed to `ntp_servers=[]` before this change:

| fixture | form | before | after |
|---|---|---|---|
| `routeros_diff_verbose_export.rsc` | v6 `primary-ntp/secondary-ntp` | `[]` | `['10.200.0.15']` |
| `taqavi_initial_provisioning.rsc` | v7 `servers` subsection | `[]` | `['time.google.com']` |
| `user_contrib_crs310_ros7.rsc` | `servers=""` (unset) | `[]` | `[]` (unchanged) |

## How

A shared `_add_ntp_servers` merge (order-preserving, de-duplicating, skips empty + the `0.0.0.0` unset sentinel) unions all three forms. `_parse_system_ntp` reads `servers=` / `primary-ntp=` / `secondary-ntp=` / `server-dns-names=`; a new `_parse_system_ntp_client_servers` handles the v7 subsection.

**Render is unchanged** — v6 / v7-subsection input re-renders as the v7 `servers=` form and reparses identically, so round-trips stay stable.

## Verification
- New `TestNtpVersionForms` (8 cases: each form, dedup, unset sentinels, both real fixtures, round-trip).
- Full `tests/unit` green; `tests/integration/test_cross_mesh_ci_guard.py` green (**CODEC_BUG=5, no new pair, cells_total=1224** — baseline untouched, as the version-vector assessment's adversarial simulation predicted).
- `ruff` clean; `parse_intent` stays under the complexity ratchet (already grandfathered; new logic is in small helpers).

Version-agnostic fidelity fix surfaced by the 2026-07-05 version-vector assessment (Phase 1a) — shipped as an ordinary bugfix, not gated on `source_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
