### PR TITLE
test(cross-mesh): ratchet YAML-less pair drift to close the coverage gap (#14)

### DIFF
--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -4182,6 +4182,448 @@
       "codec_bug_count": 1
     }
   ],
+  "pair_drift_yaml_less": [
+    {
+      "source_codec": "arista_eos",
+      "target_codec": "arista_eos",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "arista_eos",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 28
+    },
+    {
+      "source_codec": "arista_eos",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 34
+    },
+    {
+      "source_codec": "arista_eos",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 30
+    },
+    {
+      "source_codec": "arista_eos",
+      "target_codec": "vyos",
+      "drifted_total": 29
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "arista_eos",
+      "drifted_total": 30
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "aruba_aoss",
+      "drifted_total": 34
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "cisco_iosxe",
+      "drifted_total": 12
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "cisco_iosxe_cli",
+      "drifted_total": 29
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 37
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 28
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "fortigate_cli",
+      "drifted_total": 28
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "juniper_junos",
+      "drifted_total": 34
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "mikrotik_routeros",
+      "drifted_total": 27
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "opnsense",
+      "drifted_total": 29
+    },
+    {
+      "source_codec": "aruba_aoscx",
+      "target_codec": "vyos",
+      "drifted_total": 32
+    },
+    {
+      "source_codec": "aruba_aoss",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 23
+    },
+    {
+      "source_codec": "aruba_aoss",
+      "target_codec": "aruba_aoss",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "aruba_aoss",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 28
+    },
+    {
+      "source_codec": "aruba_aoss",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 19
+    },
+    {
+      "source_codec": "aruba_aoss",
+      "target_codec": "vyos",
+      "drifted_total": 23
+    },
+    {
+      "source_codec": "cisco_iosxe",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 3
+    },
+    {
+      "source_codec": "cisco_iosxe",
+      "target_codec": "cisco_iosxe",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "cisco_iosxe",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 3
+    },
+    {
+      "source_codec": "cisco_iosxe",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 3
+    },
+    {
+      "source_codec": "cisco_iosxe",
+      "target_codec": "vyos",
+      "drifted_total": 3
+    },
+    {
+      "source_codec": "cisco_iosxe_cli",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 37
+    },
+    {
+      "source_codec": "cisco_iosxe_cli",
+      "target_codec": "cisco_iosxe_cli",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "cisco_iosxe_cli",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 31
+    },
+    {
+      "source_codec": "cisco_iosxe_cli",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 31
+    },
+    {
+      "source_codec": "cisco_iosxe_cli",
+      "target_codec": "vyos",
+      "drifted_total": 34
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "arista_eos",
+      "drifted_total": 32
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 36
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "aruba_aoss",
+      "drifted_total": 39
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "cisco_iosxe",
+      "drifted_total": 11
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "cisco_iosxe_cli",
+      "drifted_total": 25
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 35
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "fortigate_cli",
+      "drifted_total": 25
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "juniper_junos",
+      "drifted_total": 34
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "mikrotik_routeros",
+      "drifted_total": 39
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "opnsense",
+      "drifted_total": 27
+    },
+    {
+      "source_codec": "cisco_iosxr",
+      "target_codec": "vyos",
+      "drifted_total": 43
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "arista_eos",
+      "drifted_total": 44
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 53
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "aruba_aoss",
+      "drifted_total": 49
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "cisco_iosxe",
+      "drifted_total": 20
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "cisco_iosxe_cli",
+      "drifted_total": 39
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 65
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "fortigate_cli",
+      "drifted_total": 57
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "juniper_junos",
+      "drifted_total": 57
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "mikrotik_routeros",
+      "drifted_total": 57
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "opnsense",
+      "drifted_total": 56
+    },
+    {
+      "source_codec": "cisco_nxos",
+      "target_codec": "vyos",
+      "drifted_total": 61
+    },
+    {
+      "source_codec": "fortigate_cli",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 29
+    },
+    {
+      "source_codec": "fortigate_cli",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 30
+    },
+    {
+      "source_codec": "fortigate_cli",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 28
+    },
+    {
+      "source_codec": "fortigate_cli",
+      "target_codec": "fortigate_cli",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "fortigate_cli",
+      "target_codec": "vyos",
+      "drifted_total": 31
+    },
+    {
+      "source_codec": "juniper_junos",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 71
+    },
+    {
+      "source_codec": "juniper_junos",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 76
+    },
+    {
+      "source_codec": "juniper_junos",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 63
+    },
+    {
+      "source_codec": "juniper_junos",
+      "target_codec": "juniper_junos",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "juniper_junos",
+      "target_codec": "vyos",
+      "drifted_total": 66
+    },
+    {
+      "source_codec": "mikrotik_routeros",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 22
+    },
+    {
+      "source_codec": "mikrotik_routeros",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 25
+    },
+    {
+      "source_codec": "mikrotik_routeros",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 23
+    },
+    {
+      "source_codec": "mikrotik_routeros",
+      "target_codec": "mikrotik_routeros",
+      "drifted_total": 1
+    },
+    {
+      "source_codec": "mikrotik_routeros",
+      "target_codec": "vyos",
+      "drifted_total": 18
+    },
+    {
+      "source_codec": "opnsense",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 34
+    },
+    {
+      "source_codec": "opnsense",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 31
+    },
+    {
+      "source_codec": "opnsense",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 33
+    },
+    {
+      "source_codec": "opnsense",
+      "target_codec": "opnsense",
+      "drifted_total": 0
+    },
+    {
+      "source_codec": "opnsense",
+      "target_codec": "vyos",
+      "drifted_total": 31
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "arista_eos",
+      "drifted_total": 27
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "aruba_aoscx",
+      "drifted_total": 41
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "aruba_aoss",
+      "drifted_total": 31
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "cisco_iosxe",
+      "drifted_total": 3
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "cisco_iosxe_cli",
+      "drifted_total": 18
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "cisco_iosxr",
+      "drifted_total": 45
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 46
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "fortigate_cli",
+      "drifted_total": 30
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "juniper_junos",
+      "drifted_total": 28
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "mikrotik_routeros",
+      "drifted_total": 23
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "opnsense",
+      "drifted_total": 32
+    },
+    {
+      "source_codec": "vyos",
+      "target_codec": "vyos",
+      "drifted_total": 0
+    }
+  ],
   "cells": [
     {
       "fixture": "tests/fixtures/real/arista_eos/batfish_eos_evpn_vlan_based_leaf.txt",

--- a/tests/integration/test_cross_mesh_ci_guard.py
+++ b/tests/integration/test_cross_mesh_ci_guard.py
@@ -11,8 +11,11 @@ committed baseline (``tests/fixtures/real/_phase4_runs/latest.json``):
 * render failures stay within a documented allowlist (a new render crash
   on the committed corpus is a codec regression),
 * the reconciled high-severity ``CODEC_BUG`` count doesn't exceed the
-  baseline (the confusion-matrix fidelity ratchet), and
-* no NEW codec-bug ``(source, target)`` pair appears.
+  baseline (the confusion-matrix fidelity ratchet),
+* no NEW codec-bug ``(source, target)`` pair appears, and
+* no YAML-less pair's raw mechanical drift exceeds the baseline — the
+  coverage ratchet that catches regressions on the ~723/1224 cells the
+  CODEC_BUG ratchet is structurally blind to (#14).
 
 This turns the manual ``python tools/run_full_mesh.py`` +
 ``run_phase4_reconciliation.py`` dogfood loop into a permanent CI
@@ -189,6 +192,47 @@ def test_no_pair_codec_bug_count_regressed(mesh_and_recon, baseline):
         "existing codec-bug pair(s) regressed (baseline→live): "
         f"{regressed}. A previously-tolerated pair now drifts MORE on the "
         "committed corpus even though the aggregate total / pair set held."
+    )
+
+
+def test_no_yaml_less_pair_drift_regressed(mesh_and_recon, baseline):
+    """No YAML-less (source, target) pair may drift MORE than the committed
+    baseline (#14).
+
+    The 56 expectation YAMLs cover only the original 8-codec cross-mesh; the
+    4 newest codecs' pairs (cisco_nxos / cisco_iosxr / aruba_aoscx / vyos)
+    plus every same-vendor pair — ~723/1224 cells — have no YAML, so their
+    ``field_variances`` is empty and NO field can classify as ``CODEC_BUG``.
+    The four CODEC_BUG guards above are therefore structurally blind to them:
+    a regression that drops every static route on ``arista_eos -> cisco_nxos``
+    keeps all of them green.  This pins each YAML-less pair's raw mechanical
+    ``fields_drifted`` total (from the Phase-1 mesh, expectation-independent)
+    with ``<=`` — a genuine improvement (less drift) still passes, a
+    regression (more drift) turns red.  Long-term fix: author expectation
+    YAMLs for these pairs so they get the richer CODEC_BUG classification.
+    """
+    _, result = mesh_and_recon
+
+    def _by_pair(rows):
+        return {
+            (r["source_codec"], r["target_codec"]): r["drifted_total"]
+            for r in rows
+        }
+
+    live = _by_pair(result["pair_drift_yaml_less"])
+    base = _by_pair(baseline["pair_drift_yaml_less"])
+    regressed = {
+        pair: (base[pair], live.get(pair, 0))
+        for pair in base
+        if live.get(pair, 0) > base[pair]
+    }
+    assert not regressed, (
+        "YAML-less cross-mesh pair(s) drifted MORE than the baseline "
+        f"(baseline->live): {regressed}.\nA field that used to round-trip on "
+        "an uncovered pair now drops, and the CODEC_BUG ratchet can't see it. "
+        "Investigate the regression before re-baselining "
+        "(regenerate tests/fixtures/real/_phase4_runs/latest.json's "
+        "pair_drift_yaml_less via tools/run_phase4_reconciliation.py)."
     )
 
 

--- a/tools/run_phase4_reconciliation.py
+++ b/tools/run_phase4_reconciliation.py
@@ -1035,6 +1035,9 @@ def run_reconciliation(mesh_json_path: Path) -> dict[str, Any]:
         "aggregate": aggregate,
         "severity_matrix": severity_matrix,
         "pair_codec_bug_counts": pair_codec_bug_counts,
+        "pair_drift_yaml_less": build_pair_drift_counts(
+            mesh.get("cells", []), set(expectations)
+        ),
         "cells": cells_out,
     }
 
@@ -1101,6 +1104,40 @@ def build_pair_codec_bug_counts(
         for (src, tgt), n in pair_counts.items()
     ]
     out.sort(key=lambda r: (-r["codec_bug_count"], r["source_codec"], r["target_codec"]))
+    return out
+
+
+def build_pair_drift_counts(
+    mesh_cells: list[dict[str, Any]],
+    yaml_pairs: set[tuple[str, str]],
+) -> list[dict[str, Any]]:
+    """Per (source, target) pair WITHOUT a Phase-3 expectation YAML: the
+    total MECHANICALLY-drifted fields summed across the pair's cells (#14).
+
+    Uses the Phase-1 mesh cell's ``summary.fields_drifted`` — the raw
+    round-trip drift count, which exists independent of any expectation
+    YAML.  (The RECONCILED disposition can't help here: a YAML-less cell
+    has ``field_variances={}`` and its every field punts to ALIGNED /
+    TRIVIAL_EMPTY, so the CODEC_BUG ratchet is structurally blind to these
+    pairs — the 4 newest codecs' pairs + every same-vendor pair, ~723/1224
+    cells.)  Pinning this coverage-independent drift total per pair against
+    the committed baseline turns a regression that silently drops fields on
+    an uncovered pair (e.g. arista -> cisco_nxos) from green into red, until
+    a proper expectation YAML is authored (the long-term fix).
+    """
+    pair_drift: dict[tuple[str, str], int] = {}
+    for cell in mesh_cells:
+        key = (cell["source_codec"], cell["target_codec"])
+        # YAML-covered pairs are already guarded by the CODEC_BUG ratchet.
+        if key in yaml_pairs:
+            continue
+        drifted = (cell.get("summary") or {}).get("fields_drifted", 0)
+        pair_drift[key] = pair_drift.get(key, 0) + drifted
+    out = [
+        {"source_codec": src, "target_codec": tgt, "drifted_total": n}
+        for (src, tgt), n in pair_drift.items()
+    ]
+    out.sort(key=lambda r: (r["source_codec"], r["target_codec"]))
     return out
 
 


### PR DESCRIPTION
## What

The cross-mesh CI guard's four `CODEC_BUG` checks only classify the 56 expectation YAMLs — the 8×7 mesh of the *original* 8 codecs. The 4 newest codecs' pairs (cisco_nxos / cisco_iosxr / aruba_aoscx / vyos) **plus every same-vendor pair** — ~723/1224 cells — have no YAML, so `field_variances={}` and no field can ever classify as `CODEC_BUG`. A regression that drops every static route on `arista_eos → cisco_nxos` kept all six guards green (2026-07-06 Fable review MAJOR #14).

## Fix (short-term, per the review)

Pin each YAML-less pair's raw **mechanical** drift against a committed baseline:

- `run_phase4_reconciliation.build_pair_drift_counts` sums the Phase-1 mesh cell's `summary.fields_drifted` (expectation-independent) per pair with no YAML, emitted as `pair_drift_yaml_less`.
- `latest.json` gains the `pair_drift_yaml_less` baseline (88 pairs, 77 with drift) — spliced in as a pure addition, no other cell touched.
- New guard `test_no_yaml_less_pair_drift_regressed` pins each pair's drift `<=` baseline (improvement passes, regression fails).

## Negative control (definitive)

Temporarily dropping `hostname` from the cisco_nxos render — a YAML-less-pair regression — turned the **new** guard RED, naming all 10 nxos-target pairs (`arista_eos→cisco_nxos` 30→36, `cisco_nxos→cisco_nxos` 0→13, …), while **all four CODEC_BUG guards stayed GREEN** — reproducing exactly the blindness the finding described. Reverted.

## Deferred (long-term)

Author expectation YAMLs for the 76 uncovered cross-vendor pairs so they get the richer CODEC_BUG classification instead of only the drift ratchet.

## Testing

Full gate green: `tests/unit` 5221 passed / 81 skipped, cross-mesh guard **7/7**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
