### PR TITLE
fix(arista): harvest legacy `vrf definition` top-level VRF stanzas

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -177,7 +177,13 @@ _RADIUS_ACCT_PORT_RE = re.compile(r"\bacct-port\s+(\d+)")
 # Key payload: bare token or quoted string.  EOS accepts both.
 _RADIUS_KEY_RE = re.compile(r'\bkey\s+(?:"([^"]*)"|(\S+))')
 
-_VRF_INSTANCE_RE = re.compile(r"^vrf\s+instance\s+(\S+)\s*$", re.MULTILINE)
+# Top-level VRF declaration.  Modern EOS (4.23+) uses ``vrf instance <name>``;
+# older EOS (<=4.22) uses ``vrf definition <name>`` for the identical stanza.
+# Accept both so a legacy config's VRFs aren't silently dropped from
+# routing_instances.  RD + RTs are populated later from the router-bgp pass.
+_VRF_INSTANCE_RE = re.compile(
+    r"^vrf\s+(?:instance|definition)\s+(\S+)\s*$", re.MULTILINE
+)
 _INTERFACE_HEADER_RE = re.compile(r"^interface\s+(\S+)\s*$")
 
 # VARP system-wide MAC (Wave C anycast-gateway wire-up).  Form:

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -371,6 +371,31 @@ class TestParseInterfaces:
         assert by_name["Ethernet1"] == "BLUE"
         assert by_name["Ethernet2"] == "forwarding"
 
+    def test_top_level_vrf_definition_legacy_harvested(self):
+        """Older EOS (<=4.22) declares a top-level VRF with
+        ``vrf definition <name>``; modern EOS (4.23+) uses
+        ``vrf instance <name>``.  Both must populate routing_instances —
+        the legacy form was previously dropped silently."""
+        raw = (
+            "hostname sw1\n"
+            "vrf definition RED\n"
+            "   rd 1:1\n"
+            "!\n"
+            "vrf instance BLUE\n"
+            "!\n"
+        )
+        intent = AristaEOSCodec().parse(raw)
+        assert sorted(r.name for r in intent.routing_instances) == ["BLUE", "RED"]
+
+    def test_top_level_vrf_definition_round_trips(self):
+        """A legacy ``vrf definition`` re-renders as the modern
+        ``vrf instance`` form and reparses to the same routing instance."""
+        raw = "hostname sw1\nvrf definition RED\n!\n"
+        codec = AristaEOSCodec()
+        tree = codec.parse(raw)
+        reparsed = codec.parse(codec.render(tree))
+        assert [r.name for r in reparsed.routing_instances] == ["RED"]
+
     def test_interface_loopback(self):
         raw = (
             "hostname sw1\n"


### PR DESCRIPTION
## The bug (reproduced)

Older EOS (≤4.22) declares a top-level VRF with `vrf definition <name>`; modern EOS (4.23+) uses `vrf instance <name>` for the identical stanza. `_VRF_INSTANCE_RE` matched **only** `vrf instance`, so a legacy config's VRFs were silently dropped from `routing_instances`:

```
vrf definition RED
   rd 1:1
!
vrf instance BLUE
```

- before: `routing_instances = ['BLUE']` ❌ (RED lost, even though an interface bound `vrf RED`)
- after: `routing_instances = ['BLUE', 'RED']` ✅

The stale comment at the interface-level VRF check even claimed `vrf definition` was "already caught by `_VRF_INSTANCE_RE`" — it wasn't; this makes that true.

## Fix

Widen `_VRF_INSTANCE_RE` to `^vrf\s+(?:instance|definition)\s+(\S+)\s*$`. RD/RTs continue to be populated from the router-bgp pass, identical to `vrf instance`. A legacy `vrf definition` re-renders as the modern `vrf instance` form and reparses to the same routing instance.

## Verification
- New tests: legacy `vrf definition` + modern `vrf instance` both harvested; round-trip stable.
- Full `tests/unit` green; `tests/integration/test_cross_mesh_ci_guard.py` green — **CODEC_BUG=5, cells_total=1224**. The committed 4.21/4.22 fixtures carry no VRFs, so the baseline is untouched.
- `ruff` clean.

Version-agnostic fidelity fix surfaced by the 2026-07-05 version-vector assessment (Phase 1b) — union grammar, not gated on `source_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
