### PR TITLE
docs: correct three stale docs-truth microcopy claims (#39/#40/#41)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,9 +41,10 @@ The rest of this document is about the migration layer.  The backup
 layer is architecturally simpler — see
 [`netcanon/collectors/README.md`](netcanon/collectors/README.md).
 Backup definitions ship for Cisco IOS-XE, Fortigate FortiOS, MikroTik
-RouterOS, OPNsense, Aruba AOS-S, Juniper Junos, and Arista EOS, plus
-provisional definitions for Cisco NX-OS, Cisco IOS-XR, Aruba AOS-CX,
-and VyOS — see [`netcanon/definitions/library/README.md`](netcanon/definitions/library/README.md) for the
+RouterOS, OPNsense, Aruba AOS-S, Juniper Junos, Arista EOS, and VyOS
+(the last live-validated 2026-06-17, #113), plus provisional definitions
+for Cisco NX-OS, Cisco IOS-XR, and Aruba AOS-CX — see
+[`netcanon/definitions/library/README.md`](netcanon/definitions/library/README.md) for the
 per-vendor authoring notes and validation status.
 
 ---

--- a/README.md
+++ b/README.md
@@ -379,11 +379,11 @@ Tests run across four layers: unit (pure functions, no I/O — the
 real-capture validation harness lives here as a unit subset),
 integration (TestClient + mocked SSH at the `get_collector`
 factory), e2e (Playwright against a live Uvicorn), and desktop
-(PySide6 + pystray mocked).  CI runs the **unit + integration** tiers
-on Python 3.11 / 3.12 / 3.13 / 3.14 against Ubuntu; the e2e + desktop
-tiers run locally, not in CI.  The CI pytest invocation uses `-x`
-(stop at first failure), so a green run reports the authoritative
-pass count while a red run stops early.
+(PySide6 + pystray mocked).  CI runs **all four tiers on every PR** —
+unit + integration on Python 3.11 / 3.12 / 3.13 / 3.14 against Ubuntu,
+plus e2e (Playwright) and desktop (PySide6) on Python 3.13.  No pytest
+invocation uses `-x`, so each tier reports its full pass/fail count
+(see `SECURITY.md` for the authoritative required merge checks).
 
 ### Layout
 

--- a/docs/HOW_WE_TEST.md
+++ b/docs/HOW_WE_TEST.md
@@ -13,9 +13,10 @@ contributor / methodology level.
 
 ## TL;DR
 
-Netcanon ships with **four test layers**.  CI gates every release on the
-**unit + integration** tiers; the **E2E** (Playwright) and **desktop**
-(PySide6) tiers run locally and on demand, not on every PR:
+Netcanon ships with **four test layers**.  CI runs **all four on every PR** —
+unit + integration across Python 3.11–3.14, plus **E2E** (Playwright) and
+**desktop** (PySide6) on 3.13.  The only maintainer-run tool below is the
+cross-mesh audit, which is NOT a CI gate:
 
 | Layer | What it tests | Speed |
 |---|---|---|
@@ -41,7 +42,7 @@ spot until the device behaves wrong in production.
 
 The cross-mesh audit runs locally / on demand — it is a maintainer tool
 re-generated on every codec change (per the doc-sync checklist), NOT a CI
-gate on every PR (only the unit + integration tiers gate).
+gate on every PR (the four pytest tiers gate; the cross-mesh audit does not).
 Its results live in
 [`tests/fixtures/real/PHASE4_RECONCILIATION.md`](../tests/fixtures/real/PHASE4_RECONCILIATION.md)
 (machine-generated; not hand-edited).
@@ -139,7 +140,8 @@ variance taxonomy and generates
 `tests/fixtures/real/PHASE4_RECONCILIATION.md` (the matrix).
 
 Both run locally / on demand — the cross-mesh audit is a maintainer tool,
-NOT a CI gate (only the unit + integration tiers gate every PR).  The
+NOT a CI gate (the four pytest tiers gate every PR; the cross-mesh audit
+does not).  The
 matrix gets regenerated on every codec change per the
 [doc-sync checklist](../AGENTS.md#documentation-sync-checklist).
 

--- a/netcanon/definitions/library/README.md
+++ b/netcanon/definitions/library/README.md
@@ -252,9 +252,10 @@ only via `resolve()`.
 - Pairs with the `aruba_aoscx` migration codec.
 
 ### VyOS 1.3 / 1.4
-- ⚠ **Not yet validated on live hardware** — collection wiring verified in
-  code + against sample output only (Notes column flags it).  Confirm on a
-  real router.
+- ✅ **Live-validated 2026-06-17 (#113)** — the backup ran end-to-end against a
+  real VyOS rolling instance (netmiko `vyos` driver → `show configuration
+  commands` set-form capture; `show version` probe matched); graduated from
+  provisional.
 - `collector.netmiko_device_type: vyos` — netmiko's VyOS driver lands in
   operational mode and disables the pager itself.
 - `connection.needs_enable: false` — no enable equivalent on VyOS.

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -1526,8 +1526,7 @@
     if (v.severity === 'ok') {
       return '<div>&#10003; Validation OK for the checked fields. Every '
            + 'translatable field Netcanon inspects maps to a supported path '
-           + 'on the target, but some advanced sub-fields (e.g. SNMPv3 '
-           + 'auth/privacy algorithms, VRRP priority/preempt) are not yet '
+           + 'on the target, but some advanced sub-fields are not yet '
            + 'checked — review the output before applying; Netcanon has no '
            + 'deploy path.</div>';
     }


### PR DESCRIPTION
## What

Three stale docs-truth microcopy claims from the 2026-07-06 review. **Documentation/template only → trivially mesh-flat.**

- **#39** — `README.md` + `docs/HOW_WE_TEST.md` (3 sites) claimed the E2E (Playwright) and desktop (PySide6) tiers "run locally, not in CI" and that CI pytest uses `-x`. Both false: `ci.yml` runs **all four tiers on every PR** (unit + integration across Python 3.11–3.14, e2e + desktop on 3.13) and no invocation uses `-x`. Reworded to name the real gate + point at `SECURITY.md` for the authoritative required checks; the cross-mesh audit is correctly still called out as a maintainer tool, not a CI gate.
- **#40** — the VyOS backup definition was documented "Not yet validated on live hardware" (`definitions/library/README.md`) + listed provisional (`ARCHITECTURE.md`), but it graduated 2026-06-17 (#113): the YAML says `LIVE-VALIDATED`, `test_vyos_definition` asserts it, and `CAPABILITIES.md` already lists only NX-OS / IOS-XR / AOS-CX as provisional. Updated both docs (NX-OS/IOS-XR/AOS-CX correctly stay provisional).
- **#41** — `migrate.html`'s "Validation OK" banner cited "SNMPv3 auth/privacy algorithms, VRRP priority/preempt" as "not yet checked", but #205/#206 walk + classify exactly those. Dropped the now-false parenthetical, keeping the honest general "some advanced sub-fields are not yet checked — review the output" tail.

## Testing

No test pinned the changed strings (verified by grep); `test_vyos_definition` already enforces the graduated YAML state these docs now match. `tests/unit` **5255 passed / 81 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
