### PR TITLE
fix(rename): honest applied/dropped bookkeeping + not-found warnings (L4)

### DIFF
--- a/netcanon/migration/canonical/port_names.py
+++ b/netcanon/migration/canonical/port_names.py
@@ -491,6 +491,29 @@ def translate_port_names(  # noqa: C901
             applied[name] = out
         return out
 
+    # (#49b) Snapshot every port name actually present in the tree BEFORE the
+    # rewrite sweep mutates names in place — used to (a) warn on operator map
+    # entries that named a port absent from the config, and (b) avoid
+    # over-reporting those absent names as "dropped" (mirrors local_user /
+    # snmpv3 honesty).
+    present_names: set[str] = set()
+    for iface in intent.interfaces:
+        present_names.add(iface.name)
+        if iface.lag_member_of:
+            present_names.add(iface.lag_member_of)
+    for vlan in intent.vlans:
+        present_names.update(vlan.tagged_ports)
+        present_names.update(vlan.untagged_ports)
+    for lag in intent.lags:
+        present_names.add(lag.name)
+        present_names.update(lag.members)
+    for route in intent.static_routes:
+        if route.interface:
+            present_names.add(route.interface)
+    for pool in intent.dhcp_servers:
+        if pool.interface:
+            present_names.add(pool.interface)
+
     # Rewrite everywhere a port name might be referenced.  Order doesn't
     # matter — memoisation keeps us idempotent.
     for iface in intent.interfaces:
@@ -516,18 +539,30 @@ def translate_port_names(  # noqa: C901
     if dropped_set:
         _strip_dropped_ports(intent, dropped_set)
 
+    # (#49b) Operator drop/rename keys that named a port absent from the tree
+    # did nothing — warn instead of silently over-reporting them as dropped.
+    for key in user_map:
+        if key not in present_names:
+            warnings.append(
+                f"port_rename: source port {key!r} does not exist in the "
+                f"parsed config; entry ignored"
+            )
+    # Report only drops that actually removed a present name (auto-dropped
+    # unmappable names were resolved from real references, so they qualify).
+    reported_dropped = sorted(d for d in dropped_set if d in present_names)
+
     logger.debug(
         "translate_port_names: exit %s → %s applied=%d dropped=%d "
         "warnings=%d",
         source_codec.name, target_codec.name,
         len(applied),
-        len(dropped_set),
+        len(reported_dropped),
         len(warnings),
     )
     return PortRenameResult(
         applied=applied,
         warnings=warnings,
-        dropped=sorted(dropped_set),
+        dropped=reported_dropped,
     )
 
 

--- a/netcanon/migration/canonical/snmpv3_user_names.py
+++ b/netcanon/migration/canonical/snmpv3_user_names.py
@@ -209,7 +209,6 @@ def translate_snmpv3_users(
             new_name = u.name
         else:
             new_name = decision
-            result.applied[u.name] = decision
         if new_name in seen_targets and seen_targets[new_name] != u.name:
             # Collision: a previous user (renamed or not) already
             # occupies this target name.  First-wins — drop this one
@@ -220,7 +219,12 @@ def translate_snmpv3_users(
                 f"{seen_targets[new_name]!r}; dropping {u.name!r} "
                 f"(first-wins)"
             )
+            # (#48) A collision-dropped record must be reported in ``dropped``,
+            # and NOT in ``applied`` — record the rename only once it survives.
+            result.dropped.append(u.name)
             continue
+        if decision != "__pass__":
+            result.applied[u.name] = decision
         seen_targets[new_name] = u.name
         # Mutate in-place to preserve all other attributes (group,
         # auth, priv, engine_id).

--- a/netcanon/migration/canonical/vlan_names.py
+++ b/netcanon/migration/canonical/vlan_names.py
@@ -113,9 +113,12 @@ def translate_vlan_ids(  # noqa: C901
       * Source or target IDs outside 1-4094 → warning; entry
         skipped (invalid IDs can't survive AOS-S validation
         downstream anyway).
-      * Mapping a VLAN ID that doesn't exist in ``intent.vlans`` →
-        warning + no-op.  The UI should avoid sending these but the
-        orchestrator doesn't crash on them.
+      * Mapping a VLAN ID that is present nowhere in the tree — neither
+        as a ``vlan`` stanza nor as an interface reference (access /
+        native / voice / trunk-allowed) → warning + no-op.  The UI should
+        avoid sending these but the orchestrator doesn't crash on them.
+        (An ID present only as an interface reference is still rewritten
+        by Pass 2, so it is NOT flagged as a no-op.)
 
     Args:
         intent: Canonical tree to mutate.  Passed through the
@@ -206,6 +209,27 @@ def translate_vlan_ids(  # noqa: C901
     # Collect which IDs exist in the source tree so "rename to
     # already-existing ID" is detectable.
     source_ids = {v.id for v in intent.vlans}
+
+    # (#49a) Warn on map entries whose source VLAN is present nowhere — not as
+    # a stanza (source_ids) and not as an interface reference (rewritten by
+    # Pass 2 below).  The docstring promises this; without it a typo'd entry
+    # silently no-ops.  Computed from ORIGINAL interface fields (Pass 2 hasn't
+    # run yet).
+    referenced_ids: set[int] = set(source_ids)
+    for iface in intent.interfaces:
+        for vid in (
+            iface.access_vlan,
+            iface.trunk_native_vlan,
+            iface.voice_vlan,
+        ):
+            if vid is not None:
+                referenced_ids.add(vid)
+        referenced_ids.update(iface.trunk_allowed_vlans or [])
+    for missing in sorted((set(renames) | drops) - referenced_ids):
+        result.warnings.append(
+            f"vlan_rename: VLAN {missing} is present nowhere in the parsed "
+            f"config (no stanza or interface reference); entry ignored"
+        )
 
     # Build the post-rewrite vlans list.  We defer actually assigning
     # back onto intent.vlans until we've resolved all collisions,

--- a/tests/unit/migration/test_port_names.py
+++ b/tests/unit/migration/test_port_names.py
@@ -1047,3 +1047,40 @@ class TestNonCanonicalIntentTreeIsNoOp:
         assert job.rendered  # the (unsafe) rendered output is present
         assert job.port_renames == {}
         assert job.warnings == []
+
+
+class TestAbsentKeyDropHonesty:
+    """Drop/rename keys for ports absent from the tree warn + aren't
+    over-reported as ``dropped`` (#49b)."""
+
+    def test_absent_drop_key_warns_not_reported(self):
+        # Same-vendor so nothing is auto-dropped as unmappable; the only drop
+        # candidate is the (absent) map key.
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(name="GigabitEthernet0/1")],
+        )
+        result = translate_port_names(
+            intent, CiscoIOSXECLICodec(), CiscoIOSXECLICodec(),
+            rename_map={"GigabitEthernet9/9": None},
+        )
+        assert result.dropped == []
+        assert any(
+            "GigabitEthernet9/9" in w and "does not exist" in w
+            for w in result.warnings
+        )
+
+    def test_present_drop_key_still_reported(self):
+        # Regression guard against over-correcting: a drop for a port that
+        # DOES exist is still reported + removed.
+        intent = CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(name="GigabitEthernet0/1"),
+                CanonicalInterface(name="GigabitEthernet0/2"),
+            ],
+        )
+        result = translate_port_names(
+            intent, CiscoIOSXECLICodec(), CiscoIOSXECLICodec(),
+            rename_map={"GigabitEthernet0/2": None},
+        )
+        assert result.dropped == ["GigabitEthernet0/2"]
+        assert [i.name for i in intent.interfaces] == ["GigabitEthernet0/1"]

--- a/tests/unit/migration/test_snmpv3_user_names.py
+++ b/tests/unit/migration/test_snmpv3_user_names.py
@@ -127,8 +127,11 @@ class TestSnmpV3UserNameRename:
             intent,
             rename_map={"userA": "shared", "userB": "shared"},
         )
-        # First-wins: userA landed at "shared", userB dropped.
-        assert r.applied == {"userA": "shared", "userB": "shared"}
+        # First-wins: userA landed at "shared", userB collided + dropped.
+        # userB is reported in `dropped`, NOT `applied` (#48 — applied used to
+        # record the rename before the collision check, contradicting reality).
+        assert r.applied == {"userA": "shared"}
+        assert r.dropped == ["userB"]
         names = [u.name for u in intent.snmp.v3_users]
         assert names.count("shared") == 1
         assert "userC" in names

--- a/tests/unit/migration/test_vlan_names.py
+++ b/tests/unit/migration/test_vlan_names.py
@@ -287,3 +287,25 @@ class TestBuildTransform:
         # Same rewrite applied twice → same applied entry, just once
         # in the result (dict semantics).
         assert result.applied == {10: 100}
+
+
+class TestNotFoundEntryWarning:
+    """Map entries for VLANs absent from the tree warn + no-op (#49a)."""
+
+    def test_absent_vlan_entry_warns(self):
+        intent = _tree_with_vlans(10, 20)
+        result = translate_vlan_ids(intent, rename_map={99: 88})
+        assert result.applied == {}
+        assert [v.id for v in intent.vlans] == [10, 20]
+        assert any("99" in w and "nowhere" in w for w in result.warnings)
+
+    def test_reference_only_vlan_not_flagged(self):
+        # VLAN 30 has no stanza but IS an interface access VLAN — Pass 2
+        # rewrites the reference, so it must NOT be flagged as a no-op (#49a).
+        intent = CanonicalIntent(
+            vlans=[CanonicalVlan(id=10, name="V10")],
+            interfaces=[CanonicalInterface(name="Gi0/1", access_vlan=30)],
+        )
+        result = translate_vlan_ids(intent, rename_map={30: 40})
+        assert intent.interfaces[0].access_vlan == 40
+        assert not any("nowhere" in w for w in result.warnings)


### PR DESCRIPTION
## L4 — rename-orchestrator bookkeeping honesty (Fable review 2026-07-06, MINOR)

Three findings where the per-pane rename orchestrators mis-reported what they did — the review's "misreport outcomes" theme.

| # | Site | Bug | Fix |
|---|------|-----|-----|
| **#48** | `snmpv3_user_names.py` | a collision-**dropped** rename was recorded in `applied` (set *before* the collision check) and never appended to `dropped` | record `applied` only after the record survives; append collision drops to `dropped` |
| **#49a** | `vlan_names.py` | docstring promised a not-found warning that never fired | warn — but only when the VLAN id is present **nowhere** (no stanza *and* no interface reference), since Pass 2 still rewrites reference-only ids; docstring corrected |
| **#49b** | `port_names.py` | `dropped` echoed every explicit-`None` map key even for a port absent from the tree | snapshot present names before the sweep; warn on absent keys, report only drops that removed a present name |

### Verification
- 5 new tests (3 bug-reproductions each **verified to fail pre-fix**, 2 regression guards against over-correction).
- One existing test (`test_collision_first_wins_drops_later`) pinned the *buggy* `applied` bookkeeping (contradicting its own "userB dropped" comment) — updated to assert the corrected `applied`/`dropped`.
- Full `tests/unit` + cross-mesh guard green (**5188 passed**); `ruff` clean. (Rename orchestrators are outside the bare parse→render mesh, so no baseline movement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
