### PR TITLE
perf(parse): kill four quadratic scans in parse/diff hot paths (#30/#31/#32/#33)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -799,17 +799,22 @@ def _parse_stanzas(raw: str, intent: CanonicalIntent) -> None:
     # captured during the pass, synthesise the LAG if the child
     # interfaces named it — EOS doesn't require a standalone
     # ``interface Port-ChannelN`` stanza.
+    # Index by name once so the per-channel-group merge is O(1), not the
+    # O(D**2) rescan of the growing intent.lags a ``next()`` scan incurred
+    # (2026-07-06 review MEDIUM #31).  Pre-seeding from intent.lags keeps the
+    # defensive else-branch semantics byte-identical.
+    lags_by_name: dict[str, CanonicalLAG] = {lag.name: lag for lag in intent.lags}
     for chan_id, members in lag_members.items():
         lag_name = f"Port-Channel{chan_id}"
-        existing = next(
-            (lag for lag in intent.lags if lag.name == lag_name), None,
-        )
+        existing = lags_by_name.get(lag_name)
         if existing is None:
-            intent.lags.append(CanonicalLAG(
+            new_lag = CanonicalLAG(
                 name=lag_name,
                 members=sorted(set(members)),
                 mode=lag_modes.get(chan_id, "active"),
-            ))
+            )
+            intent.lags.append(new_lag)
+            lags_by_name[lag_name] = new_lag
         else:
             existing.members = sorted(set(existing.members + members))
             if chan_id in lag_modes:

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -309,6 +309,13 @@ def _apply_system_ntp(block: _ConfigBlock, intent: CanonicalIntent) -> None:
 def _apply_system_interface(  # noqa: C901
     block: _ConfigBlock, intent: CanonicalIntent,
 ) -> None:
+    # Name -> interface index for O(1) LAG member reverse-linking.  Holds
+    # exactly the interfaces appended so far (the current ``iface`` is added
+    # at the end of each iteration), mirroring the previously-appended set the
+    # old ``for prev in intent.interfaces`` scan saw — but O(1) instead of the
+    # O(members x interfaces) quadratic that pinned a worker on adversarial
+    # thousand-aggregate inputs (2026-07-06 review MEDIUM #30).
+    iface_by_name: dict[str, CanonicalInterface] = {}
     for edit in block.edits:
         name = edit.edit_id
         iface = CanonicalInterface(name=name, enabled=True)
@@ -423,11 +430,11 @@ def _apply_system_interface(  # noqa: C901
             ))
             # Reverse-link on members we already know about.  Members
             # defined later in the same block will be wired up on the
-            # second-pass below.
+            # second-pass below.  O(1) name lookup — see iface_by_name.
             for m in members:
-                for prev in intent.interfaces:
-                    if prev.name == m and prev.lag_member_of is None:
-                        prev.lag_member_of = name
+                prev = iface_by_name.get(m)
+                if prev is not None and prev.lag_member_of is None:
+                    prev.lag_member_of = name
         else:
             iface.interface_type = _infer_iface_type(name)
 
@@ -520,6 +527,7 @@ def _apply_system_interface(  # noqa: C901
                 iface.vrrp_groups.append(group)
 
         intent.interfaces.append(iface)
+        iface_by_name[name] = iface
 
     # Second pass: interface-order independence — members defined after
     # their aggregate edit still get their lag_member_of stamped.

--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -184,6 +184,13 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     # Phase 4 rank-4: IRB SVI accumulator.  Keyed by vid (the irb
     # unit number); each entry holds the per-vid IPv4 list.
     irb_state: dict[int, dict[str, Any]] = {}
+    # VLAN indices threaded through the dispatcher so ``set vlans`` lookups
+    # are O(1) instead of rescanning the growing intent.vlans per line — the
+    # O(n**2) the review flagged on vlan-heavy configs (2026-07-06 MEDIUM #32).
+    # ``vlan_by_name`` is keep-first (setdefault) to preserve the old
+    # ``next(... if v.name == name)`` first-match semantics on duplicate names.
+    vlan_by_id: dict[int, CanonicalVlan] = {}
+    vlan_by_name: dict[str, CanonicalVlan] = {}
     # Cluster E.1-B: DHCP-server accumulator.  Junos has two grammars:
     #
     #  * Modern form -- ``set access address-assignment pool <P>
@@ -279,6 +286,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             _dispatch_set(
                 tokens, intent, iface_state, range_state,
                 lag_state, irb_state, dhcp_pool_state, dhcp_group_iface,
+                vlan_by_id, vlan_by_name,
             )
     # Pass 2b: apply top-level content.  Scalars set by group
     # content get overwritten; list-shaped fields accumulate
@@ -287,6 +295,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         _dispatch_set(
             tokens, intent, iface_state, range_state,
             lag_state, irb_state, dhcp_pool_state, dhcp_group_iface,
+            vlan_by_id, vlan_by_name,
         )
 
     # GAP 9b: preserve both the apply-groups STATEMENT and the
@@ -527,18 +536,21 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     # 1. Materialise CanonicalLAG records from the lag_state
     #    accumulator.  Each entry is keyed by ae-name (e.g. ``ae0``)
     #    with the ordered member list and the LACP mode.
+    # Index by name once (O(1) merge) instead of rescanning the growing
+    # intent.lags per ae — the O(D**2) sibling of the arista channel-group
+    # scan (2026-07-06 review MEDIUM #31).  Pre-seed from intent.lags so the
+    # apply-groups-composition else-branch stays byte-identical.
+    lags_by_name: dict[str, CanonicalLAG] = {lag.name: lag for lag in intent.lags}
     for ae_name, lag_entry in lag_state.items():
         members = list(lag_entry.get("members", []))
         mode = lag_entry.get("mode", "active") or "active"
         # Don't accumulate duplicates if the same LAG already exists
         # (defensive for groups + apply-groups composition).
-        existing = next(
-            (lag for lag in intent.lags if lag.name == ae_name), None,
-        )
+        existing = lags_by_name.get(ae_name)
         if existing is None:
-            intent.lags.append(
-                CanonicalLAG(name=ae_name, members=members, mode=mode)
-            )
+            new_lag = CanonicalLAG(name=ae_name, members=members, mode=mode)
+            intent.lags.append(new_lag)
+            lags_by_name[ae_name] = new_lag
         else:
             existing.mode = mode
             for m in members:
@@ -637,6 +649,9 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     # See ``project_switchport_to_vlan`` for the symmetric fix on
     # the per-port vlan-members surface.
     bound_vids: set[int] = set()
+    # O(1) id lookup for the fold; stubs appended below are added to the index
+    # so a later irb entry sharing a vid still matches (2026-07-06 MEDIUM #32).
+    fold_vlan_by_id: dict[int, CanonicalVlan] = {v.id: v for v in intent.vlans}
     for vid, irb_entry in irb_state.items():
         if "vlan_name" not in irb_entry:
             # No l3-interface binding — preserve irb.<vid> as-is.
@@ -652,11 +667,12 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         ):
             # Load-bearing — leave the iface alone, don't fold to vlan.
             continue
-        vlan = next((v for v in intent.vlans if v.id == vid), None)
+        vlan = fold_vlan_by_id.get(vid)
         if vlan is None:
             stub_name = irb_entry.get("vlan_name", f"VLAN-{vid}")
             vlan = CanonicalVlan(id=vid, name=stub_name)
             intent.vlans.append(vlan)
+            fold_vlan_by_id[vid] = vlan
         # Source-shape (a): IPs gathered from ``set interfaces irb
         # unit <vid>`` lines via the irb_state accumulator.  Wave C:
         # also carry per-address virtual_gateway_address + per-unit
@@ -1130,6 +1146,8 @@ def _dispatch_set(
     irb_state: dict[int, dict[str, Any]] | None = None,
     dhcp_pool_state: dict[str, dict[str, Any]] | None = None,
     dhcp_group_iface: dict[str, str] | None = None,
+    vlan_by_id: dict[int, CanonicalVlan] | None = None,
+    vlan_by_name: dict[str, CanonicalVlan] | None = None,
 ) -> None:
     """Apply one set-line's token list to *intent*.
 
@@ -1164,7 +1182,7 @@ def _dispatch_set(
             tokens[1:], iface_state, range_state, lag_state, irb_state,
         )
     elif head == "vlans":
-        _apply_vlans(tokens[1:], intent, irb_state)
+        _apply_vlans(tokens[1:], intent, irb_state, vlan_by_id, vlan_by_name)
     elif head == "routing-options":
         _apply_routing_options(tokens[1:], intent)
     elif head == "snmp":
@@ -1801,24 +1819,42 @@ def _apply_vlans(
     tokens: list[str],
     intent: CanonicalIntent,
     irb_state: dict[int, dict[str, Any]] | None = None,
+    vlan_by_id: dict[int, CanonicalVlan] | None = None,
+    vlan_by_name: dict[str, CanonicalVlan] | None = None,
 ) -> None:
     """``set vlans <NAME> vlan-id <N>``
     ``set vlans <NAME> vxlan vni <VNI>``  (GAP 6)
     ``set vlans <NAME> l3-interface irb.<vid>``  (Phase 4 rank-4)
+
+    ``vlan_by_id`` / ``vlan_by_name`` are the O(1) indices threaded from
+    ``parse_intent`` (2026-07-06 review MEDIUM #32).  Legacy/isolated callers
+    may omit them; we then build one-shot indices from ``intent.vlans`` so the
+    lookup stays correct (just not amortised — fine for small test inputs).
     """
     if len(tokens) < 3:
         return
+    if vlan_by_id is None:
+        vlan_by_id = {v.id: v for v in intent.vlans}
+    if vlan_by_name is None:
+        vlan_by_name = {v.name: v for v in intent.vlans if v.name}
     vlan_name = tokens[0]
     if tokens[1] == "vlan-id":
         try:
             vid = int(tokens[2])
         except ValueError:
             return
-        existing = next((v for v in intent.vlans if v.id == vid), None)
+        existing = vlan_by_id.get(vid)
         if existing is None:
-            intent.vlans.append(CanonicalVlan(id=vid, name=vlan_name))
+            new_vlan = CanonicalVlan(id=vid, name=vlan_name)
+            intent.vlans.append(new_vlan)
+            vlan_by_id[vid] = new_vlan
+            vlan_by_name.setdefault(vlan_name, new_vlan)
         else:
+            # Re-key the by-name index on rename so keep-first semantics
+            # stay consistent with the (single) renamed VLAN object.
+            vlan_by_name.pop(existing.name, None)
             existing.name = vlan_name
+            vlan_by_name.setdefault(vlan_name, existing)
         return
     # Phase 4 rank-4: l3-interface binding.  Capture the name->vid
     # link so the post-pass can attach IRB addresses to the right
@@ -1848,9 +1884,7 @@ def _apply_vlans(
             vni = int(tokens[3])
         except ValueError:
             return
-        existing_vlan = next(
-            (v for v in intent.vlans if v.name == vlan_name), None,
-        )
+        existing_vlan = vlan_by_name.get(vlan_name)
         if existing_vlan is not None:
             # Don't duplicate if already recorded.
             already = any(

--- a/netcanon/services/diff.py
+++ b/netcanon/services/diff.py
@@ -115,9 +115,13 @@ def compute_diff(
     lines: list[DiffLine] = []
     stats = {"added": 0, "removed": 0, "equal": 0}
 
-    matcher = difflib.SequenceMatcher(
-        a=left_lines, b=right_lines, autojunk=False
-    )
+    # Keep difflib's default autojunk heuristic: configs are dense with
+    # repeated delimiter lines (``!``, ``exit``, blanks) and disabling
+    # autojunk made SequenceMatcher O(n**2) on them (~25 s at 16k lines via
+    # /configs/diff — 2026-07-06 review MEDIUM #33).  autojunk treats
+    # >1%-popular lines as junk, which stays near-linear and diffs realistic
+    # configs identically.
+    matcher = difflib.SequenceMatcher(a=left_lines, b=right_lines)
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         if tag == "equal":
             for offset in range(i2 - i1):

--- a/tests/unit/migration/test_parse_quadratic_scan_perf.py
+++ b/tests/unit/migration/test_parse_quadratic_scan_perf.py
@@ -1,0 +1,209 @@
+"""Quadratic-scan sweep — parse hot paths must stay linear (#30-#33).
+
+The 2026-07-06 Fable review flagged five ``next()`` / list-membership scans
+against a list that grows per iteration inside parse hot paths — one shape,
+several sites (theme 5).  ``merge_trunk_allowed`` (#11) shipped in the prior
+wave; this batch closes the remaining four:
+
+* ``fortigate_cli`` LAG first-pass reverse-link — O(members x interfaces) (#30)
+* ``arista_eos`` channel-group reverse-link — O(D**2) via ``next()`` (#31)
+* ``juniper_junos`` ``set vlans`` id/name + irb-fold scans — O(n**2) (#32)
+* ``services.diff`` ``SequenceMatcher(autojunk=False)`` — O(n**2) (#33)
+
+Each fix is a behaviour-identical dict/set swap (order + values preserved), so
+the cross-mesh baseline is unchanged; these tests pin BOTH the behaviour
+(identity on the tricky edges) and the now-linear complexity.
+
+The perf assertions are negative controls: verified to FAIL against the
+pre-fix quadratic (times below are local, measured by stashing the fix) and
+pass with a wide margin post-fix.  Bounded cases (junos VLANs cap at VID 4094,
+so the absolute time can't blow up) use a machine-independent scaling ratio
+instead of an absolute ceiling.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+
+import pytest
+
+from netcanon.migration.codecs.arista_eos import AristaEOSCodec
+from netcanon.migration.codecs.fortigate_cli import FortiGateCLICodec
+from netcanon.migration.codecs.juniper_junos import JunosCodec
+from netcanon.models.backup import ConfigRecord
+from netcanon.services.diff import compute_diff
+
+pytestmark = pytest.mark.unit
+
+
+# ── #30 fortigate LAG reverse-link ─────────────────────────────────────
+
+
+def _fortigate_lag_config(n: int) -> str:
+    """``n`` member ports followed by ``n`` single-member aggregates."""
+    lines = ["config system interface"]
+    for i in range(n):
+        lines += [f'    edit "port{i}"', "        set vdom root", "    next"]
+    for a in range(n):
+        lines += [
+            f'    edit "agg{a}"',
+            "        set type aggregate",
+            f'        set member "port{a}"',
+            "    next",
+        ]
+    lines.append("end")
+    return "\n".join(lines) + "\n"
+
+
+class TestFortigateLagReverseLinkLinear:
+    def test_member_reverse_link_unchanged(self) -> None:
+        # Both the first-pass (member defined BEFORE its aggregate) and the
+        # second-pass (member defined AFTER) reverse-links must stamp.
+        cfg = (
+            "config system interface\n"
+            '    edit "port1"\n        set vdom root\n    next\n'      # before agg
+            '    edit "ag1"\n        set type aggregate\n'
+            '        set member "port1" "port2"\n    next\n'
+            '    edit "port2"\n        set vdom root\n    next\n'      # after agg
+            "end\n"
+        )
+        intent = FortiGateCLICodec().parse(cfg)
+        by_name = {i.name: i for i in intent.interfaces}
+        assert by_name["port1"].lag_member_of == "ag1"   # first-pass
+        assert by_name["port2"].lag_member_of == "ag1"   # second-pass
+
+    def test_first_pass_reverse_link_is_linear(self) -> None:
+        # Pre-fix (O(members x interfaces)): n=8000 ~3 s.  Post-fix ~0.26 s.
+        cfg = _fortigate_lag_config(8000)
+        start = time.perf_counter()
+        intent = FortiGateCLICodec().parse(cfg)
+        elapsed = time.perf_counter() - start
+        assert len(intent.lags) == 8000
+        assert elapsed < 1.5, f"fortigate LAG reverse-link is quadratic ({elapsed:.2f}s)"
+
+
+# ── #31 arista channel-group reverse-link ──────────────────────────────
+
+
+class TestAristaChannelGroupLinear:
+    def test_channel_group_binding_unchanged(self) -> None:
+        cfg = (
+            "hostname sw1\n"
+            "interface Ethernet1\n   channel-group 5 mode active\n"
+            "interface Ethernet2\n   channel-group 5 mode active\n"
+        )
+        intent = AristaEOSCodec().parse(cfg)
+        lag = next(lag for lag in intent.lags if lag.name == "Port-Channel5")
+        assert sorted(lag.members) == ["Ethernet1", "Ethernet2"]
+        by_name = {i.name: i for i in intent.interfaces}
+        assert by_name["Ethernet1"].lag_member_of == "Port-Channel5"
+
+    def test_channel_group_reverse_link_is_linear(self) -> None:
+        # Pre-fix (O(D**2) next() rescan): D=16000 ~3.9 s.  Post-fix ~0.19 s.
+        lines = ["hostname sw1"]
+        for i in range(1, 16001):
+            lines += [f"interface Ethernet{i}", f"   channel-group {i} mode active"]
+        cfg = "\n".join(lines) + "\n"
+        start = time.perf_counter()
+        intent = AristaEOSCodec().parse(cfg)
+        elapsed = time.perf_counter() - start
+        assert len(intent.lags) == 16000
+        assert elapsed < 1.5, f"arista channel-group scan is quadratic ({elapsed:.2f}s)"
+
+
+# ── #32 junos set-vlans id/name index ──────────────────────────────────
+
+
+class TestJunosVlanIndexLinear:
+    def test_duplicate_name_keeps_first_for_vxlan(self) -> None:
+        # Two VLANs share a name (different ids): the vxlan-vni binding by
+        # name must still resolve to the FIRST (keep-first, as next() did).
+        cfg = (
+            "set vlans DUP vlan-id 10\n"
+            "set vlans DUP vlan-id 20\n"
+            "set vlans DUP vxlan vni 5000\n"
+        )
+        intent = JunosCodec().parse(cfg)
+        assert sorted(v.id for v in intent.vlans) == [10, 20]
+        assert [(x.vlan_id, x.vni) for x in intent.vxlan_vnis] == [(10, 5000)]
+
+    def test_same_id_second_line_renames(self) -> None:
+        # ``vlan-id`` lookup is by id: the second line renames the id-10 VLAN
+        # rather than creating a duplicate.
+        cfg = "set vlans FOO vlan-id 10\nset vlans BAR vlan-id 10\n"
+        intent = JunosCodec().parse(cfg)
+        assert len(intent.vlans) == 1
+        assert intent.vlans[0].id == 10
+        assert intent.vlans[0].name == "BAR"
+
+    def test_vlan_index_is_linear_not_quadratic(self) -> None:
+        # VLAN ids cap at 4094 so the absolute time can't blow up — assert the
+        # SHAPE instead: doubling the VLAN count must not ~4x the time.
+        # Pre-fix ratio ~3.6 (quadratic); post-fix ~2.0 (linear).
+        def parse_v(v: int) -> None:
+            lines = [f"set vlans V{i} vlan-id {i}" for i in range(2, v + 2)]
+            JunosCodec().parse("\n".join(lines) + "\n")
+
+        def best(v: int) -> float:
+            times = []
+            for _ in range(3):
+                start = time.perf_counter()
+                parse_v(v)
+                times.append(time.perf_counter() - start)
+            return min(times)
+
+        parse_v(1500)  # warm up import/JIT caches
+        ratio = best(3000) / best(1500)
+        assert ratio < 3.0, f"junos vlan index scales quadratically (2x count -> {ratio:.1f}x time)"
+
+
+# ── #33 services.diff autojunk ─────────────────────────────────────────
+
+
+def _rec() -> ConfigRecord:
+    return ConfigRecord(
+        device_type="Cisco",
+        host="10.0.0.1",
+        timestamp=datetime(2026, 4, 16, tzinfo=UTC),
+        filename="c.cfg",
+        file_extension="cfg",
+        size_bytes=100,
+    )
+
+
+class TestDiffAutojunkLinear:
+    def test_realistic_diff_stays_minimal(self) -> None:
+        # On a realistic config (diverse interface stanzas with ``!``
+        # delimiters) dropping autojunk=False leaves the diff minimal: a
+        # single changed line -> exactly 1 removed + 1 added, the rest equal.
+        # (autojunk only degrades minimality on pathological >90%-repeated
+        # inputs, where the result is still correct — just noisier.)
+        lines: list[str] = []
+        for i in range(60):
+            lines += [f"interface Gi0/{i}", f" description uplink-{i}", " no shutdown", "!"]
+        left = "\n".join(lines)
+        changed = list(lines)
+        changed[1] = " description CHANGED"
+        right = "\n".join(changed)
+        report = compute_diff(_rec(), left, _rec(), right)
+        assert report.stats["removed"] == 1
+        assert report.stats["added"] == 1
+
+    def test_identical_configs_diff_fully_equal(self) -> None:
+        # The invariant that must hold regardless of autojunk: identical
+        # inputs produce zero add/remove churn.
+        text = "\n".join(["!" if i % 2 else f"line{i % 10}" for i in range(500)])
+        report = compute_diff(_rec(), text, _rec(), text)
+        assert report.stats["added"] == 0
+        assert report.stats["removed"] == 0
+
+    def test_diff_of_repeated_lines_is_linear(self) -> None:
+        # Pre-fix (autojunk=False -> O(n**2) on repeated ``!``): 30k lines
+        # ~18 s.  Post-fix (default autojunk) ~0.08 s.
+        left = "\n".join(["!" if i % 2 else f"line{i % 50}" for i in range(30000)])
+        right = left.replace("line3", "lineX", 1)
+        start = time.perf_counter()
+        compute_diff(_rec(), left, _rec(), right)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 3.0, f"compute_diff is quadratic on repeated lines ({elapsed:.2f}s)"


### PR DESCRIPTION
## What

Closes the four remaining quadratic-scan sites from the 2026-07-06 Fable review (theme 5 — `next()`/list-membership scans over a list that grows per iteration in parse hot paths). `merge_trunk_allowed` (#11) shipped last wave; these are the rest. All reachable via POST `/plan` or `/configs/diff` under the size cap.

Every fix is a **behaviour-identical dict/set swap** (order + values preserved), so the cross-mesh baseline is unchanged.

| # | Site | Before | After |
|---|---|---|---|
| 30 | `fortigate_cli` LAG first-pass reverse-link | O(members × interfaces) scan of growing list | `iface_by_name` dict — n=8000: **~3s → 0.26s** |
| 31 | `arista_eos` channel-group + `juniper_junos` ae-LAG sibling | O(D²) `next()` rescan | pre-seeded `lags_by_name` — arista D=16000: **3.9s → 0.19s** |
| 32 | `juniper_junos` `set vlans` id/name + irb-fold | O(n²) `next()` over `intent.vlans` | `vlan_by_id`/`vlan_by_name` threaded through the dispatcher (VID-bounded; **3.6× → 2.0×** per doubling) |
| 33 | `services.diff` | `SequenceMatcher(autojunk=False)` → O(n²) on repeated `!`/`exit` lines | default autojunk — 30k lines: **18.7s → 0.08s** |

## Behaviour preservation

- #32 by-name index is keep-first (`setdefault`) with rename re-keying, matching the old `next(... if v.name == ...)` first-match semantics on duplicate VLAN names; by-id is unique post-dispatch so identical.
- #33: `autojunk` is a no-op below 200 lines, so small/medium configs are byte-identical; realistic configs diff identically (verified); only pathological >90%-repeated inputs get a *less-minimal but still-correct* diff (the review's accepted trade-off).
- cross-mesh CI guard **7/7** (CODEC_BUG=5, cells=1224, `pair_drift_yaml_less` unchanged), full unit suite **5231 passed**.

## Negative control

`tests/unit/migration/test_parse_quadratic_scan_perf.py` — verified by stashing the fix:
- the **four** perf/ratio assertions **FAIL** pre-fix (diff 18.7s, arista 3.9s, fortigate ~3s, junos ratio 3.6×);
- the **six** behaviour-identity assertions **pass both** pre- and post-fix (proving the swap is output-preserving).

## Testing

`ruff` clean; `tests/unit` 5231 passed / 81 skipped; `tests/integration/test_cross_mesh_ci_guard.py` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
