### PR TITLE
fix(cisco_iosxe_cli): harvest classic IOS-12 `ip vrf` top-level stanzas

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -385,8 +385,16 @@ _TOP_NTP_SERVER_RE = re.compile(
 # <rt>``, and ``address-family ipv4 / exit-address-family`` markers
 # (the markers themselves carry no canonical state — they just gate
 # the RT import/export sub-block on the wire).
+#
+# Classic IOS 12 (and IOS-XE configs migrated from it) open the identical
+# stanza with the legacy top-level ``ip vrf <name>`` — RD + route-targets
+# hang directly under it with no address-family framing.  Accept both
+# openers so a legacy config's VRFs aren't dropped from routing_instances.
+# The trailing ``\s*$`` keeps this disjoint from the interface-level
+# ``ip vrf forwarding <name>`` membership line (two tokens after ``ip vrf``,
+# and that line is indented — this header is column-0).
 _VRF_DEFINITION_RE = re.compile(
-    r"^vrf\s+definition\s+(\S+)\s*$", re.IGNORECASE,
+    r"^(?:ip\s+vrf|vrf\s+definition)\s+(\S+)\s*$", re.IGNORECASE,
 )
 # ``(\S.*)`` (not ``(.+)``) so the ``\s+`` separator and the value can't both
 # match the same spaces -- the polynomial-ReDoS overlap CodeQL flagged

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -703,6 +703,70 @@ class TestRender:
                (second.snmp.community if second.snmp else "")
 
 
+class TestTopLevelVrfHarvest:
+    """Top-level VRF stanzas come in two forms: the modern IOS-XE
+    ``vrf definition <name>`` and the classic IOS 12 ``ip vrf <name>``
+    (RD + route-targets directly under it, no address-family framing).
+    Both must populate routing_instances — the classic form was
+    previously dropped silently while its interface binding (``ip vrf
+    forwarding``) was still captured, leaving a dangling VRF reference."""
+
+    def test_classic_ip_vrf_harvested(self):
+        intent = CiscoIOSXECLICodec().parse(
+            "ip vrf CUST\n"
+            " rd 65000:1\n"
+            " route-target export 65000:1\n"
+            " route-target import 65000:1\n"
+            "!\n"
+        )
+        ri = next(r for r in intent.routing_instances if r.name == "CUST")
+        assert ri.route_distinguisher == "65000:1"
+        assert ri.rt_exports == ["65000:1"]
+        assert ri.rt_imports == ["65000:1"]
+
+    def test_modern_vrf_definition_still_harvested(self):
+        intent = CiscoIOSXECLICodec().parse(
+            "vrf definition MODERN\n"
+            " rd 65000:2\n"
+            " address-family ipv4\n"
+            "  route-target export 65000:2\n"
+            " exit-address-family\n"
+            "!\n"
+        )
+        ri = next(r for r in intent.routing_instances if r.name == "MODERN")
+        assert ri.route_distinguisher == "65000:2"
+        assert ri.rt_exports == ["65000:2"]
+
+    def test_ip_vrf_forwarding_on_interface_not_mistaken_for_definition(self):
+        # The interface-level membership line must NOT create a top-level
+        # routing instance named "forwarding" (it binds Gi0/0 to CUST).
+        intent = CiscoIOSXECLICodec().parse(
+            "ip vrf CUST\n"
+            " rd 65000:1\n"
+            "!\n"
+            "interface GigabitEthernet0/0\n"
+            " ip vrf forwarding CUST\n"
+            " ip address 10.0.0.1 255.255.255.0\n"
+            "!\n"
+        )
+        assert [r.name for r in intent.routing_instances] == ["CUST"]
+        iface = next(
+            i for i in intent.interfaces if i.name == "GigabitEthernet0/0"
+        )
+        assert iface.vrf == "CUST"
+
+    def test_classic_ip_vrf_round_trips(self):
+        codec = CiscoIOSXECLICodec()
+        tree = codec.parse(
+            "ip vrf CUST\n rd 65000:1\n route-target both 65000:1\n!\n"
+        )
+        reparsed = codec.parse(codec.render(tree))
+        ri = next(r for r in reparsed.routing_instances if r.name == "CUST")
+        assert ri.route_distinguisher == "65000:1"
+        assert ri.rt_exports == ["65000:1"]
+        assert ri.rt_imports == ["65000:1"]
+
+
 class TestLocalUserPasswordRoundTrip:
     """Regression for the ``password 0 X`` round-trip bug.
 


### PR DESCRIPTION
## The bug (reproduced)

IOS-XE declares a top-level VRF with `vrf definition <name>`; classic IOS 12 (and configs migrated from it) use `ip vrf <name>`, with `rd` / route-targets directly under it (no `address-family` framing). The harvest matched **only** `vrf definition`:

```
ip vrf CUST
 rd 65000:1
 route-target export 65000:1
!
interface GigabitEthernet0/0
 ip vrf forwarding CUST
```

- before: `CUST` dropped from `routing_instances` — but `Gi0/0.vrf == "CUST"` was still set, leaving a **dangling VRF reference**.
- after: `routing_instances` carries `CUST` (rd `65000:1`, rt export/import `65000:1`).

## Fix

Widen the stanza-header regex to `^(?:ip\s+vrf|vrf\s+definition)\s+(\S+)\s*$`. The trailing `\s*$` keeps it disjoint from the interface-level `ip vrf forwarding <name>` membership line (two tokens after `ip vrf`, and indented — this header is column-0). Sub-line parsing (`rd` / `route-target import|export|both`) is unchanged and already tolerant of the missing address-family markers. A classic `ip vrf` re-renders as the modern `vrf definition` form and reparses identically.

## Verification
- New `TestTopLevelVrfHarvest` (4 cases: classic harvested with RD+RTs, modern still works, interface `ip vrf forwarding` not mistaken for a definition, round-trip).
- Full `tests/unit` green; `tests/integration/test_cross_mesh_ci_guard.py` green — **CODEC_BUG=5, cells_total=1224**. No committed fixture uses classic `ip vrf`, so the baseline is untouched.
- `ruff` clean; `_parse_routing_instances` unchanged in shape (regex-only widening).

Version-agnostic fidelity fix surfaced by the 2026-07-05 version-vector assessment (Phase 1c) — union grammar, not gated on `source_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
