### PR TITLE
fix(jobs): protect non-terminal jobs from eviction + persist scheduled runs (#25/#26)

### DIFF
--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -257,6 +257,19 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
 
     job_store: FileJobStore = app.state.job_store
     max_workers = getattr(app.state.settings, "backup_concurrency", 10)
+    # (#26) Persist the pending job immediately, mirroring backups.py's CONC-5
+    # save.  Without it a scheduled job LRU-evicted mid-run — or EVERY
+    # scheduled run when max_memory_jobs=0 — disk-misses and GET /{id} 404s
+    # while the job is genuinely running (the tool's primary unattended mode).
+    # run_backup_job's terminal save overwrites this pending snapshot.
+    try:
+        job_store.save(job)
+    except OSError as exc:
+        logger.warning(
+            "Could not persist pending scheduled job %s at creation: %s",
+            job.id,
+            exc,
+        )
     await asyncio.to_thread(
         run_backup_job,
         job,

--- a/netcanon/storage/job_registry.py
+++ b/netcanon/storage/job_registry.py
@@ -45,10 +45,20 @@ import threading
 from collections import OrderedDict
 from collections.abc import Iterator
 
-from ..models.backup import BackupJob
+from ..models.backup import BackupJob, JobStatus
 from .job_store import FileJobStore
 
 logger = logging.getLogger(__name__)
+
+# A job in a terminal status will not change again, so evicting it from the
+# memory cache is safe (disk retains it).  A non-terminal (pending / running)
+# job must NOT be evicted: eviction + a later poll would promote the stale
+# pending disk snapshot into the cache and mask the live job's eventual
+# terminal state forever (#25 — the terminal save writes to disk only, never
+# re-inserts into the registry).
+_TERMINAL_STATUSES = frozenset(
+    {JobStatus.completed, JobStatus.partial, JobStatus.failed}
+)
 
 
 # Default cap on memory-resident jobs.  Sized for the typical Netcanon
@@ -158,13 +168,37 @@ class BackupJobRegistry:
                 return
             self._cache[job_id] = job
             if len(self._cache) > self._max:
-                # Pop the LRU entry (the oldest insertion still in cache).
-                evicted_id, _ = self._cache.popitem(last=False)
-                logger.debug(
-                    "BackupJobRegistry evicted %s (cache at cap %d)",
-                    evicted_id,
-                    self._max,
+                # (#25) Evict the LRU-most TERMINAL job — NOT the oldest
+                # unconditionally.  Evicting a still-running/pending job and
+                # then serving a poll from disk promotes its stale pending
+                # snapshot to MRU, masking the live job's terminal state
+                # forever.  If every resident job is non-terminal, allow a
+                # temporary cap overshoot rather than evict a live job (the
+                # overshoot self-corrects as jobs terminalise).  Find the id
+                # first, then delete, to avoid mutating during iteration.
+                evict_id = next(
+                    (
+                        jid
+                        for jid, j in self._cache.items()  # oldest-first
+                        if j.status in _TERMINAL_STATUSES
+                    ),
+                    None,
                 )
+                if evict_id is not None:
+                    del self._cache[evict_id]
+                    logger.debug(
+                        "BackupJobRegistry evicted terminal %s (cache over "
+                        "cap %d)",
+                        evict_id,
+                        self._max,
+                    )
+                else:
+                    logger.debug(
+                        "BackupJobRegistry over cap %d but all %d resident "
+                        "job(s) are non-terminal; allowing temporary overshoot",
+                        self._max,
+                        len(self._cache),
+                    )
 
     def __getitem__(self, job_id: str) -> BackupJob:
         """Return the job with this ID.

--- a/tests/integration/test_load_and_memory.py
+++ b/tests/integration/test_load_and_memory.py
@@ -176,12 +176,13 @@ class TestSustainedLoad:
                 test_app.state.jobs = original_registry
 
     def test_running_job_survives_eviction_via_creation_persist(self, test_app):
-        """CONC-5: a job is persisted to disk at creation, so it stays
-        reachable via disk fallback even after an LRU eviction *before*
-        the runner's terminal save — polling an active-but-evicted job
-        returns its state instead of a 404.  The background runner is
-        stubbed out so the creation-time persist is the ONLY disk write,
-        isolating the fix from the runner's on-completion save."""
+        """CONC-5 + #25: a running (non-terminal) job is persisted to disk at
+        creation AND is never evicted from the cap-1 cache — #25 skips eviction
+        of a non-terminal job (a temporary cap overshoot) rather than evict a
+        live job and mask its eventual terminal state.  The runner is stubbed
+        so the first job stays ``pending``; a second submission would normally
+        evict the LRU entry, but the non-terminal protection keeps it resident.
+        It is reachable either way (cache OR the creation-time disk persist)."""
         with patch(
             "netcanon.api.routes.backups.run_backup_job",
         ), TestClient(test_app) as c:
@@ -193,13 +194,15 @@ class TestSustainedLoad:
                 ).json()
                 # On disk immediately — before any runner save (stubbed).
                 assert test_app.state.job_store.load_one(first["id"]) is not None
-                # A second submission evicts the first from the cap-1 cache.
+                # A second submission would evict the LRU entry — but the first
+                # job is still pending (runner stubbed), so #25 protects it: it
+                # stays resident (a cap overshoot) rather than being evicted.
                 c.post(
                     "/api/v1/backups",
                     json={"devices": [_device_payload(host="10.0.0.2")]},
                 )
-                assert first["id"] not in list(test_app.state.jobs.keys())
-                # Still reachable via disk fallback — 200, not 404.
+                assert first["id"] in list(test_app.state.jobs.keys())
+                # Reachable — 200, not 404.
                 resp = c.get(f"/api/v1/backups/{first['id']}")
                 assert resp.status_code == 200, resp.text
                 assert resp.json()["id"] == first["id"]

--- a/tests/integration/test_schedules_api.py
+++ b/tests/integration/test_schedules_api.py
@@ -331,3 +331,46 @@ class TestScheduleDeleteResurrection:
         assert sid in app.state.schedules
         assert app.state.schedules[sid].last_run_at is not None
         assert (Path(app.state.schedule_store._dir) / f"{sid}.json").exists()
+
+
+class TestScheduledJobCreationPersist:
+    """(#26) A scheduled job must be persisted to disk at creation, mirroring
+    backups.py's CONC-5 save — else an LRU-evicted scheduled job (or every run
+    under max_memory_jobs=0) 404s while genuinely running."""
+
+    @staticmethod
+    def _cisco_profile(app):
+        from netcanon.models.device_profile import DeviceProfile
+
+        profile = DeviceProfile(
+            name="sw", type_key="Cisco", host="10.0.0.1", port=22,
+            username="admin", password="pw",
+        )
+        app.state.device_profiles[profile.id] = profile
+        return profile
+
+    async def test_scheduled_job_persisted_at_creation(
+        self, client, monkeypatch,
+    ):
+        from netcanon.api.routes.schedules import _run_scheduled_backup_inner
+        from netcanon.services import backup_runner
+
+        app = client.app
+        self._cisco_profile(app)
+        sid = _create_schedule(client)["id"]
+
+        captured: list = []
+
+        def _capture(job, *a, **k):
+            # Capture the job WITHOUT saving — the creation-time persist is then
+            # the only disk write, isolating the #26 fix from the terminal save.
+            captured.append(job)
+
+        monkeypatch.setattr(backup_runner, "run_backup_job", _capture)
+        await _run_scheduled_backup_inner(sid, app)
+
+        assert captured, "runner never dispatched (no resolvable target?)"
+        job = captured[0]
+        # #26: on disk from the creation-time persist even though the stubbed
+        # runner wrote nothing.  Pre-fix the scheduled path never saved -> None.
+        assert app.state.job_store.load_one(job.id) is not None

--- a/tests/unit/test_job_registry_eviction_medium.py
+++ b/tests/unit/test_job_registry_eviction_medium.py
@@ -1,0 +1,65 @@
+"""BackupJobRegistry must not evict a non-terminal job (2026-07-06 MEDIUM #25).
+
+``__setitem__`` evicted the LRU entry unconditionally.  If that entry was a
+still-running/pending job, a later poll promoted its stale ``pending`` disk
+snapshot into the cache, and the worker's terminal save (disk-only, never
+re-inserted) was masked forever.  The fix evicts the LRU-most TERMINAL job
+instead, allowing a temporary cap overshoot when every resident job is live.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from netcanon.models.backup import BackupJob, JobStatus
+from netcanon.storage.job_registry import BackupJobRegistry
+from netcanon.storage.job_store import FileJobStore
+
+pytestmark = pytest.mark.unit
+
+
+def _job(status: JobStatus) -> BackupJob:
+    return BackupJob(
+        id=str(uuid.uuid4()), status=status, created_at=datetime.now(UTC),
+        total_devices=1,
+    )
+
+
+@pytest.fixture
+def registry(tmp_path: Path):
+    def _build(cap: int) -> BackupJobRegistry:
+        store = FileJobStore(tmp_path / f"jobs{cap}")
+        return BackupJobRegistry(store, max_memory_jobs=cap, warm_cache=False)
+    return _build
+
+
+class TestNonTerminalEvictionProtection:
+    def test_running_job_not_evicted_over_cap(self, registry):
+        reg = registry(1)
+        a, b = _job(JobStatus.running), _job(JobStatus.running)
+        reg[a.id] = a
+        reg[b.id] = b  # over cap, but both non-terminal -> overshoot, no evict
+        assert a.id in list(reg)  # pre-fix: popitem evicts a
+        assert b.id in list(reg)
+
+    def test_running_job_protected_terminal_evicted_instead(self, registry):
+        reg = registry(1)
+        running, done = _job(JobStatus.running), _job(JobStatus.completed)
+        reg[running.id] = running
+        reg[done.id] = done  # over cap -> the TERMINAL one is evicted
+        assert running.id in list(reg)   # protected (pre-fix: evicted)
+        assert done.id not in list(reg)  # pre-fix: running evicted, done kept
+
+    def test_terminal_jobs_still_evict_lru(self, registry):
+        # Regression guard: normal LRU still applies to terminal jobs.
+        reg = registry(2)
+        a, b, c = (_job(JobStatus.completed) for _ in range(3))
+        reg[a.id] = a
+        reg[b.id] = b
+        reg[c.id] = c
+        assert a.id not in list(reg)  # oldest terminal evicted
+        assert b.id in list(reg) and c.id in list(reg)


### PR DESCRIPTION
## What

Two concurrency findings from the 2026-07-06 review where a genuinely-running job became invisible. **Storage/scheduler only → mesh-flat.**

### #25 — registry evicts a running job, then masks it forever

`BackupJobRegistry.__setitem__` evicted the LRU entry **unconditionally**. If that entry was a still-running/pending job, a later poll promoted its stale `pending` disk snapshot into the cache; the worker's terminal save (disk-only, never re-inserted) was masked — the registry answered `pending` forever while disk said `completed`, and every poll pinned the lie to MRU.

**Fix:** evict the LRU-most **terminal** job (`completed`/`partial`/`failed`); if every resident job is non-terminal, allow a temporary cap overshoot rather than evict a live job. Normal LRU for terminal jobs is unchanged.

### #26 — scheduled jobs never persisted at creation

`_run_scheduled_backup_inner` inserted the job into `app.state.jobs` and dispatched with **no** `job_store.save` — the CONC-5 creation-persist landed on the manual path only. So an LRU-evicted scheduled job (or **every** scheduled run under the documented `max_memory_jobs=0`) `GET`-404'd while genuinely running — the tool's primary unattended mode.

**Fix:** mirror `backups.py` — `job_store.save(job)` in `try/except OSError` before the dispatch.

## Tests

- Updated the existing CONC-5 test: it asserted the *old* evict-then-disk-fallback behaviour for a running job; #25 makes the stronger guarantee (the running job is never evicted), so it now asserts the job stays resident.
- New registry tests (`test_job_registry_eviction_medium.py`): running job protected / terminal job evicted-instead / terminal-LRU-still-works.
- New scheduled-persist test: the scheduled job is on disk from the creation-time persist even with the runner stubbed.

## Negative control

The **4** fix-dependent assertions (2 registry, 1 scheduled-persist, 1 updated CONC-5) **FAIL** against the pre-fix code (verified by stashing both source files); the terminal-LRU regression guard passes both ways.

## Testing

`ruff` clean; `tests/unit` **5299 passed / 81 skipped**; cross-mesh guard **7/7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
