### PR TITLE
docs: L1 truth-maintenance (version-echo + strip_unsupported drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,10 @@ features**.
   not: `force` only skips the cross-device-class guard; a `block` renders
   anyway and flags the job `partial` — `strip_unsupported` is the mechanism
   that actually drops the offending paths.  (#288)
+  _Erratum (v0.5.2, #292): the `strip_unsupported` mechanism named above
+  never existed — it was vaporware.  `force` / `block` behaviour was already
+  correct, so the affordance was dropped rather than implemented; see the
+  [0.5.2] entry._
 
 ## [0.5.0] - 2026-07-04
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -421,6 +421,42 @@ XSS via template injection is not possible under the current design.
 
 ---
 
+## Content-Security-Policy (SEC-9)
+
+Every response carries a `Content-Security-Policy` header (set in the
+middleware in `netcanon/main.py`) as defense-in-depth on top of Jinja2
+autoescape.  Two policies are served:
+
+- **Default** (`_CSP_DEFAULT`, every UI page + JSON API route):
+  `default-src 'self'` with `img-src` also allowing `data:`, `object-src
+  'none'`, and `frame-ancestors 'none'` (the modern companion to the
+  `X-Frame-Options: DENY` header set alongside it).  It forbids loading or
+  connecting to any off-origin host.
+- **`/docs` variant** (`_CSP_DOCS`, the Swagger page only): the same base
+  policy widened to permit the `cdn.jsdelivr.net` (and `fastapi.tiangolo.com`
+  image) hosts Swagger UI needs, and nothing else.
+
+`script-src` / `style-src` carry `'unsafe-inline'`: the hand-written UI uses
+inline `<script>`/`style=` throughout, so a nonce/hash policy would require a
+full template refactor.  The origin restriction is the control that adds real,
+non-breaking value; the constants in `main.py` are the source of truth for the
+exact directive strings.
+
+---
+
+## SSH Session Output Bounds (SEC-5)
+
+The paramiko shell collector's pre-command flush (`_drain` in
+`netcanon/collectors/paramiko_collector.py`) carries absolute idle-poll,
+wall-clock, and byte caps so a device that streams output without ever pausing
+— wedged, or hostile once the connection is already trusted — cannot hang a
+worker or exhaust memory: without a hard cap the idle window never expires
+against a continuous stream.  `_drain` is a best-effort banner / menu flush,
+not the config capture, so on hitting a cap it returns what it has rather than
+failing the backup.
+
+---
+
 ## Dependency Supply Chain
 
 Key dependencies and their security relevance:

--- a/netcanon/api/routes/_migration_helpers.py
+++ b/netcanon/api/routes/_migration_helpers.py
@@ -170,8 +170,10 @@ def request_has_overrides_or_profile(body: MigrationPlanRequest) -> bool:
     auto-heuristic + return diagnostics the UI can render," and still
     needs the rename-aware pipeline.
 
-    Legacy callers that supply none of these get the plain
-    :func:`run_plan` path unchanged.
+    Requests that supply none of these still get auto port-name
+    translation via ``run_plan_with_overrides(port_rename_map={})`` — the
+    default ``/plan`` flow (this module imports no bare :func:`run_plan`).
+    The ``run_plan`` primitive itself remains unchanged.
     """
     return (
         body.port_rename_map is not None

--- a/netcanon/migration/codecs/aruba_aoscx/parse.py
+++ b/netcanon/migration/codecs/aruba_aoscx/parse.py
@@ -13,7 +13,7 @@ Surface (Phase 1 = Tier-1; Phase 2 adds the L2 + LAG + users surface):
 
 * ``hostname <name>`` → :attr:`CanonicalIntent.hostname`.
 * ``!Version ArubaOS-CX <ver>`` → :attr:`CanonicalIntent.source_version`
-  (metadata only; the banner is synthesised on render).
+  (echoed on same-vendor render, #297; a fresh banner otherwise).
 * ``vlan <id>`` stanzas (one id per line) + nested ``name`` / ``description``
   → :class:`CanonicalVlan`, plus SVI synthesis from ``interface vlan N``.
 * ``vrf <name>`` (top-level) → :class:`CanonicalRoutingInstance` (name
@@ -415,9 +415,10 @@ def _extract_hostname(raw: str) -> str:
 def _extract_version(raw: str) -> str:
     """Return the AOS-CX release string from the ``!Version`` banner.
 
-    Stored as :attr:`CanonicalIntent.source_version` (metadata).  The
-    render path synthesises a fresh banner rather than echoing this, so
-    it is informational only.
+    Stored as :attr:`CanonicalIntent.source_version` (metadata).  On a
+    same-vendor render the device's own release is echoed rather than
+    relabelled with a constant (#297); a cross-vendor render synthesises
+    a fresh banner.  The ``!Version ArubaOS-CX`` probe prefix is preserved.
     """
     m = _VERSION_RE.search(raw)
     return m.group(1) if m else ""

--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -310,8 +310,9 @@ def _extract_domain(raw: str) -> str:
 def _extract_version(raw: str) -> str:
     """Return the XR release from the ``!! IOS XR Configuration`` banner.
 
-    Stored as :attr:`CanonicalIntent.source_version` (metadata); the
-    render path synthesises a fresh banner so it is informational only.
+    Stored as :attr:`CanonicalIntent.source_version` (metadata).  On a
+    same-vendor render the device's own release is echoed (#297); a
+    cross-vendor render synthesises a fresh banner.
     """
     # Two banner forms occur in the wild:
     #   ``!! IOS XR Configuration 6.3.1``            (older)

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -12,7 +12,7 @@ Phase 1 surface (see ``docs/v0.2.0-planning/03-nxos-codec/``):
 
 * ``hostname <name>`` → :attr:`CanonicalIntent.hostname`.
 * ``version <N.N(N)> Bios:version`` → :attr:`CanonicalIntent.source_version`
-  (metadata only; the banner line itself is synthesised on render).
+  (echoed on same-vendor render, #297; a fresh banner otherwise).
 * ``vrf context <name>`` (top-level) → :class:`CanonicalRoutingInstance`
   (name + description + ``rd`` + ``route-target import/export/both``;
   nested per-VRF ``ip route`` → :class:`CanonicalStaticRoute` with
@@ -481,9 +481,10 @@ def _extract_hostname(raw: str) -> str:
 def _extract_version(raw: str) -> str:
     """Return the NX-OS release string from the ``version`` line.
 
-    Stored as :attr:`CanonicalIntent.source_version` (metadata).  The
-    render path synthesises a fresh banner rather than echoing this, so
-    it is informational only.
+    Stored as :attr:`CanonicalIntent.source_version` (metadata).  On a
+    same-vendor render the device's own release is echoed rather than
+    relabelled with a constant (#297); a cross-vendor render synthesises
+    a fresh banner.
     """
     m = _VERSION_RE.search(raw)
     return m.group(1) if m else ""

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -235,8 +235,10 @@ _VERSION_RE = re.compile(r"RouterOS\s+(\d[\w.]*)", re.MULTILINE)
 def _extract_version(raw: str) -> str:
     """Return the RouterOS release from the export header comment.
 
-    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
-    render path does not echo it, so it is informational.  Returns ``""``
+    Stored as :attr:`CanonicalIntent.source_version` (metadata).  The
+    render path emits no version header (MikroTik is outside #297's
+    same-vendor echo), but it DOES consume this value: ``_ros_major``
+    gates the RouterOS-6 NTP render dialect on it (#299).  Returns ``""``
     when the header comment is absent.
     """
     m = _VERSION_RE.search(raw)

--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -142,9 +142,11 @@ def _extract_version(raw: str) -> str:
     """Return the VyOS release from the trailing ``// Release version:``
     comment.
 
-    Stored as :attr:`CanonicalIntent.source_version` (metadata only); the
-    render path does not echo it, so it is informational.  Returns ``""``
-    when the trailing comment block is absent.
+    Stored as :attr:`CanonicalIntent.source_version` (metadata).  On a
+    same-vendor render the device's own release is echoed into the
+    ``// Release version`` trailer (#297); the ``// vyos-config-version``
+    component vector is never touched.  Returns ``""`` when the trailing
+    comment block is absent.
     """
     m = _VERSION_RE.search(raw)
     return m.group(1) if m else ""


### PR DESCRIPTION
## L1 — docs-truth cluster (Fable review 2026-07-06, MINOR)

First remediation batch from the [2026-07-06 Fable full review](docs/reviews/2026-07-06-fable-full-review/99-synthesis.md) (verdict SHIP-WITH-FIXES). Four low-severity **documentation-truthfulness** findings — no behaviour change.

| # | Site | Was | Now |
|---|------|-----|-----|
| #62 | 5 codec `_extract_version` docstrings + nxos/aoscx header comments | "render synthesises a fresh banner / does not echo → informational only" | echoed on same-vendor render (#297); mikrotik consumes `source_version` to gate the RouterOS-6 NTP dialect (#299) |
| #52 | `_migration_helpers.request_has_overrides_or_profile` | "bare requests get plain `run_plan` unchanged" | default `/plan` auto-translates via `run_plan_with_overrides(port_rename_map={})`; no bare `run_plan` import |
| #65 | `SECURITY.md` | no CSP or SSH-output-cap coverage | added **Content-Security-Policy (SEC-9)** + **SSH Session Output Bounds (SEC-5)** sections, referencing the code constants |
| #66 | `CHANGELOG.md` 0.5.1 API-7 bullet | asserted `strip_unsupported` "actually drops the offending paths" | inline erratum: it never existed; corrected in v0.5.2/#292 |

### Verification
- Full `tests/unit` green (`--basetemp=D:/nc-pytest-tmp`); `test_changelog.py` guard green.
- `ruff check` clean on all edited files.
- CHANGELOG.md and SECURITY.md remain pure-CRLF (spliced via `py` with `newline=""`).
- Every claim verified against live code before rewording (vyos `_release_token` echo, mikrotik `_ros_major` dialect gate, migration.py imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
