### PR TITLE
test: harden cross-mesh + round-trip guards (#35/#36/#37/#38)

### DIFF
--- a/tests/integration/test_cross_mesh_ci_guard.py
+++ b/tests/integration/test_cross_mesh_ci_guard.py
@@ -45,14 +45,14 @@ _BASELINE_PATH = (
     _REPO_ROOT / "tests" / "fixtures" / "real" / "_phase4_runs" / "latest.json"
 )
 
-# Render failures EXPECTED on the committed corpus: the vyos synthetic
-# kitchen-sink carries constructs cisco_iosxe_cli / fortigate_cli have no
-# render path for.  Any render failure OUTSIDE this set is a regression.
-# (source_codec, target_codec)
-_ALLOWED_RENDER_FAILURES = {
-    ("vyos", "cisco_iosxe_cli"),
-    ("vyos", "fortigate_cli"),
-}
+# Render failures EXPECTED on the committed corpus, keyed by
+# (source_codec, target_codec, fixture_basename) — NOT pair-only (#36): a
+# pair-scoped allowlist let a regression that crashed on any of the 12
+# committed REAL vyos captures hide inside an allowlisted (vyos, target) pair.
+# Every committed cell renders OK on current main, so this is empty; scope any
+# genuinely render-incapable cell here BY BASENAME (e.g. the vyos synthetic
+# kitchen-sink on a target lacking a render path) rather than a whole pair.
+_ALLOWED_RENDER_FAILURES: set[tuple[str, str, str]] = set()
 
 
 def _load_tool(mod_name: str, rel_path: str):
@@ -117,15 +117,16 @@ def test_render_failures_within_allowlist(mesh_and_recon):
     allowlist; a new (source, target) render crash is a codec regression."""
     mesh, _ = mesh_and_recon
     failing = {
-        (c["source_codec"], c["target_codec"])
+        (c["source_codec"], c["target_codec"], _fixture_name(c))
         for c in mesh["cells"]
         if c["render_status"] != "ok"
     }
     new = failing - _ALLOWED_RENDER_FAILURES
     assert not new, (
         f"new render failure(s) beyond the allowlist: {sorted(new)}. "
-        "If intentional, add to _ALLOWED_RENDER_FAILURES with a reason; "
-        "otherwise it's a codec render regression."
+        "If intentional, add the (source, target, fixture) triple to "
+        "_ALLOWED_RENDER_FAILURES with a reason; otherwise it's a codec "
+        "render regression."
     )
 
 
@@ -247,4 +248,40 @@ def test_mesh_cell_count_matches_baseline(mesh_and_recon, baseline):
         f"{baseline['cells_total']}. Adding/removing a fixture (or a codec) "
         "changes this — regenerate tests/fixtures/real/_phase4_runs/latest.json "
         "(python tools/run_phase4_reconciliation.py) and commit it."
+    )
+
+
+def test_expectation_yaml_coverage_not_reduced(mesh_and_recon, baseline):
+    """No pair-expectation YAML silently drops out of coverage (#35).
+
+    The four CODEC_BUG guards classify only the cells that HAVE a pair
+    expectation YAML.  A codec rename orphans a YAML silently (the loader keys
+    by filename stem), removing its CODEC_BUG classification while cells_total,
+    the aggregate count and the vanished-pair checks all stay green.  Pin the
+    coverage denominator: fewer loaded YAMLs, MORE uncovered cells, or fewer
+    classified field-cells all turn this red.  live==baseline today
+    (56>=56, 723<=723) so no re-baseline is needed."""
+    _, result = mesh_and_recon
+    assert (
+        result["expectation_yamls_loaded"]
+        >= baseline["expectation_yamls_loaded"]
+    ), (
+        "expectation-YAML coverage regressed: "
+        f"{result['expectation_yamls_loaded']} < baseline "
+        f"{baseline['expectation_yamls_loaded']} — a pair YAML was "
+        "deleted/orphaned (codec rename?) and its CODEC_BUG coverage vanished."
+    )
+    assert len(result["cells_without_expectation_yaml"]) <= len(
+        baseline["cells_without_expectation_yaml"]
+    ), (
+        "cross-vendor cells without a pair YAML rose vs baseline — a pair lost "
+        "its expectation YAML; the CODEC_BUG ratchet is now blind to it. "
+        "Investigate before re-baselining latest.json."
+    )
+    assert (
+        result["aggregate"]["fields_total"]
+        >= baseline["aggregate"]["fields_total"]
+    ), (
+        "reconciled field-cells dropped vs baseline — fewer fields are being "
+        "classified than the committed coverage floor."
     )

--- a/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
+++ b/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
@@ -92,7 +92,12 @@ _FIXTURE_EXTENSIONS = {".txt", ".cfg", ".xml", ".conf", ".rsc", ".set"}
 # Mirrors the precedent set by ``test_real_captures::
 # _KNOWN_ROUNDTRIP_GAPS``.  Key format is ``"<codec_name>::<filename>"``
 # matching the parametrise id so the lookup is unambiguous.
-_KNOWN_ROUNDTRIP_GAPS: dict[str, str] = {
+# (#37) Each value is ``(reason, expected_diff_paths)``: the reason plus the
+# EXACT set of dotted leaf paths that may differ after parse->render->parse.
+# The round-trip still runs (it is NOT skipped fixture-wide) and asserts the
+# diff equals this set precisely — a WIDER diff is a new regression, a NARROWER
+# one means the gap was fixed and this entry must be deleted (rot detection).
+_KNOWN_ROUNDTRIP_GAPS: dict[str, tuple[str, frozenset[str]]] = {
     # mikrotik_routeros: bond-interface ``description`` round-trip drop
     # — surfaced by the kitchen-sink's "LACP bond to upstream core"
     # description on a synthetic bonding interface.  The render path
@@ -100,9 +105,11 @@ _KNOWN_ROUNDTRIP_GAPS: dict[str, str] = {
     # the second parse sees an empty description.  Real-capture
     # coverage doesn't hit this because none of the committed real
     # RouterOS exports describe a bond with a description string.
+    # bond1 / bond2 sort to interfaces[0] / [1] (``_compare`` sorts by name).
     "mikrotik_routeros::kitchen_sink.rsc": (
         "bond-interface description not preserved through render — "
-        "TODO on mikrotik_routeros codec"
+        "TODO on mikrotik_routeros codec",
+        frozenset({"interfaces[0].description", "interfaces[1].description"}),
     ),
 }
 
@@ -244,10 +251,6 @@ def test_synthetic_round_trips_stable(
             f"{codec_name} is parse_only; round-trip not applicable"
         )
 
-    gap_reason = _KNOWN_ROUNDTRIP_GAPS.get(f"{codec_name}::{path.name}")
-    if gap_reason is not None:
-        pytest.skip(f"known round-trip gap: {gap_reason}")
-
     raw = path.read_text(encoding="utf-8")
     try:
         first = codec.parse(raw)
@@ -271,10 +274,48 @@ def test_synthetic_round_trips_stable(
             f"Rendered (first 400 chars): {rendered[:400]!r}"
         )
 
-    assert _compare(first) == _compare(second), (
+    a, b = _compare(first), _compare(second)
+    gap = _KNOWN_ROUNDTRIP_GAPS.get(f"{codec_name}::{path.name}")
+    if gap is not None:
+        # (#37) Field-targeted exemption: run the FULL comparison and assert
+        # the diff is EXACTLY the documented gap — so every OTHER field is
+        # still covered (the old fixture-wide skip asserted nothing), and the
+        # entry rots loudly once the gap is fixed or a new field starts drifting.
+        reason, expected = gap
+        actual = _leaf_diff_paths(a, b)
+        assert actual == expected, (
+            f"{codec_name} round-trip diff on {path.name} != the documented "
+            f"gap ({reason}).\n"
+            f"  new regression (unexpected drift): {sorted(actual - expected)}\n"
+            f"  gap fixed (delete the _KNOWN_ROUNDTRIP_GAPS entry): "
+            f"{sorted(expected - actual)}"
+        )
+        return
+    assert a == b, (
         f"{codec_name} round-trip not stable on synthetic {path.name}: "
         f"canonical representation changed after parse->render->parse"
     )
+
+
+def _leaf_diff_paths(a: Any, b: Any, prefix: str = "") -> set[str]:
+    """Dotted leaf paths where two ``_compare`` dumps differ (#37).
+
+    Recurses dicts + equal-length lists; a length/type mismatch or a differing
+    scalar is reported at the current path (e.g. ``interfaces[0].description``).
+    """
+    if isinstance(a, dict) and isinstance(b, dict):
+        out: set[str] = set()
+        for k in set(a) | set(b):
+            out |= _leaf_diff_paths(
+                a.get(k), b.get(k), f"{prefix}.{k}" if prefix else k
+            )
+        return out
+    if isinstance(a, list) and isinstance(b, list) and len(a) == len(b):
+        out = set()
+        for i, (ai, bi) in enumerate(zip(a, b)):
+            out |= _leaf_diff_paths(ai, bi, f"{prefix}[{i}]")
+        return out
+    return set() if a == b else {prefix}
 
 
 def _compare(intent: CanonicalIntent) -> dict[str, Any]:
@@ -287,6 +328,12 @@ def _compare(intent: CanonicalIntent) -> dict[str, Any]:
     d.pop("source_vendor", None)
     d.pop("source_format", None)
     d.pop("source_version", None)
+    # (#38) Match the test_real_captures twin exactly: drop the Tier-3
+    # notification metadata (correct-by-design to differ) and sort
+    # routing_instances.  The synthetic copy had drifted from the real twin
+    # (missing both), so a second Tier-3 stanza would have failed here while
+    # passing the real harness.  Both are pure relaxations -> green stays green.
+    d.pop("dropped_tier3_sections", None)
     for key, id_key in [
         ("interfaces", "name"),
         ("vlans", "id"),
@@ -295,6 +342,7 @@ def _compare(intent: CanonicalIntent) -> dict[str, Any]:
         ("dhcp_servers", "network"),
         ("local_users", "name"),
         ("radius_servers", "host"),
+        ("routing_instances", "name"),
     ]:
         if key in d and isinstance(d[key], list):
             d[key] = sorted(d[key], key=lambda x: x.get(id_key, ""))


### PR DESCRIPTION
test: harden cross-mesh + round-trip guards (#35/#36/#37/#38)

Four test-quality guard gaps from the 2026-07-06 review.  Test-only ->
mesh-flat (cross-mesh guard now 8/8).

- #35 The cross-mesh guard never pinned expectation-YAML coverage: a codec
  rename orphans a pair YAML silently (the loader keys by filename stem),
  removing its CODEC_BUG classification while cells_total, the aggregate and
  the vanished-pair checks all stay green.  New
  test_expectation_yaml_coverage_not_reduced pins expectation_yamls_loaded >=
  baseline, len(cells_without_expectation_yaml) <= baseline, and
  aggregate.fields_total >= baseline (live==baseline today: 56/723 — no
  re-baseline).  Verified: hiding one of the 56 YAMLs turns it RED.
- #36 The render-failure allowlist was pair-scoped, so a regression crashing
  on any of the 12 committed REAL vyos captures could hide inside an
  allowlisted (vyos, target) pair.  Re-keyed _ALLOWED_RENDER_FAILURES by
  (source, target, fixture_basename).  Every committed cell renders OK on
  current main (those codecs gained render paths), so the allowlist is now
  the empty set — a strictly STRONGER guard (any per-fixture render failure
  turns red).
- #37 The MikroTik synthetic kitchen-sink round-trip was SKIPPED fixture-wide
  for a single bond-description gap, so it asserted nothing — a regression on
  VLANs/VRRP/routes/NTP stayed green.  Replaced the skip with a field-targeted
  assertion: _KNOWN_ROUNDTRIP_GAPS now carries the EXACT expected leaf-diff
  set ({interfaces[0].description, interfaces[1].description}) and the test
  asserts the actual diff equals it — so every other field is covered and the
  entry rots loudly once the gap is fixed or a new field drifts.
- #38 (part 1) The synthetic round-trip _compare had drifted from its
  test_real_captures twin — missing the dropped_tier3_sections pop + the
  routing_instances sort — so a second Tier-3 stanza would false-fail here
  while passing the real harness.  Added both (pure relaxations; green stays
  green).  DEFERRED with cause: extracting ONE shared canonical_compare_dump
  helper (#38 part 2) is a larger refactor of the real twin's NESTED _compare
  across a big test file; the concrete divergence is now closed.

Test-only; no codec parse/render touched.  Gate: ruff clean, tests/unit 5264
passed / 80 skipped, cross-mesh guard 8/8.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
