### PR TITLE
fix(api): sanitize 422 + OpenAPI accuracy + validate device type_key (L5)

### DIFF
--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -12,6 +12,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
+from ...definitions.schema import DeviceDefinition
 from ...models.device_profile import (
     DeviceProfile,
     DeviceProfileCreate,
@@ -23,10 +24,34 @@ from ...storage.device_profile_store import (
     FileDeviceProfileStore,
 )
 from ...storage.schedule_store import SCHEDULE_REGISTRY_LOCK
-from ..deps import get_device_profile_store, get_device_profiles
+from ..deps import (
+    get_definitions,
+    get_device_profile_store,
+    get_device_profiles,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/devices", tags=["device-profiles"])
+
+
+def _require_known_type_key(
+    type_key: str, definitions: dict[str, DeviceDefinition]
+) -> None:
+    """422 if *type_key* is not a loaded definition (review #53).
+
+    The docs have always said ``type_key`` "must match a loaded definition",
+    but the value was previously only checked at backup time — so a typo'd
+    profile 201'd and failed days later.  Validate at create/update instead,
+    mirroring the POST /backups check.
+    """
+    if type_key not in definitions:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Unknown type_key {type_key!r}. "
+                f"Loaded definitions: {sorted(definitions.keys())}"
+            ),
+        )
 
 
 @router.get(
@@ -79,6 +104,7 @@ def create_device_profile(
     body: DeviceProfileCreate,
     device_profiles: dict[str, DeviceProfile] = Depends(get_device_profiles),
     device_profile_store: FileDeviceProfileStore = Depends(get_device_profile_store),
+    definitions: dict[str, DeviceDefinition] = Depends(get_definitions),
 ) -> DeviceProfile:
     """Create a new device profile and persist it to disk.
 
@@ -87,7 +113,11 @@ def create_device_profile(
 
     Returns:
         The newly created ``DeviceProfile``.
+
+    Raises:
+        HTTPException 422: If ``type_key`` is not a loaded definition.
     """
+    _require_known_type_key(body.type_key, definitions)
     profile = DeviceProfile(**body.model_dump())
     # Serialise dict-mutate + persist against the backup worker thread and
     # the other route mutators (review finding #10).  The cap check runs
@@ -129,6 +159,7 @@ def update_device_profile(
     body: DeviceProfileUpdate,
     device_profiles: dict[str, DeviceProfile] = Depends(get_device_profiles),
     device_profile_store: FileDeviceProfileStore = Depends(get_device_profile_store),
+    definitions: dict[str, DeviceDefinition] = Depends(get_definitions),
 ) -> DeviceProfile:
     """Partially update an existing device profile.
 
@@ -144,7 +175,12 @@ def update_device_profile(
 
     Raises:
         HTTPException 404: If no profile with *profile_id* exists.
+        HTTPException 422: If a supplied ``type_key`` is not a loaded definition.
     """
+    # Validate an explicitly-supplied type_key against loaded definitions
+    # (review #53) before taking the lock — fail fast, not at backup time.
+    if body.type_key is not None:
+        _require_known_type_key(body.type_key, definitions)
     # Hold the lock across the existence check + mutate + persist so a
     # concurrent delete can't slip between them (review finding #10).
     with DEVICE_PROFILE_REGISTRY_LOCK:

--- a/netcanon/api/routes/sanitize.py
+++ b/netcanon/api/routes/sanitize.py
@@ -40,6 +40,36 @@ logger = logging.getLogger(__name__)
         "sanitized config as text/plain by default, or a JSON "
         "audit log when `dry_run=true`."
     ),
+    # Default response is text/plain (the sanitized config); the dry_run
+    # branch returns JSON explicitly.  Declaring the class + both content
+    # types + the count header keeps the generated OpenAPI honest (#51).
+    response_class=PlainTextResponse,
+    responses={
+        200: {
+            "description": (
+                "Sanitized config — `text/plain` by default, or a JSON "
+                "substitution audit when `dry_run=true`."
+            ),
+            "content": {"text/plain": {}, "application/json": {}},
+            "headers": {
+                "X-Netcanon-Substitution-Count": {
+                    "description": (
+                        "Number of PII substitutions applied "
+                        "(text/plain response only)."
+                    ),
+                    "schema": {"type": "integer"},
+                },
+            },
+        },
+        400: {"description": "Upload could not be parsed as `source_vendor`."},
+        413: {"description": "Upload exceeds the configured size cap."},
+        422: {
+            "description": (
+                "Unknown `source_vendor`, or the sanitized tree could not be "
+                "re-rendered in that vendor's format."
+            )
+        },
+    },
 )
 async def post_sanitize(
     source_vendor: str = Form(...),
@@ -48,8 +78,10 @@ async def post_sanitize(
 ):
     available = list_public_codecs()
     if source_vendor not in available:
+        # 422 (not 400) — unify with every migration endpoint's unknown-vendor
+        # rejection so an unknown codec is one consistent status (#50).
         raise HTTPException(
-            status_code=400,
+            status_code=422,
             detail=f"Unknown source_vendor {source_vendor!r}; available: {available}",
         )
 

--- a/tests/integration/test_device_profiles_api.py
+++ b/tests/integration/test_device_profiles_api.py
@@ -218,3 +218,29 @@ class TestPersistFailureRollback:
         # The in-memory profile keeps its pre-update value (not the 18.1 that
         # failed to persist).
         assert client.app.state.device_profiles[pid].os_version == "17.12"
+
+
+class TestTypeKeyValidation:
+    """create/update validate type_key against loaded definitions (#53) — a
+    typo'd key now 422s at write time instead of 201'ing and failing days
+    later at backup time."""
+
+    def test_create_unknown_type_key_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/devices/", json=_create_body(type_key="NoSuchVendor"),
+        )
+        assert resp.status_code == 422
+        assert "type_key" in resp.json()["detail"]
+
+    def test_update_unknown_type_key_returns_422(self, client):
+        pid = client.post("/api/v1/devices/", json=_create_body()).json()["id"]
+        resp = client.put(
+            f"/api/v1/devices/{pid}", json={"type_key": "NoSuchVendor"},
+        )
+        assert resp.status_code == 422
+        assert "type_key" in resp.json()["detail"]
+
+    def test_create_known_type_key_still_201(self, client):
+        # Regression guard: the valid type_key path is unaffected.
+        resp = client.post("/api/v1/devices/", json=_create_body())
+        assert resp.status_code == 201

--- a/tests/integration/test_sanitize_api.py
+++ b/tests/integration/test_sanitize_api.py
@@ -106,13 +106,15 @@ class TestSanitizeEndpoint:
 
 
 class TestSanitizeEndpointErrors:
-    def test_unknown_source_vendor_returns_400(self, client):
+    def test_unknown_source_vendor_returns_422(self, client):
+        # 422 (unified with every migration endpoint's unknown-vendor
+        # rejection) since review #50 — was 400.
         response = client.post(
             "/api/v1/sanitize",
             data={"source_vendor": "no_such_vendor"},
             files={"config": ("test.cfg", b"hostname x\n", "text/plain")},
         )
-        assert response.status_code == 400
+        assert response.status_code == 422
         assert "Unknown source_vendor" in response.json()["detail"]
 
     def test_missing_source_vendor_returns_422(self, client):

--- a/tests/unit/test_device_profiles_lock.py
+++ b/tests/unit/test_device_profiles_lock.py
@@ -111,11 +111,18 @@ def test_create_cap_check_is_inside_lock(tmp_path) -> None:
         password="hunter2",
     )
     outcome: dict[str, object] = {}
+    # create_device_profile validates type_key against loaded definitions
+    # (review #53); on a direct call the Depends() default isn't resolved, so
+    # pass a stand-in — _require_known_type_key only tests key membership.
+    defs = {"Cisco": None}
 
     def _create() -> None:
         try:
             routes_mod.create_device_profile(
-                body, device_profiles=registry, device_profile_store=store
+                body,
+                device_profiles=registry,
+                device_profile_store=store,
+                definitions=defs,
             )
             outcome["result"] = "created"
         except HTTPException as exc:


### PR DESCRIPTION
## L5 — API contract (Fable review 2026-07-06, MINOR)

Per the decisions in-session: unify to 422 (#50) and validate `type_key` (#53).

| # | Site | Fix |
|---|------|-----|
| **#50** | `sanitize.py` | unknown `source_vendor` now **422** (was 400), matching every migration endpoint; integration assertion updated |
| **#51** | `sanitize.py` | added `response_class=PlainTextResponse` + a `responses={}` map so OpenAPI declares the real `text/plain` (and `application/json` dry-run) 200, the `X-Netcanon-Substitution-Count` header, and 400/413/422 |
| **#53** | `device_profiles.py` | create/update now validate `type_key` against loaded definitions → **422** + loaded-keys list (shared `_require_known_type_key`, mirrors POST /backups), instead of 201'ing a typo'd profile that fails days later at backup time |

**Scope note:** #51's broader "declare 404/400/403/409/501 across every CRUD route" half is deferred — it's pure OpenAPI-doc completeness (no behaviour impact) and better as a dedicated pass than bloating this PR.

### Verification
- 4 new tests (3 bug-reproductions **verified to fail pre-fix** + 1 valid-path guard); direct-call cap test updated to pass `definitions`.
- Full `tests/unit` + `tests/integration` green (**5694 passed**, incl. swagger-docs + cross-mesh guard); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
