### PR TITLE
fix(junos): parse pre-ELS `port-mode` so an access port stays access

### DIFF
--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -1529,12 +1529,18 @@ def _apply_interfaces(  # noqa: C901
 
         # --- Phase 4 rank-4: L2 family ethernet-switching ---
         # ``unit 0 family ethernet-switching interface-mode access|trunk``
+        # ELS (EX/QFX 15.1+ on most platforms) spells this ``interface-mode``;
+        # pre-ELS Junos (and platforms like the EX4550 that stayed non-ELS at
+        # 15.1) spell the identical construct ``port-mode``.  Accept both — a
+        # ``port-mode access`` port must record mode=access here, otherwise the
+        # ``vlan members``-without-explicit-mode default below silently
+        # promotes it to a trunk (an access port becoming a trunk on reparse).
         if (
             unit_num == 0
             and len(tokens) >= 7
             and tokens[3] == "family"
             and tokens[4] == "ethernet-switching"
-            and tokens[5] == "interface-mode"
+            and tokens[5] in ("interface-mode", "port-mode")
         ):
             mode = tokens[6]
             if mode in ("access", "trunk"):

--- a/tests/unit/migration/test_juniper_junos.py
+++ b/tests/unit/migration/test_juniper_junos.py
@@ -1156,6 +1156,88 @@ class TestSubInterfaces:
 # ---------------------------------------------------------------------------
 
 
+class TestPreElsPortMode:
+    """Pre-ELS Junos (and platforms like the EX4550 that stayed non-ELS at
+    15.1) spell the L2 switchport mode ``port-mode`` where ELS spells it
+    ``interface-mode``.  Both must parse — otherwise a ``port-mode access``
+    port falls through to the ``vlan members``-without-explicit-mode default
+    and is silently promoted to a TRUNK on reparse (an access port becoming
+    a trunk = a real data-fidelity bug)."""
+
+    def test_pre_els_port_mode_access_stays_access(self):
+        raw = (
+            "set vlans V10 vlan-id 10\n"
+            "set interfaces ge-0/0/1 unit 0 family ethernet-switching "
+            "port-mode access\n"
+            "set interfaces ge-0/0/1 unit 0 family ethernet-switching "
+            "vlan members V10\n"
+        )
+        intent = JunosCodec().parse(raw)
+        iface = next(i for i in intent.interfaces if i.name == "ge-0/0/1")
+        assert iface.switchport_mode == "access"
+        assert iface.access_vlan == 10
+        assert iface.trunk_allowed_vlans == []  # NOT promoted to a trunk
+
+    def test_pre_els_port_mode_trunk_stays_trunk(self):
+        raw = (
+            "set vlans V10 vlan-id 10\n"
+            "set vlans V20 vlan-id 20\n"
+            "set interfaces xe-0/0/0 unit 0 family ethernet-switching "
+            "port-mode trunk\n"
+            "set interfaces xe-0/0/0 unit 0 family ethernet-switching "
+            "vlan members V10\n"
+            "set interfaces xe-0/0/0 unit 0 family ethernet-switching "
+            "vlan members V20\n"
+        )
+        intent = JunosCodec().parse(raw)
+        iface = next(i for i in intent.interfaces if i.name == "xe-0/0/0")
+        assert iface.switchport_mode == "trunk"
+        assert iface.trunk_allowed_vlans == [10, 20]
+
+    def test_els_interface_mode_still_parses(self):
+        raw = (
+            "set vlans V10 vlan-id 10\n"
+            "set interfaces ge-0/0/2 unit 0 family ethernet-switching "
+            "interface-mode trunk\n"
+            "set interfaces ge-0/0/2 unit 0 family ethernet-switching "
+            "vlan members V10\n"
+        )
+        intent = JunosCodec().parse(raw)
+        iface = next(i for i in intent.interfaces if i.name == "ge-0/0/2")
+        assert iface.switchport_mode == "trunk"
+        assert iface.trunk_allowed_vlans == [10]
+
+    def test_pre_els_access_round_trips(self):
+        raw = (
+            "set vlans V10 vlan-id 10\n"
+            "set interfaces ge-0/0/1 unit 0 family ethernet-switching "
+            "port-mode access\n"
+            "set interfaces ge-0/0/1 unit 0 family ethernet-switching "
+            "vlan members V10\n"
+        )
+        codec = JunosCodec()
+        tree = codec.parse(raw)
+        reparsed = codec.parse(codec.render(tree))
+        iface = next(i for i in reparsed.interfaces if i.name == "ge-0/0/1")
+        assert iface.switchport_mode == "access"
+        assert iface.access_vlan == 10
+
+    def test_ksator_ex4550_trunk_ports_unchanged(self):
+        """The committed real 15.1 EX4550 fixture uses ``port-mode trunk`` on
+        xe-0/0/0-2 — recognising ``port-mode`` explicitly must leave those
+        trunk ports (and their allowed-VLAN lists) exactly as before."""
+        import pathlib
+        raw = pathlib.Path(
+            "tests/fixtures/real/junos/"
+            "ksator_labmgmt_ex4550_junos151.set"
+        ).read_text(encoding="utf-8")
+        intent = JunosCodec().parse(raw)
+        by_name = {i.name: i for i in intent.interfaces}
+        for name in ("xe-0/0/0", "xe-0/0/1", "xe-0/0/2"):
+            assert by_name[name].switchport_mode == "trunk"
+            assert by_name[name].trunk_allowed_vlans  # non-empty
+
+
 class TestPerUnitVlanTagging:
     """``set interfaces <parent> unit <N> vlan-id <tag>`` is Junos's
     per-subinterface 802.1Q tag primitive — semantically equivalent to


### PR DESCRIPTION
## The bug (reproduced)

Pre-ELS Junos — and platforms like the **EX4550 that stayed non-ELS at 15.1** — spell the L2 switchport mode `unit 0 family ethernet-switching port-mode access|trunk`. ELS spells the identical construct `interface-mode`. The parser recognised **only** `interface-mode`.

So a `port-mode access` port recorded no `switchport_mode`, then hit the `vlan members`-without-explicit-mode default that promotes to trunk:

```
set interfaces ge-0/0/1 unit 0 family ethernet-switching port-mode access
set interfaces ge-0/0/1 unit 0 family ethernet-switching vlan members V10
```

| | before | after |
|---|---|---|
| `switchport_mode` | **`trunk`** ❌ | `access` ✅ |
| `access_vlan` | `None` | `10` |
| `trunk_allowed_vlans` | `[10]` | `[]` |

**An access port silently became a trunk on reparse** — a real semantic-inversion / fidelity bug.

## Fix

Accept `port-mode` as a synonym for `interface-mode` at the one parse site. The explicit mode now populates `switchport_mode` *before* the trunk default (which already guards on `switchport_mode is None`), so the heuristic no longer overrides it. One-token change; trunk ports resolve to the identical tree (now via the explicit mode rather than the default).

## Verification
- New `TestPreElsPortMode` (5 cases: pre-ELS access stays access, pre-ELS trunk stays trunk, ELS `interface-mode` still parses, access round-trips, **committed EX4550 15.1 fixture trunk ports unchanged**).
- Full `tests/unit` green; `tests/integration/test_cross_mesh_ci_guard.py` green — **CODEC_BUG=5, no new pair, cells_total=1224**. No committed fixture carries a pre-ELS *access* port (ksator EX4550 is all trunk), so the baseline is untouched.
- `ruff` clean.

Version-agnostic fidelity fix surfaced by the 2026-07-05 version-vector assessment (Phase 1d) — union grammar, not gated on `source_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
