### PR TITLE
fix: error-path guards — CLI write, open 501, profile save rollback (L3)

### DIFF
--- a/netcanon/api/routes/configs.py
+++ b/netcanon/api/routes/configs.py
@@ -188,6 +188,22 @@ def open_config(
             import subprocess
             subprocess.run(["xdg-open", str(path)], check=True)
         logger.info("Opened config %r in default editor", filename)
+    except FileNotFoundError as exc:
+        # subprocess couldn't find the "open"/"xdg-open" helper — a platform
+        # capability gap, not a server fault, so 501 like the os.startfile
+        # NotImplementedError branch below (review #47a).  The config path
+        # itself was already resolved (404s above) so this is not a missing file.
+        logger.warning(
+            "OS open helper missing while opening config %r: %s", filename, exc
+        )
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"No OS default-editor helper is available on this platform "
+                f"({sys.platform!r}).  Use the download link to fetch the file "
+                f"instead."
+            ),
+        ) from exc
     except NotImplementedError as exc:
         # os.startfile is Windows-only; the linux/darwin branches above use
         # subprocess so this typically fires only on exotic platforms.

--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -101,7 +101,18 @@ def create_device_profile(
                 detail="Maximum device profile limit reached (1000). Delete unused profiles first.",
             )
         device_profiles[profile.id] = profile
-        device_profile_store.save(profile)
+        try:
+            device_profile_store.save(profile)
+        except OSError as exc:
+            # This save is the SOLE persistence — a partial insert would leave
+            # the registry ahead of disk (lost on restart).  Roll the in-memory
+            # insert back and 500 rather than swallow (review #47b).
+            del device_profiles[profile.id]
+            logger.error("Failed to persist new device profile: %s", exc)
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to persist device profile to disk.",
+            ) from exc
     logger.info(
         "Created device profile '%s' (id=%s)", profile.name, profile.id[:8]
     )
@@ -145,7 +156,17 @@ def update_device_profile(
         updates = {k: v for k, v in body.model_dump().items() if v is not None}
         updated_profile = profile.model_copy(update=updates)
         device_profiles[profile_id] = updated_profile
-        device_profile_store.save(updated_profile)
+        try:
+            device_profile_store.save(updated_profile)
+        except OSError as exc:
+            # Sole persistence — roll the registry back to the pre-update
+            # profile so memory can't drift ahead of disk (review #47b).
+            device_profiles[profile_id] = profile
+            logger.error("Failed to persist updated device profile: %s", exc)
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to persist device profile to disk.",
+            ) from exc
     logger.info(
         "Updated device profile '%s' (id=%s)", updated_profile.name, profile_id[:8]
     )

--- a/netcanon/cli.py
+++ b/netcanon/cli.py
@@ -180,7 +180,15 @@ def _cmd_sanitize(args: argparse.Namespace) -> int:
         return 0
 
     if args.output:
-        Path(args.output).write_text(result.sanitized_text, encoding="utf-8")
+        try:
+            Path(args.output).write_text(result.sanitized_text, encoding="utf-8")
+        except OSError as e:
+            # The read half is already guarded above; guard the write too so a
+            # missing parent dir / read-only target is a clean error instead of
+            # a traceback with the sanitized output lost (review #46 — the write
+            # half of API-3; #285 fixed only the read/render halves).
+            print(f"error: cannot write {args.output!r}: {e}", file=sys.stderr)
+            return 2
         print(
             f"Sanitized output written to {args.output} "
             f"({len(result.substitutions)} substitutions applied).",

--- a/tests/integration/test_configs_api.py
+++ b/tests/integration/test_configs_api.py
@@ -229,6 +229,20 @@ class TestOpenConfig:
         # Privacy fix — raw exception text must NOT leak through.
         assert "access denied" not in detail
 
+    def test_open_returns_501_when_helper_missing(self, open_client):
+        """A missing OS launcher (``xdg-open`` / ``open`` / ``os.startfile``)
+        is a platform capability gap, not a server fault: 501, not the generic
+        500 (review #47a).  Patches both launcher paths so it runs on any host.
+        """
+        filename = _seed_config(open_client)
+        with patch(
+            "subprocess.run", side_effect=FileNotFoundError("xdg-open")
+        ), patch(
+            "os.startfile", create=True, side_effect=FileNotFoundError("startfile")
+        ):
+            resp = open_client.post(f"/api/v1/configs/{filename}/open")
+        assert resp.status_code == 501
+
     def test_open_rejects_disallowed_extension(self, open_client):
         """Executable and other non-config extensions must return 400."""
         # No patch needed — extension whitelist rejects with 400 before

--- a/tests/integration/test_device_profiles_api.py
+++ b/tests/integration/test_device_profiles_api.py
@@ -185,3 +185,36 @@ class TestCredentialsNeverSerialised:
         for key in self._CRED_KEYS:
             assert key not in body, f"PUT response leaked {key!r}"
         assert body["notes"] == "rotated"
+
+
+def _raise_oserror(*_args, **_kwargs):
+    raise OSError("disk full")
+
+
+class TestPersistFailureRollback:
+    """Create/update roll the in-memory registry back when the sole-persistence
+    disk save fails, so the registry can't drift ahead of disk (review #47b)."""
+
+    def test_create_rolls_back_on_save_oserror(self, client, monkeypatch):
+        monkeypatch.setattr(
+            client.app.state.device_profile_store, "save", _raise_oserror
+        )
+        resp = client.post("/api/v1/devices/", json=_create_body())
+        assert resp.status_code == 500
+        # No phantom profile left behind in the in-memory registry.
+        assert client.app.state.device_profiles == {}
+
+    def test_update_rolls_back_to_pre_update_on_save_oserror(
+        self, client, monkeypatch
+    ):
+        pid = client.post(
+            "/api/v1/devices/", json=_create_body(os_version="17.12")
+        ).json()["id"]
+        monkeypatch.setattr(
+            client.app.state.device_profile_store, "save", _raise_oserror
+        )
+        resp = client.put(f"/api/v1/devices/{pid}", json={"os_version": "18.1"})
+        assert resp.status_code == 500
+        # The in-memory profile keeps its pre-update value (not the 18.1 that
+        # failed to persist).
+        assert client.app.state.device_profiles[pid].os_version == "17.12"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -116,6 +116,21 @@ class TestCLIErrorHandling:
         assert rc == 2
         assert "cannot read" in capsys.readouterr().err
 
+    def test_unwritable_output_reports_error(self, capsys, tmp_path):
+        # The write half is now guarded like the read half (review #46 — the
+        # write half of API-3): a missing parent dir is a clean `error: cannot
+        # write ...` + exit 2, not a raw traceback with the output lost.
+        target = tmp_path / "no_such_dir" / "out.cfg"  # parent does not exist
+        rc = main([
+            "sanitize",
+            "-i", str(ARUBA_FIXTURE),
+            "-s", "aruba_aoss",
+            "-o", str(target),
+        ])
+        assert rc == 2
+        assert "cannot write" in capsys.readouterr().err
+        assert not target.exists()
+
 
 class TestCLIArgvFromList:
     """Pass argv as a list (not relying on sys.argv) for in-process testing."""


### PR DESCRIPTION
## L3 — error-path guards (Fable review 2026-07-06, MINOR)

Three error-handling findings, each surfacing an unguarded failure as a raw traceback / wrong status.

| # | Site | Bug | Fix |
|---|------|-----|-----|
| **#46** | `cli.py` | `sanitize -o <unwritable>` dumps a traceback, exit 1, output lost (read half was guarded; write half wasn't — #285 fixed only read/render) | wrap the write in `try/except OSError` → `error: cannot write …` + exit 2 |
| **#47a** | `configs.py` | missing OS `open`/`xdg-open` launcher → `FileNotFoundError` → generic `except Exception` → **500** | dedicated `except FileNotFoundError` → **501** (platform gap), mirroring the `os.startfile` `NotImplementedError` branch |
| **#47b** | `device_profiles.py` | create/update mutate the registry then call the **sole-persistence** `store.save()` unguarded → an `OSError` leaves memory ahead of disk + a raw 500 | roll the in-memory registry back (delete insert / restore pre-update) and 500 cleanly |

### Verification
- 4 **deterministic** regression tests, each **verified to fail on the pre-fix code** and pass after (the 501 test patches both launcher paths so it runs on Windows *and* Linux CI, not skipped).
- Full `tests/unit` + `tests/integration` (exit 0, includes the cross-mesh guard); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
