### PR TITLE
fix(render): echo the device's own OS version on same-vendor re-render

### DIFF
--- a/netcanon/migration/codecs/aruba_aoscx/render.py
+++ b/netcanon/migration/codecs/aruba_aoscx/render.py
@@ -47,11 +47,23 @@ import re
 from ...canonical.intent import CanonicalIntent
 from .._helpers import _coalesce_vlan_ids
 
-#: Synthesised AOS-CX release stamped into the ``!Version`` banner.
-#: Cosmetic — the parsed ``source_version`` is metadata only and not
-#: echoed (mirrors the cisco_nxos ``_DEFAULT_VERSION`` convention).  The
-#: ``Virtual.`` prefix is the AOS-CX simulator image family.
+#: Synthesised AOS-CX release stamped into the ``!Version`` banner when the
+#: source device's own release is unknown.  When the tree was parsed from THIS
+#: codec and carries a ``source_version`` (sanitize / AOS-CX→AOS-CX
+#: re-render), that real release is echoed instead, so a same-vendor pass
+#: doesn't relabel the device with a constant.  The ``!Version ArubaOS-CX``
+#: PREFIX is this codec's detection marker and is always preserved; only the
+#: release token varies.  Comparator-invisible (``source_version`` is
+#: metadata-excluded).  The ``Virtual.`` prefix is the simulator image family.
 _DEFAULT_VERSION = "Virtual.10.13.1000"
+
+
+def _version_token(tree: CanonicalIntent) -> str:
+    """The AOS-CX release token to stamp after ``!Version ArubaOS-CX``: the
+    device's own when same-vendor and known, else the synthetic default."""
+    if tree.source_vendor == "aruba_aoscx" and tree.source_version:
+        return tree.source_version
+    return _DEFAULT_VERSION
 
 #: Canonical SNMPv3 privacy cipher -> AOS-CX `priv` keyword.  AOS-CX
 #: supports `des` and `aes`; NX-OS-style aes128/192/256 collapse to
@@ -69,7 +81,7 @@ def render_intent(tree: CanonicalIntent) -> str:
 
     # ── Banner / version ──
     lines.append("!")
-    lines.append(f"!Version ArubaOS-CX {_DEFAULT_VERSION}")
+    lines.append(f"!Version ArubaOS-CX {_version_token(tree)}")
     lines.append("!export-password: default")
     lines.append(f"hostname {hostname}")
 

--- a/netcanon/migration/codecs/cisco_iosxr/render.py
+++ b/netcanon/migration/codecs/cisco_iosxr/render.py
@@ -43,10 +43,21 @@ from ...canonical.intent import CanonicalIntent, CanonicalRoutingInstance
 from .._helpers import _prefix_to_mask
 from . import port_names as _port_names
 
-#: Synthesised IOS-XR release stamped into the banner.  Cosmetic — the
-#: parsed ``source_version`` is metadata only and not echoed (mirrors the
-#: cisco_nxos render convention).
+#: Synthesised IOS-XR release stamped into the banner when the source
+#: device's own release is unknown.  When the tree was parsed from THIS codec
+#: and carries a ``source_version`` (sanitize / IOS-XR→IOS-XR re-render), that
+#: real release is echoed instead, so a same-vendor pass doesn't relabel the
+#: device with a constant.  Comparator-invisible (``source_version`` is
+#: metadata-excluded).  Mirrors the cisco_nxos render convention.
 _DEFAULT_VERSION = "6.6.2"
+
+
+def _version_token(tree: CanonicalIntent) -> str:
+    """The IOS-XR release to stamp: the device's own when same-vendor and
+    known, else the synthetic default."""
+    if tree.source_vendor == "cisco_iosxr" and tree.source_version:
+        return tree.source_version
+    return _DEFAULT_VERSION
 
 #: Canonical LAG mode → IOS-XR ``bundle id ... mode`` keyword (inverse of
 #: parse._IOSXR_LAG_MODE_MAP; canonical ``static`` → XR ``on``).
@@ -67,7 +78,7 @@ def render_intent(tree: CanonicalIntent) -> str:
     lines: list[str] = []
 
     # ── Banner ──
-    lines.append(f"!! IOS XR Configuration {_DEFAULT_VERSION}")
+    lines.append(f"!! IOS XR Configuration {_version_token(tree)}")
     lines.append("!")
     lines.append(f"hostname {hostname}")
     if tree.domain:

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -35,9 +35,21 @@ from ...canonical.intent import CanonicalIntent, CanonicalRoutingInstance
 from .._helpers import _coalesce_vlan_ids
 from . import port_names as _port_names
 
-#: Synthesised NX-OS release stamped into the banner.  Cosmetic — the
-#: parsed ``source_version`` is metadata only and not echoed.
+#: Synthesised NX-OS release stamped into the banner when the source device's
+#: own release is unknown.  When the tree was parsed from THIS codec and
+#: carries a ``source_version`` (i.e. sanitize / NX-OS→NX-OS re-render), that
+#: real release is echoed instead — otherwise a same-vendor pass silently
+#: relabels the device's config with a constant.  Comparator-invisible
+#: (``source_version`` is metadata-excluded from every comparator).
 _DEFAULT_VERSION = "9.3(11)"
+
+
+def _version_token(tree: CanonicalIntent) -> str:
+    """The NX-OS release to stamp: the device's own when same-vendor and
+    known, else the synthetic default."""
+    if tree.source_vendor == "cisco_nxos" and tree.source_version:
+        return tree.source_version
+    return _DEFAULT_VERSION
 
 #: Canonical LAG mode -> NX-OS ``channel-group ... mode`` keyword
 #: (inverse of parse._NXOS_LAG_MODE_MAP; canonical ``static`` -> ``on``).
@@ -67,7 +79,7 @@ def render_intent(tree: CanonicalIntent) -> str:
     # ── Banner / version / vdc wrapper ──
     lines.append("!Command: show running-config")
     lines.append("")
-    lines.append(f"version {_DEFAULT_VERSION} Bios:version")
+    lines.append(f"version {_version_token(tree)} Bios:version")
     lines.append(f"hostname {hostname}")
     lines.append(f"vdc {hostname} id 1")
     lines.append("")
@@ -168,7 +180,7 @@ def render_intent(tree: CanonicalIntent) -> str:
     # ── Footers (synthesised defaults) ──
     lines.append("line console")
     lines.append("line vty")
-    lines.append(f"boot nxos bootflash:/nxos.{_DEFAULT_VERSION}.bin")
+    lines.append(f"boot nxos bootflash:/nxos.{_version_token(tree)}.bin")
 
     return "\n".join(lines) + "\n"
 

--- a/netcanon/migration/codecs/vyos/render.py
+++ b/netcanon/migration/codecs/vyos/render.py
@@ -56,8 +56,23 @@ _CONFIG_VERSION = (
     "pptp@2:qos@2:quagga@11:rpki@2:salt@1:snmp@3:ssh@2:sstp@6:system@27:"
     "vrf@3:vrrp@4:wanloadbalance@3:webproxy@2"
 )
-#: Stamped into the ``// Release version`` trailer (cosmetic).
+#: Stamped into the ``// Release version`` trailer when the source device's
+#: own release is unknown.  When the tree was parsed from THIS codec and
+#: carries a ``source_version`` (sanitize / VyOS→VyOS re-render), that real
+#: release is echoed instead, so a same-vendor pass doesn't relabel the
+#: device with a constant.  Only the ``// Release version`` trailer varies —
+#: the ``// vyos-config-version`` component vector above is NEVER touched
+#: (it's a component-schema fingerprint, a different axis).  Comparator-
+#: invisible (``source_version`` is metadata-excluded).
 _RELEASE_VERSION = "1.4"
+
+
+def _release_token(tree: CanonicalIntent) -> str:
+    """The VyOS release to stamp into ``// Release version``: the device's own
+    when same-vendor and known, else the synthetic default."""
+    if tree.source_vendor == "vyos" and tree.source_version:
+        return tree.source_version
+    return _RELEASE_VERSION
 
 #: Interface-type render rank — ethernet, then loopback, dummy, bonding.
 _TYPE_RANK = {"ethernet": 0, "loopback": 1, "dummy": 2, "bonding": 3}
@@ -100,7 +115,7 @@ def render_intent(tree: CanonicalIntent) -> str:
     # Trailer — every config.boot ends with the component-version stamp.
     lines.append("// Warning: Do not remove the following line.")
     lines.append(f'// vyos-config-version: "{_CONFIG_VERSION}"')
-    lines.append(f"// Release version: {_RELEASE_VERSION}")
+    lines.append(f"// Release version: {_release_token(tree)}")
 
     return "\n".join(lines) + "\n"
 

--- a/tests/unit/migration/test_aruba_aoscx.py
+++ b/tests/unit/migration/test_aruba_aoscx.py
@@ -718,3 +718,29 @@ def test_port_name_classify(name: str, kind: str) -> None:
 def test_port_name_round_trip(name: str) -> None:
     ident = port_names.classify_port_name(name)
     assert port_names.format_port_identity(ident) == name
+
+
+def test_same_vendor_banner_echoes_source_version() -> None:
+    """Sanitize / AOS-CX→AOS-CX re-render echoes the device's own release
+    token after ``!Version ArubaOS-CX`` instead of the synthetic default —
+    and the probe-marker prefix is preserved so it still detects as AOS-CX."""
+    from netcanon.migration.canonical.intent import CanonicalIntent
+    tree = CanonicalIntent(
+        hostname="sw1", source_vendor="aruba_aoscx",
+        source_version="FL.10.10.1000",
+    )
+    out = ArubaAOSCXCodec().render(tree)
+    assert "!Version ArubaOS-CX FL.10.10.1000" in out
+    assert "Virtual.10.13.1000" not in out
+    assert ArubaAOSCXCodec.probe(out) is not None  # marker prefix survived
+
+
+def test_cross_vendor_banner_uses_default_version() -> None:
+    from netcanon.migration.canonical.intent import CanonicalIntent
+    codec = ArubaAOSCXCodec()
+    cross = CanonicalIntent(
+        hostname="sw1", source_vendor="cisco_nxos", source_version="10.3(2)"
+    )
+    assert "!Version ArubaOS-CX Virtual.10.13.1000" in codec.render(cross)
+    empty = CanonicalIntent(hostname="sw1", source_vendor="aruba_aoscx")
+    assert "!Version ArubaOS-CX Virtual.10.13.1000" in codec.render(empty)

--- a/tests/unit/migration/test_cisco_iosxr.py
+++ b/tests/unit/migration/test_cisco_iosxr.py
@@ -695,3 +695,26 @@ class TestTier3Display:
         assert any(d.startswith("route-policy ") for d in dropped)
         # The `.35` dot1q subinterface still synthesises a VLAN.
         assert intent.vlans
+
+
+class TestSameVendorBannerEcho:
+    """Sanitize / IOS-XR→IOS-XR re-render echoes the device's own release
+    into the ``!! IOS XR Configuration`` banner; cross-vendor / unknown-
+    version renders keep the synthetic default."""
+
+    def test_same_vendor_echoes_source_version(self):
+        tree = CanonicalIntent(
+            hostname="R1", source_vendor="cisco_iosxr", source_version="7.5.2"
+        )
+        out = CiscoIOSXRCodec().render(tree)
+        assert "!! IOS XR Configuration 7.5.2" in out
+        assert "6.6.2" not in out
+
+    def test_cross_vendor_and_empty_use_default(self):
+        codec = CiscoIOSXRCodec()
+        cross = CanonicalIntent(
+            hostname="R1", source_vendor="cisco_nxos", source_version="10.3(2)"
+        )
+        assert "!! IOS XR Configuration 6.6.2" in codec.render(cross)
+        empty = CanonicalIntent(hostname="R1", source_vendor="cisco_iosxr")
+        assert "!! IOS XR Configuration 6.6.2" in codec.render(empty)

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -1440,3 +1440,28 @@ class TestAnycastGateway:
             [(a.ip, a.virtual_gateway_address) for a in s1.ipv4_addresses]
             == [(a.ip, a.virtual_gateway_address) for a in s2.ipv4_addresses]
         )
+
+
+class TestSameVendorBannerEcho:
+    """Sanitize / NX-OS→NX-OS re-render must echo the device's own release
+    into the version banner + boot string, not relabel it with the synthetic
+    default.  Cross-vendor / unknown-version renders keep the default."""
+
+    def test_same_vendor_echoes_source_version(self):
+        tree = CanonicalIntent(
+            hostname="sw1", source_vendor="cisco_nxos", source_version="10.3(2)"
+        )
+        out = CiscoNXOSCodec().render(tree)
+        assert "version 10.3(2) Bios:version" in out
+        assert "nxos.10.3(2).bin" in out
+        assert "9.3(11)" not in out
+
+    def test_cross_vendor_and_empty_use_default(self):
+        codec = CiscoNXOSCodec()
+        cross = CanonicalIntent(
+            hostname="sw1", source_vendor="juniper_junos",
+            source_version="25.4R1",
+        )
+        assert "version 9.3(11) Bios:version" in codec.render(cross)
+        empty = CanonicalIntent(hostname="sw1", source_vendor="cisco_nxos")
+        assert "version 9.3(11) Bios:version" in codec.render(empty)

--- a/tests/unit/migration/test_vyos.py
+++ b/tests/unit/migration/test_vyos.py
@@ -937,3 +937,29 @@ def test_matrix_lossy(codec: VyOSCodec, path: str) -> None:
 ])
 def test_matrix_unsupported(codec: VyOSCodec, path: str) -> None:
     assert codec.capabilities.classify(path) == "unsupported"
+
+
+def test_same_vendor_release_trailer_echoes_source_version() -> None:
+    """Sanitize / VyOS→VyOS re-render echoes the device's own release into
+    the ``// Release version`` trailer; the ``// vyos-config-version``
+    component vector is a different axis and stays fixed."""
+    from netcanon.migration.canonical.intent import CanonicalIntent
+    tree = CanonicalIntent(
+        hostname="vyos", source_vendor="vyos", source_version="1.5"
+    )
+    out = VyOSCodec().render(tree)
+    assert "// Release version: 1.5" in out
+    assert "// Release version: 1.4" not in out
+    # The component-version fingerprint is untouched.
+    assert "// vyos-config-version:" in out
+
+
+def test_cross_vendor_release_trailer_uses_default() -> None:
+    from netcanon.migration.canonical.intent import CanonicalIntent
+    codec = VyOSCodec()
+    cross = CanonicalIntent(
+        hostname="vyos", source_vendor="cisco_nxos", source_version="10.3(2)"
+    )
+    assert "// Release version: 1.4" in codec.render(cross)
+    empty = CanonicalIntent(hostname="vyos", source_vendor="vyos")
+    assert "// Release version: 1.4" in codec.render(empty)


### PR DESCRIPTION
## The bug (reproduced end-to-end)

Four codec renderers stamp a hardcoded release constant into their version banner:

| codec | constant | site |
|---|---|---|
| cisco_nxos | `9.3(11)` | `version … Bios:version` + boot string |
| cisco_iosxr | `6.6.2` | `!! IOS XR Configuration …` |
| aruba_aoscx | `Virtual.10.13.1000` | `!Version ArubaOS-CX …` |
| vyos | `1.4` | `// Release version:` trailer |

On a **same-vendor** pass — `sanitize` (parse+render with one codec) and X→X migration — this silently **relabels the device's real OS version** with the constant:

```
$ sanitize_text("version 10.3(2) Bios:version\n…", "cisco_nxos")
# before: version 9.3(11) Bios:version   ← wrong; device is 10.3(2)
# after:  version 10.3(2) Bios:version   ✅
```

## Fix

Each renderer echoes `tree.source_version` **when the tree was parsed from this codec** (`source_vendor` matches) and carries a version; otherwise it falls back to today's constant. Cross-vendor renders and unknown-version (`source_version == ""`) trees are **byte-identical to before** — the echo is scoped to the one context where the source version *is* the device's version.

Preserved exactly:
- the aruba_aoscx `!Version ArubaOS-CX` **prefix** (the codec's own detection marker — only the release token varies; probe still detects post-render);
- the vyos `// vyos-config-version` component-schema vector (a different axis — never touched).

Comparator-invisible: `source_version` is excluded from every round-trip / cross-mesh comparator, so the bare mesh is unaffected.

## Verification
- End-to-end: sanitizing a `10.3(2)` NX-OS config returns `version 10.3(2)`.
- Per codec: same-vendor echoes the real version; cross-vendor + empty use the default; aoscx still `probe`-detects post-render; vyos component vector untouched.
- Full `tests/unit` green; `tests/integration/test_cross_mesh_ci_guard.py` green — **CODEC_BUG=5, cells_total=1224**.
- `ruff` clean.

Version-agnostic fidelity fix surfaced by the 2026-07-05 version-vector assessment (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
