### PR TITLE
ci(pii-guard): widen the operator-path grep to every spelling (#34)

### DIFF
--- a/.github/workflows/pii-guard.yml
+++ b/.github/workflows/pii-guard.yml
@@ -46,10 +46,19 @@ jobs:
           #      Both forms are verified against real operator-path
           #      content.
           #
+          # The grep is case-insensitive (`-i`) and covers every spelling of
+          # the user-profile path (#34): the drive-letter branch collapses the
+          # single-backslash, doubled-backslash (`+`), and forward-slash forms
+          # (a `[\/]` class matches either separator — the doubled-backslash
+          # form is exactly how job-record / traceback JSONs serialise Windows
+          # paths), and a separate branch covers the Git-Bash MSYS `/c/…` form.
+          # Every branch keeps a char class breaking the contiguous literal, so
+          # the widened pattern still never matches its own text.
+          #
           # `git grep` exits 0 on match, 1 on no-match, 2 on error; we
           # treat the error case as a FAILURE (fail closed), not "clean".
           set +e
-          git grep -nI -E 'samuelr[i]pp09|C:[\]Users' -- .
+          git grep -inI -E 'samuelr[i]pp09|c:[\/]+users|/c/[u]sers' -- .
           rc=$?
           set -e
           if [ "${rc}" -eq 0 ]; then

--- a/docs/reviews/2026-07-03-fable-full-review/18-ci-packaging.md
+++ b/docs/reviews/2026-07-03-fable-full-review/18-ci-packaging.md
@@ -140,8 +140,10 @@ must be empty — that blocks by path regardless of content. (3) Optional:
 correct the comment.
 
 Minor note while verifying: the `C:[\]Users` pattern misses the
-forward-slash form (`C:/Users/...`). `git grep -E 'C:/Users'` over tracked
+forward-slash form (`C:/[U]sers/...`). `git grep -E 'C:/[U]sers'` over tracked
 files is currently clean (verified), so this is a hardening nit, not a leak.
+(Remediated in #34 — the guard now collapses both separators case-insensitively;
+the fragments here are masked so the widened guard does not flag this note.)
 
 ---
 


### PR DESCRIPTION
ci(pii-guard): widen the operator-path grep to every spelling (#34)

The recurrence guard matched only the exact-case single-backslash Windows
user-profile path form, so a committed traceback / JSON paste in the
forward-slash form, the doubled-backslash form (exactly how job-record /
traceback JSONs serialise Windows paths), the Git-Bash MSYS `/c/…` form, or a
case variant would re-leak the operator username with CI GREEN — the incident
class that forced the 2026-06 history rewrite (2026-07-06 review MEDIUM #34).

- pii-guard.yml: `git grep -nI -E 'samuelr[i]pp09|C:[\]Users'` ->
  `git grep -inI -E 'samuelr[i]pp09|c:[\/]+users|/c/[u]sers'`.  `-i` adds
  case-insensitivity; `c:[\/]+users` collapses single-backslash, doubled-
  backslash (`+`), and forward-slash into one branch (a `[\/]` class matches
  either separator, reliable in `git grep -E` like the existing `[\]` trick);
  `/c/[u]sers` covers the MSYS form.  Every branch keeps a char class breaking
  the contiguous literal, so the widened pattern still never matches its own
  text (verified: the guard runs clean over the tracked tree).
- Masked the one pre-existing forward-slash occurrence the widened guard would
  otherwise flag: docs/reviews/2026-07-03-fable-full-review/18-ci-packaging.md
  (the review note describing this very gap) -> `C:/[U]sers`.

Negative control (echo-based, no repo pollution): for the forward-slash,
doubled-backslash, `/c/users`, and case-variant forms the OLD pattern MISSES
and the NEW pattern CATCHES; the widened grep over the tracked tree exits 1
(clean) and does not self-flag.  No test pins the pattern.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
