### PR TITLE
fix(rename): close four rename-orchestrator completeness gaps (#17/#18/#19/#20)

### DIFF
--- a/netcanon/migration/canonical/port_names.py
+++ b/netcanon/migration/canonical/port_names.py
@@ -333,6 +333,25 @@ def translate_port_names(  # noqa: C901
         return PortRenameResult(applied={}, warnings=[], dropped=[])
 
     user_map = dict(rename_map or {})
+    applied: dict[str, str] = {}
+    warnings: list[str] = []
+    memo: dict[str, str] = {}
+
+    # (#19) Reject empty / blank source keys BEFORE the drop/rename split.
+    # ``interface`` defaults to '' on gateway-only static routes and unbound
+    # DHCP pools, so an empty-string drop key (``{'': None}``) would match all
+    # of them in _strip_dropped_ports and silently delete every such
+    # route/pool.  Pydantic accepts the key (port_rename_map is
+    # ``dict[str, str | None]``) and a UI row with a blank source + "drop"
+    # produces exactly this.  Mirror local_user_names.py: warn + skip.
+    for key in list(user_map):
+        if not isinstance(key, str) or not key.strip():
+            warnings.append(
+                f"port_rename: source port {key!r} is empty or blank; "
+                f"entry skipped"
+            )
+            del user_map[key]
+
     # Split user map into drops (value is None) and renames (value is str).
     # Drops never go through the target codec.
     #
@@ -349,9 +368,6 @@ def translate_port_names(  # noqa: C901
     str_map: dict[str, str] = {
         name: tgt for name, tgt in user_map.items() if isinstance(tgt, str)
     }
-    applied: dict[str, str] = {}
-    warnings: list[str] = []
-    memo: dict[str, str] = {}
     # Auto-drops accumulate DURING resolve() when ``strip_unmappable`` removes a
     # name the target codec can't format.  Unlike user drops, these names stay
     # verbatim through the sweep (they were never renamed to something else), so
@@ -577,6 +593,31 @@ def translate_port_names(  # noqa: C901
     if auto_dropped:
         _strip_dropped_ports(intent, auto_dropped)
 
+    # (#17) Detect rename TARGET collisions: two+ source ports resolving to the
+    # same final interface/LAG name render duplicate stanzas (same-vendor) or
+    # fuse into one interface on re-parse (cross-vendor) — previously silent
+    # (warnings=[]).  The vlan / local-user / snmpv3 orchestrators surface
+    # target collisions; the ports pane didn't.  Warn (naming the colliding
+    # sources) so the operator can map each source to a distinct target.  We do
+    # NOT drop/merge here: some targets already dedupe + annotate the collision
+    # at render time (FortiGate emits ``# port collision``), and dropping at the
+    # orchestrator would pre-empt that and silently discard a port's config.
+    def _warn_collisions(objs: list, kind: str) -> None:
+        counts: dict[str, int] = {}
+        for obj in objs:
+            counts[obj.name] = counts.get(obj.name, 0) + 1
+        for final in sorted(n for n, c in counts.items() if c > 1):
+            sources = sorted(s for s, f in memo.items() if f == final) or [final]
+            warnings.append(
+                f"port_rename: multiple source ports map to {final!r} "
+                f"(sources: {', '.join(sources)}); the target will render "
+                f"duplicate/fused {kind} stanzas — map each source to a "
+                f"distinct target"
+            )
+
+    _warn_collisions(intent.interfaces, "interface")
+    _warn_collisions(intent.lags, "LAG")
+
     # (#49b) Operator drop/rename keys that named a port absent from the tree
     # did nothing — warn instead of silently over-reporting them as dropped.
     for key in user_map:
@@ -672,11 +713,16 @@ def _strip_dropped_ports(
     intent.lags = [lag for lag in intent.lags if lag.name not in dropped]
     for lag in intent.lags:
         lag.members = [m for m in lag.members if m not in dropped]
+    # (#19) Guard on a truthy interface: a gateway-only route / unbound pool
+    # has ``interface == ''`` and must never be matched by a drop set (an
+    # empty-string drop key would otherwise delete every one of them).
     intent.static_routes = [
-        r for r in intent.static_routes if r.interface not in dropped
+        r for r in intent.static_routes
+        if not (r.interface and r.interface in dropped)
     ]
     intent.dhcp_servers = [
-        p for p in intent.dhcp_servers if p.interface not in dropped
+        p for p in intent.dhcp_servers
+        if not (p.interface and p.interface in dropped)
     ]
     # (#3) Clear dangling VXLAN VTEP source-interface references.
     for vx in intent.vxlan_vnis:

--- a/netcanon/migration/canonical/transforms.py
+++ b/netcanon/migration/canonical/transforms.py
@@ -144,6 +144,31 @@ def project_switchport_to_vlan(intent: CanonicalIntent) -> None:
     _TRUNK_ALL_RANGE_FULL = set(range(1, 4095))
     _TRUNK_ALL_RANGE_OPERATIONAL = set(range(2, 4095))
 
+    # (#20) PASS 1 — materialise every VLAN record a switchport references
+    # BEFORE any membership stamping.  The trunk-all branch below stamps the
+    # iface onto every VLAN in ``intent.vlans``; if a trunk-all uplink is
+    # declared BEFORE an access port whose VLAN has no top-level stanza, that
+    # VLAN is synthesised only later and the trunk-all stamp misses it — an
+    # interface-order dependence that also made a second call add the entry
+    # (violating the documented idempotency).  Pre-materialising decouples the
+    # VLAN set from interface order.  This never stamps, so it can't change
+    # what an already-order-correct config produced.
+    for iface in intent.interfaces:
+        mode = iface.switchport_mode
+        if mode == "access":
+            if iface.access_vlan is not None:
+                _vlan(iface.access_vlan)
+        elif mode == "trunk":
+            allowed_set = set(iface.trunk_allowed_vlans)
+            if allowed_set not in (
+                _TRUNK_ALL_RANGE_FULL, _TRUNK_ALL_RANGE_OPERATIONAL
+            ):
+                for vid in iface.trunk_allowed_vlans:
+                    _vlan(vid)
+            if iface.trunk_native_vlan is not None:
+                _vlan(iface.trunk_native_vlan)
+
+    # PASS 2 — stamp membership; the trunk-all branch now sees the full set.
     for iface in intent.interfaces:
         mode = iface.switchport_mode
         if mode is None:

--- a/netcanon/migration/canonical/vlan_names.py
+++ b/netcanon/migration/canonical/vlan_names.py
@@ -50,24 +50,34 @@ Collision detection:
       non-collision rename conflict) → same merge semantics: the
       renamed VLAN's membership is unioned into the existing one.
 
-The orchestrator does NOT rename SVI interfaces (``Vlan10`` →
-``Vlan20``).  Those live in the port-rename pipeline's domain —
-their naming convention is vendor-specific (``Vlan10`` on Cisco,
-``vlan0.10`` on OPNsense, etc.), so it's the port-rename
-orchestrator's job to rewrite them.  If the operator wants SVI
-renames to follow their VLAN renames, the UI composes the two maps
-on the client side before posting.
+SVI interfaces named with the canonical ``Vlan<N>`` spelling (Cisco /
+Arista / NX-OS — the exact form render-side
+``synthesize_svis_from_vlan_l3`` keys off) DO track the VLAN rename
+(#18): renaming VLAN 10→20 also renames ``interface Vlan10`` → ``Vlan20``
+(merging into an existing ``Vlan20`` SVI rather than rendering two
+same-named stanzas), and dropping VLAN 10 removes the ``Vlan10`` SVI.
+Without this, the renamed VLAN's L3 rendered a fresh ``interface Vlan20``
+while the stale ``Vlan10`` still rendered — two overlapping-subnet SVIs
+the device rejects.  Vendor-specific SVI spellings that are NOT
+``Vlan<N>`` (OPNsense ``vlan0.10``, Junos ``irb.10``) are left to the
+port-rename orchestrator's domain.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
+
+# Canonical SVI interface spelling (Cisco / Arista / NX-OS) — the exact form
+# render-side ``synthesize_svis_from_vlan_l3`` synthesises and keys off.  Used
+# by Pass 2b (#18) to keep an SVI interface's name tracking its VLAN rename.
+_SVI_NAME_RE = re.compile(r"^Vlan(\d+)$")
 
 if TYPE_CHECKING:
     from .intent import CanonicalIntent
@@ -344,6 +354,56 @@ def translate_vlan_ids(  # noqa: C901
             iface.trunk_allowed_vlans = new_list
 
     # ------------------------------------------------------------------
+    # Pass 2b — track the rename/drop on canonical ``Vlan<N>`` SVIs (#18).
+    # ------------------------------------------------------------------
+    # A Cisco/Arista/NX-OS SVI is a CanonicalInterface named ``Vlan<N>``.  The
+    # passes above renamed the CanonicalVlan record + its folded L3 but left
+    # the SVI interface NAME untouched, so render-side synthesis emitted a new
+    # ``interface Vlan<M>`` (from the renamed VLAN's L3) while the stale
+    # ``Vlan<N>`` also rendered — two overlapping-subnet SVIs the device
+    # rejects, with no warning.  Rename the SVI alongside its VLAN (merging
+    # into a pre-existing ``Vlan<M>`` SVI) / drop it when the VLAN is dropped.
+    if renames or drops:
+        svi_kept: list = []
+        iface_by_name: dict[str, object] = {
+            i.name: i for i in intent.interfaces
+        }
+        for iface in intent.interfaces:
+            m = _SVI_NAME_RE.match(iface.name)
+            if m is None:
+                svi_kept.append(iface)
+                continue
+            svi_vid = int(m.group(1))
+            if svi_vid in drops:
+                result.warnings.append(
+                    f"vlan_rename: SVI interface {iface.name!r} removed "
+                    f"because VLAN {svi_vid} was dropped"
+                )
+                continue  # SVI disappears with its VLAN
+            if svi_vid in renames:
+                new_name = f"Vlan{renames[svi_vid]}"
+                existing = iface_by_name.get(new_name)
+                if existing is not None and existing is not iface:
+                    # A Vlan<M> SVI already exists — merge this SVI's L3
+                    # into it rather than render two same-named stanzas.
+                    _merge_svi_addresses(existing, iface)
+                    result.warnings.append(
+                        f"vlan_rename: SVI {iface.name!r} merged into existing "
+                        f"{new_name!r} (VLAN {svi_vid}->{renames[svi_vid]} "
+                        f"rename)"
+                    )
+                    continue
+                result.warnings.append(
+                    f"vlan_rename: SVI interface renamed {iface.name!r}->"
+                    f"{new_name!r} to track the VLAN "
+                    f"{svi_vid}->{renames[svi_vid]} rename"
+                )
+                iface.name = new_name
+                iface_by_name[new_name] = iface
+            svi_kept.append(iface)
+        intent.interfaces = svi_kept
+
+    # ------------------------------------------------------------------
     # Pass 3 — VXLAN VNI records carry a vlan_id that must track the rename.
     # ------------------------------------------------------------------
     # intent.py documents that CanonicalVxlan.vlan_id stays in sync with
@@ -415,6 +475,25 @@ def _merge_vlan(dest, src) -> None:
         dest.name = src.name
     if not dest.description and src.description:
         dest.description = src.description
+
+
+def _merge_svi_addresses(dest, src) -> None:
+    """Merge SVI *src* interface's L3 addresses into *dest* in-place (#18).
+
+    Used when a VLAN rename lands a ``Vlan<N>`` SVI onto an already-present
+    ``Vlan<M>`` interface — union the v4/v6 address lists (dedupe on
+    ``(ip, prefix_length)``) so the target renders one SVI, not two.
+    """
+    seen4 = {(a.ip, a.prefix_length) for a in dest.ipv4_addresses}
+    for a in src.ipv4_addresses:
+        if (a.ip, a.prefix_length) not in seen4:
+            seen4.add((a.ip, a.prefix_length))
+            dest.ipv4_addresses.append(a)
+    seen6 = {(a.ip, a.prefix_length) for a in dest.ipv6_addresses}
+    for a in src.ipv6_addresses:
+        if (a.ip, a.prefix_length) not in seen6:
+            seen6.add((a.ip, a.prefix_length))
+            dest.ipv6_addresses.append(a)
 
 
 def build_vlan_rename_transform(

--- a/tests/unit/migration/test_rename_orchestrator_completeness_medium.py
+++ b/tests/unit/migration/test_rename_orchestrator_completeness_medium.py
@@ -1,0 +1,184 @@
+"""Rename-orchestrator completeness — 2026-07-06 review theme 2 (#17-#20).
+
+The rename/transform orchestrators walked an incomplete canonical-reference
+set and misreported.  These are the four MEDIUM completeness gaps:
+
+* #17 port-rename target collision: two sources -> one name, no detection.
+* #18 VLAN rename with an existing SVI: two overlapping ``Vlan<N>`` stanzas.
+* #19 empty-string port-rename drop key deletes gateway-only routes / pools.
+* #20 ``project_switchport_to_vlan`` trunk-all stamp is order-dependent +
+  non-idempotent.
+
+All four are on the /plan-with-overrides (or codec-parse transform) path, not
+the bare cross-mesh, so they are mesh-flat.  Each assertion below fails against
+the pre-fix code (verified by stashing the fix).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalInterface,
+    CanonicalIPv4Address,
+    CanonicalStaticRoute,
+    CanonicalVlan,
+)
+from netcanon.migration.canonical.port_names import translate_port_names
+from netcanon.migration.canonical.transforms import project_switchport_to_vlan
+from netcanon.migration.canonical.vlan_names import translate_vlan_ids
+from netcanon.migration.codecs.cisco_iosxe_cli import CiscoIOSXECLICodec
+
+pytestmark = pytest.mark.unit
+
+
+# ── #17 port-rename target collision ───────────────────────────────────
+
+
+class TestPortRenameTargetCollision:
+    def test_two_sources_to_one_target_warns(self) -> None:
+        # Two ports renamed onto one target name previously collided silently
+        # (warnings=[]).  The orchestrator now surfaces it (warn-only: it does
+        # not drop config, so render-side dedup on targets that have it — e.g.
+        # FortiGate — still runs).
+        intent = CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(name="GigabitEthernet1/0/1", description="LINK-A"),
+                CanonicalInterface(name="GigabitEthernet1/0/2", description="LINK-B"),
+            ],
+        )
+        result = translate_port_names(
+            intent,
+            CiscoIOSXECLICodec(),
+            CiscoIOSXECLICodec(),
+            rename_map={
+                "GigabitEthernet1/0/1": "GigabitEthernet1/0/9",
+                "GigabitEthernet1/0/2": "GigabitEthernet1/0/9",
+            },
+        )
+        assert any(
+            "map to 'GigabitEthernet1/0/9'" in w and "GigabitEthernet1/0/1" in w
+            for w in result.warnings
+        )
+
+
+# ── #18 VLAN rename with an existing SVI ───────────────────────────────
+
+
+class TestSviRenameTracking:
+    def _svi_intent(self) -> CanonicalIntent:
+        return CanonicalIntent(
+            vlans=[CanonicalVlan(id=10, name="DATA")],
+            interfaces=[
+                CanonicalInterface(
+                    name="Vlan10",
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="10.1.1.1", prefix_length=24)
+                    ],
+                ),
+            ],
+        )
+
+    def test_rename_renames_the_svi_interface(self) -> None:
+        intent = self._svi_intent()
+        translate_vlan_ids(intent, {10: 20})
+        names = [i.name for i in intent.interfaces]
+        assert names == ["Vlan20"]  # not both Vlan10 and Vlan20
+
+    def test_drop_removes_the_svi_interface(self) -> None:
+        intent = self._svi_intent()
+        result = translate_vlan_ids(intent, {10: None})
+        assert [i.name for i in intent.interfaces] == []
+        assert any("Vlan10" in w and "dropped" in w for w in result.warnings)
+
+    def test_rename_onto_existing_svi_merges(self) -> None:
+        intent = CanonicalIntent(
+            vlans=[CanonicalVlan(id=10), CanonicalVlan(id=20)],
+            interfaces=[
+                CanonicalInterface(
+                    name="Vlan10",
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="10.1.1.1", prefix_length=24)
+                    ],
+                ),
+                CanonicalInterface(
+                    name="Vlan20",
+                    ipv4_addresses=[
+                        CanonicalIPv4Address(ip="10.2.2.1", prefix_length=24)
+                    ],
+                ),
+            ],
+        )
+        translate_vlan_ids(intent, {10: 20})
+        svis = [i for i in intent.interfaces if i.name == "Vlan20"]
+        assert len(svis) == 1  # merged, not duplicated
+        ips = {a.ip for a in svis[0].ipv4_addresses}
+        assert ips == {"10.1.1.1", "10.2.2.1"}
+
+
+# ── #19 empty-string drop key ──────────────────────────────────────────
+
+
+class TestEmptyKeyDropGuard:
+    def test_empty_key_does_not_delete_gateway_only_route(self) -> None:
+        intent = CanonicalIntent(
+            static_routes=[
+                CanonicalStaticRoute(destination="0.0.0.0/0", gateway="1.2.3.4"),
+            ],
+        )
+        result = translate_port_names(
+            intent,
+            CiscoIOSXECLICodec(),
+            CiscoIOSXECLICodec(),
+            rename_map={"": None},
+        )
+        # The default route (interface == '') must survive the empty drop key.
+        assert len(intent.static_routes) == 1
+        assert intent.static_routes[0].destination == "0.0.0.0/0"
+        assert any("empty or blank" in w for w in result.warnings)
+
+
+# ── #20 trunk-all projection order-independence + idempotency ──────────
+
+
+class TestProjectSwitchportTrunkAllOrder:
+    def _uplink_before_access(self) -> CanonicalIntent:
+        # Trunk-all uplink DECLARED BEFORE an access port whose VLAN has no
+        # top-level stanza (realistic: stacked switch, uplink on member 1).
+        return CanonicalIntent(
+            interfaces=[
+                CanonicalInterface(
+                    name="Ethernet1",
+                    switchport_mode="trunk",
+                    trunk_allowed_vlans=list(range(1, 4095)),  # trunk-all sentinel
+                ),
+                CanonicalInterface(
+                    name="Ethernet2",
+                    switchport_mode="access",
+                    access_vlan=99,  # no CanonicalVlan(99) declared
+                ),
+            ],
+        )
+
+    def test_trunk_all_stamps_regardless_of_interface_order(self) -> None:
+        intent = self._uplink_before_access()
+        project_switchport_to_vlan(intent)
+        vlan99 = next(v for v in intent.vlans if v.id == 99)
+        # The trunk-all uplink must be tagged on the later-synthesised VLAN.
+        assert "Ethernet1" in vlan99.tagged_ports
+        assert "Ethernet2" in vlan99.untagged_ports
+
+    def test_projection_is_idempotent(self) -> None:
+        intent = self._uplink_before_access()
+        project_switchport_to_vlan(intent)
+        first = {
+            v.id: (sorted(v.tagged_ports), sorted(v.untagged_ports))
+            for v in intent.vlans
+        }
+        project_switchport_to_vlan(intent)
+        second = {
+            v.id: (sorted(v.tagged_ports), sorted(v.untagged_ports))
+            for v in intent.vlans
+        }
+        assert first == second


### PR DESCRIPTION
## What

Closes the four MEDIUM **rename-orchestrator completeness** gaps from the 2026-07-06 Fable review (theme 2 — orchestrators walk an incomplete canonical-reference set and misreport). All on the `/plan-with-overrides` (or codec-parse transform) path → **mesh-flat**.

| # | Gap | Fix |
|---|---|---|
| 17 | Port-rename target collision was silent (`warnings=[]`) | Detect + **warn** naming the colliding sources (warn-only — don't drop/merge, so FortiGate's render-time dedup+comment still runs) |
| 18 | VLAN rename left the `Vlan<N>` SVI interface name stale → two overlapping SVIs | New **Pass 2b** renames the SVI with its VLAN (merges into a pre-existing `Vlan<M>`) / drops it on VLAN drop; fixed the false "UI composes the maps" docstring |
| 19 | `{'': None}` drop key deleted every gateway-only route + unbound DHCP pool | Reject empty/blank source keys before the split (mirrors `local_user_names.py`) + guard `_strip_dropped_ports` on a truthy interface |
| 20 | `project_switchport_to_vlan` trunk-all stamp order-dependent + non-idempotent | Two-pass: **PASS 1** materialise all referenced VLANs, **PASS 2** stamp — trunk-all now sees the full set regardless of interface order |

## Why warn-only for #17

Two distinct source ports auto-translating to the same target name is a genuine collision, but FortiGate **already** dedupes and emits `# port collision: <name>` at render time. Dropping the loser at the orchestrator would pre-empt that and silently discard a port's config — worse than the warn. So the orchestrator surfaces the collision (the review's core ask: no more `warnings=[]`) without changing data flow; the existing render-side handling is preserved (`test_collision_emits_review_comment` passes unchanged).

## Mesh impact

`project_switchport_to_vlan` (#20) runs in the bare codec-parse path, so it's the one change the cross-mesh guard validates — **byte-identical** on the committed corpus (each codec's phantom-VLAN guard prunes the synthesised VLANs the fix touches). The port/vlan-name orchestrators run only on `/plan-with-overrides`. Cross-mesh guard **7/7** (CODEC_BUG=5, cells=1224, drift flat).

## Negative control

`tests/unit/migration/test_rename_orchestrator_completeness_medium.py` — all **7** assertions **FAIL** against the pre-fix code (verified by stashing the three source files) and pass after.

## Testing

`ruff` clean; `tests/unit` **5245 passed / 81 skipped**; `tests/integration/test_cross_mesh_ci_guard.py` **7/7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
