### PR TITLE
fix(api): engage auto port-name translation on the four per-pane endpoints (#16)

### DIFF
--- a/netcanon/api/routes/migration.py
+++ b/netcanon/api/routes/migration.py
@@ -409,6 +409,11 @@ def plan_migration_vlans(
     raw_text = resolve_input_text(body, storage)
     job = run_plan_with_overrides(
         source, target, raw_text,
+        # (#16) Engage auto port-name translation like /plan's default path;
+        # {} is auto-only (an explicit port map on this VLAN pane stays
+        # ignored) — without it the render leaks invalid source-vendor
+        # interface names that /plan translates.
+        port_rename_map={},
         vlan_rename_map=body.vlan_rename_map or {},
         force=body.force,
     )
@@ -472,6 +477,9 @@ def plan_migration_local_users(
     raw_text = resolve_input_text(body, storage)
     job = run_plan_with_overrides(
         source, target, raw_text,
+        # (#16) Engage auto port-name translation like /plan; {} is auto-only
+        # (an explicit port map on this pane stays ignored).
+        port_rename_map={},
         local_user_rename_map=body.local_user_rename_map or {},
         force=body.force,
     )
@@ -536,6 +544,9 @@ def plan_migration_snmp(
     raw_text = resolve_input_text(body, storage)
     job = run_plan_with_overrides(
         source, target, raw_text,
+        # (#16) Engage auto port-name translation like /plan; {} is auto-only
+        # (an explicit port map on this pane stays ignored).
+        port_rename_map={},
         snmp_community_rename_map=body.snmp_community_rename_map or {},
         force=body.force,
     )
@@ -600,6 +611,9 @@ def plan_migration_snmpv3(
     raw_text = resolve_input_text(body, storage)
     job = run_plan_with_overrides(
         source, target, raw_text,
+        # (#16) Engage auto port-name translation like /plan; {} is auto-only
+        # (an explicit port map on this pane stays ignored).
+        port_rename_map={},
         snmpv3_user_rename_map=body.snmpv3_user_rename_map or {},
         force=body.force,
     )

--- a/tests/integration/test_migration_api.py
+++ b/tests/integration/test_migration_api.py
@@ -744,10 +744,15 @@ interface GigabitEthernet1/0/1
         )
         assert resp.status_code == 200
         body = resp.json()
-        # VLAN applied, port NOT applied.
+        # VLAN applied.  Port auto-translation IS now engaged (#16) — Gi1/0/1
+        # -> aruba 1/1 — so the render carries no invalid source-vendor name;
+        # but the EXPLICIT port map on this VLAN pane is still ignored
+        # (GigabitEthernet99 never applied).
         vlan_renames = body["vlan_renames"]
         assert "10" in vlan_renames or 10 in vlan_renames
-        assert body["port_renames"] == {}
+        assert body["port_renames"].get("GigabitEthernet1/0/1") == "1/1"
+        assert "GigabitEthernet99" not in body["port_renames"].values()
+        assert "GigabitEthernet1/0/1" not in (body["rendered"] or "")
 
 
 class TestPlanLocalUsersEndpoint:
@@ -837,8 +842,11 @@ interface GigabitEthernet1/0/1
         assert resp.status_code == 200
         body = resp.json()
         assert body["local_user_renames"] == {"admin": "netadmin"}
-        # Neither port nor VLAN maps engaged.
-        assert body["port_renames"] == {}
+        # VLAN map ignored; port auto-translation IS engaged (#16) — Gi1/0/1
+        # -> aruba 1/1 — but the EXPLICIT port map (GigabitEthernet99) is not
+        # applied.
+        assert body["port_renames"].get("GigabitEthernet1/0/1") == "1/1"
+        assert "GigabitEthernet99" not in body["port_renames"].values()
         assert body["vlan_renames"] == {}
 
 
@@ -1942,3 +1950,39 @@ class TestDroppedTier3SectionsWireThrough:
         # ACL header is in dropped_tier3_sections (notification),
         # NOT in rendered (would mean we accidentally translated it).
         assert "access-list extended OUTSIDE_IN" not in rendered
+
+
+class TestPerPanePortNameParity:
+    """(#16) Every per-pane endpoint must engage auto port-name translation
+    like /plan, so a cross-vendor render never leaks an invalid source-vendor
+    interface name — even when the pane's own category map is empty.  Before
+    the fix, /plan/{vlans,local_users,snmp,snmpv3} left port_rename_map=None,
+    disengaging the translator and rendering ``GigabitEthernet1/0/1`` verbatim
+    into a Junos config."""
+
+    _IOSXE = (
+        "hostname r1\n!\n"
+        "interface GigabitEthernet1/0/1\n"
+        " description uplink\n"
+        "!\n"
+        "vlan 10\n name DATA\n!\n"
+    )
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        ["plan/vlans", "plan/local_users", "plan/snmp", "plan/snmpv3"],
+    )
+    def test_per_pane_translates_port_names(self, client, endpoint):
+        resp = client.post(
+            f"/api/v1/migration/{endpoint}",
+            json={
+                "source": "cisco_iosxe_cli",
+                "target": "juniper_junos",
+                "raw_text": self._IOSXE,
+            },
+        )
+        assert resp.status_code == 200
+        rendered = resp.json().get("rendered") or ""
+        # Source-vendor name must NOT survive; the Junos-format name must.
+        assert "GigabitEthernet1/0/1" not in rendered
+        assert "ge-1/0/1" in rendered


### PR DESCRIPTION
## What

`/plan/vlans`, `/plan/local_users`, `/plan/snmp`, `/plan/snmpv3` called `run_plan_with_overrides` **without** `port_rename_map`, leaving it `None` — which disengages the port-name translator. The same body that renders `ge-1/0/2` on `/plan` rendered the invalid source-vendor `GigabitEthernet1/0/2` on `/plan/vlans`, contradicting `/plan`'s own post-v0.5.0 contract (2026-07-06 review MEDIUM #16). Exposure is API-only (the shipped UI posts only to `/plan`).

## Fix

Pass `port_rename_map={}` in all four handlers — **auto-only**, matching `/plan`'s else-branch (#254). `{}` engages auto-translation while still ignoring an explicit port map posted to a non-port pane, preserving each endpoint's documented "apply this category only" contract (the alternative `body.port_rename_map if not None else {}` would newly *honor* such a map, breaking that contract).

## Tests

- Relaxed the two ignore-tests that asserted `port_renames == {}` → now assert the **explicit** override (`GigabitEthernet99`) is *not* applied **and** the port auto-translates (`Gi1/0/1 → aruba 1/1`), with no source-vendor name in the render. (`/plan/snmp`'s ignore-test is unchanged — its fixture has no interfaces, so `port_renames` stays `{}` there.)
- New `TestPerPanePortNameParity`: a cisco→junos body through **each** of the four per-pane endpoints must render `ge-1/0/1` and never `GigabitEthernet1/0/1`.

## Mesh impact

API-only — the cross-mesh harness runs bare `parse→render`, never these handlers. **Mesh-flat** (cross-mesh guard 7/7, CODEC_BUG=5, cells=1224).

## Negative control

The 2 relaxed ignore-tests + all 4 parity tests **FAIL** against the pre-fix handlers (verified by stashing `migration.py`).

## Testing

`ruff` clean; `tests/unit` **5245 passed / 81 skipped**; `tests/integration/test_migration_api.py` **115 passed**; cross-mesh guard **7/7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
