### PR TITLE
fix(security): Docker :latest pre-release gate + TOFU host-key merge (do-now MAJORs)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -214,14 +214,17 @@ jobs:
             # Major.minor floating tag (only emits for stable releases
             # by default; pre-releases like `-rc4` are skipped).
             type=semver,pattern={{major}}.{{minor}}
-            # `:latest` updates on every release-tag push.  Earlier
+            # `:latest` tracks the newest STABLE release only.  An earlier
             # `enable={{is_default_branch}}` gate suppressed `:latest`
             # entirely on tag-triggered runs (the ref is the tag, not
-            # `main`, so `is_default_branch` evaluated false).  The
-            # README + CHANGELOG both document `docker pull
-            # netcanon/netcanon:latest` as the recommended quickstart;
-            # `:latest` needs to actually exist for that to work.
-            type=raw,value=latest
+            # `main`); dropping it (commit e809839) then let a pre-release
+            # tag like `v0.6.0-rc1` repoint `:latest` — the README/SECURITY
+            # quickstart pull — onto an rc (review #13).  Gate on the tag
+            # NOT being a semver pre-release (those carry a `-`), so rc
+            # pushes publish their versioned image without touching
+            # `:latest`, while a stable tag updates the documented quickstart
+            # tag.  `{{major}}.{{minor}}` above is already prerelease-aware.
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         id: build

--- a/netcanon/collectors/hostkey.py
+++ b/netcanon/collectors/hostkey.py
@@ -40,9 +40,11 @@ from ..config import Settings
 
 logger = logging.getLogger(__name__)
 
-#: Serialises read + write of the shared ``known_hosts`` store.  Backups run
-#: in a ThreadPoolExecutor (up to 10 workers), so two concurrent TOFU
-#: ``save_host_keys`` calls could otherwise interleave and corrupt the file.
+#: Serialises read-merge-write of the shared ``known_hosts`` store.  Backups
+#: run in a ThreadPoolExecutor (up to 10 workers); without one lock spanning
+#: the whole load+merge+save, two concurrent TOFU persists (or a Netmiko
+#: ``verify_host_key`` save) would each write only their own learned key and
+#: clobber the other's freshly-pinned entry (review #2).
 _KNOWN_HOSTS_LOCK = threading.Lock()
 
 #: Socket + key-exchange timeout (seconds) for the Netmiko host-key
@@ -89,6 +91,16 @@ def persist_paramiko_host_keys(
 ) -> None:
     """Persist newly-learned host keys after a successful ``tofu`` connect.
 
+    Read-merge-write under one lock hold (review #2).  ``client.save_host_keys``
+    plain-overwrites the file with only THIS client's in-memory keys, so when
+    the store didn't exist at policy-apply time (nothing loaded), two concurrent
+    first-time backups — or a concurrent Netmiko ``verify_host_key`` save —
+    would each write just their own key and silently drop the other's pin,
+    re-TOFU'ing the dropped device unverified next run (the MITM window v0.4.5
+    closed).  Instead load the current file, union in the client's learned
+    keys, and save the merged set; never call ``client.save_host_keys``.
+    Mirrors the already-atomic :func:`verify_host_key`.
+
     No-op for ``auto_add`` (no store) and ``reject`` (the store is operator-
     curated; we never extend it implicitly).
     """
@@ -97,8 +109,17 @@ def persist_paramiko_host_keys(
     kh = known_hosts_path(settings)
     try:
         with _KNOWN_HOSTS_LOCK:
+            merged = paramiko.HostKeys()
+            if kh.exists():
+                try:
+                    merged.load(str(kh))
+                except OSError as exc:  # race: file vanished/locked since exists()
+                    logger.warning("Could not read known_hosts at %s: %s", kh, exc)
+            for hostname, keytypes in client.get_host_keys().items():
+                for keytype, key in keytypes.items():
+                    merged.add(hostname, keytype, key)
             kh.parent.mkdir(parents=True, exist_ok=True)
-            client.save_host_keys(str(kh))
+            merged.save(str(kh))
     except OSError as exc:  # pragma: no cover - disk/permission edge
         logger.warning("Could not persist known_hosts at %s: %s", kh, exc)
 

--- a/tests/unit/test_hostkey.py
+++ b/tests/unit/test_hostkey.py
@@ -13,6 +13,7 @@ from netcanon.collectors.hostkey import (
     host_key_warning_reason,
     known_hosts_path,
     netmiko_host_key_params,
+    persist_paramiko_host_keys,
 )
 from netcanon.config import Settings
 
@@ -65,3 +66,36 @@ def test_warning_reason_fires_when_auto_add_selected(tmp_path) -> None:
 def test_no_warning_reason_for_strict_modes(tmp_path, mode) -> None:
     s = Settings(ssh_host_key_checking=mode, data_dir=tmp_path)
     assert host_key_warning_reason(s) is None
+
+
+def test_persist_merges_concurrent_first_time_keys(tmp_path) -> None:
+    """persist_paramiko_host_keys read-merge-writes the store (review #2).
+
+    Two first-time TOFU backups that each learned a different device key must
+    BOTH end up pinned.  ``client.save_host_keys`` (the pre-fix call) plain-
+    overwrites with only the calling client's keys, so the second persist
+    would drop the first device's pin — silently re-TOFU'ing it unverified.
+    """
+    import paramiko
+
+    s = Settings(ssh_host_key_checking="tofu", data_dir=tmp_path)
+    kh = known_hosts_path(s)
+
+    def _client_with(hostname: str, key) -> paramiko.SSHClient:
+        c = paramiko.SSHClient()
+        c.get_host_keys().add(hostname, key.get_name(), key)
+        return c
+
+    key_a = paramiko.ECDSAKey.generate()
+    key_b = paramiko.ECDSAKey.generate()
+    # Each worker starts from an EMPTY in-memory store (the file did not exist
+    # when its client applied the policy), then persists in sequence.
+    persist_paramiko_host_keys(_client_with("10.0.0.1", key_a), s)
+    persist_paramiko_host_keys(_client_with("10.0.0.2", key_b), s)
+
+    saved = paramiko.HostKeys()
+    saved.load(str(kh))
+    assert saved.lookup("10.0.0.1") is not None, (
+        "first device's pin was clobbered — persist overwrote instead of merging"
+    )
+    assert saved.lookup("10.0.0.2") is not None


### PR DESCRIPTION
## Do-now MAJORs — Docker `:latest` gate + TOFU host-key merge (Fable review 2026-07-06)

The two items the synthesis flagged for immediate attention independent of the low-severity wave.

| # | Site | Bug | Fix |
|---|------|-----|-----|
| **#13** | `.github/workflows/docker-publish.yml` | `type=raw,value=latest` is unconditional → a pre-release tag (`v0.6.0-rc1`) repoints `:latest` (the README/SECURITY quickstart pull) onto an rc. History-proven (rc5–rc9 after `e809839`). | gate on the tag not being a semver pre-release: `enable=${{ !contains(github.ref_name, '-') }}` |
| **#2** | `netcanon/collectors/hostkey.py` | `persist_paramiko_host_keys` calls `client.save_host_keys()` — a plain overwrite with only the calling client's keys. Concurrent first-time TOFU backups (or a concurrent `verify_host_key` save) clobber each other's freshly-pinned key → device silently re-TOFU'd unverified next run (re-opens the MITM window v0.4.5 closed). | read-merge-write under one `_KNOWN_HOSTS_LOCK` hold, mirroring the already-atomic `verify_host_key`; never call `client.save_host_keys()` |

### Verification
- Merge regression test (`test_persist_merges_concurrent_first_time_keys`) **verified to fail pre-fix** (first device's pin clobbered) and pass after.
- Full `tests/unit` + `test_ssh_hostkey` (real in-process SSH server) + cross-mesh guard green (**5200 passed**); `ruff` clean; workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
