### PR TITLE
docs: reconcile three stale version-vector claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -356,8 +356,10 @@ persisted under
 `netcanon.rename-ack.v1:<source_codec>:<target_codec>:<hostname>`.
 Moving to a different device (different hostname), different
 codec pair, or pressing Reset-all clears or scopes away saved
-state.  Version segments for source/target are omitted until
-parsers start populating `CanonicalIntent.source_version`.
+state.  Version segments for source/target are omitted from the
+key today: all 12 parsers populate `CanonicalIntent.source_version`
+now, but the ack key is not yet version-scoped (it would only matter
+once version-targeted rendering grows an operator-facing surface).
 
 **Source-shape capture:** `run_plan_with_overrides` injects a
 capture-first transform that populates `MigrationJob.source_vlans`,

--- a/netcanon/migration/codecs/base.py
+++ b/netcanon/migration/codecs/base.py
@@ -146,8 +146,12 @@ class CodecBase(ABC):
         name: Class-level registration key.  Must be unique across the
             registry and stable across releases.
         version_hint: Optional vendor OS version this adapter targets
-            (e.g. ``"17.x"`` for Cisco IOS-XE 17.x).  Informational;
-            version gating lives in the :class:`CapabilityMatrix`.
+            (e.g. ``"17.x"`` for Cisco IOS-XE 17.x).  DISPLAY-ONLY — surfaced
+            in the /migrate codec catalogue; nothing reads it to gate parse
+            or render.  Where a codec does vary output by OS version it reads
+            the parsed ``CanonicalIntent.source_version`` at render time (see
+            the MikroTik RouterOS-6 NTP dialect), not this hint.  There is no
+            version-scoped ``CapabilityMatrix``.
         input_format: Short catalogue tag describing what ``parse()``
             expects.  Used by the UI to (a) show a human-readable hint
             on the /migrate page, (b) provide a matching placeholder,

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -1893,12 +1893,14 @@
    * of clobbering the operator's prior work.
    *
    * Versioning (source_version / target_version) is intentionally
-   * NOT part of the key today — the canonical parsers don't yet
-   * populate source_version, so folding empty strings into the key
-   * adds noise without discrimination.  When per-OS-version parsers
-   * land (P1C3+), extend _ackKey to append @<version> for each side
-   * and bump _ACK_SCHEMA_VERSION so any old entries get ignored on
-   * next load (cheap migration — the entries are strictly optional).
+   * NOT part of the key today.  All 12 parsers populate
+   * source_version now, but there is no operator-facing target-version
+   * knob and wild source_version coverage is uneven, so folding it into
+   * the key would add noise without reliable discrimination.  If a
+   * target-version channel lands, extend _ackKey to append @<version>
+   * for each side and bump _ACK_SCHEMA_VERSION so any old entries get
+   * ignored on next load (cheap migration — the entries are strictly
+   * optional).
    *
    * Schema (v1 — additive-only; new category maps can be added as
    * new keys without bumping the version because missing keys load


### PR DESCRIPTION
Docs/comment only — **no behaviour change**. Three claims drifted out of date once all 12 parsers began populating `source_version` (#235 / v0.4.12) and — with the sibling [MikroTik RouterOS-6 NTP dialect](https://github.com/netcanon/netcanon/pull/299) — version-conditional rendering actually exists:

1. **`codecs/base.py`** — the `version_hint` docstring claimed *"version gating lives in the CapabilityMatrix."* That's a phantom: nothing reads `version_hint`, and there is no version-scoped matrix. Reworded to say it's display-only, and that where a codec varies output by OS version it reads the parsed `source_version` at render time (the MikroTik v6 NTP dialect).
2. **`ARCHITECTURE.md`** — said the rename-ack key omits version segments *"until parsers start populating `CanonicalIntent.source_version`."* They populate it now; the key just isn't version-scoped yet.
3. **`migrate.html`** — the `_ackKey` comment said *"the canonical parsers don't yet populate source_version."* Same staleness; reworded to the real reasons the key stays version-less (no target-version knob + uneven wild coverage), keeping the `@<version>` extension plan.

Phase 0 (truth maintenance) of the 2026-07-05 version-vector assessment, per the #292 no-phantom-affordance doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
