### PR TITLE
feat(mikrotik): render RouterOS-6 NTP dialect on same-vendor output

### DIFF
--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -31,6 +31,7 @@ render → parse for shared utilities is fine).
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from typing import Any
 
@@ -94,6 +95,75 @@ def _routeros_group_for_privilege(level: int) -> str:
 # ---------------------------------------------------------------------------
 # Top-level entry
 # ---------------------------------------------------------------------------
+
+
+def _ros_major(version: str) -> int | None:
+    """RouterOS major version (6 or 7) from a captured ``source_version`` like
+    ``6.48.1`` / ``7.18.2``.
+
+    Returns ``None`` for an empty string, garbage, or a dot-less token — the
+    v6 NTP dialect gate only fires on affirmative dotted major-version
+    evidence, never on a guess.
+    """
+    m = re.match(r"(\d+)\.", version or "")
+    return int(m.group(1)) if m else None
+
+
+def _all_ip_literals(servers: list[str]) -> bool:
+    """True iff ``servers`` is non-empty and every entry is an IP literal.
+
+    RouterOS 6's ``primary-ntp=``/``secondary-ntp=`` slots accept IP
+    addresses only; a hostname NTP server must stay on the v7 ``servers=``
+    form (or the v6 ``server-dns-names=`` key, which this renderer doesn't
+    emit)."""
+    if not servers:
+        return False
+    for s in servers:
+        try:
+            ipaddress.ip_address(s)
+        except ValueError:
+            return False
+    return True
+
+
+def _render_ntp_client(tree: Any) -> list[str]:
+    """Render the ``/system ntp client`` block, dialect-aware.
+
+    RouterOS 7 (the default, and every cross-vendor / unknown-version render)
+    uses the inline ``set ... servers=A,B`` form.  When the tree was parsed
+    from a RouterOS **6** device (same-vendor sanitize / mikrotik→mikrotik)
+    and carries one or two IP-literal NTP servers, emit the RouterOS-6
+    ``set ... primary-ntp=A [secondary-ntp=B]`` form instead — a 6.x device
+    rejects the v7 ``servers=`` key outright.
+
+    Every other case (cross-vendor source, unknown version, hostname servers,
+    3+ servers) keeps today's v7 output byte-identically.  The parser unions
+    both forms, so the round-trip is stable on either dialect.
+
+    Note: not idempotent across a *double* sanitize — the v6 output carries
+    no version header, so a second pass sees ``source_version == ""`` and
+    falls back to v7.  The canonical tree (``ntp_servers``) is preserved
+    either way; only the emitted dialect differs, and a single sanitize (the
+    real use case) produces valid 6.x output.
+    """
+    if not tree.ntp_servers:
+        return []
+    servers = tree.ntp_servers
+    lines = ["/system ntp client"]
+    if (
+        tree.source_vendor == "mikrotik_routeros"
+        and _ros_major(tree.source_version) == 6
+        and 1 <= len(servers) <= 2
+        and _all_ip_literals(servers)
+    ):
+        parts = ["set enabled=yes", f"primary-ntp={servers[0]}"]
+        if len(servers) == 2:
+            parts.append(f"secondary-ntp={servers[1]}")
+        lines.append(" ".join(parts))
+    else:
+        lines.append(f"set enabled=yes servers={','.join(servers)}")
+    lines.append("")
+    return lines
 
 
 def render_intent(tree: Any) -> str:  # noqa: C901
@@ -724,13 +794,8 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         lines.append(f"set servers={','.join(tree.dns_servers)}")
         lines.append("")
 
-    # ----- /system ntp client -----
-    if tree.ntp_servers:
-        lines.append("/system ntp client")
-        lines.append(
-            f"set enabled=yes servers={','.join(tree.ntp_servers)}"
-        )
-        lines.append("")
+    # ----- /system ntp client (dialect-aware: v6 vs v7) -----
+    lines.extend(_render_ntp_client(tree))
 
     # Trim trailing blanks, leave exactly one newline at EOF.
     while lines and lines[-1] == "":

--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -104,9 +104,16 @@ def _ros_major(version: str) -> int | None:
     Returns ``None`` for an empty string, garbage, or a dot-less token — the
     v6 NTP dialect gate only fires on affirmative dotted major-version
     evidence, never on a guess.
+
+    Regex-free (a plain split): ``source_version`` is parser-derived from
+    config text, so a regex here trips CodeQL's polynomial-ReDoS check for
+    no real benefit.
     """
-    m = re.match(r"(\d+)\.", version or "")
-    return int(m.group(1)) if m else None
+    v = version or ""
+    if "." not in v:
+        return None
+    head = v.split(".", 1)[0]
+    return int(head) if head.isdigit() else None
 
 
 def _all_ip_literals(servers: list[str]) -> bool:

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -300,6 +300,81 @@ class TestNtpVersionForms:
         assert reparsed.ntp_servers == tree.ntp_servers == ["10.0.0.1", "10.0.0.2"]
 
 
+class TestNtpV6RenderDialect:
+    """On a same-vendor render (sanitize / mikrotik→mikrotik) of a RouterOS 6
+    device with IP-literal NTP servers, emit the v6
+    ``primary-ntp=``/``secondary-ntp=`` form (a 6.x device rejects the v7
+    ``servers=`` key).  Every other case keeps today's v7 output."""
+
+    def _ntp_line(self, out: str) -> str:
+        return next(
+            (ln for ln in out.splitlines()
+             if ln.startswith("set ") and ("ntp" in ln or "servers=" in ln)),
+            "",
+        )
+
+    def _render(self, **kw) -> str:
+        tree = CanonicalIntent(hostname="r", **kw)
+        return self._ntp_line(MikroTikRouterOSCodec().render(tree))
+
+    def test_v6_one_ip_emits_primary(self):
+        line = self._render(
+            source_vendor="mikrotik_routeros", source_version="6.48.1",
+            ntp_servers=["10.0.0.1"],
+        )
+        assert line == "set enabled=yes primary-ntp=10.0.0.1"
+
+    def test_v6_two_ips_emits_primary_secondary(self):
+        line = self._render(
+            source_vendor="mikrotik_routeros", source_version="6.48.6",
+            ntp_servers=["10.0.0.1", "10.0.0.2"],
+        )
+        assert line == (
+            "set enabled=yes primary-ntp=10.0.0.1 secondary-ntp=10.0.0.2"
+        )
+
+    def test_v6_hostname_falls_back_to_v7(self):
+        # v6 primary-ntp slots are IP-only; a hostname must stay on servers=.
+        line = self._render(
+            source_vendor="mikrotik_routeros", source_version="6.48.1",
+            ntp_servers=["pool.ntp.org"],
+        )
+        assert line == "set enabled=yes servers=pool.ntp.org"
+
+    def test_v6_three_servers_falls_back_to_v7(self):
+        # v6 has only primary/secondary slots — 3+ servers stay on servers=.
+        line = self._render(
+            source_vendor="mikrotik_routeros", source_version="6.48.1",
+            ntp_servers=["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+        )
+        assert line == "set enabled=yes servers=10.0.0.1,10.0.0.2,10.0.0.3"
+
+    @pytest.mark.parametrize("vendor,version", [
+        ("mikrotik_routeros", "7.18.2"),  # v7 source
+        ("mikrotik_routeros", ""),         # unknown version
+        ("cisco_nxos", "6.0"),             # cross-vendor (never gates)
+    ])
+    def test_non_v6_cases_use_v7_form(self, vendor, version):
+        line = self._render(
+            source_vendor=vendor, source_version=version,
+            ntp_servers=["10.0.0.1"],
+        )
+        assert line == "set enabled=yes servers=10.0.0.1"
+
+    def test_real_v6_fixture_renders_v6_and_round_trips(self):
+        codec = MikroTikRouterOSCodec()
+        raw = (
+            Path(__file__).resolve().parents[2]
+            / "fixtures" / "real" / "mikrotik"
+            / "routeros_diff_verbose_export.rsc"
+        ).read_text(encoding="utf-8")
+        tree = codec.parse(raw)
+        out = codec.render(tree)
+        assert "primary-ntp=10.200.0.15" in out
+        assert "servers=10.200.0.15" not in out
+        assert codec.parse(out).ntp_servers == tree.ntp_servers == ["10.200.0.15"]
+
+
 class TestParseErrors:
     def test_empty_input_raises(self):
         with pytest.raises(ParseError, match="empty input"):


### PR DESCRIPTION
## Why

RouterOS 6 configures NTP as `set ... primary-ntp=A secondary-ntp=B`; RouterOS 7 uses `set ... servers=A,B`, which a **6.x device rejects outright**. The renderer only emitted the v7 form, so sanitizing (or mikrotik→mikrotik re-rendering) a RouterOS 6 device produced config its own box won't accept.

This is the one semantic version-gating slice the [2026-07-05 version-vector assessment](docs/reviews/2026-07-05-version-vector-assessment/plan.md) recommended building (Phase 3) — the backlog's flagship 6-vs-7 case. The rest of the "version vector" stays a no-go.

## What

Gate the `/system ntp client` block on **affirmative same-vendor v6 evidence**:

```
source_vendor == "mikrotik_routeros"  AND  major(source_version) == 6
AND  1 <= len(ntp_servers) <= 2       AND  all servers are IP literals
```

→ emit `set enabled=yes primary-ntp=A [secondary-ntp=B]`. **Everything else** — cross-vendor source, unknown version, hostname servers, 3+ servers — keeps today's v7 `servers=` form byte-identically. The gate never fires on a guess. Parse already unions both forms (#293), so the round-trip is stable on either dialect.

| source | ntp | emits |
|---|---|---|
| mikrotik 6.48.1 | 1 IP | `primary-ntp=…` |
| mikrotik 6.48.6 | 2 IPs | `primary-ntp=… secondary-ntp=…` |
| mikrotik 6.x | hostname / 3+ | v7 `servers=…` |
| mikrotik 7.x / `""` | any | v7 `servers=…` |
| any non-mikrotik source | any | v7 `servers=…` |

## Safety / scope
- Only mikrotik→mikrotik **self-cells** are affected (cross-vendor renders use the other codec's renderer).
- `_render_ntp_client` extraction *lowers* the grandfathered `render_intent`'s complexity.
- **Cross-mesh CI guard unchanged** (CODEC_BUG=5, cells_total=1224): the real `routeros_diff_verbose_export.rsc` (6.48.1) self-cell now renders v6 NTP and reparses to the identical tree — `source_version` is comparator-excluded.
- Not idempotent across a *double* sanitize (v6 output has no version header → a second pass falls back to v7); the canonical tree is preserved either way — documented in-code. Happy to add a version-comment echo for stickiness as a follow-up if you'd prefer.

## Verification
- New `TestNtpV6RenderDialect` (v6 1-IP / 2-IP / hostname-fallback / 3-server-fallback / non-v6 matrix / real-fixture round-trip).
- Full `tests/unit` green; cross-mesh guard green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
