### PR TITLE
fix(codec): split mikrotik %-gateway on parse + carry aoss SVI IPv6 (#9/#10)

### DIFF
--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -544,22 +544,27 @@ def _infer_iface_type(name: str) -> str:
 
 def _parse_vlan_stanza(
     lines: list[str], start: int, vlan_id: int,
-) -> tuple[CanonicalVlan, list[CanonicalVRRPGroup], int]:
+) -> tuple[
+    CanonicalVlan, list[CanonicalVRRPGroup], list[CanonicalIPv6Address], int
+]:
     """Parse a ``vlan N`` stanza starting at *start* (body line).
 
     Returns the parsed :class:`CanonicalVlan`, the list of nested
     :class:`CanonicalVRRPGroup` instances (one per ``vrrp vrid N``
-    sub-block), and the index of the first line AFTER the stanza's
-    outer ``exit``.
+    sub-block), the list of SVI :class:`CanonicalIPv6Address` records
+    (``ipv6 address`` inside the stanza — #10), and the index of the
+    first line AFTER the stanza's outer ``exit``.
 
-    VRRP groups parse here (rather than at the top level) because
-    AOS-S nests the ``vrrp vrid N`` block INSIDE the ``vlan N``
-    stanza — the VLAN is the SVI on this platform.  Returned groups
-    attach to the synthesised ``Vlan<N>`` :class:`CanonicalInterface`
-    by the caller (the SVI-absorption path in :func:`parse_intent`).
+    VRRP groups and SVI IPv6 addresses parse here (rather than at the
+    top level) because AOS-S nests them INSIDE the ``vlan N`` stanza —
+    the VLAN is the SVI on this platform.  Both attach to the
+    synthesised ``Vlan<N>`` :class:`CanonicalInterface` by the caller
+    (the SVI-absorption path in :func:`parse_intent`); ``CanonicalVlan``
+    itself is IPv4-only.
     """
     vlan = CanonicalVlan(id=vlan_id)
     vrrp_groups: list[CanonicalVRRPGroup] = []
+    svi_ipv6: list[CanonicalIPv6Address] = []
     i = start
     while i < len(lines):
         line = lines[i]
@@ -623,13 +628,25 @@ def _parse_vlan_stanza(
             i += 1
             continue
 
-        # GAP-EVPN-3: IPv6 address.  CanonicalVlan does not carry an
-        # ipv6_addresses list today (the SVI-on-VLAN model is IPv4-
-        # only), so we skip the line.  Static IPv6 addresses inside
-        # `vlan <N>` stanzas are rare on AOS-S in practice; if they
-        # appear in a future fixture corpus we extend CanonicalVlan
-        # at that point.
-        if _IPV6_ADDR_RE.match(stripped):
+        # (#10) Vlan-context IPv6 SVI address.  CanonicalVlan is
+        # IPv4-only, so — exactly like VRRP below — collect it here and
+        # let the caller attach it to the synthesised ``Vlan<N>``
+        # CanonicalInterface (the canonical SVI home).  Previously the
+        # line was skipped outright → a SILENT, UNDECLARED drop on both
+        # the aoss round-trip and any cross-vendor render.  ``ipv6
+        # address dhcp full`` has no static address and doesn't match
+        # the regex, so it still falls through.
+        v6m = _IPV6_ADDR_RE.match(stripped)
+        if v6m:
+            scope = "link-local" if v6m.group(3) else "global"
+            try:
+                svi_ipv6.append(CanonicalIPv6Address(
+                    ip=v6m.group(1),
+                    prefix_length=int(v6m.group(2)),
+                    scope=scope,
+                ))
+            except ValueError:
+                pass
             i += 1
             continue
 
@@ -648,7 +665,7 @@ def _parse_vlan_stanza(
             continue
 
         i += 1
-    return vlan, vrrp_groups, i
+    return vlan, vrrp_groups, svi_ipv6, i
 
 
 def _parse_vrrp_group_stanza(
@@ -1201,7 +1218,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         vm = _VLAN_HEADER_RE.match(stripped_line)
         if vm:
             vlan_id = int(vm.group(1))
-            vlan, vrrp_groups, next_i = _parse_vlan_stanza(
+            vlan, vrrp_groups, svi_ipv6, next_i = _parse_vlan_stanza(
                 lines, i + 1, vlan_id,
             )
             # Aruba AOS-S VLAN reassignment semantic: when a port
@@ -1244,13 +1261,14 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             # implies an SVI), we still synthesise the Vlan<N>
             # interface so the groups have somewhere to attach.
             # Render path is robust to either input shape.
-            if vlan.ipv4_addresses or vrrp_groups:
+            if vlan.ipv4_addresses or vrrp_groups or svi_ipv6:
                 intent.interfaces.append(CanonicalInterface(
                     name=f"Vlan{vlan_id}",
                     description=vlan.name,
                     enabled=True,
                     interface_type="ianaift:l3ipvlan",
                     ipv4_addresses=list(vlan.ipv4_addresses),
+                    ipv6_addresses=list(svi_ipv6),
                     vrrp_groups=list(vrrp_groups),
                 ))
             i = next_i

--- a/netcanon/migration/codecs/aruba_aoss/render.py
+++ b/netcanon/migration/codecs/aruba_aoss/render.py
@@ -636,6 +636,22 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             lines.append(
                 f"   ip address {addr.ip}/{addr.prefix_length}"
             )
+        # (#10) SVI IPv6 — CanonicalVlan is IPv4-only, so a vlan-context
+        # ``ipv6 address`` rides on the sibling ``Vlan<N>`` (or vlan-id-
+        # encoding) interface.  Emit it inside the vlan stanza so the
+        # absorbed SVI carries v6 on aoss round-trip AND cross-vendor
+        # input (was a silent, undeclared drop).  Mirror the IPv4 lookup:
+        # Vlan<N> first, then any vlan-id-encoding interface.
+        v6_source = svi_iface if svi_iface is not None else id_match
+        if v6_source is not None and v6_source.ipv6_addresses:
+            absorbed_iface_names.add(v6_source.name)
+            for addr in v6_source.ipv6_addresses:
+                suffix = (
+                    " link-local" if addr.scope == "link-local" else ""
+                )
+                lines.append(
+                    f"   ipv6 address {addr.ip}/{addr.prefix_length}{suffix}"
+                )
         # VRRP groups — emit nested ``ip vrrp vrid N`` sub-blocks
         # (Wave B v0.2.0).  AOS-S only mounts VRRP inside ``vlan N``
         # blocks; the canonical model attaches groups to a sibling

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -1281,14 +1281,31 @@ def _parse_ip_route(lines: list[str], intent: CanonicalIntent) -> None:
         dest = kv.get("dst-address")
         if not dest:
             continue
-        gateway = kv.get("gateway", "")
-        # gateway may be an IP or an interface name; both are fine for
-        # the canonical form since we expose both fields.
-        route = CanonicalStaticRoute(
-            destination=dest,
-            gateway=gateway,
-            description=kv.get("comment", ""),
-        )
+        gateway_raw = kv.get("gateway", "")
+        # (#9) RouterOS combines an IP next-hop and an egress interface
+        # into one ``gateway=<ip>%<iface>`` argument (also the shape of an
+        # IPv6 link-local scoped next-hop, ``fe80::1%ether1``).  render.py
+        # emits exactly this form, but parse used to store the whole token
+        # in ``gateway`` — so cross-vendor targets got an invalid next-hop
+        # (`ip route 0.0.0.0 0.0.0.0 192.168.88.1%ether1`) and the codec's
+        # own emission reparsed asymmetrically.  Split on ``%`` into the
+        # two canonical fields we already expose.
+        gw, sep, egress = gateway_raw.partition("%")
+        if sep:
+            route = CanonicalStaticRoute(
+                destination=dest,
+                gateway=gw,
+                interface=egress,
+                description=kv.get("comment", ""),
+            )
+        else:
+            # Bare IP or bare interface name — kept in ``gateway`` as before
+            # (render's gateway/interface ladder round-trips both).
+            route = CanonicalStaticRoute(
+                destination=dest,
+                gateway=gateway_raw,
+                description=kv.get("comment", ""),
+            )
         intent.static_routes.append(route)
 
 

--- a/tests/unit/migration/codecs/aruba_aoss/test_svi_ipv6_absorption.py
+++ b/tests/unit/migration/codecs/aruba_aoss/test_svi_ipv6_absorption.py
@@ -1,0 +1,85 @@
+"""aruba_aoss SVI-mounted IPv6 — 2026-07-06 Fable review #10.
+
+AOS-S packs the SVI L3 inside the ``vlan N`` stanza. IPv4 was absorbed
+onto a synthesised ``Vlan<N>`` CanonicalInterface, but ``ipv6 address``
+lines were skipped outright — a SILENT, UNDECLARED drop on both the
+aoss round-trip and any cross-vendor render (the matrix declared the
+ipv6 path supported, so validate reported zero findings). These tests
+pin the parse + absorption-render round-trip.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalInterface,
+    CanonicalIPv6Address,
+    CanonicalVlan,
+)
+from netcanon.migration.codecs.aruba_aoss import ArubaAOSSCodec
+
+pytestmark = pytest.mark.unit
+
+
+class TestSviIpv6Parse:
+    def test_vlan_context_ipv6_lands_on_svi_interface(self):
+        cfg = (
+            "vlan 10\n"
+            '   name "V10"\n'
+            "   ip address 10.0.10.1/24\n"
+            "   ipv6 address 2001:db8:10::1/64\n"
+            "   exit\n"
+        )
+        intent = ArubaAOSSCodec().parse(cfg)
+        svi = next(i for i in intent.interfaces if i.name == "Vlan10")
+        # Pre-fix: ipv6_addresses == [] (line silently skipped).
+        assert [a.ip for a in svi.ipv6_addresses] == ["2001:db8:10::1"]
+        assert svi.ipv6_addresses[0].prefix_length == 64
+
+    def test_link_local_scope_preserved(self):
+        cfg = (
+            "vlan 20\n"
+            "   ipv6 address fe80::1/64 link-local\n"
+            "   exit\n"
+        )
+        intent = ArubaAOSSCodec().parse(cfg)
+        svi = next(i for i in intent.interfaces if i.name == "Vlan20")
+        assert svi.ipv6_addresses[0].scope == "link-local"
+
+
+class TestSviIpv6Render:
+    def test_cross_vendor_svi_ipv6_emitted_in_vlan_stanza(self):
+        # A cross-vendor source (Vlan10 interface carrying ipv6) must
+        # render the ipv6 address inside the vlan stanza — was dropped.
+        tree = CanonicalIntent(
+            vlans=[CanonicalVlan(id=10, name="V10")],
+            interfaces=[
+                CanonicalInterface(
+                    name="Vlan10",
+                    interface_type="ianaift:l3ipvlan",
+                    ipv6_addresses=[
+                        CanonicalIPv6Address(ip="2001:db8:10::1", prefix_length=64)
+                    ],
+                ),
+            ],
+        )
+        out = ArubaAOSSCodec().render(tree)
+        assert "ipv6 address 2001:db8:10::1/64" in out
+        # SVI iface absorbed into the vlan stanza → no stray
+        # `interface Vlan10` block.
+        assert "interface Vlan10" not in out
+
+    def test_aoss_round_trip_preserves_svi_ipv6(self):
+        c = ArubaAOSSCodec()
+        cfg = (
+            "vlan 30\n"
+            '   name "V30"\n'
+            "   ip address 10.0.30.1/24\n"
+            "   ipv6 address 2001:db8:30::1/64\n"
+            "   exit\n"
+        )
+        reparsed = c.parse(c.render(c.parse(cfg)))
+        svi = next(i for i in reparsed.interfaces if i.name == "Vlan30")
+        assert [a.ip for a in svi.ipv6_addresses] == ["2001:db8:30::1"]

--- a/tests/unit/migration/codecs/mikrotik_routeros/test_loopback_tunnel_and_static_route.py
+++ b/tests/unit/migration/codecs/mikrotik_routeros/test_loopback_tunnel_and_static_route.py
@@ -58,9 +58,50 @@ from netcanon.migration.canonical.intent import (
     CanonicalIPv4Address,
     CanonicalStaticRoute,
 )
+from netcanon.migration.codecs.mikrotik_routeros.parse import parse_intent
 from netcanon.migration.codecs.mikrotik_routeros.render import render_intent
 
 pytestmark = pytest.mark.unit
+
+
+class TestCombinedGatewayParse:
+    """(#9) ``gateway=<ip>%<iface>`` must split into gateway + interface
+    on parse (RouterOS emits this form; the previous parse stored the
+    whole token in ``gateway`` → invalid next-hop on every target)."""
+
+    def test_ipv4_gateway_iface_split(self):
+        intent = parse_intent(
+            "/ip route\nadd dst-address=0.0.0.0/0 gateway=192.168.88.1%ether1\n"
+        )
+        r = intent.static_routes[0]
+        assert r.gateway == "192.168.88.1"
+        assert r.interface == "ether1"
+
+    def test_ipv6_linklocal_scoped_gateway_split(self):
+        # IPv6 link-local next-hops carry the egress as a %-scope zone;
+        # the same split applies.
+        intent = parse_intent(
+            "/ip route\nadd dst-address=::/0 gateway=fe80::1%ether2\n"
+        )
+        r = intent.static_routes[0]
+        assert r.gateway == "fe80::1"
+        assert r.interface == "ether2"
+
+    def test_bare_gateway_unchanged(self):
+        intent = parse_intent(
+            "/ip route\nadd dst-address=10.0.0.0/24 gateway=192.168.1.1\n"
+        )
+        r = intent.static_routes[0]
+        assert r.gateway == "192.168.1.1"
+        assert r.interface == ""
+
+    def test_combined_form_round_trips(self):
+        # parse -> render must reproduce the combined ``%`` token.
+        cfg = (
+            "/ip route\nadd dst-address=0.0.0.0/0 gateway=192.168.88.1%ether1\n"
+        )
+        out = render_intent(parse_intent(cfg))
+        assert "gateway=192.168.88.1%ether1" in out
 
 # ---------------------------------------------------------------------------
 # Issue 1: Loopback / Tunnel emission


### PR DESCRIPTION
## What

Two codec-input findings from the 2026-07-06 Fable review. No committed fixtures exercise either form, so the cross-mesh was blind to both.

| # | Where | Bug |
|---|-------|-----|
| **#9** | `mikrotik_routeros/parse.py` | `gateway=<ip>%<iface>` stored whole in `route.gateway` → cisco renders invalid `ip route … 192.168.88.1%ether1`; junos next-hop commit-rejected; the codec's own emission reparses asymmetrically |
| **#10** | `aruba_aoss/parse.py` + `render.py` | vlan-context `ipv6 address` skipped outright → SILENT, UNDECLARED drop on aoss round-trip AND cross-vendor render, while the matrix declared the ipv6 path supported |

## Fix

- **#9** — `gateway.partition('%')` → `gateway` + `interface` (the two canonical fields already exposed). Also correctly handles IPv6 link-local scoped next-hops (`fe80::1%ether1`). Bare IP / bare-interface forms unchanged; parse↔render round-trips the combined `%` token.
- **#10** — `_parse_vlan_stanza` now collects vlan-context IPv6 and the caller attaches it to the synthesised `Vlan<N>` interface (exactly like VRRP already does); the SVI-absorption render emits `ipv6 address <addr>/<prefix> [link-local]` inside the vlan stanza. The `/interfaces/interface/ipv6/address/*` matrix declaration is now **honest** rather than aspirational.

## Safety / testing

- **Cross-mesh guard stays flat** (`CODEC_BUG=5`, `cells_total=1224`) — no committed fixture uses `%`-gateways or vlan-context IPv6, so no cell moves.
- New tests: mikrotik `TestCombinedGatewayParse` (v4 / v6-link-local / bare / round-trip); aoss `test_svi_ipv6_absorption` (parse, link-local scope, cross-vendor render absorbed with no stray `interface Vlan10`, aoss round-trip). The 6 fix-dependent assertions **verified to FAIL pre-fix**; the 2 controls pass both ways.
- Full gate green: `tests/unit` 5217 passed / 81 skipped, cross-mesh guard + codec suites pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
