### PR TITLE
perf(backups): dedicated capped executor for backup jobs — infra + scheduled path (#27)

### DIFF
--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -144,7 +144,7 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
 
     from ...models.device import BackupRequest, DeviceCredentials, DeviceTarget
     from ...models.device_profile import DeviceProfile
-    from ...services.backup_runner import run_backup_job
+    from ...services.backup_runner import _job_executor, run_backup_job
     from ...storage.device_profile_store import DEVICE_PROFILE_REGISTRY_LOCK
 
     schedules = app.state.schedules
@@ -270,7 +270,17 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
             job.id,
             exc,
         )
-    await asyncio.to_thread(
+    # (#27) Dispatch onto the dedicated backup-job executor rather than
+    # asyncio's default pool — the default pool is shared with /sanitize and
+    # the egress DNS filter, and startup re-registration anchors same-interval
+    # schedules together so they burst after a restart.  ``run_in_executor``
+    # keeps the exact await-to-completion semantics ``asyncio.to_thread`` had
+    # (this coroutine still blocks until the run finishes); only the pool
+    # changes.  Args are passed positionally — ``run_in_executor`` takes no
+    # kwargs, which matches ``run_backup_job``'s positional call here.
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(
+        _job_executor(),
         run_backup_job,
         job,
         request,

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -66,6 +66,55 @@ def _resolve_global_backup_ceiling() -> int:
 MAX_GLOBAL_BACKUP_CONCURRENCY: int = _resolve_global_backup_ceiling()
 
 
+#: Default ceiling on the number of *backup jobs* dispatched concurrently.
+#: Distinct from the two device-level caps above: those bound how many
+#: *devices* a job (or the whole process) collects at once; this bounds how
+#: many whole jobs run in parallel on the dedicated backup executor.  A job
+#: submitted while the executor is saturated waits in its FIFO queue (stays
+#: ``pending`` until a slot frees — back-pressure, never a failure).
+#:
+#: The executor exists to keep minutes-long backup runs off the shared pools
+#: that serve the rest of the app: pre-fix the manual (``POST /backups``)
+#: path ran each job on one of anyio's ~40 default worker-thread tokens — so
+#: ~40 in-flight jobs starved *every* synchronous route — and the scheduled
+#: path shared asyncio's default executor with ``/sanitize`` and the egress
+#: filter (2026-07-06 review MEDIUM #27).  8 is a conservative default; raise
+#: it (8-16 typical) for large deployments via
+#: ``NETCANON_MAX_CONCURRENT_BACKUP_JOBS``.
+_DEFAULT_MAX_CONCURRENT_BACKUP_JOBS: int = 8
+
+
+def _resolve_max_concurrent_backup_jobs() -> int:
+    """Read the max-concurrent-*jobs* ceiling from the environment.
+
+    Module-level (not a :class:`Settings` field) because the executor it
+    sizes is a single *process-wide* object created once, independent of any
+    per-job ``Settings`` snapshot — exactly like
+    :func:`_resolve_global_backup_ceiling`.  Reads
+    ``NETCANON_MAX_CONCURRENT_BACKUP_JOBS``, falling back to
+    :data:`_DEFAULT_MAX_CONCURRENT_BACKUP_JOBS` when unset or unparseable;
+    floored at 1 so the executor always has at least one worker.
+    """
+    raw = os.environ.get("NETCANON_MAX_CONCURRENT_BACKUP_JOBS")
+    if raw is None:
+        return _DEFAULT_MAX_CONCURRENT_BACKUP_JOBS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        warnings.warn(
+            f"NETCANON_MAX_CONCURRENT_BACKUP_JOBS={raw!r} is not an integer; "
+            f"falling back to {_DEFAULT_MAX_CONCURRENT_BACKUP_JOBS}",
+            stacklevel=2,
+        )
+        return _DEFAULT_MAX_CONCURRENT_BACKUP_JOBS
+
+
+#: Resolved at import; the backup executor in
+#: :mod:`netcanon.services.backup_runner` reads
+#: ``config.MAX_CONCURRENT_BACKUP_JOBS`` when it lazily builds its pool.
+MAX_CONCURRENT_BACKUP_JOBS: int = _resolve_max_concurrent_backup_jobs()
+
+
 #: Default ceiling on a single ``POST /api/v1/sanitize`` upload (16 MiB).
 #: Network configs are well under a megabyte even for large chassis, so 16 MiB
 #: is generous headroom while still bounding the work an unauthenticated /

--- a/netcanon/main.py
+++ b/netcanon/main.py
@@ -270,6 +270,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         scheduler.shutdown(wait=False)
         logger.info("Scheduler stopped")
+        # Release the dedicated backup-job executor's threads (#27).  Let
+        # already-queued runs drain (cancel_futures=False) but don't block
+        # server shutdown behind an in-flight backup (wait=False).  Dropping
+        # the module-level singleton also lets a subsequent create_app() in
+        # the same process — every test builds a fresh app — rebuild a live
+        # executor instead of reusing a shut-down one.
+        from .services.backup_runner import reset_job_executor
+        reset_job_executor(wait=False, cancel_futures=False)
 
     # Resolve the package version from installed metadata so the
     # OpenAPI doc / Swagger UI tracks the actual release rather than

--- a/netcanon/services/backup_runner.py
+++ b/netcanon/services/backup_runner.py
@@ -54,11 +54,12 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 from datetime import UTC, datetime
 
 from ..config import (
     MAX_BACKUP_CONCURRENCY,
+    MAX_CONCURRENT_BACKUP_JOBS,
     MAX_GLOBAL_BACKUP_CONCURRENCY,
     Settings,
 )
@@ -121,6 +122,99 @@ def reset_global_limiter() -> None:
     global _GLOBAL_LIMITER
     with _GLOBAL_LIMITER_LOCK:
         _GLOBAL_LIMITER = None
+
+
+# ---------------------------------------------------------------------------
+# Dedicated backup-job executor (2026-07-06 review MEDIUM #27)
+# ---------------------------------------------------------------------------
+# ``run_backup_job`` is a minutes-long, blocking (SSH/NETCONF) call.  Both
+# entry points used to dispatch it onto a *shared* pool:
+#
+#   * the manual ``POST /api/v1/backups`` route via FastAPI ``BackgroundTasks``
+#     — which runs sync tasks on anyio's ~40-token default worker pool, the
+#     SAME pool that serves every synchronous route, so ~40 in-flight jobs
+#     froze the whole sync API while async ``/health`` stayed green;
+#   * the scheduler via ``asyncio.to_thread`` — asyncio's default executor,
+#     shared with ``/sanitize`` and the egress DNS filter.
+#
+# Neither capped the *number of jobs* (only the per-job / global device
+# fan-out).  This module-level ``ThreadPoolExecutor`` is a dedicated pool for
+# whole jobs: work runs off the shared pools, and ``max_workers`` gives an
+# explicit ceiling on concurrent jobs (extra submissions queue FIFO and start
+# as slots free — the job just stays ``pending`` until its turn, never a
+# failure).  It mirrors the ``_GLOBAL_LIMITER`` idiom above: a lazily-built
+# process-wide singleton behind a double-checked lock, with a reset helper so
+# the size can be monkeypatched before first use in tests.
+_JOB_EXECUTOR: ThreadPoolExecutor | None = None
+_JOB_EXECUTOR_LOCK = threading.Lock()
+
+
+def _job_executor() -> ThreadPoolExecutor:
+    """Return the process-wide backup-job executor, building it once.
+
+    Sized from :data:`~netcanon.config.MAX_CONCURRENT_BACKUP_JOBS`.  Lazily
+    created (double-checked lock) so the size can be monkeypatched before
+    first use in tests; :func:`reset_job_executor` drops the cached instance
+    so a later call rebuilds at the patched size.  ``thread_name_prefix`` is
+    ``"backup-job"`` so the dedicated threads are identifiable in logs / a
+    thread dump (and assertable in tests).
+    """
+    global _JOB_EXECUTOR
+    if _JOB_EXECUTOR is None:
+        with _JOB_EXECUTOR_LOCK:
+            if _JOB_EXECUTOR is None:
+                _JOB_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=MAX_CONCURRENT_BACKUP_JOBS,
+                    thread_name_prefix="backup-job",
+                )
+    return _JOB_EXECUTOR
+
+
+def reset_job_executor(*, wait: bool = False, cancel_futures: bool = True) -> None:
+    """Drop and shut down the cached backup-job executor.
+
+    Called from the application lifespan on shutdown (clean thread release)
+    and from tests (to rebuild the pool at a monkeypatched size).  The
+    reference is cleared *inside* the lock and the (potentially blocking)
+    ``shutdown`` runs *outside* it, so a concurrent :func:`_job_executor`
+    immediately builds a fresh pool rather than handing back one that is
+    being torn down.
+
+    Args:
+        wait: Passed to ``ThreadPoolExecutor.shutdown``.  Defaults to
+            ``False`` so neither server shutdown nor a test teardown blocks
+            behind an in-flight (possibly minutes-long) backup.
+        cancel_futures: Passed to ``shutdown``.  Defaults to ``True`` so
+            queued-but-not-started jobs are dropped on reset; the lifespan
+            passes ``cancel_futures=False`` to let already-queued runs drain.
+    """
+    global _JOB_EXECUTOR
+    with _JOB_EXECUTOR_LOCK:
+        executor = _JOB_EXECUTOR
+        _JOB_EXECUTOR = None
+    if executor is not None:
+        executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+
+def submit_backup_job(*args, **kwargs) -> Future:
+    """Submit :func:`run_backup_job` to the dedicated backup-job executor.
+
+    The single dispatch seam for the manual ``POST /api/v1/backups`` route
+    (the scheduler uses ``loop.run_in_executor(_job_executor(), ...)`` so it
+    can *await* completion on the event loop).  Positional / keyword arguments
+    are forwarded verbatim to :func:`run_backup_job`.  Returns the
+    :class:`~concurrent.futures.Future`; the route fires and forgets (the job
+    mutates its own ``BackupJob`` state, persisted by ``run_backup_job``), so
+    the caller need not hold the future — but returning it keeps the function
+    testable and lets a caller wait if it wants to.
+
+    Unlike the old ``BackgroundTasks`` dispatch, this does **not** run
+    synchronously before the POST response: the job runs truly in the
+    background, so ``POST /backups`` returns while the job is still
+    ``pending`` and callers must poll ``GET /backups/{id}`` for the terminal
+    state (see AGENTS.md "Hard Rules").
+    """
+    return _job_executor().submit(run_backup_job, *args, **kwargs)
 
 
 def _process_one_device_limited(*args, **kwargs) -> None:

--- a/tests/unit/test_backup_job_executor.py
+++ b/tests/unit/test_backup_job_executor.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for the dedicated backup-*job* executor (2026-07-06 review
+MEDIUM #27).
+
+The r7 ceiling (``tests/unit/test_backup_global_concurrency.py``) bounds how
+many *devices* collect at once.  This module covers the orthogonal, newer
+ceiling: how many whole *jobs* run at once.  Both backup entry points used to
+dispatch the minutes-long :func:`run_backup_job` onto a *shared* pool — the
+manual path onto anyio's ~40-token default worker pool (starving every sync
+route), the scheduled path onto asyncio's default executor (shared with
+``/sanitize`` + the egress filter).  A dedicated module-level
+``ThreadPoolExecutor`` now runs jobs off those shared pools and caps
+concurrent jobs at :data:`~netcanon.config.MAX_CONCURRENT_BACKUP_JOBS`.
+
+The cap test pins the "<= cap" direction deterministically: with a cap of N
+and N+1 submissions, exactly N stubs enter the pool and the (N+1)th cannot
+start until one frees — an uncapped executor would start all N+1 and fail the
+assertion.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from netcanon.services import backup_runner
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def small_job_cap(monkeypatch):
+    """Shrink the concurrent-jobs cap and rebuild the executor around it.
+
+    ``reset_job_executor`` on both edges keeps the small pool from leaking
+    into (or being shadowed by) other tests in the same process.
+    """
+    cap = 2
+    monkeypatch.setattr(backup_runner, "MAX_CONCURRENT_BACKUP_JOBS", cap)
+    backup_runner.reset_job_executor()
+    yield cap
+    backup_runner.reset_job_executor()
+
+
+# ---------------------------------------------------------------------------
+# Executor singleton + thread naming + reset
+# ---------------------------------------------------------------------------
+
+
+def test_job_executor_is_a_built_once_singleton():
+    backup_runner.reset_job_executor()
+    ex = backup_runner._job_executor()
+    try:
+        assert backup_runner._job_executor() is ex  # built once
+        assert ex._thread_name_prefix == "backup-job"
+    finally:
+        backup_runner.reset_job_executor()
+
+
+def test_reset_job_executor_rebuilds_at_current_cap(monkeypatch):
+    """After a reset the executor rebuilds from the current cap value."""
+    monkeypatch.setattr(backup_runner, "MAX_CONCURRENT_BACKUP_JOBS", 4)
+    backup_runner.reset_job_executor()
+    ex = backup_runner._job_executor()
+    try:
+        assert ex._max_workers == 4
+        assert backup_runner._job_executor() is ex  # same instance on re-call
+    finally:
+        backup_runner.reset_job_executor()
+
+
+def test_jobs_run_on_the_dedicated_backup_job_threads():
+    """Work submitted to the executor runs on a ``backup-job``-named thread —
+    i.e. off anyio's / asyncio's shared default pools."""
+    backup_runner.reset_job_executor()
+    seen: dict[str, str] = {}
+
+    def stub() -> None:
+        seen["thread"] = threading.current_thread().name
+
+    try:
+        backup_runner._job_executor().submit(stub).result(timeout=10)
+        assert seen["thread"].startswith("backup-job")
+    finally:
+        backup_runner.reset_job_executor()
+
+
+# ---------------------------------------------------------------------------
+# The cap bounds concurrent JOBS (the actual #27 fix)
+# ---------------------------------------------------------------------------
+
+
+def test_executor_caps_concurrent_jobs_below_submission_count(small_job_cap):
+    """Submit cap+1 blocking stubs → exactly ``cap`` run at once; the extra
+    one waits in the FIFO queue until a slot frees.  An uncapped executor
+    would start all cap+1 and this assertion would fail."""
+    cap = small_job_cap
+    entered = threading.Semaphore(0)   # released once per stub that STARTS
+    release = threading.Event()        # test opens this to let stubs finish
+    lock = threading.Lock()
+    state = {"inflight": 0, "peak": 0}
+
+    def blocking_stub() -> None:
+        with lock:
+            state["inflight"] += 1
+            state["peak"] = max(state["peak"], state["inflight"])
+        entered.release()
+        # Bounded wait so a logic bug can never hang the suite forever.
+        release.wait(timeout=15)
+        with lock:
+            state["inflight"] -= 1
+
+    ex = backup_runner._job_executor()
+    futures = [ex.submit(blocking_stub) for _ in range(cap + 1)]
+    try:
+        # Wait until `cap` stubs have actually started.
+        for _ in range(cap):
+            assert entered.acquire(timeout=10), "a stub never started"
+        # The (cap+1)th must NOT have started — the pool is full.  A short
+        # bounded probe: if it HAD started, this acquire would succeed.
+        assert not entered.acquire(timeout=0.3), (
+            "more than the cap started concurrently — the executor is not "
+            "bounding concurrent jobs"
+        )
+        with lock:
+            assert state["peak"] == cap
+    finally:
+        release.set()
+        for f in futures:
+            f.result(timeout=15)
+
+    # After everything drains the extra job ran too, but the peak never
+    # exceeded the cap.
+    assert state["peak"] == cap
+    assert state["inflight"] == 0
+
+
+# ---------------------------------------------------------------------------
+# submit_backup_job dispatches run_backup_job onto the dedicated executor
+# ---------------------------------------------------------------------------
+
+
+def test_submit_backup_job_runs_run_backup_job_on_the_dedicated_pool(monkeypatch):
+    """``submit_backup_job(*args)`` runs ``run_backup_job(*args)`` on a
+    ``backup-job`` thread — the single manual-path dispatch seam."""
+    backup_runner.reset_job_executor()
+    captured: dict[str, object] = {}
+
+    def fake_run_backup_job(*args, **kwargs) -> str:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        captured["thread"] = threading.current_thread().name
+        return "done"
+
+    monkeypatch.setattr(backup_runner, "run_backup_job", fake_run_backup_job)
+    try:
+        fut = backup_runner.submit_backup_job(
+            "job-sentinel", "request-sentinel", 42
+        )
+        assert fut.result(timeout=10) == "done"
+        assert captured["args"] == ("job-sentinel", "request-sentinel", 42)
+        assert captured["thread"].startswith("backup-job")
+    finally:
+        backup_runner.reset_job_executor()
+
+
+# ---------------------------------------------------------------------------
+# Config resolution: default / env override / floor / garbage fallback
+# ---------------------------------------------------------------------------
+
+
+def test_default_concurrent_jobs_cap_is_eight():
+    from netcanon import config
+
+    assert config.MAX_CONCURRENT_BACKUP_JOBS == 8
+
+
+def test_env_override_sets_cap(monkeypatch):
+    from netcanon import config
+
+    monkeypatch.setenv("NETCANON_MAX_CONCURRENT_BACKUP_JOBS", "16")
+    assert config._resolve_max_concurrent_backup_jobs() == 16
+
+
+def test_env_override_floors_at_one(monkeypatch):
+    from netcanon import config
+
+    monkeypatch.setenv("NETCANON_MAX_CONCURRENT_BACKUP_JOBS", "0")
+    assert config._resolve_max_concurrent_backup_jobs() == 1
+
+
+def test_env_override_garbage_falls_back_to_default(monkeypatch):
+    from netcanon import config
+
+    monkeypatch.setenv("NETCANON_MAX_CONCURRENT_BACKUP_JOBS", "not-a-number")
+    with pytest.warns(UserWarning):
+        assert config._resolve_max_concurrent_backup_jobs() == 8


### PR DESCRIPTION
## What

Land the **dedicated backup-job executor** (infra) and move the **scheduled** dispatch path onto it. Fixes the safe half of 2026-07-06 review **MEDIUM #27**; the manual (`POST /backups`) swap — which changes the documented TestClient synchronous-background contract and touches ~two dozen tests — lands in a contract-breaking follow-up so this PR stays behaviour-neutral for the manual path.

## Why

Backup jobs are minutes-long, blocking SSH/NETCONF runs, but both entry points dispatched `run_backup_job` onto a **shared** pool with no ceiling on the number of concurrent **jobs** (only on per-job / process-wide *device* fan-out):

- **manual path** → FastAPI `BackgroundTasks` runs sync tasks on anyio's ~40-token default worker pool, the same pool that serves every synchronous route → ~40 in-flight jobs freeze the whole sync API while async `/health` stays green;
- **scheduled path** → `asyncio.to_thread` = asyncio's default executor, shared with `/sanitize` and the egress DNS filter; startup re-registration anchors same-interval schedules together so they burst after a restart.

## Changes

- **`config.py`** — `NETCANON_MAX_CONCURRENT_BACKUP_JOBS` knob (default **8**, floored at 1, garbage → warn + fallback), mirroring the r7 `_resolve_global_backup_ceiling` resolver. Orthogonal to `backup_concurrency` (per-job devices) and `MAX_GLOBAL_BACKUP_CONCURRENCY` (process-wide devices).
- **`services/backup_runner.py`** — module-level `_JOB_EXECUTOR` behind `_job_executor()` (lazy, double-checked lock, `thread_name_prefix="backup-job"`), `reset_job_executor()` (drop + shutdown — ref cleared inside the lock, `shutdown` outside), and `submit_backup_job()` (the single manual-path dispatch seam, used in the follow-up). Mirrors the existing `_GLOBAL_LIMITER` / `reset_global_limiter` idiom.
- **`api/routes/schedules.py`** — `await asyncio.to_thread(run_backup_job, …)` → `await loop.run_in_executor(_job_executor(), run_backup_job, …)`. Keeps the exact **await-to-completion** semantics `to_thread` had (the scheduler coroutine still blocks until the run finishes; scheduled tests `await _run_scheduled_backup_inner` directly, so they're unaffected) — only the pool changes.
- **`main.py` lifespan** — `reset_job_executor(cancel_futures=False)` on shutdown: already-queued runs drain without blocking server shutdown, and a fresh `create_app()` in the same process (every test builds one) rebuilds a live executor instead of reusing a shut-down one.

## Tests

`tests/unit/test_backup_job_executor.py`: built-once singleton on `backup-job` threads; `reset` rebuilds at the current cap; **the cap bounds concurrent jobs below the submission count** (submit cap+1 blocking stubs → exactly `cap` start, the extra waits FIFO — an *uncapped* executor starts all cap+1 and fails the assertion; negative control verified out-of-band); `submit_backup_job` runs `run_backup_job` on the dedicated pool; config default / env override / floor / garbage-fallback.

Mesh-flat (no codec touched). Full unit suite + cross-mesh CI guard green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
