### PR TITLE
fix: linear trunk-allowed 'add' merge + honest PUT null-clear semantics (#11/#12)

### DIFF
--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -9,6 +9,7 @@ do not need to be re-entered for each operation.
 from __future__ import annotations
 
 import logging
+from typing import get_args
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -32,6 +33,17 @@ from ..deps import (
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/devices", tags=["device-profiles"])
+
+#: DeviceProfile fields whose annotation admits ``None`` — the only fields a
+#: PUT may explicitly clear (``enable_password``, ``notes``, ``os_version``,
+#: ``model``; plus the API-read-only ``detected_facts``).  Derived from the
+#: model so a future nullable field is covered automatically.  An explicit
+#: ``null`` for any OTHER (required) field is a 422, not a silent no-op (#12).
+_NULLABLE_PROFILE_FIELDS = frozenset(
+    name
+    for name, field in DeviceProfile.model_fields.items()
+    if type(None) in get_args(field.annotation)
+)
 
 
 def _require_known_type_key(
@@ -163,8 +175,12 @@ def update_device_profile(
 ) -> DeviceProfile:
     """Partially update an existing device profile.
 
-    Only fields that are explicitly supplied (non-``None``) in the request
-    body are applied; omitted fields remain unchanged.
+    Only fields the client actually SENT are applied; omitted fields remain
+    unchanged.  An explicit ``null`` clears a nullable field
+    (``enable_password`` / ``notes`` / ``os_version`` / ``model``); an
+    explicit ``null`` for a required field (name, type_key, host, port,
+    username, password) is rejected with 422 rather than being silently
+    ignored (#12).
 
     Args:
         profile_id: UUID of the profile to update.
@@ -175,12 +191,25 @@ def update_device_profile(
 
     Raises:
         HTTPException 404: If no profile with *profile_id* exists.
-        HTTPException 422: If a supplied ``type_key`` is not a loaded definition.
+        HTTPException 422: If a supplied ``type_key`` is not a loaded
+            definition, or a required field was explicitly set to ``null``.
     """
+    # (#12) exclude_unset distinguishes "field omitted" (leave unchanged)
+    # from "field explicitly null" (clear it) — the previous ``v is not
+    # None`` filter conflated the two, so a nullable field could never be
+    # cleared via the API despite the docstring promising it.
+    updates = body.model_dump(exclude_unset=True)
+    for field, value in updates.items():
+        if value is None and field not in _NULLABLE_PROFILE_FIELDS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Field {field!r} is required and cannot be cleared "
+                f"(null).",
+            )
     # Validate an explicitly-supplied type_key against loaded definitions
     # (review #53) before taking the lock — fail fast, not at backup time.
-    if body.type_key is not None:
-        _require_known_type_key(body.type_key, definitions)
+    if updates.get("type_key") is not None:
+        _require_known_type_key(updates["type_key"], definitions)
     # Hold the lock across the existence check + mutate + persist so a
     # concurrent delete can't slip between them (review finding #10).
     with DEVICE_PROFILE_REGISTRY_LOCK:
@@ -189,7 +218,6 @@ def update_device_profile(
                 status_code=404, detail=f"Device profile not found: {profile_id!r}"
             )
         profile = device_profiles[profile_id]
-        updates = {k: v for k, v in body.model_dump().items() if v is not None}
         updated_profile = profile.model_copy(update=updates)
         device_profiles[profile_id] = updated_profile
         try:

--- a/netcanon/migration/codecs/_helpers.py
+++ b/netcanon/migration/codecs/_helpers.py
@@ -220,7 +220,15 @@ def merge_trunk_allowed(
         return [vid for vid in range(1, 4095) if vid not in blocked]
     base = list(existing)
     if keyword == "add":
-        return base + [vid for vid in ids if vid not in base]
+        # (#11) ``vid not in base`` is an O(len(base)) list scan per id;
+        # a config with K× ``allowed vlan add 1-4094`` lines drove the
+        # accumulating 4094-element list to ~8.4M comparisons per line
+        # (K=200 → ~7 s parse; near-cap bodies → hours, on the default
+        # local bind).  A set membership check is O(1) and behaviour-
+        # identical (order preserved; the comprehension doesn't observe
+        # its own additions either way, so duplicate ids resolve the same).
+        seen = set(base)
+        return base + [vid for vid in ids if vid not in seen]
     # keyword == "remove"
     drop = set(ids)
     return [vid for vid in base if vid not in drop]

--- a/tests/integration/test_device_profiles_api.py
+++ b/tests/integration/test_device_profiles_api.py
@@ -65,9 +65,10 @@ class TestCreateWithPins:
 class TestUpdatePins:
     """``PUT /api/v1/devices/{id}`` updates pin fields.
 
-    UI contract: omitted fields = "keep existing" (handler filters
-    ``None`` values before model_copy).  So the UI sends pins only
-    when they have values; blanks are interpreted as "unchanged"."""
+    UI contract: an OMITTED field = "keep existing" (the handler uses
+    ``model_dump(exclude_unset=True)``); an EXPLICIT ``null`` clears a
+    nullable field (see :class:`TestUpdateNullSemantics`).  So the UI
+    omits a pin to leave it unchanged and sends ``null`` to clear it."""
 
     def test_update_adds_os_version_pin(self, client):
         created = client.post(
@@ -114,6 +115,59 @@ class TestUpdatePins:
         assert body["os_version"] == "17.12"
         assert body["model"] == "C9300-48P"
         assert body["notes"] == "updated notes"
+
+
+class TestUpdateNullSemantics:
+    """(#12) An explicit ``null`` clears a nullable field; a ``null`` for a
+    required field is a 422 — the previous handler silently ignored BOTH
+    (``v is not None`` filter), so a pin could never be cleared via the API
+    despite the docstring promising ``pass None to clear``."""
+
+    def test_explicit_null_clears_os_version_pin(self, client):
+        created = client.post(
+            "/api/v1/devices/", json=_create_body(os_version="17.12"),
+        ).json()
+        pid = created["id"]
+        resp = client.put(
+            f"/api/v1/devices/{pid}", json={"os_version": None},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["os_version"] is None
+        # Persisted, not just echoed.
+        assert client.get(f"/api/v1/devices/{pid}").json()["os_version"] is None
+
+    def test_explicit_null_clears_model_and_notes(self, client):
+        created = client.post(
+            "/api/v1/devices/",
+            json=_create_body(model="C9300-48P", notes="rack 3"),
+        ).json()
+        pid = created["id"]
+        resp = client.put(
+            f"/api/v1/devices/{pid}", json={"model": None, "notes": None},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["model"] is None
+        assert body["notes"] is None
+
+    def test_omitted_field_still_preserved(self, client):
+        # Regression guard: exclude_unset must NOT clear a field just
+        # because it wasn't sent (only explicit null clears).
+        created = client.post(
+            "/api/v1/devices/", json=_create_body(os_version="17.12"),
+        ).json()
+        pid = created["id"]
+        resp = client.put(f"/api/v1/devices/{pid}", json={"notes": "x"})
+        assert resp.status_code == 200
+        assert resp.json()["os_version"] == "17.12"
+
+    def test_explicit_null_on_required_field_is_422(self, client):
+        created = client.post("/api/v1/devices/", json=_create_body()).json()
+        pid = created["id"]
+        resp = client.put(f"/api/v1/devices/{pid}", json={"host": None})
+        assert resp.status_code == 422
+        # The stored profile is untouched.
+        assert client.get(f"/api/v1/devices/{pid}").json()["host"] == "10.0.0.1"
 
 
 class TestGetReturnsAllFields:

--- a/tests/unit/migration/test_trunk_allowed_vlan_add.py
+++ b/tests/unit/migration/test_trunk_allowed_vlan_add.py
@@ -162,3 +162,31 @@ class TestMultiLineAddWiring:
 
     def test_bare_single_line_unchanged_arista(self) -> None:
         assert _arista_trunk("10,20,30-32") == [10, 20, 30, 31, 32]
+
+
+class TestAddIsLinearNotQuadratic:
+    """(#11) The ``add`` branch used ``vid not in base`` (O(len(base)) per
+    id), so K repeated ``add 1-4094`` lines cost ~8.4M comparisons each.
+    The set-membership fix is behaviour-identical AND linear."""
+
+    def test_add_semantics_unchanged(self) -> None:
+        # Behaviour identity: union, order preserved, no re-dup of ids
+        # already present, ids duplicated within one line still resolve
+        # the same (the comprehension never observed its own additions).
+        assert merge_trunk_allowed([10, 20], "add 30,40") == [10, 20, 30, 40]
+        assert merge_trunk_allowed([10, 20], "add 20,30") == [10, 20, 30]
+        assert merge_trunk_allowed([10], "add 30,30") == [10, 30, 30]
+
+    def test_repeated_full_range_add_is_fast(self) -> None:
+        # Pre-fix: 200× ``add 1-4094`` against a growing 4094-list took
+        # ~7 s (quadratic).  Post-fix it's ~0.03 s.  A 4 s ceiling fails
+        # the quadratic path with a wide margin either direction.
+        import time
+
+        existing: list[int] = []
+        start = time.perf_counter()
+        for _ in range(200):
+            existing = merge_trunk_allowed(existing, "add 1-4094")
+        elapsed = time.perf_counter() - start
+        assert existing == list(range(1, 4095))
+        assert elapsed < 4.0, f"add merge is quadratic ({elapsed:.1f}s)"


### PR DESCRIPTION
## What

| # | Where | Bug |
|---|-------|-----|
| **#11** (perf) | `codecs/_helpers.py` `merge_trunk_allowed` | `add` branch used `vid not in base` (O(len(base)) per id) → K× `allowed vlan add 1-4094` lines = ~8.4M comparisons each; K=200 → ~7 s, near-cap bodies pin a worker for minutes/hours, unauthenticated on the default local bind |
| **#12** (API) | `api/routes/device_profiles.py` PUT | `{k: v … if v is not None}` conflated "omitted" with "explicit null" → a nullable pin could NEVER be cleared via the API (docstring promised `pass None to clear`); a null on a required field was silently ignored |

## Fix

- **#11** — `seen = set(base); return base + [vid for vid in ids if vid not in seen]`. O(1) membership, **behaviour-identical**: order preserved, and the comprehension never observed its own additions either way so duplicate ids resolve the same. (`remove`/`except` already used sets.)
- **#12** — `model_dump(exclude_unset=True)` applies only fields the client sent; an explicit `null` clears a nullable field (`enable_password`/`notes`/`os_version`/`model`) and is **rejected 422** for a required one. The nullable set is derived from `DeviceProfile.model_fields` (robust to future fields). Composes with the low-wave type_key validation (#53) in the same handler.

## Safety / testing

- **Cross-mesh guard flat** (`CODEC_BUG=5`, `cells_total=1224`) — #11 is behaviour-identical; #12 is API-only.
- New tests (fix-dependent assertions **verified to FAIL pre-fix**): `TestAddIsLinearNotQuadratic` (add-semantics identity + a 4 s ceiling the ~7 s quadratic path blows) and `TestUpdateNullSemantics` (clear pin via null; clear model+notes; omitted-preserved control; null-required → 422 with the store untouched).
- Full gate green: `tests/unit` + integration 5245 passed / 81 skipped, cross-mesh guard passes, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
