### PR TITLE
fix(api): tolerate non-UTF-8 configs + honest jobs-list contract (#28/#29)

### DIFF
--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -266,12 +266,19 @@ def create_backup(
 @router.get(
     "/",
     response_model=list[BackupJob],
-    summary="List all backup jobs",
+    summary="List recent (memory-resident) backup jobs",
 )
 def list_jobs(
     jobs: BackupJobRegistry = Depends(get_jobs),
 ) -> list[BackupJob]:
-    """Return all backup jobs, sorted newest-first."""
+    """Return the most-recent memory-resident backup jobs, newest-first (#29).
+
+    NOT full disk history: this reflects only the LRU cache (up to
+    ``max_memory_jobs``, default 1000).  Older jobs are evicted from this
+    list but remain retrievable by ID via ``GET /{job_id}`` (disk lazy-load).
+    With ``max_memory_jobs=0`` the cache is disabled, so this list is always
+    empty even though jobs are still persisted and get-by-id works.
+    """
     return sorted(jobs.values(), key=lambda j: j.created_at, reverse=True)
 
 

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -174,7 +174,9 @@ class Settings(BaseSettings):
             of this setting.  Jobs evicted from memory remain accessible
             by ID via the registry's transparent disk lazy-load.  Default
             1000 caps memory at ~5 MB.  Set to 0 to disable in-memory
-            caching entirely (every read hits disk).
+            caching entirely: get-by-id still works (it hits disk), but the
+            ``GET /backups`` LIST endpoint reflects only the cache and so
+            returns empty at 0 (#29) — jobs are still persisted.
         block_private_egress: When ``True``, the backup entry points
             reject targets that resolve to loopback (``127.0.0.0/8``,
             ``::1``) or link-local (``169.254.0.0/16`` — which includes the

--- a/netcanon/storage/file_store.py
+++ b/netcanon/storage/file_store.py
@@ -257,10 +257,19 @@ class FileConfigStore(BaseConfigStore):
     def get_content(self, filename: str) -> str:
         """Return the text of a stored config file.
 
+        Invalid UTF-8 bytes are replaced with U+FFFD rather than raising
+        (#28): this is the codec/CLI/sanitizer stack convention
+        (``errors="replace"``), and a strict decode here escaped as a bare
+        500 on GET /configs/{f}, /configs/diff, /migration/detect and the six
+        plan/render endpoints for any out-of-band non-UTF-8 file dropped in
+        the store dir — while the file was still listable + selectable.
+
         Raises:
             FileNotFoundError: If the file does not exist.
         """
-        return self.resolve_path(filename).read_text(encoding="utf-8")
+        return self.resolve_path(filename).read_text(
+            encoding="utf-8", errors="replace"
+        )
 
     def delete(self, filename: str) -> None:
         """Delete a stored config file.

--- a/tests/unit/test_file_store_non_utf8_medium.py
+++ b/tests/unit/test_file_store_non_utf8_medium.py
@@ -1,0 +1,36 @@
+"""FileConfigStore.get_content must not 500 on a non-UTF-8 file (#28).
+
+``get_content`` was the lone strict UTF-8 decoder in the stack; a config with
+invalid bytes (an out-of-band drop / foreign backup tool) was still listable +
+selectable, but any read/diff/detect/plan action on it escaped a
+UnicodeDecodeError as a bare 500.  The fix decodes with ``errors="replace"``,
+matching the collector / CLI / sanitizer convention.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from netcanon.storage.file_store import FileConfigStore
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_content_replaces_invalid_utf8_bytes(tmp_path: Path):
+    store = FileConfigStore(tmp_path)
+    record = store.save(
+        "Cisco", "10.0.0.1", datetime(2026, 4, 14, tzinfo=UTC), "cfg",
+        "hostname R1\n",
+    )
+    # Simulate an out-of-band non-UTF-8 file (e.g. a latin-1 config): 0xe9 is
+    # an invalid standalone UTF-8 byte.  The file stays listable/selectable.
+    store.resolve_path(record.filename).write_bytes(
+        b"hostname R1\ndescription caf\xe9\n"
+    )
+    # #28: must decode with U+FFFD replacement, NOT raise UnicodeDecodeError.
+    content = store.get_content(record.filename)
+    assert "hostname R1" in content
+    assert "�" in content  # the invalid byte became the replacement char


### PR DESCRIPTION
## What

Two API error/contract honesty findings from the 2026-07-06 review. **Storage / docs only → mesh-flat.**

### #28 — non-UTF-8 stored config → opaque 500

`FileConfigStore.get_content` was the **lone strict UTF-8 decoder** in the stack (collectors / CLI / sanitizer all use `errors="replace"`). A stored config with invalid bytes (an out-of-band drop / foreign backup tool) is still listable + selectable, but `GET /configs/{f}`, `/configs/diff`, `/migration/detect` and the six plan/render endpoints catch only `FileNotFoundError` — so a `UnicodeDecodeError` escaped as a bare **500**.

**Fix:** decode with `errors="replace"` at the choke point (covers all consumers at once); valid UTF-8 round-trips byte-identically.

### #29 — `GET /backups` claims "all" but returns only the LRU cache

Summarised "List all backup jobs" / "Return all backup jobs", but returns only the memory-resident cache; with the documented `max_memory_jobs=0` the list is permanently empty while POSTs `202` and get-by-id works.

**Fix:** reworded the route summary/docstring and the `config.py` `max_memory_jobs` docstring — get-by-id hits disk, but the **list** reflects only the cache (empty at 0). The registry LRU semantics are intentional; only the "all" promise was stale.

## Negative control

`tests/unit/test_file_store_non_utf8_medium.py` — the non-UTF-8 read raises `UnicodeDecodeError` with `file_store.py` stashed and returns a U+FFFD-replaced string after. #29 is a doc-honesty reword (no test pinned the old summary — verified by grep).

## Testing

`ruff` clean; `tests/unit` **5310 passed / 81 skipped**; cross-mesh guard **7/7**; `test_backups_api` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
