### PR TITLE
refactor(codecs): inherit iter_xpaths from CodecBase, drop 9 sibling-import overrides (L8c, #64)

### DIFF
--- a/netcanon/migration/codecs/README.md
+++ b/netcanon/migration/codecs/README.md
@@ -82,9 +82,10 @@ god-file cleanup), **opnsense** (XML wire-format reference),
 **aruba_aoss** (banner + positional port-list reference),
 **arista_eos** (Cisco-dialect parallel reference),
 **mikrotik_routeros** (slash-prefixed CLI reference),
-**cisco_iosxe_cli** (largest render path; ``_walk_canonical`` kept
-at module level in ``codec.py`` to preserve the cross-codec import
-surface every other codec's ``iter_xpaths`` reuses), and
+**cisco_iosxe_cli** (largest render path; ``_walk_canonical`` is
+re-exported at module level in ``codec.py`` for back-compat, though the
+walker's real home is ``canonical/xpath_walker.py`` and codecs now inherit
+``iter_xpaths`` from ``CodecBase``), and
 **juniper_junos** (two-pass groups-then-top-level dispatch +
 block-form-to-set-form conversion both kept cohesive in
 ``parse.py``).  All shipped CLI/XML codecs now follow the split
@@ -179,11 +180,11 @@ class MyVendorCodec(CodecBase):
         # Return a config string the vendor can ingest.
         ...
 
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        # Yield canonical xpaths present in `tree`.  Used by capability
-        # validation.  The cisco_iosxe_cli codec exports a shared
-        # `_walk_canonical` helper most other codecs reuse.
-        ...
+    # iter_xpaths is INHERITED from CodecBase: it walks a CanonicalIntent
+    # via the shared `canonical/xpath_walker.py` walker (and handles the flat
+    # mock dict).  A canonical-bridged codec needs NO override.  Override only
+    # if your tree has a genuinely different shape (e.g. the NETCONF
+    # cisco_iosxe codec's nested XML dict).
 
     @classmethod
     def probe(cls, raw_prefix: str) -> tuple[int, str] | None:
@@ -402,9 +403,11 @@ public.
 
 The cross-codec matrix validates that every xpath a codec yields via
 `iter_xpaths(tree)` is declared in its `capabilities`.  A mismatch is
-a test failure.  Use the shared `_walk_canonical` from
-`cisco_iosxe_cli/codec.py` when possible — it's the canonical walker
-every canonical-bridged codec reuses.
+a test failure.  `CodecBase.iter_xpaths` already walks a `CanonicalIntent`
+via the shared walker in `canonical/xpath_walker.py`, so a canonical-bridged
+codec inherits the right behaviour and should NOT override it (nor import
+`_walk_canonical` through `cisco_iosxe_cli`).  Override only for a genuinely
+different tree shape (e.g. the NETCONF codec's nested XML dict).
 
 ---
 

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -37,7 +37,6 @@ all of these and the codec must tolerate them.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -420,15 +419,6 @@ class AristaEOSCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths — reuse the shared canonical walker.
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation

--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -20,10 +20,9 @@ Module layout mirrors the ``cisco_nxos`` post-split shape:
 * ``port_names.py`` — cross-vendor port-name bridge (the multi-token
   ``vlan N`` / ``lag N`` / ``1/1/1`` name shapes).
 
-``iter_xpaths`` reuses ``_walk_canonical`` from
-:mod:`netcanon.migration.codecs.cisco_iosxe_cli.codec` — AOS-CX
-introduces no new canonical xpaths in Phase 1, so the shared walker
-yields exactly the right set.
+``iter_xpaths`` is inherited from :class:`CodecBase`, which walks a
+``CanonicalIntent`` via the shared ``canonical.xpath_walker`` — AOS-CX
+introduces no new canonical xpaths, so no override is needed (#64).
 
 This codec landed in phases (Tier-1 first, mirroring the ``cisco_nxos``
 cadence).  **Phase 1**: hostname, basic-L3 interfaces (description /
@@ -55,7 +54,6 @@ IRB L3VNI (``vni N / vrf``), VSX, and VRRP.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -682,16 +680,6 @@ class ArubaAOSCXCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths — reuse the shared canonical walker
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        """Yield schema xpaths from a :class:`CanonicalIntent`."""
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation (delegated to .port_names)

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -28,7 +28,6 @@ purely for backwards compatibility.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -456,18 +455,6 @@ class ArubaAOSSCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            # The shared walker now emits the VLAN port-membership xpaths
-            # (/vlans/vlan/{tagged,untagged}-ports) for every codec, so no
-            # codec-local supplement is needed here (review #9 completion).
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation

--- a/netcanon/migration/codecs/base.py
+++ b/netcanon/migration/codecs/base.py
@@ -335,16 +335,28 @@ class CodecBase(ABC):
         strings declared in ``CapabilityMatrix.supported /
         .lossy / .unsupported``.
 
-        The default implementation handles the flat ``dict[str, str]``
-        shape used by the reference mock adapter.  Adapters with
-        nested tree shapes (e.g. :class:`CiscoIOSXECodec`, which
-        uses a nested dict mirroring the OpenConfig XML tree) MUST
-        override.
+        Handles the two shapes every codec actually produces: the flat
+        ``dict[str, str]`` of the reference mock adapter, and a
+        :class:`CanonicalIntent`, walked by the shared
+        ``canonical.xpath_walker._walk_canonical`` — the walker's real
+        home (a NON-vendor package).  Before review #64 each codec
+        copy-pasted an override that reached the walker THROUGH the
+        ``cisco_iosxe_cli`` package; inheriting this default removes that
+        cross-vendor edge.  A codec with a genuinely different tree shape
+        (e.g. the NETCONF ``cisco_iosxe`` codec's nested XML dict) still
+        overrides.  Imports are deferred so ``base`` carries no
+        canonical-layer import at module load.
         """
         if isinstance(tree, dict):
             for key in tree:
                 if isinstance(key, str):
                     yield key
+            return
+        from ..canonical.intent import CanonicalIntent
+        from ..canonical.xpath_walker import _walk_canonical
+
+        if isinstance(tree, CanonicalIntent):
+            yield from _walk_canonical(tree)
 
     # ------------------------------------------------------------------
     # Cross-vendor port-name translation — vendor-agnostic bridge

--- a/netcanon/migration/codecs/cisco_iosxe/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe/codec.py
@@ -975,7 +975,9 @@ class CiscoIOSXECodec(CodecBase):
         """
         from ...canonical.intent import CanonicalIntent
         if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
+            # Shared canonical walker, from its real home — a non-vendor
+            # package — not through cisco_iosxe_cli (#64).
+            from ...canonical.xpath_walker import _walk_canonical
             yield from _walk_canonical(tree)
             return
         if not isinstance(tree, dict):

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -19,10 +19,9 @@ shape:
 * ``render.py`` — canonical tree → IOS-XR running-config text.
 * ``port_names.py`` — cross-vendor 4-segment port-name bridge.
 
-``iter_xpaths`` reuses ``_walk_canonical`` from
-:mod:`netcanon.migration.codecs.cisco_iosxe_cli.codec` — IOS-XR
-introduces no new canonical xpaths, so the shared walker yields exactly
-the right set.
+``iter_xpaths`` is inherited from :class:`CodecBase`, which walks a
+``CanonicalIntent`` via the shared ``canonical.xpath_walker`` — IOS-XR
+introduces no new canonical xpaths, so no override is needed (#64).
 
 This codec lands in four phases (see
 ``docs/v0.2.0-planning/04-iosxr-codec/``).  **Phases 1-2 are complete.**
@@ -55,7 +54,6 @@ batfish lacks), all parsing + round-tripping cleanly — well past the
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -597,16 +595,6 @@ class CiscoIOSXRCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths — reuse the shared canonical walker
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        """Yield schema xpaths from a :class:`CanonicalIntent`."""
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation (delegated to .port_names)

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -17,10 +17,9 @@ Module layout mirrors the ``cisco_iosxe_cli`` post-split shape:
 * ``render.py`` — canonical tree → NX-OS running-config text.
 * ``port_names.py`` — cross-vendor port-name bridge.
 
-``iter_xpaths`` reuses ``_walk_canonical`` from
-:mod:`netcanon.migration.codecs.cisco_iosxe_cli.codec` — NX-OS
-introduces no new canonical xpaths in Phase 1, so the shared walker
-yields exactly the right set.
+``iter_xpaths`` is inherited from :class:`CodecBase`, which walks a
+``CanonicalIntent`` via the shared ``canonical.xpath_walker`` — NX-OS
+introduces no new canonical xpaths, so no override is needed (#64).
 
 This codec lands in four phases (see
 ``docs/v0.2.0-planning/03-nxos-codec/``).  **All four phases are
@@ -47,7 +46,6 @@ L2VNI, EVPN L3VNI, BGP-redistribute) in
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -607,16 +605,6 @@ class CiscoNXOSCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths — reuse the shared canonical walker
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        """Yield schema xpaths from a :class:`CanonicalIntent`."""
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation (delegated to .port_names)

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -27,7 +27,6 @@ re-exports are purely for backwards compatibility.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -532,15 +531,6 @@ class FortiGateCLICodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -55,7 +55,6 @@ bodies + the ``set apply-groups`` statements.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -407,15 +406,6 @@ class JunosCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths — reuse the shared canonical walker.
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -64,7 +64,6 @@ default, so repeated parse/render cycles stabilise after one pass.
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -474,18 +473,6 @@ class MikroTikRouterOSCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        """Yield schema xpaths from a :class:`CanonicalIntent`."""
-        if isinstance(tree, CanonicalIntent):
-            # Reuse the shared canonical walker so every codec emits
-            # the same set of xpaths for the same tree.
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -587,8 +587,9 @@ class OPNsenseCodec(CodecBase):
     def iter_xpaths(self, tree: Any) -> Iterable[str]:
         """Yield schema xpaths from a :class:`CanonicalIntent` or legacy dict."""
         if isinstance(tree, CanonicalIntent):
-            # Reuse the CLI codec's canonical walker.
-            from ..cisco_iosxe_cli.codec import _walk_canonical
+            # Shared canonical walker, imported from its real home — a
+            # non-vendor package — not through cisco_iosxe_cli (#64).
+            from ...canonical.xpath_walker import _walk_canonical
             yield from _walk_canonical(tree)
             return
         if not isinstance(tree, dict):

--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -19,9 +19,9 @@ Module layout mirrors the ``cisco_nxos`` / ``aruba_aoscx`` post-split shape:
 * ``port_names.py`` — cross-vendor port-name bridge (Linux-style
   ``ethN`` / ``lo`` / ``bondN`` device names).
 
-``iter_xpaths`` reuses ``_walk_canonical`` from
-:mod:`netcanon.migration.codecs.cisco_iosxe_cli.codec` — VyOS introduces
-no new canonical xpaths in Phase 1.
+``iter_xpaths`` is inherited from :class:`CodecBase`, which walks a
+``CanonicalIntent`` via the shared ``canonical.xpath_walker`` — VyOS
+introduces no new canonical xpaths, so no override is needed (#64).
 
 This codec lands in phases (Tier-1 first, mirroring the ``aruba_aoscx``
 cadence).  **Phase 1**: ``system host-name``; interfaces (``ethernet``
@@ -52,7 +52,6 @@ VyOS set-form from Junos set-form (which the ``juniper_junos`` codec owns).
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import Any, ClassVar
 
 from ....models.migration import (
@@ -619,16 +618,6 @@ class VyOSCodec(CodecBase):
 
     def render(self, tree: Any) -> str:
         return render_intent(tree)
-
-    # -----------------------------------------------------------------
-    # iter_xpaths — reuse the shared canonical walker
-    # -----------------------------------------------------------------
-
-    def iter_xpaths(self, tree: Any) -> Iterable[str]:
-        """Yield schema xpaths from a :class:`CanonicalIntent`."""
-        if isinstance(tree, CanonicalIntent):
-            from ..cisco_iosxe_cli.codec import _walk_canonical
-            yield from _walk_canonical(tree)
 
     # -----------------------------------------------------------------
     # Cross-vendor port-name translation (delegated to .port_names)


### PR DESCRIPTION
## L8c — inherit `iter_xpaths` from `CodecBase` (Fable review 2026-07-06, MINOR #64)

The canonical xpath walker was relocated to `canonical/xpath_walker.py` to escape the vendor packages, yet 11 codecs still reached it **through** the `cisco_iosxe_cli` package (`from ..cisco_iosxe_cli.codec import _walk_canonical`) via a copy-pasted `iter_xpaths` override — the exact cross-vendor edge the relocation meant to remove, and the pattern the README taught codec #13.

**Fix:**
- `CodecBase.iter_xpaths` now walks a `CanonicalIntent` via the shared `canonical.xpath_walker` (runtime import; keeps the flat mock-dict branch).
- Deleted the **9 byte-identical overrides** → they inherit; removed orphaned `Iterable` imports.
- **cisco_iosxe (XML)** and **opnsense** keep their overrides (genuine nested-dict paths) but import the walker from its real home, not the sibling package.
- `cisco_iosxe_cli` keeps its module-level re-export for back-compat.
- README (3 spots) + 4 codec module-docstrings corrected.

> The finding said "11 identical overrides"; two of the eleven (cisco_iosxe XML, opnsense) actually have a distinct nested-dict path, so they're kept (import swapped) — **9** deleted.

### Verification
- **Behaviour-preserving:** sanity-checked that all 13 codecs' `iter_xpaths` still yield the expected xpaths (same walker, now via base). Full `tests/unit` + cross-mesh guard green (**5200 passed**) — the **walker-completeness + capability-honesty** guards are the proof that no codec's classification changed. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
