### PR TITLE
fix(rename): close three rename-transform-seam data-loss bugs (#3/#5/#6)

### DIFF
--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -695,8 +695,11 @@ class CanonicalVxlan(BaseModel):
         source_interface: VTEP source interface name in operator-form
             (Arista ``Loopback0``, Junos ``lo0.0``, NX-OS ``loopback0``).
             Opaque string — cross-vendor renders accept whatever the
-            source codec emitted; operators rename via the existing
-            port-rename pane when crossing platforms.  Empty string
+            source codec emitted; the port-rename orchestrator
+            (``translate_port_names``) rewrites this field alongside the
+            other port-name references when a rename/drop is applied, so
+            a cross-platform rename keeps the VTEP binding valid.  Empty
+            string
             means undeclared and codecs should fall back to a sensible
             default (typically ``Loopback0`` on Arista, ``lo0.0`` on
             Junos).  This is a switch-level / global attribute on the

--- a/netcanon/migration/canonical/port_names.py
+++ b/netcanon/migration/canonical/port_names.py
@@ -292,12 +292,14 @@ def translate_port_names(  # noqa: C901
 
         * ``intent.interfaces[].name``
         * ``intent.interfaces[].lag_member_of``
+        * ``intent.interfaces[].vrrp_groups[].track_interfaces[]``
         * ``intent.vlans[].tagged_ports[]``
         * ``intent.vlans[].untagged_ports[]``
         * ``intent.lags[].name``
         * ``intent.lags[].members[]``
         * ``intent.static_routes[].interface``
         * ``intent.dhcp_servers[].interface``
+        * ``intent.vxlan_vnis[].source_interface``
 
     Mutates *intent* in place.
 
@@ -332,9 +334,16 @@ def translate_port_names(  # noqa: C901
 
     user_map = dict(rename_map or {})
     # Split user map into drops (value is None) and renames (value is str).
-    # Drops never go through the target codec — they're stripped from the
-    # canonical tree after the rename pass completes.
-    dropped_set: set[str] = {
+    # Drops never go through the target codec.
+    #
+    # (#6) User drops are keyed by SOURCE names and are stripped BEFORE the
+    # rename sweep, not after: a rename can move a DIFFERENT interface ONTO a
+    # dropped name (``{A: B, B: None}``), and a post-sweep strip keyed by ``B``
+    # would then also delete the freshly-renamed survivor — silently losing a
+    # configured interface while ``applied`` still claims the rename landed.
+    # Stripping first (while names are still source-form) removes exactly the
+    # operator's target and leaves the renamed survivor intact.
+    user_dropped: set[str] = {
         name for name, tgt in user_map.items() if tgt is None
     }
     str_map: dict[str, str] = {
@@ -343,6 +352,12 @@ def translate_port_names(  # noqa: C901
     applied: dict[str, str] = {}
     warnings: list[str] = []
     memo: dict[str, str] = {}
+    # Auto-drops accumulate DURING resolve() when ``strip_unmappable`` removes a
+    # name the target codec can't format.  Unlike user drops, these names stay
+    # verbatim through the sweep (they were never renamed to something else), so
+    # their post-sweep name still equals their source name and stripping them
+    # AFTER the sweep is safe.
+    auto_dropped: set[str] = set()
 
     # Per-interface kind overrides — populated by source codecs that
     # detect logical role (mgmt, etc.) from CONTEXT rather than from
@@ -366,10 +381,11 @@ def translate_port_names(  # noqa: C901
         # the same output without re-classifying.
         if name in memo:
             return memo[name]
-        if name in dropped_set:
-            # Leave verbatim in the rename pass — the strip pass
-            # below removes the name entirely.  Memoise to skip the
-            # classifier lookup for subsequent references.
+        if name in user_dropped:
+            # User drops are stripped from the tree BEFORE this sweep runs,
+            # so resolve() normally never sees them; this guard is defensive
+            # (any residual reference stays verbatim rather than being
+            # classified/renamed).  Memoise to skip the classifier lookup.
             memo[name] = name
             return name
         if name in str_map:
@@ -464,7 +480,7 @@ def translate_port_names(  # noqa: C901
             # keep it can use a verbatim-override (``map[name] =
             # name``) or the Tier 3 UI's "keep verbatim" link.
             if strip_unmappable:
-                dropped_set.add(name)
+                auto_dropped.add(name)
             memo[name] = name
             return name
         # A structurally-clean rename can STILL drop a source-side
@@ -501,6 +517,9 @@ def translate_port_names(  # noqa: C901
         present_names.add(iface.name)
         if iface.lag_member_of:
             present_names.add(iface.lag_member_of)
+        # (#3) VRRP track-interface references are port names too.
+        for grp in iface.vrrp_groups:
+            present_names.update(grp.track_interfaces)
     for vlan in intent.vlans:
         present_names.update(vlan.tagged_ports)
         present_names.update(vlan.untagged_ports)
@@ -513,6 +532,15 @@ def translate_port_names(  # noqa: C901
     for pool in intent.dhcp_servers:
         if pool.interface:
             present_names.add(pool.interface)
+    # (#3) VXLAN VTEP source-interface is a port name (Loopback0 / lo0.0).
+    for vx in intent.vxlan_vnis:
+        if vx.source_interface:
+            present_names.add(vx.source_interface)
+
+    # (#6) Strip operator-requested drops BEFORE the rename sweep so a rename
+    # TARGET that reuses a dropped SOURCE name isn't itself deleted afterwards.
+    if user_dropped:
+        _strip_dropped_ports(intent, user_dropped)
 
     # Rewrite everywhere a port name might be referenced.  Order doesn't
     # matter — memoisation keeps us idempotent.
@@ -520,6 +548,10 @@ def translate_port_names(  # noqa: C901
         iface.name = resolve(iface.name)
         if iface.lag_member_of:
             iface.lag_member_of = resolve(iface.lag_member_of)
+        # (#3) Rewrite each VRRP group's track-interface list so failover
+        # tracking survives a rename (a stale name silently disables it).
+        for grp in iface.vrrp_groups:
+            grp.track_interfaces = [resolve(t) for t in grp.track_interfaces]
     for vlan in intent.vlans:
         vlan.tagged_ports = [resolve(p) for p in vlan.tagged_ports]
         vlan.untagged_ports = [resolve(p) for p in vlan.untagged_ports]
@@ -532,12 +564,18 @@ def translate_port_names(  # noqa: C901
     for pool in intent.dhcp_servers:
         if pool.interface:
             pool.interface = resolve(pool.interface)
+    # (#3) Rewrite the VXLAN VTEP source-interface so the binding stays valid
+    # on the target (a stale source name breaks the whole VTEP).
+    for vx in intent.vxlan_vnis:
+        if vx.source_interface:
+            vx.source_interface = resolve(vx.source_interface)
 
-    # Strip pass: remove every reference to a dropped name from the
-    # canonical tree.  Runs AFTER the rename sweep so dropped entries
-    # don't interfere with other sources' resolution.
-    if dropped_set:
-        _strip_dropped_ports(intent, dropped_set)
+    # Strip pass: remove every reference to an AUTO-dropped (unmappable) name
+    # from the canonical tree.  Runs AFTER the rename sweep — these names stay
+    # verbatim through the sweep so their post-sweep name equals their source
+    # name.  (User drops were already stripped above, pre-sweep — see #6.)
+    if auto_dropped:
+        _strip_dropped_ports(intent, auto_dropped)
 
     # (#49b) Operator drop/rename keys that named a port absent from the tree
     # did nothing — warn instead of silently over-reporting them as dropped.
@@ -549,7 +587,9 @@ def translate_port_names(  # noqa: C901
             )
     # Report only drops that actually removed a present name (auto-dropped
     # unmappable names were resolved from real references, so they qualify).
-    reported_dropped = sorted(d for d in dropped_set if d in present_names)
+    reported_dropped = sorted(
+        d for d in (user_dropped | auto_dropped) if d in present_names
+    )
 
     logger.debug(
         "translate_port_names: exit %s → %s applied=%d dropped=%d "
@@ -584,6 +624,11 @@ def _strip_dropped_ports(
           dropped are deleted (they no longer have a viable egress).
         * ``intent.dhcp_servers`` — pools whose ``interface`` is
           dropped are deleted (pool has no interface to serve).
+        * ``intent.interfaces[].vrrp_groups[].track_interfaces`` — dropped
+          names filtered out (a dangling track ref silently disables
+          failover on the target).
+        * ``intent.vxlan_vnis[].source_interface`` — cleared if dropped
+          (a dangling VTEP source breaks the whole overlay binding).
 
     Mutates *intent* in place.  Idempotent: subsequent calls with the
     same *dropped* set are no-ops.
@@ -594,6 +639,11 @@ def _strip_dropped_ports(
     for iface in intent.interfaces:
         if iface.lag_member_of in dropped:
             iface.lag_member_of = None
+        # (#3) Drop dangling VRRP track-interface references.
+        for grp in iface.vrrp_groups:
+            grp.track_interfaces = [
+                t for t in grp.track_interfaces if t not in dropped
+            ]
     for vlan in intent.vlans:
         vlan.tagged_ports = [
             p for p in vlan.tagged_ports if p not in dropped
@@ -610,6 +660,10 @@ def _strip_dropped_ports(
     intent.dhcp_servers = [
         p for p in intent.dhcp_servers if p.interface not in dropped
     ]
+    # (#3) Clear dangling VXLAN VTEP source-interface references.
+    for vx in intent.vxlan_vnis:
+        if vx.source_interface in dropped:
+            vx.source_interface = ""
 
 
 def build_port_rename_transform(

--- a/netcanon/migration/canonical/vlan_names.py
+++ b/netcanon/migration/canonical/vlan_names.py
@@ -23,6 +23,8 @@ field:
     CanonicalInterface.trunk_allowed_vlans (list)
     CanonicalInterface.trunk_native_vlan
     CanonicalInterface.voice_vlan
+    CanonicalInterface.dot1q_vlan (routed L3 sub-interface tag)
+    CanonicalVxlan.vlan_id (VLAN-to-VNI mapping)
 
 Drop semantics (map value is None):
 
@@ -101,8 +103,10 @@ def translate_vlan_ids(  # noqa: C901
 
     For each entry ``{src: tgt}``:
       * ``tgt`` is an int → rename the VLAN + update every
-        referring field (access_vlan, trunk lists, native, voice).
-      * ``tgt`` is None → drop the VLAN entirely.
+        referring field (access_vlan, trunk lists, native, voice,
+        routed-sub-interface dot1q tag, and VXLAN VNI vlan_id).
+      * ``tgt`` is None → drop the VLAN entirely (interfaces detached,
+        matching VXLAN VNI mappings removed).
 
     Collisions (two source VLANs → same target ID, or target ID
     already exists in the tree) merge tagged/untagged port lists
@@ -221,10 +225,16 @@ def translate_vlan_ids(  # noqa: C901
             iface.access_vlan,
             iface.trunk_native_vlan,
             iface.voice_vlan,
+            iface.dot1q_vlan,
         ):
             if vid is not None:
                 referenced_ids.add(vid)
         referenced_ids.update(iface.trunk_allowed_vlans or [])
+    # (#5) VXLAN VNI records carry a vlan_id that this orchestrator now
+    # rewrites (Pass 3) — count it as a reference so a rename touching ONLY a
+    # vni mapping isn't wrongly flagged "present nowhere".
+    for vx in intent.vxlan_vnis:
+        referenced_ids.add(vx.vlan_id)
     for missing in sorted((set(renames) | drops) - referenced_ids):
         result.warnings.append(
             f"vlan_rename: VLAN {missing} is present nowhere in the parsed "
@@ -306,6 +316,20 @@ def translate_vlan_ids(  # noqa: C901
             elif iface.voice_vlan in renames:
                 iface.voice_vlan = renames[iface.voice_vlan]
 
+        # (#5) 802.1Q tag on a routed (L3) sub-interface.  A stale tag
+        # renders ``encapsulation dot1Q <old>`` on the renumbered VLAN —
+        # L3 dead on deploy.  Rewrite like access_vlan.
+        if iface.dot1q_vlan is not None:
+            if iface.dot1q_vlan in drops:
+                result.warnings.append(
+                    f"vlan_rename: interface {iface.name!r} had 802.1Q "
+                    f"sub-interface VLAN {iface.dot1q_vlan} which was dropped "
+                    f"— tag cleared"
+                )
+                iface.dot1q_vlan = None
+            elif iface.dot1q_vlan in renames:
+                iface.dot1q_vlan = renames[iface.dot1q_vlan]
+
         # Trunk allowed list — remove drops, rename renames, dedupe.
         if iface.trunk_allowed_vlans:
             new_list: list[int] = []
@@ -318,6 +342,28 @@ def translate_vlan_ids(  # noqa: C901
                     seen.add(new_vid)
                     new_list.append(new_vid)
             iface.trunk_allowed_vlans = new_list
+
+    # ------------------------------------------------------------------
+    # Pass 3 — VXLAN VNI records carry a vlan_id that must track the rename.
+    # ------------------------------------------------------------------
+    # intent.py documents that CanonicalVxlan.vlan_id stays in sync with
+    # CanonicalVlan.id.  cisco_nxos render unions vni vlan_ids into the
+    # emitted VLAN list, so a stale vlan_id resurrects the OLD VLAN with the
+    # vn-segment bound to it — a rename/drop that skips this leaves a broken
+    # overlay.  Rename in place; drop the whole VNI record with a warning.
+    if intent.vxlan_vnis:
+        kept_vnis: list = []
+        for vx in intent.vxlan_vnis:
+            if vx.vlan_id in drops:
+                result.warnings.append(
+                    f"vlan_rename: VXLAN VNI {vx.vni} mapped to VLAN "
+                    f"{vx.vlan_id} which was dropped — VNI mapping removed"
+                )
+                continue
+            if vx.vlan_id in renames:
+                vx.vlan_id = renames[vx.vlan_id]
+            kept_vnis.append(vx)
+        intent.vxlan_vnis = kept_vnis
 
     logger.debug(
         "translate_vlan_ids: exit applied=%d dropped=%d warnings=%d",

--- a/tests/unit/migration/test_port_names.py
+++ b/tests/unit/migration/test_port_names.py
@@ -33,6 +33,8 @@ from netcanon.migration.canonical.intent import (
     CanonicalLAG,
     CanonicalStaticRoute,
     CanonicalVlan,
+    CanonicalVRRPGroup,
+    CanonicalVxlan,
 )
 from netcanon.migration.canonical.port_names import (
     build_port_rename_transform,
@@ -1084,3 +1086,86 @@ class TestAbsentKeyDropHonesty:
         )
         assert result.dropped == ["GigabitEthernet0/2"]
         assert [i.name for i in intent.interfaces] == ["GigabitEthernet0/1"]
+
+
+class TestRenameOntoDroppedName:
+    """(#6) Renaming A onto B while dropping B must keep the renamed
+    survivor: user drops are stripped BEFORE the rename sweep, so the
+    post-rename tree isn't re-filtered against the (reused) source name."""
+
+    def test_rename_onto_dropped_target_keeps_survivor(self):
+        intent = CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(name="GigabitEthernet1/0/1"),
+                CanonicalInterface(name="GigabitEthernet1/0/2"),
+            ],
+        )
+        result = translate_port_names(
+            intent, CiscoIOSXECLICodec(), CiscoIOSXECLICodec(),
+            rename_map={
+                "GigabitEthernet1/0/1": "GigabitEthernet1/0/2",
+                "GigabitEthernet1/0/2": None,
+            },
+        )
+        # Pre-fix: BOTH interfaces were deleted (0 survivors) while
+        # ``applied`` still claimed the rename landed.
+        assert [i.name for i in intent.interfaces] == ["GigabitEthernet1/0/2"]
+        assert result.applied == {
+            "GigabitEthernet1/0/1": "GigabitEthernet1/0/2"
+        }
+        assert result.dropped == ["GigabitEthernet1/0/2"]
+
+
+class TestCrossReferenceRewrite:
+    """(#3) The rename sweep must rewrite VRRP ``track_interfaces`` and
+    VXLAN ``source_interface`` — else a cross-vendor rename leaves dangling
+    references (failover silently disabled, VTEP binding broken)."""
+
+    def _tree(self):
+        return CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(name="GigabitEthernet1/0/1"),
+                CanonicalInterface(
+                    name="Vlan10",
+                    vrrp_groups=[
+                        CanonicalVRRPGroup(
+                            group_id=10,
+                            virtual_ips=["10.0.0.1"],
+                            track_interfaces=["GigabitEthernet1/0/1"],
+                        )
+                    ],
+                ),
+            ],
+            vxlan_vnis=[
+                CanonicalVxlan(
+                    vlan_id=10, vni=10010, source_interface="Loopback0"
+                )
+            ],
+        )
+
+    def test_rename_rewrites_track_and_source(self):
+        intent = self._tree()
+        translate_port_names(
+            intent, CiscoIOSXECLICodec(), CiscoIOSXECLICodec(),
+            rename_map={
+                "GigabitEthernet1/0/1": "TenGigabitEthernet1/0/1",
+                "Loopback0": "Loopback5",
+            },
+        )
+        vlan_if = next(i for i in intent.interfaces if i.name == "Vlan10")
+        assert vlan_if.vrrp_groups[0].track_interfaces == [
+            "TenGigabitEthernet1/0/1"
+        ]
+        assert intent.vxlan_vnis[0].source_interface == "Loopback5"
+
+    def test_drop_clears_track_and_source(self):
+        intent = self._tree()
+        translate_port_names(
+            intent, CiscoIOSXECLICodec(), CiscoIOSXECLICodec(),
+            rename_map={"GigabitEthernet1/0/1": None, "Loopback0": None},
+        )
+        vlan_if = next(i for i in intent.interfaces if i.name == "Vlan10")
+        # Dangling references removed rather than left pointing at a
+        # now-deleted interface.
+        assert vlan_if.vrrp_groups[0].track_interfaces == []
+        assert intent.vxlan_vnis[0].source_interface == ""

--- a/tests/unit/migration/test_vlan_names.py
+++ b/tests/unit/migration/test_vlan_names.py
@@ -20,6 +20,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalInterface,
     CanonicalIPv4Address,
     CanonicalVlan,
+    CanonicalVxlan,
 )
 from netcanon.migration.canonical.vlan_names import (
     build_vlan_rename_transform,
@@ -308,4 +309,48 @@ class TestNotFoundEntryWarning:
         )
         result = translate_vlan_ids(intent, rename_map={30: 40})
         assert intent.interfaces[0].access_vlan == 40
+        assert not any("nowhere" in w for w in result.warnings)
+
+
+class TestDot1qAndVxlanRewrite:
+    """(#5) translate_vlan_ids must rewrite the routed-sub-interface
+    ``dot1q_vlan`` tag and the VXLAN VNI ``vlan_id`` — else a rename
+    renders broken configs (L3 sub-if on the old tag; nxos resurrects
+    the old VLAN via the vni union)."""
+
+    def test_rename_rewrites_dot1q_and_vxlan(self):
+        intent = CanonicalIntent(
+            vlans=[CanonicalVlan(id=10, name="V10")],
+            interfaces=[
+                CanonicalInterface(name="Gi0/1.10", dot1q_vlan=10),
+            ],
+            vxlan_vnis=[CanonicalVxlan(vlan_id=10, vni=10010)],
+        )
+        result = translate_vlan_ids(intent, rename_map={10: 20})
+        assert intent.interfaces[0].dot1q_vlan == 20
+        assert intent.vxlan_vnis[0].vlan_id == 20
+        assert result.applied == {10: 20}
+
+    def test_drop_clears_dot1q_and_removes_vni(self):
+        intent = CanonicalIntent(
+            vlans=[CanonicalVlan(id=10, name="V10")],
+            interfaces=[
+                CanonicalInterface(name="Gi0/1.10", dot1q_vlan=10),
+            ],
+            vxlan_vnis=[CanonicalVxlan(vlan_id=10, vni=10010)],
+        )
+        result = translate_vlan_ids(intent, rename_map={10: None})
+        assert intent.interfaces[0].dot1q_vlan is None
+        assert intent.vxlan_vnis == []
+        assert any("802.1Q sub-interface" in w for w in result.warnings)
+        assert any("VNI 10010" in w for w in result.warnings)
+
+    def test_reference_only_via_dot1q_not_flagged(self):
+        # VLAN 55 exists only as a dot1q sub-interface tag — Pass 2 now
+        # rewrites it, so it must NOT be flagged "present nowhere" (#5+#49a).
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(name="Gi0/1.55", dot1q_vlan=55)],
+        )
+        result = translate_vlan_ids(intent, rename_map={55: 66})
+        assert intent.interfaces[0].dot1q_vlan == 66
         assert not any("nowhere" in w for w in result.warnings)


### PR DESCRIPTION
## What

Closes three confirmed **rename-transform-seam** data-loss bugs from the 2026-07-06 Fable review (the review's dominant theme). All are reachable via the **default `/plan` auto-translate flow** and all lose data **silently** (job completes, zero warnings) — the worst class.

| # | File | Bug |
|---|------|-----|
| **#6** | `canonical/port_names.py` | rename map `{A: B, B: None}` deleted **both** interfaces (strip pass filtered the post-rename tree against source-name drops, so renamed-A matched B's drop) |
| **#3** | `canonical/port_names.py` | sweep never rewrote VRRP `track_interfaces` / VXLAN `source_interface` → dangling refs (`vrrp N track <old>` = failover disabled; `vxlan source-interface <old>` = VTEP broken) |
| **#5** | `canonical/vlan_names.py` | `translate_vlan_ids` missed `dot1q_vlan` (L3 sub-if) + `vxlan_vnis[].vlan_id` → `encapsulation dot1Q <old>` (L3 dead) + VNI bound to old VLAN (nxos resurrects it via the vni→VLAN union) |

## Fix

- **#6** — strip user-requested drops **before** the rename sweep (they're source-keyed); keep the post-sweep strip only for the `strip_unmappable` auto-drop set (those names stay verbatim through the sweep, so it's safe there).
- **#3** — resolve `track_interfaces` + `source_interface` in the sweep; filter/clear both in `_strip_dropped_ports`. Corrects the false-coverage docstring on `CanonicalVxlan.source_interface`.
- **#5** — rewrite `dot1q_vlan` in Pass 2 (rename→renumber, drop→warn+clear); new Pass 3 over `vxlan_vnis` (rename `vlan_id`, drop→remove record+warn). Extends the `#49a` present-nowhere reference set so a rename touching only dot1q/vni isn't wrongly flagged a no-op.

## Safety / testing

- **Mesh-neutral** — the rename orchestrators run only in the override/rename flow, not the bare parse→render cross-mesh. Guard stays flat (`CODEC_BUG=5`, `cells_total=1224`).
- New regression tests (`TestRenameOntoDroppedName`, `TestCrossReferenceRewrite`, `TestDot1qAndVxlanRewrite`) — **each verified to FAIL before the fix** (negative control via source stash).
- Full gate green: `tests/unit` 5200 passed / 81 skipped, `test_run_plan_overrides` + cross-mesh guard pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
