### PR TITLE
refactor(codecs): dedup same-vendor version-echo into shared helper (L8b, #63)

### DIFF
--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -21,8 +21,32 @@ from __future__ import annotations
 import ipaddress
 import re
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from .base import ParseError, RenderError
+
+if TYPE_CHECKING:
+    from ..canonical.intent import CanonicalIntent
+
+
+def same_vendor_version(
+    tree: CanonicalIntent, *, vendor_id: str, default: str
+) -> str:
+    """The version token to stamp on render: the device's OWN ``source_version``
+    when the tree was parsed by THIS codec (``source_vendor == vendor_id``) and
+    carries a version, else the synthetic *default*.
+
+    Compare against the codec's ``capabilities.vendor_id`` — NOT its registry
+    key.  Some codecs stamp a different vendor_id than their registry name
+    (``cisco_iosxe_cli`` → ``cisco_iosxe``, ``fortigate_cli`` → ``fortigate``),
+    so a registry-key literal would silently never fire for those.  Keeps a
+    same-vendor re-render (sanitize / X→X) echoing the device's real release
+    instead of relabelling it with a constant.  ``source_version`` is
+    metadata-excluded from every comparator, so this is round-trip-invisible.
+    """
+    if tree.source_vendor == vendor_id and tree.source_version:
+        return tree.source_version
+    return default
 
 
 def _normalise_mac_to_colon_hex(mac: str) -> str:

--- a/netcanon/migration/codecs/aruba_aoscx/render.py
+++ b/netcanon/migration/codecs/aruba_aoscx/render.py
@@ -45,7 +45,7 @@ import ipaddress
 import re
 
 from ...canonical.intent import CanonicalIntent
-from .._helpers import _coalesce_vlan_ids
+from .._helpers import _coalesce_vlan_ids, same_vendor_version
 
 #: Synthesised AOS-CX release stamped into the ``!Version`` banner when the
 #: source device's own release is unknown.  When the tree was parsed from THIS
@@ -60,10 +60,11 @@ _DEFAULT_VERSION = "Virtual.10.13.1000"
 
 def _version_token(tree: CanonicalIntent) -> str:
     """The AOS-CX release token to stamp after ``!Version ArubaOS-CX``: the
-    device's own when same-vendor and known, else the synthetic default."""
-    if tree.source_vendor == "aruba_aoscx" and tree.source_version:
-        return tree.source_version
-    return _DEFAULT_VERSION
+    device's own when same-vendor and known, else the synthetic default
+    (review #63 — shared helper)."""
+    return same_vendor_version(
+        tree, vendor_id="aruba_aoscx", default=_DEFAULT_VERSION
+    )
 
 #: Canonical SNMPv3 privacy cipher -> AOS-CX `priv` keyword.  AOS-CX
 #: supports `des` and `aes`; NX-OS-style aes128/192/256 collapse to

--- a/netcanon/migration/codecs/cisco_iosxr/render.py
+++ b/netcanon/migration/codecs/cisco_iosxr/render.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import re
 
 from ...canonical.intent import CanonicalIntent, CanonicalRoutingInstance
-from .._helpers import _prefix_to_mask
+from .._helpers import _prefix_to_mask, same_vendor_version
 from . import port_names as _port_names
 
 #: Synthesised IOS-XR release stamped into the banner when the source
@@ -54,10 +54,10 @@ _DEFAULT_VERSION = "6.6.2"
 
 def _version_token(tree: CanonicalIntent) -> str:
     """The IOS-XR release to stamp: the device's own when same-vendor and
-    known, else the synthetic default."""
-    if tree.source_vendor == "cisco_iosxr" and tree.source_version:
-        return tree.source_version
-    return _DEFAULT_VERSION
+    known, else the synthetic default (review #63 — shared helper)."""
+    return same_vendor_version(
+        tree, vendor_id="cisco_iosxr", default=_DEFAULT_VERSION
+    )
 
 #: Canonical LAG mode → IOS-XR ``bundle id ... mode`` keyword (inverse of
 #: parse._IOSXR_LAG_MODE_MAP; canonical ``static`` → XR ``on``).

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import re
 
 from ...canonical.intent import CanonicalIntent, CanonicalRoutingInstance
-from .._helpers import _coalesce_vlan_ids
+from .._helpers import _coalesce_vlan_ids, same_vendor_version
 from . import port_names as _port_names
 
 #: Synthesised NX-OS release stamped into the banner when the source device's
@@ -46,10 +46,10 @@ _DEFAULT_VERSION = "9.3(11)"
 
 def _version_token(tree: CanonicalIntent) -> str:
     """The NX-OS release to stamp: the device's own when same-vendor and
-    known, else the synthetic default."""
-    if tree.source_vendor == "cisco_nxos" and tree.source_version:
-        return tree.source_version
-    return _DEFAULT_VERSION
+    known, else the synthetic default (review #63 — shared helper)."""
+    return same_vendor_version(
+        tree, vendor_id="cisco_nxos", default=_DEFAULT_VERSION
+    )
 
 #: Canonical LAG mode -> NX-OS ``channel-group ... mode`` keyword
 #: (inverse of parse._NXOS_LAG_MODE_MAP; canonical ``static`` -> ``on``).

--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -37,6 +37,7 @@ from typing import Any
 
 from ..._user_secrets import classify_hash, format_review_comment, is_migratable
 from ...canonical.intent import CanonicalIntent, CanonicalVlan
+from .._helpers import same_vendor_version
 from ..base import RenderError
 from .parse import (
     _is_ethernet_name,
@@ -194,8 +195,11 @@ def render_intent(tree: Any) -> str:  # noqa: C901
     # the v6 NTP dialect gate stays idempotent across a double sanitize instead
     # of decaying to the v7 form on pass 2 (when no header was emitted, pass 2
     # saw source_version == "").
-    if tree.source_vendor == "mikrotik_routeros" and tree.source_version:
-        lines.append(f"# by RouterOS {tree.source_version}")
+    header_version = same_vendor_version(
+        tree, vendor_id="mikrotik_routeros", default=""
+    )
+    if header_version:
+        lines.append(f"# by RouterOS {header_version}")
         lines.append("")
 
     # ----- /system identity -----

--- a/netcanon/migration/codecs/vyos/render.py
+++ b/netcanon/migration/codecs/vyos/render.py
@@ -40,6 +40,7 @@ import logging
 import re
 
 from ...canonical.intent import CanonicalIntent
+from .._helpers import same_vendor_version
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +70,9 @@ _RELEASE_VERSION = "1.4"
 
 def _release_token(tree: CanonicalIntent) -> str:
     """The VyOS release to stamp into ``// Release version``: the device's own
-    when same-vendor and known, else the synthetic default."""
-    if tree.source_vendor == "vyos" and tree.source_version:
-        return tree.source_version
-    return _RELEASE_VERSION
+    when same-vendor and known, else the synthetic default (review #63 —
+    shared helper)."""
+    return same_vendor_version(tree, vendor_id="vyos", default=_RELEASE_VERSION)
 
 #: Interface-type render rank — ethernet, then loopback, dummy, bonding.
 _TYPE_RANK = {"ethernet": 0, "loopback": 1, "dummy": 2, "bonding": 3}

--- a/tests/unit/migration/test_version_echo_invariant.py
+++ b/tests/unit/migration/test_version_echo_invariant.py
@@ -1,0 +1,69 @@
+"""Registry-wide invariant for the same-vendor version-echo (review #63).
+
+The shared ``same_vendor_version`` helper (``codecs/_helpers.py``) decides
+whether a render echoes the device's own OS release.  It must compare against
+each codec's ``capabilities.vendor_id`` — NOT its registry key — because some
+codecs stamp a different vendor_id than their registry name (``cisco_iosxe_cli``
+→ ``cisco_iosxe``, ``fortigate_cli`` → ``fortigate``).  A codec wiring the wrong
+literal would silently stop echoing; the parametrised test below pins the
+behaviour end-to-end so a future copy can't drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import CanonicalIntent
+from netcanon.migration.codecs._helpers import same_vendor_version
+from netcanon.migration.codecs.aruba_aoscx import ArubaAOSCXCodec
+from netcanon.migration.codecs.cisco_iosxr import CiscoIOSXRCodec
+from netcanon.migration.codecs.cisco_nxos import CiscoNXOSCodec
+from netcanon.migration.codecs.mikrotik_routeros import MikroTikRouterOSCodec
+from netcanon.migration.codecs.vyos import VyOSCodec
+
+pytestmark = pytest.mark.unit
+
+#: Codecs whose render echoes the device's own OS release on a same-vendor pass
+#: (#297 banner echo + #61 MikroTik export header).
+_ECHOING_CODECS = [
+    ArubaAOSCXCodec,
+    CiscoIOSXRCodec,
+    CiscoNXOSCodec,
+    MikroTikRouterOSCodec,
+    VyOSCodec,
+]
+
+
+class TestSameVendorVersionHelper:
+    def test_same_vendor_with_version_returns_it(self):
+        t = CanonicalIntent(source_vendor="cisco_nxos", source_version="9.9.9")
+        assert same_vendor_version(t, vendor_id="cisco_nxos", default="D") == "9.9.9"
+
+    def test_cross_vendor_returns_default(self):
+        t = CanonicalIntent(source_vendor="cisco_nxos", source_version="9.9.9")
+        assert same_vendor_version(t, vendor_id="vyos", default="D") == "D"
+
+    def test_same_vendor_without_version_returns_default(self):
+        t = CanonicalIntent(source_vendor="cisco_nxos", source_version="")
+        assert same_vendor_version(t, vendor_id="cisco_nxos", default="D") == "D"
+
+
+@pytest.mark.parametrize(
+    "codec_cls", _ECHOING_CODECS, ids=lambda c: c().capabilities.vendor_id
+)
+def test_same_vendor_render_echoes_source_version(codec_cls):
+    """A same-vendor tree's ``source_version`` must appear in the render — proof
+    the codec compares against ``capabilities.vendor_id``, not a stale literal
+    that could silently diverge (review #63)."""
+    codec = codec_cls()
+    vid = codec.capabilities.vendor_id
+    tree = CanonicalIntent(
+        hostname="echo-probe",
+        source_vendor=vid,
+        source_version="9.9.9-echo",
+    )
+    out = codec.render(tree)
+    assert "9.9.9-echo" in out, (
+        f"{vid}: same-vendor render did not echo source_version — its render "
+        "vendor_id literal likely diverged from capabilities.vendor_id"
+    )


### PR DESCRIPTION
## L8b — dedup same-vendor version-echo (Fable review 2026-07-06, MINOR #63)

The version-echo logic (`if source_vendor == <literal> and source_version: echo else default`) was copy-pasted across **five** render paths (nxos/iosxr/aoscx `_version_token`, vyos `_release_token`, the mikrotik #61 header gate). Each hardcoded its vendor literal; a future codec using its **registry key** where `capabilities.vendor_id` differs (`cisco_iosxe_cli`→`cisco_iosxe`, `fortigate_cli`→`fortigate`) would silently never echo — and no round-trip test could catch it (`source_version` is comparator-excluded).

**Fix:** one `same_vendor_version(tree, *, vendor_id, default)` in `codecs/_helpers.py`; all five delegate to it. Plus a **registry-wide behavioural invariant** — for every echoing codec, a same-vendor tree's `source_version` must appear in its render, pinning `render vendor_id == capabilities.vendor_id`.

### Verification
- Echo invariant + helper unit tests (8) green; sanity-checked that a **wrong** vendor_id literal makes the echo test fail (temporarily broke nxos → its case failed → reverted).
- **Behaviour-preserving** (all five echo byte-identically) and **mesh-neutral**. Full `tests/unit` + cross-mesh guard green (**5200 passed**); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
