### PR TITLE
fix(arista): harvest the vrf definition stanza body (rd/description/rt) (#21)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -141,6 +141,17 @@ class AristaEOSCodec(CodecBase):
         ],
         lossy=[
             LossyPath(
+                path="/routing-instances/instance/description",
+                reason=(
+                    "The VRF/routing-instance is harvested with its rd + "
+                    "route-targets (which render under `router bgp / vrf`), "
+                    "but EOS render has no `vrf instance <name> / description` "
+                    "emit path, so a description parsed from a legacy "
+                    "`vrf definition` stanza is dropped on render (#21)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(
                     "Arista EOS renders only IETF VRRP; a cross-family source "

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -184,7 +184,54 @@ _RADIUS_KEY_RE = re.compile(r'\bkey\s+(?:"([^"]*)"|(\S+))')
 _VRF_INSTANCE_RE = re.compile(
     r"^vrf\s+(?:instance|definition)\s+(\S+)\s*$", re.MULTILINE
 )
+# (#21) Indented body lines inside a ``vrf instance|definition`` stanza.
+# Pre-4.23 EOS (the ``vrf definition`` dialect) carries rd / description /
+# route-target IOS-style in the stanza body; the header-only harvest dropped
+# them.  ``route-target`` accepts the optional EOS ``evpn`` keyword.
+_VRF_RD_RE = re.compile(r"^\s+rd\s+(\S+)\s*$")
+_VRF_DESC_RE = re.compile(r"^\s+description\s+(.+?)\s*$")
+_VRF_RT_RE = re.compile(
+    r"^\s+route-target\s+(import|export|both)\s+(?:evpn\s+)?(\S+)\s*$"
+)
 _INTERFACE_HEADER_RE = re.compile(r"^interface\s+(\S+)\s*$")
+
+
+def _parse_vrf_stanzas(raw: str) -> list[CanonicalRoutingInstance]:
+    """Harvest ``vrf instance|definition <name>`` stanzas INCLUDING the body
+    (rd / description / route-target), mirroring cisco_iosxe_cli's
+    ``_parse_routing_instances``.  The header-only predecessor created the
+    instance with an empty RD/description, so a legacy ``vrf definition`` RD
+    was silently lost (2026-07-06 review MEDIUM #21).  The ``_parse_router_bgp``
+    pass merges by name on top and its RD wins where present (EOS precedence).
+    """
+    def _on_line(line: str, current: CanonicalRoutingInstance) -> None:
+        dm = _VRF_DESC_RE.match(line)
+        if dm:
+            current.description = dm.group(1).strip()
+            return
+        rm = _VRF_RD_RE.match(line)
+        if rm:
+            current.route_distinguisher = rm.group(1)
+            return
+        rtm = _VRF_RT_RE.match(line)
+        if rtm:
+            direction = rtm.group(1).lower()
+            rt = rtm.group(2)
+            if direction in ("import", "both") and rt not in current.rt_imports:
+                current.rt_imports.append(rt)
+            if direction in ("export", "both") and rt not in current.rt_exports:
+                current.rt_exports.append(rt)
+
+    return scan_stanzas(
+        raw.splitlines(),
+        is_header=_VRF_INSTANCE_RE.match,
+        open_scratch=lambda m: CanonicalRoutingInstance(name=m.group(1)),
+        on_line=_on_line,
+        build=lambda ri: ri,
+        is_terminator=lambda line: (
+            line.startswith("!") or (line and not line[0].isspace())
+        ),
+    )
 
 # VARP system-wide MAC (Wave C anycast-gateway wire-up).  Form:
 # ``ip virtual-router mac-address 00:1c:73:00:dc:01``.  Top-level
@@ -568,13 +615,12 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     #     "DHCP and DHCP Relay".
     intent.dhcp_servers = _parse_dhcp_pools(raw)
 
-    # --- VRF declarations (GAP 6) — ``vrf instance <name>`` top-
-    #     level lines create CanonicalRoutingInstance records.
-    #     RD + RTs get populated later from the router-bgp pass.
-    for vrf_m in _VRF_INSTANCE_RE.finditer(raw):
-        intent.routing_instances.append(
-            CanonicalRoutingInstance(name=vrf_m.group(1))
-        )
+    # --- VRF declarations (GAP 6 + #21) — ``vrf instance|definition <name>``
+    #     stanzas create CanonicalRoutingInstance records, harvesting the
+    #     stanza BODY (rd / description / route-target) so a legacy
+    #     ``vrf definition`` RD isn't silently lost.  The router-bgp pass
+    #     below merges by name on top (its RD wins where present).
+    intent.routing_instances.extend(_parse_vrf_stanzas(raw))
 
     # --- Interface + VLAN + Vxlan stanzas (line-scan with
     #     current-stanza tracking, same pattern as cisco_iosxe_cli) ---

--- a/tests/unit/migration/codecs/arista_eos/test_vrf_definition_body_harvest_medium.py
+++ b/tests/unit/migration/codecs/arista_eos/test_vrf_definition_body_harvest_medium.py
@@ -1,0 +1,72 @@
+"""Arista legacy ``vrf definition`` body harvest (2026-07-06 review MEDIUM #21).
+
+Pre-4.23 EOS carries the RD / description / route-targets INSIDE the
+``vrf definition <name>`` stanza (IOS-style).  The harvest read only the
+header, so those dropped: an EOS->EOS re-render emitted ``vrf instance RED``
+with no rd (silent same-vendor loss) and L3VPN targets lost the RD.  The fix
+harvests the stanza body; the router-bgp pass still merges by name on top.
+
+No committed arista fixture carries an inline-VRF-body, so this is mesh-flat.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.codecs.arista_eos import AristaEOSCodec
+
+pytestmark = pytest.mark.unit
+
+
+def _ri(intent, name):
+    return next(r for r in intent.routing_instances if r.name == name)
+
+
+class TestVrfDefinitionBodyHarvest:
+    def test_legacy_vrf_definition_body_is_harvested(self):
+        cfg = (
+            "vrf definition RED\n"
+            "   rd 65000:1\n"
+            "   description tenant red\n"
+            "   route-target import 100:1\n"
+            "   route-target export 100:2\n"
+            "!\n"
+        )
+        ri = _ri(AristaEOSCodec().parse(cfg), "RED")
+        assert ri.route_distinguisher == "65000:1"
+        assert ri.description == "tenant red"
+        assert ri.rt_imports == ["100:1"]
+        assert ri.rt_exports == ["100:2"]
+
+    def test_route_target_both_expands(self):
+        cfg = (
+            "vrf definition GREEN\n"
+            "   rd 65000:3\n"
+            "   route-target both 100:3\n"
+            "!\n"
+        )
+        ri = _ri(AristaEOSCodec().parse(cfg), "GREEN")
+        assert ri.rt_imports == ["100:3"]
+        assert ri.rt_exports == ["100:3"]
+
+    def test_modern_header_only_vrf_instance_still_works(self):
+        # 4.23+ ``vrf instance`` is header-only (RD comes from router bgp);
+        # the harvester must still create the bare instance.
+        cfg = "vrf instance BLUE\n!\n"
+        ri = _ri(AristaEOSCodec().parse(cfg), "BLUE")
+        assert ri.name == "BLUE"
+        assert ri.route_distinguisher == ""
+
+    def test_router_bgp_rd_wins_over_stanza_body(self):
+        # EOS precedence: the router-bgp submode RD overrides the deprecated
+        # stanza-body RD.  The merge-by-name must keep the router-bgp value.
+        cfg = (
+            "vrf definition RED\n"
+            "   rd 65000:1\n"
+            "!\n"
+            "router bgp 65000\n"
+            "   vrf RED\n"
+            "      rd 65000:999\n"
+        )
+        ri = _ri(AristaEOSCodec().parse(cfg), "RED")
+        assert ri.route_distinguisher == "65000:999"


### PR DESCRIPTION
## What

The legacy `vrf definition <name>` harvest (#295) read only the header via a `finditer`, so a pre-4.23 EOS config that carries the RD / description / route-targets **inside** the stanza (IOS-style) lost them — an EOS→EOS re-render emitted `vrf instance RED` with no rd (silent same-vendor loss), and L3VPN targets lost the RD (2026-07-06 review MEDIUM #21).

## Fix

- Replace the header-only `finditer` with `_parse_vrf_stanzas` — a `scan_stanzas` body walker (`rd` / `description` / `route-target`, `both` expanded, optional EOS `evpn` keyword) mirroring `cisco_iosxe_cli._parse_routing_instances`.
- `_parse_router_bgp` is **unchanged** and still merges by name on top: its RD wins where present, matching EOS precedence (the submode `rd` is deprecated — "no effect on the system").
- RD + route-targets round-trip (render emits them under `router bgp / vrf`), but EOS render has **no** `vrf instance / description` emit path — so harvesting `description` would introduce a *new* silent drop. Declared `/routing-instances/instance/description` **lossy** on arista (the walker already yields it → reverse-parity satisfied).

## Mesh impact

No committed arista fixture carries an inline VRF body → **mesh-flat** (cross-mesh guard 7/7, CODEC_BUG=5, cells=1224). The router-bgp pass is untouched, so the EVPN/router-bgp-sourced VRFs in the committed fixtures parse identically.

## Negative control

`tests/unit/migration/codecs/arista_eos/test_vrf_definition_body_harvest_medium.py` — the two body-harvest tests **FAIL** with `parse.py` stashed (header-only), while the header-only `vrf instance` + router-bgp-RD-wins tests pass both ways (proving the merge precedence).

## Testing

`ruff` clean; `tests/unit` **5256 passed / 81 skipped**; cross-mesh guard **7/7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
