### PR TITLE
fix(honesty): declare SNMPv3 algo substitution + DHCP lease-time loss (#23/#24)

### DIFF
--- a/netcanon/migration/canonical/xpath_walker.py
+++ b/netcanon/migration/canonical/xpath_walker.py
@@ -292,8 +292,23 @@ def _walk_canonical(intent: CanonicalIntent) -> Iterable[str]:  # noqa: C901
                 yield "/snmp/v3-user/group"
             if v3.engine_id:
                 yield "/snmp/v3-user/engine-id"
-    for _ in intent.dhcp_servers:
+    for pool in intent.dhcp_servers:
         yield "/dhcp-servers/pool"
+        # (#24) DHCP was the one Tier-2 surface with no sub-field vocabulary,
+        # so a codec that drops a pool sub-field (MikroTik silently resets a
+        # non-default lease_time to the 86400 default) could not declare it
+        # honestly — a /dhcp-servers/pool/lease-time declaration was flagged as
+        # a dead path by the honesty guard.  Walk the sub-fields (only when
+        # populated / non-default) so classify() sees them instead of
+        # fail-opening to "supported".
+        if pool.gateway:
+            yield "/dhcp-servers/pool/gateway"
+        if pool.dns_servers:
+            yield "/dhcp-servers/pool/dns-servers"
+        if pool.domain_name:
+            yield "/dhcp-servers/pool/domain-name"
+        if pool.lease_time is not None and pool.lease_time != 86400:
+            yield "/dhcp-servers/pool/lease-time"
     for _ in intent.lags:
         yield "/lags/lag/name"
         yield "/lags/lag/members"

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -241,6 +241,27 @@ class ArubaAOSSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/snmp/v3-user/auth-protocol",
+                reason=(
+                    "AOS-S emits the auth protocol verbatim but its parser "
+                    "accepts only md5 / sha / sha256; sha224 / sha384 / sha512 "
+                    "render an unreadable clause that drops the auth config on "
+                    "re-parse.  Declared lossy so the loss is not reported as "
+                    "severity:ok (#23)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason=(
+                    "AOS-S privacy emits aes128 as bare `aes`, losing the "
+                    "key-length designation, and has no representation for "
+                    "aes192 / aes256; the privacy config round-trips lossily. "
+                    "Declared lossy so validate_against surfaces it (#23)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -251,6 +251,38 @@ class MikroTikRouterOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
+                path="/snmp/v3-user/auth-protocol",
+                reason=(
+                    "RouterOS SNMPv3 auth supports only MD5 / SHA1; the "
+                    "renderer substitutes sha224->SHA256, sha384->SHA512, and "
+                    "any unknown algorithm->SHA1, so an SNMP manager keyed for "
+                    "the source algorithm stops authenticating.  Declared lossy "
+                    "so validate_against surfaces the downgrade (#23)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/snmp/v3-user/priv-protocol",
+                reason=(
+                    "RouterOS SNMPv3 privacy supports only DES / AES; the "
+                    "renderer substitutes 3des->DES (a strength DOWNGRADE) and "
+                    "any unknown algorithm->AES.  Declared lossy so the crypto "
+                    "substitution is not reported as severity:ok (#23)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/dhcp-servers/pool/lease-time",
+                reason=(
+                    "RouterOS lease-time lives on the `/ip dhcp-server` "
+                    "instance, not the `/ip dhcp-server network` this codec "
+                    "renders, so a non-default lease_time is not emitted and "
+                    "re-parses as the 86400 default — a 2h lease policy "
+                    "silently becomes 1 day.  Declared lossy (#24)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/routing/static-route/metric",
                 reason=(
                     "Render emits destination + gateway + comment only; the "

--- a/tests/unit/migration/test_dhcp_snmpv3_lossy_honesty_medium.py
+++ b/tests/unit/migration/test_dhcp_snmpv3_lossy_honesty_medium.py
@@ -1,0 +1,79 @@
+"""Honesty-machinery lossy declarations — 2026-07-06 review theme 3 (#23/#24).
+
+Two declared-supported-but-actually-lossy surfaces were silent (classify()
+fail-opened to "supported"):
+
+* #23 MikroTik + AOS-S substitute SNMPv3 auth/priv algorithms on render
+  (sha224->SHA256, 3des->DES, aes128->aes, ...) with no lossy declaration, so
+  validation reported ok during a crypto change.
+* #24 DHCP pool had zero sub-field walker vocabulary, so MikroTik (which drops
+  a non-default lease_time to the 86400 default) could not declare the loss —
+  a /dhcp-servers/pool/lease-time declaration was flagged a dead path.
+
+Matrix/walker-only — no parse/render change, so mesh-flat.  Each assertion
+fails against the pre-fix code (verified by stashing).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalDHCPPool,
+    CanonicalIntent,
+)
+from netcanon.migration.canonical.xpath_walker import _walk_canonical
+from netcanon.migration.codecs.registry import get_codec
+
+pytestmark = pytest.mark.unit
+
+
+# ── #23 SNMPv3 algorithm substitution declared lossy ───────────────────
+
+
+@pytest.mark.parametrize("codec_name", ["mikrotik_routeros", "aruba_aoss"])
+@pytest.mark.parametrize(
+    "path", ["/snmp/v3-user/auth-protocol", "/snmp/v3-user/priv-protocol"]
+)
+def test_snmpv3_algorithm_substitution_declared_lossy(codec_name, path):
+    caps = get_codec(codec_name).capabilities
+    assert caps.classify(path) == "lossy", (
+        f"{codec_name} silently substitutes {path} — must declare it lossy "
+        "so validation surfaces the crypto downgrade (#23)"
+    )
+
+
+# ── #24 DHCP lease-time walker vocabulary + MikroTik lossy ──────────────
+
+
+def _pool_intent(lease_time: int) -> CanonicalIntent:
+    return CanonicalIntent(
+        dhcp_servers=[CanonicalDHCPPool(
+            network="10.0.0.0/24", start_ip="10.0.0.10", end_ip="10.0.0.99",
+            gateway="10.0.0.1", dns_servers=["10.0.0.2"],
+            domain_name="lab.example", lease_time=lease_time,
+        )],
+    )
+
+
+def test_dhcp_subfields_are_walked_when_populated():
+    walked = set(_walk_canonical(_pool_intent(7200)))
+    assert "/dhcp-servers/pool/gateway" in walked
+    assert "/dhcp-servers/pool/dns-servers" in walked
+    assert "/dhcp-servers/pool/domain-name" in walked
+    # Non-default lease -> walked (so a dropping codec can declare it).
+    assert "/dhcp-servers/pool/lease-time" in walked
+
+
+def test_default_lease_time_is_not_walked():
+    # The 86400 default round-trips implicitly, so no codec need declare it.
+    walked = set(_walk_canonical(_pool_intent(86400)))
+    assert "/dhcp-servers/pool/lease-time" not in walked
+
+
+def test_mikrotik_declares_lease_time_lossy():
+    caps = get_codec("mikrotik_routeros").capabilities
+    assert caps.classify("/dhcp-servers/pool/lease-time") == "lossy", (
+        "MikroTik silently resets a non-default lease_time to 86400 — must "
+        "declare /dhcp-servers/pool/lease-time lossy (#24)"
+    )

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -205,7 +205,13 @@ def _maximal_intent() -> CanonicalIntent:
             metric=200, description="primary uplink", interface="Ethernet2")],
         anycast_gateway_mac="00:1c:73:00:dc:01",
         dhcp_servers=[CanonicalDHCPPool(
-            network="10.0.0.0/24", start_ip="10.0.0.10", end_ip="10.0.0.99")],
+            network="10.0.0.0/24", start_ip="10.0.0.10", end_ip="10.0.0.99",
+            # (#24) Populate the sub-fields + a NON-default lease so the walker
+            # yields /dhcp-servers/pool/{gateway,dns-servers,domain-name,
+            # lease-time} — otherwise a codec's lease-time lossy declaration is
+            # an un-walkable dead path the honesty guard rejects.
+            gateway="10.0.0.1", dns_servers=["10.0.0.2"],
+            domain_name="lab.example", lease_time=7200)],
         snmp=CanonicalSNMP(
             community="c", location="l", contact="ct", trap_hosts=["10.0.0.9"],
             v3_users=[CanonicalSNMPv3User(

--- a/tests/unit/migration/test_snmpv3_subfield_walk_expansion.py
+++ b/tests/unit/migration/test_snmpv3_subfield_walk_expansion.py
@@ -32,12 +32,14 @@ _SUBPATHS = [
 # explicit lossy/unsupported declaration or the silent loss returns.
 _EXPECTED: dict[str, dict[str, str]] = {
     "/snmp/v3-user/auth-protocol": {
-        "aruba_aoscx": "lossy", "vyos": "lossy",
+        "aruba_aoscx": "lossy", "aruba_aoss": "lossy",
+        "mikrotik_routeros": "lossy", "vyos": "lossy",
         "cisco_iosxe": "unsupported", "cisco_iosxr": "unsupported",
         "opnsense": "unsupported",
     },
     "/snmp/v3-user/priv-protocol": {
-        "aruba_aoscx": "lossy", "fortigate_cli": "lossy", "vyos": "lossy",
+        "aruba_aoscx": "lossy", "aruba_aoss": "lossy", "fortigate_cli": "lossy",
+        "mikrotik_routeros": "lossy", "vyos": "lossy",
         "cisco_iosxe": "unsupported", "cisco_iosxr": "unsupported",
         "opnsense": "unsupported",
     },


### PR DESCRIPTION
## What

Two declared-supported-but-actually-lossy surfaces from the 2026-07-06 review (theme 3, honesty-machinery blind spots) where `classify()` fail-opened to `"supported"` so validation reported `ok` during a real loss. **Matrix + walker only — no parse/render change → mesh-flat.**

### #23 — SNMPv3 auth/priv algorithm substitution

- MikroTik render substitutes `sha224→SHA256`, `sha384→SHA512`, `3des→DES` (a strength downgrade), `unknown→SHA1|AES`.
- AOS-S emits the auth protocol verbatim: its parser accepts only `md5/sha/sha256`, so `sha224/384/512` render an unreadable clause that drops on re-parse; `aes128` emits as bare `aes`.

The walker already yields `/snmp/v3-user/{auth,priv}-protocol`; six codecs declared them, MikroTik and AOS-S didn't → an SNMP manager keyed for the source algorithm silently stopped authenticating. Added the four `LossyPath` declarations + the `mikrotik_routeros`/`aruba_aoss = lossy` rows in the walk-expansion disposition matrix.

### #24 — DHCP lease-time (the one Tier-2 surface with no sub-field vocabulary)

MikroTik's render omits a non-default `lease_time` (RouterOS keeps it on the `/ip dhcp-server` instance, not the `network` this codec renders) → it re-parses as the 86400 default: a 2h lease policy silently becomes 1 day. The codec **could not declare it** — a `/dhcp-servers/pool/lease-time` declaration was flagged a dead path because the walker only yielded the bare `/dhcp-servers/pool` anchor.

Extended `_walk_canonical` with conditional DHCP sub-field yields (`gateway`/`dns-servers`/`domain-name` when populated; `lease-time` when `!= 86400`), declared `/dhcp-servers/pool/lease-time` lossy on MikroTik, and populated the `_maximal_intent` DHCP pool so the new paths are walkable. The other 5 DHCP-rendering codecs round-trip the sub-fields, so the expansion forces no new declarations on them.

## Mesh impact

`LossyPath` is not an `UnsupportedPath`, and the cross-mesh comparator reads only the unsupported list + `model_dump()` — never the walker. **Mesh-flat** (cross-mesh guard 7/7).

## Negative control

`tests/unit/migration/test_dhcp_snmpv3_lossy_honesty_medium.py` — all fix-dependent assertions **FAIL** against the pre-fix code (verified by stashing the walker + two matrices); the `default-86400-not-walked` control passes both ways.

## Testing

`ruff` clean; `tests/unit` **5252 passed / 81 skipped**; cross-mesh guard **7/7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
