### PR TITLE
fix(api): device-profile cap-in-lock + schedule snapshot (L2)

### DIFF
--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -22,6 +22,7 @@ from ...storage.device_profile_store import (
     DEVICE_PROFILE_REGISTRY_LOCK,
     FileDeviceProfileStore,
 )
+from ...storage.schedule_store import SCHEDULE_REGISTRY_LOCK
 from ..deps import get_device_profile_store, get_device_profiles
 
 logger = logging.getLogger(__name__)
@@ -87,15 +88,18 @@ def create_device_profile(
     Returns:
         The newly created ``DeviceProfile``.
     """
-    if len(device_profiles) >= 1000:
-        raise HTTPException(
-            status_code=409,
-            detail="Maximum device profile limit reached (1000). Delete unused profiles first.",
-        )
     profile = DeviceProfile(**body.model_dump())
     # Serialise dict-mutate + persist against the backup worker thread and
-    # the other route mutators (review finding #10).
+    # the other route mutators (review finding #10).  The cap check runs
+    # INSIDE the lock (review #44): checked outside, two concurrent creates
+    # both passed at 999 and landed 1001 profiles.  create_schedule already
+    # enforces its cap under the lock — this mirrors it.
     with DEVICE_PROFILE_REGISTRY_LOCK:
+        if len(device_profiles) >= 1000:
+            raise HTTPException(
+                status_code=409,
+                detail="Maximum device profile limit reached (1000). Delete unused profiles first.",
+            )
         device_profiles[profile.id] = profile
         device_profile_store.save(profile)
     logger.info(
@@ -169,20 +173,25 @@ def delete_device_profile(
     Raises:
         HTTPException 404: If no profile with *profile_id* exists.
     """
-    # Hold the lock across the existence check + delete + file removal so it
-    # can't interleave with the backup worker's detected_facts save and
+    # Snapshot the schedules under THEIR lock (review #43).  Iterating the
+    # live dict here under the profile lock races a concurrent schedule
+    # create/delete → "dictionary changed size during iteration".  Take a
+    # copy under SCHEDULE_REGISTRY_LOCK first (released immediately), then
+    # warn on the copy — the CONC-6 snapshot pattern.  The two registry
+    # locks are never held nested.
+    with SCHEDULE_REGISTRY_LOCK:
+        schedules_snapshot = list(request.app.state.schedules.values())
+    referencing = [
+        s.name for s in schedules_snapshot if profile_id in s.target_device_ids
+    ]
+    # Hold the profile lock across the existence check + delete + file removal
+    # so it can't interleave with the backup worker's detected_facts save and
     # resurrect the profile on disk (review finding #10).
     with DEVICE_PROFILE_REGISTRY_LOCK:
         if profile_id not in device_profiles:
             raise HTTPException(
                 status_code=404, detail=f"Device profile not found: {profile_id!r}"
             )
-        # Warn if any schedules reference this profile.
-        referencing = [
-            s.name
-            for s in request.app.state.schedules.values()
-            if profile_id in s.target_device_ids
-        ]
         if referencing:
             logger.warning(
                 "Deleting profile %s which is referenced by schedules: %s",

--- a/tests/unit/test_device_profiles_lock.py
+++ b/tests/unit/test_device_profiles_lock.py
@@ -15,11 +15,14 @@ in-memory registry and the on-disk store in agreement under contention.
 from __future__ import annotations
 
 import threading
+import time
+import types
 
 import pytest
+from fastapi import HTTPException
 
 from netcanon.api.routes import device_profiles as routes_mod
-from netcanon.models.device_profile import DeviceProfile
+from netcanon.models.device_profile import DeviceProfile, DeviceProfileCreate
 from netcanon.services import backup_runner as runner_mod
 from netcanon.storage.device_profile_store import (
     DEVICE_PROFILE_REGISTRY_LOCK,
@@ -87,3 +90,96 @@ def test_locked_persist_and_delete_never_resurrect(tmp_path) -> None:
             "registry/disk disagreement (resurrection): "
             f"on_disk={on_disk} in_memory={in_memory}"
         )
+
+
+def test_create_cap_check_is_inside_lock(tmp_path) -> None:
+    """The 1000-profile cap must be evaluated under the registry lock (#44).
+
+    Deterministic interleave: hold the lock, start a create (it must block on
+    the lock *before* it evaluates the cap — that is the fix), then fill the
+    last slot and release.  A create that checked the cap outside the lock
+    already passed at 999 and inserts a 1001st profile; the fixed create
+    re-reads 1000 under the lock and returns 409.
+    """
+    store = FileDeviceProfileStore(tmp_path)
+    registry = {f"p{i}": _profile(f"p{i}") for i in range(999)}  # one slot left
+    body = DeviceProfileCreate(
+        name="new",
+        type_key="Cisco",
+        host="10.0.0.9",
+        username="admin",
+        password="hunter2",
+    )
+    outcome: dict[str, object] = {}
+
+    def _create() -> None:
+        try:
+            routes_mod.create_device_profile(
+                body, device_profiles=registry, device_profile_store=store
+            )
+            outcome["result"] = "created"
+        except HTTPException as exc:
+            outcome["result"] = exc.status_code
+
+    with DEVICE_PROFILE_REGISTRY_LOCK:
+        t = threading.Thread(target=_create)
+        t.start()
+        time.sleep(0.1)  # let the thread reach the lock (fixed) / the check (unfixed)
+        registry["filler"] = _profile("filler")  # now exactly at the 1000 cap
+    t.join()
+
+    assert outcome["result"] == 409, (
+        f"create at cap returned {outcome['result']!r}, not 409 — the cap check "
+        "ran outside the lock, before the last slot filled"
+    )
+    assert len(registry) == 1000, f"cap breached: {len(registry)}"
+
+
+def test_delete_snapshots_schedules_no_iteration_race(tmp_path) -> None:
+    """delete_device_profile must snapshot ``app.state.schedules`` under
+    ``SCHEDULE_REGISTRY_LOCK`` before iterating it (#43).
+
+    Deterministic reproduction: a schedule whose ``target_device_ids`` mutates
+    the backing dict when read.  Iterating the LIVE dict then raises
+    ``RuntimeError: dictionary changed size during iteration``; iterating a
+    snapshot list is immune.
+    """
+    store = FileDeviceProfileStore(tmp_path)
+    schedules: dict[str, object] = {}
+
+    class _MutatingSchedule:
+        """Reading ``target_device_ids`` injects a new key into the backing
+        dict — forcing a size change mid-iteration iff delete walks the live
+        dict rather than a snapshot."""
+
+        name = "evil"
+        _n = 0
+
+        def __init__(self, backing: dict) -> None:
+            self._backing = backing
+
+        @property
+        def target_device_ids(self) -> list:
+            type(self)._n += 1
+            self._backing[f"injected{type(self)._n}"] = types.SimpleNamespace(
+                name="x", target_device_ids=[]
+            )
+            return []
+
+    schedules["a"] = _MutatingSchedule(schedules)
+    for i in range(5):  # padding so the values-view iteration takes >1 step
+        schedules[f"pad{i}"] = types.SimpleNamespace(
+            name=f"pad{i}", target_device_ids=[]
+        )
+
+    state = types.SimpleNamespace(schedules=schedules)
+    request = types.SimpleNamespace(app=types.SimpleNamespace(state=state))
+    pid = "race-id"
+    registry: dict[str, DeviceProfile] = {pid: _profile(pid)}
+    store.save(registry[pid])
+
+    # Unfixed: RuntimeError escapes here.  Fixed: clean delete off the snapshot.
+    routes_mod.delete_device_profile(
+        pid, request, device_profiles=registry, device_profile_store=store
+    )
+    assert pid not in registry


### PR DESCRIPTION
## L2 — device-profile lock siblings (Fable review 2026-07-06, MINOR)

Two concurrency findings on `netcanon/api/routes/device_profiles.py` — both the classic *hardened-path / un-hardened-sibling* pattern, where the schedule routes already do it right.

| # | Bug | Fix |
|---|-----|-----|
| **#44** | `create_device_profile` checks the 1000-profile cap **outside** `DEVICE_PROFILE_REGISTRY_LOCK` → concurrent creates each read 999 and insert past the cap | move the check inside the lock, mirroring `create_schedule` |
| **#43** | `delete_device_profile` iterates the live `app.state.schedules` dict under the **profile** lock → `RuntimeError: dictionary changed size during iteration` when a schedule is created/deleted concurrently | snapshot `list(schedules.values())` under `SCHEDULE_REGISTRY_LOCK` first (CONC-6 pattern); the two registry locks are never nested |

### Verification
- Two **deterministic** regression tests (lock-holding interleave for #44; mutate-on-access schedule for #43), each **verified to fail on the pre-fix route** — cap create returns `'created'` instead of `409`; delete raises `RuntimeError` at `device_profiles.py:183` — and pass after the fix. (First-cut threaded versions passed on both fixed *and* unfixed code, so they were rewritten to guarantee they actually guard the invariant.)
- Full `tests/unit` (exit 0) + `test_cross_mesh_ci_guard` green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
