### PR TITLE
docs: correct the Tier-1 timezone/syslog over-promise (HIGH #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,10 +283,14 @@ across vendors.  Full per-codec matrix is in
 
 * **Tier 1 — auto-translatable.**  hostname, interfaces (name /
   description / enabled state / IPv4 + IPv6 addresses / per-interface
-  VRF binding), VLANs, static routes, DNS / NTP / syslog servers,
-  timezone.  Every shipped codec parses + renders these fully (the
-  experimental `cisco_iosxe` NETCONF stub excepted — it renders
-  interfaces only).
+  VRF binding), VLANs, static routes.  Every shipped codec parses +
+  renders these fully (the experimental `cisco_iosxe` NETCONF stub
+  excepted — it renders interfaces only).  DNS / NTP servers translate
+  on most codecs; `syslog` servers and `timezone` are wired on only a
+  subset — check the per-codec matrices in
+  [`docs\CAPABILITIES.md`](docs\CAPABILITIES.md), and note that where a
+  codec doesn't wire a field the source-side value is currently dropped
+  without a banner.
 * **Tier 2 — translatable with caveats.**  SNMP (incl. SNMPv3 USM),
   LAGs, local users, RADIUS, DHCP server pools, VXLAN VNIs, EVPN
   type-5 routes, routing instances / VRFs, Junos `apply-groups`.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -89,7 +89,14 @@ names the canonical surface, not a blanket guarantee.
 * `static_routes` — `destination`, `gateway`, `interface`, `metric`,
   `description`; plus per-VRF `vrf` discriminator (v0.2.0 Wave A —
   see Tier 2 ship-before-wire note below)
-* `dns_servers`, `ntp_servers`, `syslog_servers`, `timezone`
+* `dns_servers`, `ntp_servers` — wired on most codecs (not all: e.g.
+  cisco_nxos / cisco_iosxr render-drop the management plane); plus
+  `syslog_servers` and `timezone`, which are schema slots wired on only
+  a **subset** of codecs (`timezone` on none as of this release;
+  `syslog_servers` on juniper_junos).  These two are Tier-1 by data
+  shape but NOT a cross-vendor guarantee — the §A per-codec panels are
+  authoritative, and an unwired field is currently dropped silently on
+  parse.
 * `interfaces[].vrrp_groups` (v0.2.0 Wave B — classic FHRP
   redundancy, mode discriminator `vrrp` / `hsrp` / `carp`) — wired
   across the bidirectional codecs.  See

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -37,7 +37,9 @@ by concern and listed alphabetically within each section.
   in the matching schema-test guard files.
 - **Tier 1 / Tier 2 / Tier 3** — canonical-field categorisation.
   Tier 1 = cross-vendor stable, auto-translatable (hostname,
-  interfaces, vlans, static_routes, DNS/NTP/syslog).  Tier 2 =
+  interfaces, vlans, static_routes, DNS/NTP; plus `timezone` and
+  `syslog_servers`, which are Tier-1 by data shape but wired on only a
+  subset of codecs — see `docs/CAPABILITIES.md`).  Tier 2 =
   translatable with caveats (SNMP, local_users, lags, dhcp,
   radius, vxlan_vnis, evpn_type5_routes, routing_instances,
   apply_groups).  Tier 3 = detected-but-deliberately-not-translated;

--- a/docs/vendors/arista_eos.md
+++ b/docs/vendors/arista_eos.md
@@ -19,7 +19,9 @@ corpus yet — operator captures from EOS 4.27+ are welcome (see
 
 [Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable):
 
-- `hostname`, `domain`, DNS / NTP / syslog servers
+- `hostname`, `domain`, DNS / NTP servers (`syslog_servers` and
+  `timezone` are declared **unsupported** on this codec — see the
+  capability matrix; they do not round-trip)
 - Interfaces — `Ethernet<N>` and QSFP-breakout `Ethernet<N>/<M>`,
   Loopback, Management1; descriptions, IPv4 + IPv6, VRF binding
 - VLANs — ID, name, tagged/untagged member lists

--- a/docs/vendors/aruba_aoss.md
+++ b/docs/vendors/aruba_aoss.md
@@ -20,8 +20,9 @@ see [`../../BUG_REPORTING.md`](../../BUG_REPORTING.md)).
 
 [Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable):
 
-- `hostname`, `domain`, DNS / NTP / syslog servers, `timezone`
-  + DST rule
+- `hostname`, DNS / NTP servers (`domain`, `syslog_servers` and
+  `timezone` + DST rule are declared **unsupported** on this codec —
+  see the capability matrix; they do not round-trip)
 - Interfaces — slot-port and letter-slot-port (`A1-A24`, `B1-B24`
   on modular 5400R) port-id ranges, descriptions, IPv4 SVI L3
 - VLANs — ID, name, tagged/untagged port lists with comma-separated

--- a/docs/vendors/cisco_iosxe.md
+++ b/docs/vendors/cisco_iosxe.md
@@ -24,7 +24,10 @@ vendors (or vice versa), use `cisco_iosxe_cli`.
 [Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable)
 — auto-translatable:
 
-- `hostname`, `domain`, DNS / NTP / syslog servers, `timezone`
+- `hostname`, `domain`, DNS / NTP servers (`syslog_servers` and
+  `timezone` are declared **unsupported** in the capability matrix and
+  do not round-trip; the NETCONF `cisco_iosxe` stub renders interfaces
+  only, so the rest of this list applies to `cisco_iosxe_cli`)
 - Interfaces — name, description, enabled state, IPv4 + IPv6
   addresses, MTU, VRF binding, `kind` override
 - VLANs — ID, name, tagged/untagged port lists, SVI L3 (via

--- a/docs/vendors/fortigate.md
+++ b/docs/vendors/fortigate.md
@@ -24,7 +24,9 @@ firewall translation is your primary need, see
 
 [Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable):
 
-- `hostname` (alias / hostname), `domain`, DNS / NTP / syslog
+- `hostname` (alias / hostname), `domain`, DNS / NTP servers
+  (`syslog_servers` is declared **unsupported** in the capability
+  matrix and does not round-trip)
 - Interfaces — physical (`port1`-`portN`, `wan1`/`wan2`,
   `internal1`-`internalN`), VLAN sub-interfaces (`VL_<id>`,
   `LAN_TRUNK`), aggregate (`fortilink`, `LAG_INTERNAL`), tunnel

--- a/netcanon/migration/canonical/README.md
+++ b/netcanon/migration/canonical/README.md
@@ -188,10 +188,16 @@ section comments.  The tier governs the pipeline's validation banner
 and the codec's `CapabilityMatrix` declarations:
 
 * **Tier 1 — auto-translatable.**  Every vendor models the concept;
-  cross-vendor semantics are stable.  Fields: `hostname`, `domain`,
-  `dns_servers`, `ntp_servers`, `timezone`, `syslog_servers`,
-  `interfaces`, `vlans`, `static_routes`.  Codecs that don't yet wire
-  a Tier 1 field are bugs, not gaps.
+  cross-vendor semantics are stable.  Core fields — `hostname`,
+  `domain`, `interfaces`, `vlans`, `static_routes` — are wired on every
+  bidirectional codec, and a codec that fails to wire one of these is a
+  bug, not a gap.  `dns_servers` / `ntp_servers` are wired on most
+  codecs; `timezone` and `syslog_servers` are Tier-1 *schema slots* that
+  are wired on only a subset (`timezone` on none as of this release;
+  `syslog_servers` on `juniper_junos`) — for these two, an unwired codec
+  is a known gap declared `unsupported` in its `CapabilityMatrix`, not a
+  bug, and the source-side value is currently dropped on parse without a
+  banner.  Per-codec truth lives in the `CapabilityMatrix` tables.
 * **Tier 2 — auto-translate with review.**  Common enough to model;
   vendor mappings are partially lossy.  Fields: `dhcp_servers`,
   `snmp` (community + v3 users), `lags`, `local_users`,

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -832,9 +832,17 @@ class CanonicalIntent(BaseModel):
         dns_servers: Tier 1 — DNS resolver IPs in operator-stated
             order.
         ntp_servers: Tier 1 — NTP peer IPs / hostnames.
-        timezone: Tier 1 — operator-stated timezone string (vendor-
-            specific format; e.g. ``"PST -8"``, ``"Europe/London"``).
-        syslog_servers: Tier 1 — syslog destination IPs / hostnames.
+        timezone: Tier 1 *schema slot* — operator-stated timezone string
+            (vendor-specific format; e.g. ``"PST -8"``,
+            ``"Europe/London"``).  NOTE: wired on NO shipped codec as of
+            this release (every ``CapabilityMatrix`` declares
+            ``/system/timezone`` unsupported); a source-side value is
+            currently dropped on parse.  Kept Tier-1 by data shape, not
+            a cross-vendor round-trip guarantee — see docs/CAPABILITIES.md.
+        syslog_servers: Tier 1 *schema slot* — syslog destination IPs /
+            hostnames.  NOTE: wired on ``juniper_junos`` only as of this
+            release; other codecs declare it unsupported and drop it on
+            parse.  Tier-1 by data shape, not a universal guarantee.
         interfaces: Tier 1 — per-interface configuration records.
         vlans: Tier 1 — VLAN definitions with port membership.
         static_routes: Tier 1 — static route entries.

--- a/tests/unit/migration/test_tier1_wiring_honesty.py
+++ b/tests/unit/migration/test_tier1_wiring_honesty.py
@@ -1,0 +1,70 @@
+"""Truth-maintenance guard for the Tier-1 timezone / syslog docs (#1).
+
+The 2026-07-06 Fable review found the Tier-1 promise (README, CAPABILITIES.md,
+canonical/README.md, intent.py, several vendor pages) claimed ``timezone`` and
+``syslog_servers`` round-trip on every shipped codec, while ``timezone`` is
+wired on **none** and ``syslog_servers`` is declared-supported on **none**
+(juniper_junos renders it via a fail-open undeclared path).  The docs were
+corrected to say so.
+
+These guards pin the underlying matrix facts so a future codec that wires
+either field trips the test — forcing the Tier-1 docs to be updated in
+lockstep rather than silently drifting back into the over-promise.  They also
+lock the honesty property that ``timezone``'s drop is *declared* (so the
+cross-vendor unsupported banner fires) rather than undeclared (fail-open =
+silent loss).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.registry import get_codec, list_codecs
+
+pytestmark = pytest.mark.unit
+
+# The mock codec has no real vendor capability matrix.
+_REAL_CODECS = [c for c in list_codecs() if c != "mock"]
+
+
+def _status(codec_name: str, path: str) -> str:
+    m = get_codec(codec_name).capabilities
+    if path in set(m.supported):
+        return "supported"
+    if any(p.path == path for p in m.lossy):
+        return "lossy"
+    if any(p.path == path for p in m.unsupported):
+        return "unsupported"
+    return "undeclared"
+
+
+def test_timezone_declared_unsupported_on_every_codec() -> None:
+    """`/system/timezone` must be declared ``unsupported`` on every shipped
+    codec — this both pins the docs' "wired on no codec" claim and keeps the
+    drop DECLARED (banner fires cross-vendor) rather than undeclared
+    (fail-open silent loss)."""
+    offenders = {
+        c: _status(c, "/system/timezone")
+        for c in _REAL_CODECS
+        if _status(c, "/system/timezone") != "unsupported"
+    }
+    assert not offenders, (
+        f"/system/timezone is no longer 'unsupported' on {offenders} — update "
+        f"the Tier-1 docs (README / CAPABILITIES.md / canonical/README.md / "
+        f"intent.py / vendor pages) to match before relaxing this guard."
+    )
+
+
+def test_syslog_not_declared_supported_on_any_codec() -> None:
+    """No codec lists `/system/syslog-server` under ``supported`` — the docs
+    say it is wired narrowly (juniper_junos, via a fail-open undeclared
+    path), not a cross-vendor Tier-1 guarantee.  If a codec adds it to
+    ``supported``, update the Tier-1 docs alongside."""
+    offenders = [
+        c for c in _REAL_CODECS
+        if _status(c, "/system/syslog-server") == "supported"
+    ]
+    assert not offenders, (
+        f"/system/syslog-server is now 'supported' on {offenders} — update the "
+        f"Tier-1 docs to reflect the broader wiring."
+    )


### PR DESCRIPTION
## What

The lone **HIGH** of the 2026-07-06 Fable review — a documentation defect. Every Tier-1 capability claim promised *"hostname … DNS / NTP / syslog servers, timezone. Every shipped codec parses + renders these fully"*, but:

- `timezone` is wired on **0/12** codecs (every `CapabilityMatrix` declares `/system/timezone` unsupported),
- `syslog_servers` on **1** (juniper_junos, via a fail-open undeclared path),
- DNS/NTP is not universal either (nxos/iosxr render-drop the management plane).

A cisco source with `clock timezone` + `logging host` parses both to empty with **no banner** — the device ships with the wrong clock and no audit logging, silently, contradicting the promise.

## Fix (docs + docstring + guard; no runtime change)

- **README.md / CAPABILITIES.md / canonical/README.md / glossary.md** — scope DNS/NTP as "most codecs", demote `timezone` + `syslog_servers` to Tier-1 *schema slots* wired on only a subset, and note the unwired-field parse-time drop is currently silent.
- **intent.py** — the `timezone` / `syslog_servers` field docstrings now state their real wiring status.
- **4 vendor pages** (arista_eos, aruba_aoss, cisco_iosxe, fortigate) — removed syslog/timezone (and `domain` on aoss) from the confident "translates well" lists, per each codec's actual matrix; clarified the cisco_iosxe NETCONF stub renders interfaces only.
- **`test_tier1_wiring_honesty.py`** — truth-maintenance guard pinning `/system/timezone` = unsupported on every codec and no codec declaring `/system/syslog-server` supported, so a future wiring trips the test and forces a lockstep doc update.

## Deferred (with cause)

The optional half of the finding — adding `logging` / `clock timezone` to IOS Tier-3 detection so the silent drop *banners* — is a codec change that would move `dropped_tier3_sections` on real cisco fixtures and needs a conscious mesh re-baseline. Left for a follow-up.

## Testing

Mesh flat (docs/docstring only). Full gate green: `tests/unit` 5221 passed / 81 skipped (incl. the 2 new guards), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
