### PR TITLE
fix(junos): expand bracket/numeric VLAN members + flatten stale apply-groups on rename (#7/#8/#4)

### DIFF
--- a/netcanon/migration/canonical/port_names.py
+++ b/netcanon/migration/canonical/port_names.py
@@ -591,6 +591,24 @@ def translate_port_names(  # noqa: C901
         d for d in (user_dropped | auto_dropped) if d in present_names
     )
 
+    # (#4) A rename/drop invalidates any verbatim vendor-provenance group
+    # bodies (Junos apply-groups): the target's render re-emits those bodies
+    # UNCHANGED, resurrecting the PRE-rename interface names alongside the
+    # renamed ones (the same IP ends up on two ports).  The flattened
+    # canonical tree already carries the group semantics, so drop the
+    # verbatim bodies + apply-group refs once names have moved — mirrors the
+    # sanitizer's group_content strip.  Fail closed with a warning.
+    if (applied or reported_dropped) and (
+        intent.group_content or intent.apply_groups
+    ):
+        intent.group_content = {}
+        intent.apply_groups = []
+        warnings.append(
+            "port_rename: cleared verbatim apply-group bodies because a "
+            "rename/drop was applied — group content was flattened into the "
+            "canonical tree to avoid resurrecting pre-rename names"
+        )
+
     logger.debug(
         "translate_port_names: exit %s → %s applied=%d dropped=%d "
         "warnings=%d",

--- a/netcanon/migration/canonical/vlan_names.py
+++ b/netcanon/migration/canonical/vlan_names.py
@@ -365,6 +365,22 @@ def translate_vlan_ids(  # noqa: C901
             kept_vnis.append(vx)
         intent.vxlan_vnis = kept_vnis
 
+    # (#4) A rename/drop invalidates verbatim vendor-provenance group bodies
+    # (Junos apply-groups): re-emitting them resurrects the PRE-renumber VLAN
+    # definitions alongside the renumbered ones.  The flattened canonical tree
+    # already carries the semantics, so clear the bodies + apply-group refs
+    # once IDs have moved — mirrors the port-rename orchestrator + sanitizer.
+    if (result.applied or result.dropped) and (
+        intent.group_content or intent.apply_groups
+    ):
+        intent.group_content = {}
+        intent.apply_groups = []
+        result.warnings.append(
+            "vlan_rename: cleared verbatim apply-group bodies because a "
+            "rename/drop was applied — group content was flattened into the "
+            "canonical tree to avoid resurrecting pre-rename VLAN ids"
+        )
+
     logger.debug(
         "translate_vlan_ids: exit applied=%d dropped=%d warnings=%d",
         len(result.applied),

--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -74,6 +74,39 @@ from ..base import ParseError
 logger = logging.getLogger(__name__)
 
 
+def _resolve_vlan_member_to_vids(
+    vname: str, vid_by_vlan_name: dict[str, int]
+) -> list[int]:
+    """Resolve one Junos ``vlan members`` token to VID(s).
+
+    Junos accepts three member spellings; the parser must handle all
+    three or the membership is silently dropped (port lands in VLAN 1 /
+    trunk defaults to all-4094 on cross-vendor targets — #8):
+
+      * a VLAN *name* present in ``vid_by_vlan_name`` → its VID
+      * a bare numeric VID (``100``) → that VID (1-4094)
+      * a numeric range (``100-110``) → every VID in the inclusive range
+
+    Returns ``[]`` for anything that doesn't resolve (unknown name,
+    out-of-range, malformed) — matching the parser's silent tolerance.
+    Numeric parsing uses ``str.isdigit`` / ``str.partition`` (not a
+    regex over parser-derived text) to stay clear of CodeQL's
+    polynomial-redos rule.
+    """
+    vid = vid_by_vlan_name.get(vname)
+    if vid is not None:
+        return [vid]
+    if vname.isdigit():
+        n = int(vname)
+        return [n] if 1 <= n <= 4094 else []
+    lo_str, sep, hi_str = vname.partition("-")
+    if sep and lo_str.isdigit() and hi_str.isdigit():
+        lo, hi = int(lo_str), int(hi_str)
+        if 1 <= lo <= hi <= 4094:
+            return list(range(lo, hi + 1))
+    return []
+
+
 def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     """Parse Junos ``set``-form (or block-form) text into a
     :class:`CanonicalIntent`.
@@ -540,10 +573,12 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         if iface.switchport_mode == "access":
             # Access mode: the first resolved member becomes the
             # access_vlan (operators rarely declare more than one).
+            # (#8) Numeric ``members <vid>`` resolve directly, not just
+            # via the name→id map.
             for vname in names_list:
-                vid = vid_by_vlan_name.get(vname)
-                if vid is not None:
-                    iface.access_vlan = vid
+                vids = _resolve_vlan_member_to_vids(vname, vid_by_vlan_name)
+                if vids:
+                    iface.access_vlan = vids[0]
                     break
         elif iface.switchport_mode == "trunk":
             # Junos `vlan members all` is the operator-form for "all
@@ -556,10 +591,14 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             if any(vname == "all" for vname in names_list):
                 iface.trunk_allowed_vlans = list(range(1, 4095))
                 continue
+            # (#8) Each member may be a name, a numeric VID, or a numeric
+            # range (``100-110``) — resolve/expand all three.
             for vname in names_list:
-                vid = vid_by_vlan_name.get(vname)
-                if vid is not None and vid not in iface.trunk_allowed_vlans:
-                    iface.trunk_allowed_vlans.append(vid)
+                for vid in _resolve_vlan_member_to_vids(
+                    vname, vid_by_vlan_name
+                ):
+                    if vid not in iface.trunk_allowed_vlans:
+                        iface.trunk_allowed_vlans.append(vid)
 
     # 3. Attach IRB SVI L3 addresses to the matching CanonicalVlan
     #    AND prune the redundant irb.<vid> interface — but ONLY
@@ -986,6 +1025,28 @@ def _blockform_to_setform(raw: str) -> str:
     def emit_leaf(words: list[str]) -> None:
         if not words:
             return
+        # (#7) Expand a bracket value-list into one set-line per value.
+        # Block-form writes multi-value leaves as ``key [ v1 v2 … ];``;
+        # the set-form equivalent is one ``set <path> key <vi>`` per value.
+        # Without this the literal ``[`` / values are ingested as data
+        # (``name-server [ 8.8.8.8 1.1.1.1 ]`` → dns_servers == ['[']).
+        if "[" in words:
+            lb = words.index("[")
+            prefix = words[:lb]
+            try:
+                rb = words.index("]", lb + 1)
+            except ValueError:
+                rb = len(words)
+            values = words[lb + 1:rb]
+            trailing = words[rb + 1:]  # tokens after ] (rare); kept verbatim
+            if prefix and values:
+                for v in values:
+                    out_lines.append(
+                        "set " + " ".join(path_stack + prefix + [v] + trailing)
+                    )
+                return
+            # Empty list or bracket-first (no leaf key) — fall through to
+            # verbatim emission rather than silently dropping the line.
         line = "set " + " ".join(path_stack + words)
         out_lines.append(line)
 

--- a/tests/unit/migration/codecs/juniper_junos/test_blockform_brackets_and_numeric_members.py
+++ b/tests/unit/migration/codecs/juniper_junos/test_blockform_brackets_and_numeric_members.py
@@ -1,0 +1,92 @@
+"""Junos parse regressions from the 2026-07-06 Fable review.
+
+#7 — block-form (``show configuration``) bracket value-lists
+    (``name-server [ a b ];``, ``members [ v1 v2 ]``) must be expanded
+    into one set-line per value, not ingested with the literal ``[``.
+
+#8 — numeric ``vlan members <vid>`` / ``<vid-range>`` must resolve
+    directly (not only via the name→id map), else membership is
+    silently dropped (port → VLAN 1 on access; bare trunk = all-4094).
+
+The committed junos fixtures are all set-form files, so the cross-mesh
+never exercised the block-form path — these tests close that gap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.juniper_junos.parse import parse_intent
+
+pytestmark = pytest.mark.unit
+
+
+class TestBlockFormBracketLists:
+    def test_name_server_bracket_list_expanded(self) -> None:
+        cfg = "system {\n    name-server [ 8.8.8.8 1.1.1.1 ];\n}\n"
+        intent = parse_intent(cfg)
+        # Pre-fix: dns_servers == ['['] (both servers lost, literal bracket).
+        assert intent.dns_servers == ["8.8.8.8", "1.1.1.1"]
+
+    def test_trunk_members_bracket_list_expanded(self) -> None:
+        cfg = (
+            "vlans {\n"
+            "    v10 { vlan-id 10; }\n"
+            "    v20 { vlan-id 20; }\n"
+            "}\n"
+            "interfaces {\n"
+            "    ge-0/0/0 {\n"
+            "        unit 0 {\n"
+            "            family ethernet-switching {\n"
+            "                interface-mode trunk;\n"
+            "                vlan { members [ v10 v20 ]; }\n"
+            "            }\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        intent = parse_intent(cfg)
+        ge0 = next(i for i in intent.interfaces if i.name.startswith("ge-0/0/0"))
+        # Pre-fix: trunk_allowed_vlans == [] → IOS target renders bare
+        # `switchport mode trunk` = ALL vlans allowed.
+        assert sorted(ge0.trunk_allowed_vlans) == [10, 20]
+
+
+class TestNumericVlanMembers:
+    def test_numeric_access_member_resolves(self) -> None:
+        cfg = (
+            "set vlans v100 vlan-id 100\n"
+            "set interfaces ge-0/0/1 unit 0 family ethernet-switching "
+            "interface-mode access\n"
+            "set interfaces ge-0/0/1 unit 0 family ethernet-switching "
+            "vlan members 100\n"
+        )
+        intent = parse_intent(cfg)
+        ge1 = next(i for i in intent.interfaces if i.name.startswith("ge-0/0/1"))
+        # Pre-fix: access_vlan is None (numeric never resolved) → VLAN 1.
+        assert ge1.access_vlan == 100
+
+    def test_numeric_range_trunk_members_expand(self) -> None:
+        cfg = (
+            "set interfaces ge-0/0/2 unit 0 family ethernet-switching "
+            "interface-mode trunk\n"
+            "set interfaces ge-0/0/2 unit 0 family ethernet-switching "
+            "vlan members 100-110\n"
+        )
+        intent = parse_intent(cfg)
+        ge2 = next(i for i in intent.interfaces if i.name.startswith("ge-0/0/2"))
+        # Pre-fix: [] → bare trunk = 4094 VLANs instead of 11.
+        assert ge2.trunk_allowed_vlans == list(range(100, 111))
+
+    def test_out_of_range_numeric_member_ignored(self) -> None:
+        # 9999 is out of the 1-4094 VID range — must NOT be added (and
+        # must not crash); guards the resolver's bounds check.
+        cfg = (
+            "set interfaces ge-0/0/3 unit 0 family ethernet-switching "
+            "interface-mode trunk\n"
+            "set interfaces ge-0/0/3 unit 0 family ethernet-switching "
+            "vlan members 9999\n"
+        )
+        intent = parse_intent(cfg)
+        ge3 = next(i for i in intent.interfaces if i.name.startswith("ge-0/0/3"))
+        assert ge3.trunk_allowed_vlans == []

--- a/tests/unit/migration/test_port_names.py
+++ b/tests/unit/migration/test_port_names.py
@@ -1169,3 +1169,40 @@ class TestCrossReferenceRewrite:
         # now-deleted interface.
         assert vlan_if.vrrp_groups[0].track_interfaces == []
         assert intent.vxlan_vnis[0].source_interface == ""
+
+
+class TestGroupContentFlattenedOnRename:
+    """(#4) Verbatim apply-group bodies must be cleared once a rename/drop
+    is applied — else the target render re-emits the group body under the
+    PRE-rename name, resurrecting the interface with the same IP."""
+
+    def _tree(self):
+        return CanonicalIntent(
+            interfaces=[CanonicalInterface(name="GigabitEthernet1/0/1")],
+            apply_groups=["G"],
+            group_content={
+                "G": [["interfaces", "GigabitEthernet1/0/1", "x"]]
+            },
+        )
+
+    def test_rename_clears_group_content_and_warns(self):
+        intent = self._tree()
+        result = translate_port_names(
+            intent, CiscoIOSXECLICodec(), CiscoIOSXECLICodec(),
+            rename_map={"GigabitEthernet1/0/1": "TenGigabitEthernet1/0/1"},
+        )
+        assert intent.group_content == {}
+        assert intent.apply_groups == []
+        assert any("apply-group" in w for w in result.warnings)
+
+    def test_noop_keeps_group_content(self):
+        # No rename applied (identity map) → verbatim bodies preserved for
+        # same-vendor round-trip fidelity.
+        intent = self._tree()
+        result = translate_port_names(
+            intent, CiscoIOSXECLICodec(), CiscoIOSXECLICodec(),
+            rename_map={},
+        )
+        assert intent.group_content != {}
+        assert intent.apply_groups == ["G"]
+        assert not any("apply-group" in w for w in result.warnings)

--- a/tests/unit/migration/test_vlan_names.py
+++ b/tests/unit/migration/test_vlan_names.py
@@ -354,3 +354,30 @@ class TestDot1qAndVxlanRewrite:
         result = translate_vlan_ids(intent, rename_map={55: 66})
         assert intent.interfaces[0].dot1q_vlan == 66
         assert not any("nowhere" in w for w in result.warnings)
+
+
+class TestGroupContentFlattenedOnVlanRename:
+    """(#4) A VLAN renumber must clear verbatim apply-group bodies — else
+    the render re-emits the group's pre-renumber VLAN definitions."""
+
+    def test_rename_clears_group_content_and_warns(self):
+        intent = CanonicalIntent(
+            vlans=[CanonicalVlan(id=10, name="V10")],
+            apply_groups=["G"],
+            group_content={"G": [["vlans", "V10", "vlan-id", "10"]]},
+        )
+        result = translate_vlan_ids(intent, rename_map={10: 20})
+        assert intent.group_content == {}
+        assert intent.apply_groups == []
+        assert any("apply-group" in w for w in result.warnings)
+
+    def test_noop_keeps_group_content(self):
+        intent = CanonicalIntent(
+            vlans=[CanonicalVlan(id=10, name="V10")],
+            apply_groups=["G"],
+            group_content={"G": [["vlans", "V10", "vlan-id", "10"]]},
+        )
+        result = translate_vlan_ids(intent, rename_map={})
+        assert intent.group_content != {}
+        assert intent.apply_groups == ["G"]
+        assert not any("apply-group" in w for w in result.warnings)


### PR DESCRIPTION
## What

Three junos-depth findings from the 2026-07-06 Fable review. All committed junos fixtures are set-form `.set` files, so the cross-mesh never exercised the block-form input path or these member spellings.

| # | Where | Bug |
|---|-------|-----|
| **#7** | `juniper_junos/parse.py` (`_blockform_to_setform`) | block-form bracket lists (`name-server [ a b ]`, `members [ v10 v20 ]`) ingested with the literal `[` → `dns_servers==['[']` (servers lost); `trunk_allowed_vlans==[]` (IOS renders bare trunk = ALL VLANs) |
| **#8** | `juniper_junos/parse.py` (resolve pass) | numeric `vlan members 100` / range `100-110` never resolved (map-only lookup) → access → VLAN 1; trunk → all-4094 |
| **#4** | `canonical/port_names.py` + `vlan_names.py` | junos `group_content` (verbatim apply-group bodies) re-emitted unchanged after a rename/drop → re-parse yields BOTH the renamed iface and the pre-rename one, same /30 on two ports, `warnings=[]` |

## Fix

- **#7** — `emit_leaf` expands `key [ v1 v2 … ]` into one `set <path> key <vi>` per value.
- **#8** — new `_resolve_vlan_member_to_vids` resolves a name, bare VID (1-4094), or numeric range; uses `str.isdigit`/`str.partition` (not a regex over parser text) to stay clear of CodeQL polynomial-redos.
- **#4** — both rename orchestrators clear `group_content` + `apply_groups` (+ warn) **only when a rename/drop was actually applied**; a no-op keeps the verbatim bodies for same-vendor round-trip. Mirrors the existing `tools/sanitize.py` strip.

## Safety / testing

- **Cross-mesh guard stays flat** (`CODEC_BUG=5`, `cells_total=1224`) — the committed fixtures don't use these forms, so no mesh cell moves.
- New tests: `test_blockform_brackets_and_numeric_members.py` (#7/#8, incl. an out-of-range-VID control) + `TestGroupContentFlattenedOnRename` / `TestGroupContentFlattenedOnVlanRename` (#4, incl. a no-op control). The 6 fix-dependent assertions **verified to FAIL pre-fix**; the 3 controls correctly pass both ways.
- Full gate green: `tests/unit` 5209 passed / 81 skipped, cross-mesh guard + `test_run_plan_overrides` pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
