### PR TITLE
fix(mikrotik): preserve VRRP VIP prefix instead of the parent-interface mask (#22)

### DIFF
--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -601,6 +601,14 @@ class CanonicalVRRPGroup(BaseModel):
             ``vrrp N track Ethernet1 decrement 10``.  The
             priority-decrement value is per-vendor lossy.
         description: Operator-supplied description.
+        virtual_ip_prefix: Prefix length (0-32) of the IPv4 VIP when the
+            vendor carries the VIP with its own mask (MikroTik ``/ip address
+            add address=X/Y interface=vrrpN``).  ``0`` = unset; the renderer
+            then falls back to the parent interface's prefix.  Only MikroTik
+            populates it today — other vendors' VRRP VIPs have no independent
+            mask (#22).
+        virtual_ip6_prefix: IPv6 counterpart (0-128); ``0`` = unset (renderer
+            falls back to the parent v6 prefix / ``/128`` host form).
 
     Wired in v0.2.0 (Wave B/C): the seven bidirectional codecs declare
     ``/interfaces/interface/vrrp-groups/group`` ``supported``/``lossy``
@@ -620,6 +628,11 @@ class CanonicalVRRPGroup(BaseModel):
     authentication: str = ""
     track_interfaces: list[str] = Field(default_factory=list)
     description: str = ""
+    # (#22) VIP prefix carried on the group when the vendor models the VIP
+    # with its own mask (MikroTik).  0 = unset -> render falls back to the
+    # parent interface prefix.  Walked only when non-zero (see xpath_walker).
+    virtual_ip_prefix: int = Field(default=0, ge=0, le=32)
+    virtual_ip6_prefix: int = Field(default=0, ge=0, le=128)
 
 
 class CanonicalLocalUser(BaseModel):

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -885,6 +885,11 @@ def _materialise_vrrp_groups(
             preempt=scratch["preempt"],
             advertisement_interval=scratch["advertisement_interval"],
             authentication=scratch["authentication"],
+            # (#22) Carry the VIP prefix stashed by the /ip[v6] address
+            # post-pass onto the group so render preserves the on-wire netmask
+            # instead of falling back to the parent interface's prefix.
+            virtual_ip_prefix=scratch.get("virtual_ip_prefix", 0),
+            virtual_ip6_prefix=scratch.get("virtual_ip6_prefix", 0),
         )
         parent_iface.vrrp_groups.append(group)
 

--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -1006,16 +1006,14 @@ def _render_vrrp(
     the address emit.  Mirrors the per-user review-comment pattern in
     the ``/user`` render block.
 
-    VIP prefix-length recovery:
-    * If the canonical record was created by the MikroTik parser, the
-      prefix lives in the scratch dict (see ``_parse_interface_vrrp``)
-      and is mirrored onto the group via the ``virtual_ip_prefix``
-      hint stashed on the parent interface during a same-vendor round-
-      trip.  Currently we use the parent interface's first ipv4 prefix
-      as a fallback when the source canonical tree didn't carry one
-      (cross-vendor case).
-    * IPv6 VIPs fall back to ``/128`` host-form when no parent prefix
-      is available.
+    VIP prefix-length recovery (#22):
+    * ``CanonicalVRRPGroup.virtual_ip_prefix`` / ``virtual_ip6_prefix``
+      carry the VIP mask when the source modelled it (the MikroTik parser
+      stashes it via the ``/ip[v6] address`` post-pass); render prefers it so
+      a same-vendor round-trip preserves the on-wire netmask.
+    * When the group carries no prefix (``0`` — the cross-vendor case, where
+      the source VIP had no independent mask) we fall back to the parent
+      interface's first ipv4 prefix, and ``/128`` host-form for IPv6.
     """
     vrrp_lines: list[str] = []
     v4_rows: list[tuple[str, int, str]] = []
@@ -1059,16 +1057,18 @@ def _render_vrrp(
             parts.extend(auth_kv)
             vrrp_lines.append(" ".join(parts))
 
-            # /ip address VIP rows — fall back to parent's first ipv4
-            # prefix when the canonical record didn't preserve one.
-            v4_prefix = (
+            # /ip address VIP rows — prefer the prefix the group carried
+            # (#22: MikroTik source stashes it), else fall back to the parent's
+            # first ipv4 prefix.  Without the group prefix a same-vendor
+            # round-trip silently rewrote e.g. a /28 VIP to the parent's /24.
+            v4_prefix = group.virtual_ip_prefix or (
                 iface.ipv4_addresses[0].prefix_length
                 if iface.ipv4_addresses else 32
             )
             for vip in group.virtual_ips:
                 v4_rows.append((vip, v4_prefix, pseudo_name))
             # /ipv6 address VIP rows.
-            v6_prefix = (
+            v6_prefix = group.virtual_ip6_prefix or (
                 iface.ipv6_addresses[0].prefix_length
                 if iface.ipv6_addresses else 128
             )

--- a/tests/unit/migration/codecs/mikrotik_routeros/test_vrrp_vip_prefix_medium.py
+++ b/tests/unit/migration/codecs/mikrotik_routeros/test_vrrp_vip_prefix_medium.py
@@ -1,0 +1,51 @@
+"""MikroTik VRRP VIP prefix must round-trip (2026-07-06 review MEDIUM #22).
+
+RouterOS models the VRRP virtual IP with its own mask on the
+``/ip address add address=X/Y interface=vrrpN`` line.  The parser stashed the
+prefix but ``_materialise_vrrp_groups`` dropped it (written, never read), so
+render fell back to the PARENT interface's prefix — a same-vendor sanitize
+silently rewrote e.g. a ``/28`` VIP to the parent's ``/24``, altering the
+connected route.  The fix carries the prefix on ``CanonicalVRRPGroup`` and
+render prefers it.
+
+No committed MikroTik VRRP fixture exists, so this is mesh-flat.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.mikrotik_routeros import MikroTikRouterOSCodec
+
+pytestmark = pytest.mark.unit
+
+_CFG = """\
+/interface ethernet
+add name=ether1
+/interface vrrp
+add interface=ether1 name=vrrp10 vrid=10 priority=110
+/ip address
+add address=10.0.0.1/24 interface=ether1
+add address=10.0.0.100/28 interface=vrrp10
+"""
+
+
+def _group(intent):
+    return next(
+        g for iface in intent.interfaces for g in iface.vrrp_groups
+    )
+
+
+def test_vip_prefix_is_parsed_onto_the_group():
+    intent = MikroTikRouterOSCodec().parse(_CFG)
+    assert _group(intent).virtual_ip_prefix == 28
+
+
+def test_vip_prefix_round_trips_not_parent_fallback():
+    codec = MikroTikRouterOSCodec()
+    rendered = codec.render(codec.parse(_CFG))
+    # The VIP row must keep its own /28 — NOT the parent ether1 /24.
+    assert "add address=10.0.0.100/28 interface=vrrp10" in rendered
+    assert "10.0.0.100/24" not in rendered
+    # And it survives a full round-trip on the canonical surface.
+    assert _group(codec.parse(rendered)).virtual_ip_prefix == 28

--- a/tests/unit/migration/test_walker_completeness.py
+++ b/tests/unit/migration/test_walker_completeness.py
@@ -174,6 +174,12 @@ _WALK_EXEMPT: dict[tuple[str, str], tuple[str, str]] = {
     ("CanonicalEvpnType5Route", "rt_exports"): ("ENVELOPE_AUDIT_BACKSTOPPED", "EVPN-Type5 sub-leaf; audit-backstopped"),
     ("CanonicalRADIUSServer", "auth_port"): ("ENVELOPE_AUDIT_BACKSTOPPED", "defaulted 1812; non-default backstopped"),
     ("CanonicalRADIUSServer", "acct_port"): ("ENVELOPE_AUDIT_BACKSTOPPED", "defaulted 1813; non-default backstopped"),
+    # (#22) VIP prefix is a MikroTik-specific VIP mask (other vendors' VRRP
+    # VIPs have no independent prefix).  The /vrrp-groups/group envelope is
+    # walked; MikroTik round-trips the prefix losslessly and it is now a model
+    # field, so the offline cross-mesh model_dump audit backstops any drop.
+    ("CanonicalVRRPGroup", "virtual_ip_prefix"): ("ENVELOPE_AUDIT_BACKSTOPPED", "MikroTik VIP mask; audit-backstopped"),
+    ("CanonicalVRRPGroup", "virtual_ip6_prefix"): ("ENVELOPE_AUDIT_BACKSTOPPED", "MikroTik v6 VIP mask; backstopped"),
     # NOTE: the former KNOWN_GAP exemptions (IPv6 scope, routing-instance
     # instance_type, static-route gateway) are now WALKED -- PR-2c (audit
     # e5b77d7) closed the last three silent-loss leaves, completing the


### PR DESCRIPTION
## What

RouterOS models the VRRP virtual IP with its own mask (`/ip address add address=X/Y interface=vrrpN`). The parser stashed the prefix but `_materialise_vrrp_groups` never read it — so render fell back to the **parent interface's** prefix, silently rewriting e.g. a `/28` VIP to the parent's `/24` on a same-vendor round-trip, altering the connected route with no banner (2026-07-06 review MEDIUM #22). The render docstring even *claimed* the mirroring worked — it didn't.

## Fix

- `CanonicalVRRPGroup` gains optional `virtual_ip_prefix` / `virtual_ip6_prefix` ints (`0` = unset). Only MikroTik populates them — other vendors' VRRP VIPs have no independent mask.
- MikroTik parse carries the stashed prefix onto the group; `_render_vrrp` prefers `group.virtual_ip[6]_prefix` over the parent fallback (docstring corrected).

```
# before:  add address=10.0.0.100/24 interface=vrrp10   (parent ether1 /24)
# after:   add address=10.0.0.100/28 interface=vrrp10   (VIP's own /28)
```

## Walker-completeness

The two new leaves are **exempt** (`ENVELOPE_AUDIT_BACKSTOPPED`): the `/vrrp-groups/group` envelope is walked, MikroTik round-trips the prefix losslessly, and it's now a model field so the offline cross-mesh `model_dump` audit backstops any drop. Walking + declaring it across ~11 codecs would be disproportionate for a MikroTik-only refinement (matches the DHCP/EVPN/RADIUS sub-field pattern).

## Mesh impact

No committed MikroTik VRRP fixture exists → **mesh-flat** (cross-mesh guard 7/7, CODEC_BUG=5, cells=1224).

## Negative control

`tests/unit/migration/codecs/mikrotik_routeros/test_vrrp_vip_prefix_medium.py` — the round-trip assertion **FAILS** with `render.py` stashed (emits `/24`) and passes after; the parse assertion is independent.

## Testing

`ruff` clean; `tests/unit` **5254 passed / 81 skipped**; cross-mesh guard **7/7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
