### PR TITLE
fix(mikrotik): echo RouterOS version header for idempotent v6 NTP gate (L8a, #61)

### DIFF
--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -147,11 +147,11 @@ def _render_ntp_client(tree: Any) -> list[str]:
     3+ servers) keeps today's v7 output byte-identically.  The parser unions
     both forms, so the round-trip is stable on either dialect.
 
-    Note: not idempotent across a *double* sanitize — the v6 output carries
-    no version header, so a second pass sees ``source_version == ""`` and
-    falls back to v7.  The canonical tree (``ntp_servers``) is preserved
-    either way; only the emitted dialect differs, and a single sanitize (the
-    real use case) produces valid 6.x output.
+    Idempotent across a double sanitize: ``render_intent`` now echoes a
+    ``# by RouterOS <ver>`` export-header comment on a same-vendor render
+    (review #61), which the parser reads back into ``source_version`` — so a
+    second pass still sees major==6 and re-emits the v6 form.  The canonical
+    tree (``ntp_servers``) is preserved regardless of dialect.
     """
     if not tree.ntp_servers:
         return []
@@ -187,6 +187,16 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         )
 
     lines: list[str] = []
+
+    # Echo the device's own RouterOS release as an export-header comment on a
+    # same-vendor render (review #61 — brings MikroTik into #297's same-vendor
+    # echo).  The parser reads it back into source_version (see _VERSION_RE), so
+    # the v6 NTP dialect gate stays idempotent across a double sanitize instead
+    # of decaying to the v7 form on pass 2 (when no header was emitted, pass 2
+    # saw source_version == "").
+    if tree.source_vendor == "mikrotik_routeros" and tree.source_version:
+        lines.append(f"# by RouterOS {tree.source_version}")
+        lines.append("")
 
     # ----- /system identity -----
     if tree.hostname:

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -374,6 +374,26 @@ class TestNtpV6RenderDialect:
         assert "servers=10.200.0.15" not in out
         assert codec.parse(out).ntp_servers == tree.ntp_servers == ["10.200.0.15"]
 
+    def test_v6_gate_idempotent_across_double_sanitize(self):
+        # #61: a same-vendor render now echoes a `# by RouterOS <ver>` header
+        # that the parser reads back into source_version, so a SECOND sanitize
+        # still sees major==6 and keeps the v6 dialect.  Pre-fix, pass 2 saw
+        # source_version="" (no header) and decayed to the v7 `servers=` form.
+        codec = MikroTikRouterOSCodec()
+        tree = CanonicalIntent(
+            hostname="r",
+            source_vendor="mikrotik_routeros",
+            source_version="6.48.6",
+            ntp_servers=["10.0.0.1", "10.0.0.2"],
+        )
+        first = codec.render(tree)
+        assert "# by RouterOS 6.48.6" in first
+        second = codec.render(codec.parse(first))
+        assert self._ntp_line(second) == (
+            "set enabled=yes primary-ntp=10.0.0.1 secondary-ntp=10.0.0.2"
+        )
+        assert first == second  # true fixpoint — no dialect decay on re-sanitize
+
 
 class TestParseErrors:
     def test_empty_input_raises(self):


### PR DESCRIPTION
## L8a — MikroTik v6-NTP gate idempotency (Fable review 2026-07-06, MINOR #61)

`render_intent` emitted no version header, so a **second** same-vendor sanitize saw `source_version=""` and the RouterOS-6 NTP dialect gate (#299) decayed to the v7 `servers=` form — output a 6.x device rejects.

**Fix:** echo a `# by RouterOS <ver>` export-header comment on a same-vendor render when `source_version` is set (MikroTik was the one codec *consuming* `source_version` yet left out of #297's echo). The parser's `_VERSION_RE` reads it straight back, so a double sanitize stays on the v6 form and render is a true fixpoint (`pass2 == pass1`). Cross-vendor renders are unaffected (gate requires `source_vendor == "mikrotik_routeros"`).

### Verification
- Idempotency test **verified to fail pre-fix** (pass 2 decays to v7) and pass after.
- **Mesh-neutral:** the header round-trips to `source_version`, which the comparator excludes as metadata. Full `tests/unit` + cross-mesh guard green (**5186 passed**); `ruff` clean.

**Deferred sibling — #60** (junos render byte-order fixpoint): its interface/lag re-ordering touches a core codec's tree order with mesh-wide blast radius and needs a full mesh reconciliation + deliberate re-baseline to verify safely — better as its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
