### PR TITLE
perf(backups): route manual POST through the dedicated executor (#27, contract half)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,8 +281,13 @@ tests use these exclusively — never CSS classes or element structure.  See
   patch `netcanon.api.routes.backups.get_collector` instead (the single
   factory used by the backup route).
 - **Never** assert on the POST `/api/v1/backups` response body for final job
-  state — it always returns `pending` (serialised before background task runs).
-  Always GET the job by ID to read the completed state.
+  state — it always returns `pending` (the job runs in the background).  Since
+  #27 the job runs on a dedicated executor (`backup_runner.submit_backup_job`),
+  NOT synchronously before the response — even under `TestClient` — so do not
+  assume it has finished the instant the POST returns.  **Poll** `GET /{id}`
+  until the status is terminal (`completed`/`partial`/`failed`): use the
+  `wait_for_job(client, job_id)` helper in `tests/conftest.py` (the integration
+  `client` fixture applies it automatically after a backups POST).
 - **Never** change the signatures of the existing pipeline-stage functions
   in `netcanon/services/migration_pipeline.py`.  API routes and dozens of
   tests depend on their exact shape.  Later phases add NEW public

--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -6,10 +6,12 @@ Endpoints:
     POST /api/v1/backups/
         → Create a backup job.  Validates every device's ``type_key``
           against loaded definitions, creates the :class:`BackupJob`
-          synchronously in ``pending`` state, then enqueues the actual
-          SSH / NETCONF / REST collection as a FastAPI
-          ``BackgroundTask``.  Returns the freshly-created job (always
-          ``pending`` at this point — see test-mocking note below).
+          synchronously in ``pending`` state, then submits the actual
+          SSH / NETCONF / REST collection to the dedicated backup-job
+          executor (:func:`netcanon.services.backup_runner.submit_backup_job`).
+          Returns the freshly-created job (always ``pending`` at this
+          point — the job runs in the background; see test-mocking note
+          below).
 
     GET  /api/v1/backups/
         → List every :class:`BackupJob` in memory, newest first.
@@ -19,17 +21,23 @@ Endpoints:
           to observe progression through ``running`` → ``completed`` /
           ``partial`` / ``failed``.
 
-Backup jobs are created immediately (synchronously) and then run in a
-FastAPI ``BackgroundTask``.  Callers receive a job ID and poll
-``GET /api/v1/backups/{job_id}`` for status.
+Backup jobs are created immediately (synchronously) and then run on a
+dedicated, capped background thread pool
+(:func:`netcanon.services.backup_runner.submit_backup_job`, #27).
+Callers receive a job ID and poll ``GET /api/v1/backups/{job_id}`` for
+status.
 
-During testing, FastAPI's ``TestClient`` executes background tasks
-synchronously before returning the response, so integration tests see
-a completed job immediately after ``POST /api/v1/backups`` — but the
-POST response body itself is always serialised in ``pending`` state
-(it's built before the background task runs).  Tests that need the
-final job state must always GET the job by ID after POSTing — never
-assert on the POST response body.  See AGENTS.md "Hard Rules".
+Async contract (changed by #27): the job runs *truly* in the
+background, so ``POST /api/v1/backups`` returns while the job is still
+``pending`` — it is NOT run synchronously before the response, even
+under ``TestClient`` (the pre-#27 behaviour, where FastAPI
+``BackgroundTasks`` ran the job before the next request).  Tests that
+need the final job state must poll ``GET /{id}`` until it is terminal —
+never assert final state on the POST body, and never assume the job has
+finished the instant the POST returns.  The ``wait_for_job`` helper
+(``tests/conftest.py``) does the poll; the integration ``client``
+fixture applies it automatically after a backups POST.  See AGENTS.md
+"Hard Rules".
 
 Mocking convention: tests mock collection by patching
 ``netcanon.api.routes.backups.get_collector`` — the single factory
@@ -48,7 +56,6 @@ from datetime import UTC, datetime
 
 from fastapi import (
     APIRouter,
-    BackgroundTasks,
     Depends,
     HTTPException,
     Path,
@@ -67,7 +74,7 @@ from ...definitions.schema import DeviceDefinition
 from ...models.backup import BackupJob, JobStatus
 from ...models.device import BackupRequest, DeviceCredentials, DeviceTarget
 from ...models.device_profile import DeviceProfile
-from ...services.backup_runner import run_backup_job
+from ...services.backup_runner import submit_backup_job
 from ...services.egress import EgressBlocked, assert_egress_allowed
 from ...storage.base import BaseConfigStore
 from ...storage.device_profile_store import FileDeviceProfileStore
@@ -153,7 +160,6 @@ def _resolve_credentials(
 )
 def create_backup(
     request_body: BackupRequest,
-    background_tasks: BackgroundTasks,
     request: Request,
     definitions: dict[str, DeviceDefinition] = Depends(get_definitions),
     definition_loader: DefinitionLoader = Depends(get_definition_loader),
@@ -242,8 +248,25 @@ def create_backup(
     max_workers = getattr(
         request.app.state.settings, "backup_concurrency", MAX_BACKUP_CONCURRENCY
     )
-    background_tasks.add_task(
-        run_backup_job,
+    # (#27) Snapshot the pending job for the response BEFORE handing the live
+    # object to the executor.  The worker thread flips job.status to `running`
+    # and appends results the instant it is scheduled — which can happen before
+    # FastAPI finishes serialising the response — so returning the live `job`
+    # would race a non-deterministic pending/running/completed status into the
+    # POST body.  The registry + disk hold the LIVE object (GET /{id} reflects
+    # real-time state); the response is a frozen `pending` acknowledgement,
+    # preserving the documented "POST always returns pending" contract.
+    pending_snapshot = job.model_copy(deep=True)
+    # Dispatch onto the dedicated backup-job executor rather than FastAPI
+    # BackgroundTasks.  BackgroundTasks ran the minutes-long, blocking
+    # run_backup_job on one of anyio's ~40 shared worker-thread tokens — the
+    # same pool that serves every synchronous route — so ~40 in-flight jobs
+    # froze the whole sync API.  submit_backup_job runs the job on a dedicated,
+    # capped pool instead.  The job now runs truly in the background, so
+    # callers must poll GET /backups/{id} for the terminal state; the job is
+    # already in the registry + persisted above, so the poll sees it
+    # immediately.  See AGENTS.md "Hard Rules".
+    submit_backup_job(
         job,
         resolved_request,
         definitions,
@@ -260,7 +283,7 @@ def create_backup(
         job.total_devices,
         max_workers,
     )
-    return job
+    return pending_snapshot
 
 
 @router.get(

--- a/netcanon/services/backup_runner.py
+++ b/netcanon/services/backup_runner.py
@@ -6,8 +6,10 @@ list of :class:`~netcanon.models.device.DeviceTarget` into persisted
 config records funnels through :func:`run_backup_job`.  The
 ``POST /api/v1/backups`` route (:mod:`netcanon.api.routes.backups`) and
 the APScheduler-driven scheduler
-(:mod:`netcanon.api.routes.schedules`) both dispatch this function into
-a worker thread; integration / e2e / desktop tests drive it
+(:mod:`netcanon.api.routes.schedules`) both dispatch this function onto
+the dedicated backup-job executor below (:func:`_job_executor` — the
+route via :func:`submit_backup_job`, the scheduler via
+``loop.run_in_executor``); integration / e2e / desktop tests drive it
 transitively through those endpoints.
 
 Structural sibling of :mod:`netcanon.services.migration_pipeline`:
@@ -38,9 +40,11 @@ Mock-point contract (AGENTS.md "Hard Rules" — load-bearing):
 Thread-safety / async-boundary contract (unchanged from the original
 route-module home):
 
-    * Runs in a worker thread, never on the event loop.  The route
-      dispatches via FastAPI ``BackgroundTasks``; the scheduler via
-      ``asyncio.to_thread`` — blocking SSH must not run on the loop.
+    * Runs in a worker thread, never on the event loop.  Both entry
+      points use the dedicated backup-job executor (:func:`_job_executor`)
+      — the route via :func:`submit_backup_job`, the scheduler via
+      ``loop.run_in_executor`` — so blocking SSH never runs on the loop
+      and never on the shared anyio / default pools (#27).
     * ``job.results`` is pre-populated before dispatch and never
       resized; each worker mutates exactly one element, so no locking
       is required (the GIL makes the individual attribute writes
@@ -485,13 +489,15 @@ def run_backup_job(
 ) -> None:
     """Execute all device backups for *job* and update its state.
 
-    Runs in a worker thread (FastAPI ``BackgroundTasks`` for the route,
-    ``asyncio.to_thread`` for the scheduler); never returns to the route
-    response — see AGENTS.md "Hard Rules".  ``POST /api/v1/backups``
-    always returns ``status=pending`` and the caller polls
-    ``GET /api/v1/backups/{id}`` for the terminal state this function
-    writes.  Tests rely on TestClient executing background tasks
-    synchronously before the POST response is returned.
+    Runs in a worker thread on the dedicated backup-job executor
+    (:func:`submit_backup_job` for the route, ``loop.run_in_executor`` for
+    the scheduler); never returns to the route response — see AGENTS.md
+    "Hard Rules".  ``POST /api/v1/backups`` always returns
+    ``status=pending`` and the caller polls ``GET /api/v1/backups/{id}``
+    for the terminal state this function writes.  Because the job runs
+    truly in the background (not synchronously before the POST response,
+    even under ``TestClient``, unlike the pre-#27 ``BackgroundTasks``
+    dispatch), tests must poll for completion (``wait_for_job``).
 
     Device work is dispatched to a bounded ``ThreadPoolExecutor`` so up
     to *max_workers* devices are processed in parallel; additional

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,11 @@ Session-scoped resources for the live-server E2E layer live in
 from __future__ import annotations
 
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
+from fastapi.testclient import TestClient
 
 from netcanon.collectors.base import BaseCollector
 from netcanon.config import Settings
@@ -86,6 +88,94 @@ OPNSENSE_FAKE_OUTPUT = (
     '<?xml version="1.0"?>\n'
     "<opnsense><version>25.1</version></opnsense>\n"
 )
+
+
+# ---------------------------------------------------------------------------
+# Backup-job polling helper (#27)
+# ---------------------------------------------------------------------------
+
+#: Terminal backup-job statuses — a job in one of these has finished running.
+TERMINAL_JOB_STATUSES = frozenset({"completed", "partial", "failed"})
+
+
+def wait_for_job(client, job_id: str, *, timeout: float = 10.0, poll: float = 0.01):
+    """Poll ``GET /api/v1/backups/{job_id}`` until the job reaches a terminal
+    state, and return that terminal job JSON.
+
+    Since #27, backup dispatch runs on a dedicated background
+    ``ThreadPoolExecutor`` (``backup_runner.submit_backup_job``) rather than
+    FastAPI ``BackgroundTasks``, so a ``POST /api/v1/backups`` returns while
+    the job is still ``pending`` — it is no longer executed synchronously
+    before the next request under ``TestClient``.  Any test that needs the
+    terminal job state (or a side effect of the run, e.g. the stored config
+    file) must wait for completion first.  Mocked collectors finish in
+    milliseconds, so this returns almost immediately; ``timeout`` is only a
+    backstop against a genuinely stuck job.
+
+    The integration ``client`` fixture applies this automatically after a
+    successful backups POST; call it explicitly only when you build your own
+    ``TestClient`` (custom collector / settings).
+
+    Args:
+        client: A ``TestClient`` (or anything with ``.get(url)`` returning an
+            object exposing ``.status_code`` and ``.json()``).
+        job_id: The job id from the POST response body.
+        timeout: Seconds to wait before raising ``AssertionError``.
+        poll: Seconds between polls.
+
+    Raises:
+        AssertionError: The job did not reach a terminal state in *timeout*.
+    """
+    deadline = time.monotonic() + timeout
+    last_status: str | None = None
+    while True:
+        resp = client.get(f"/api/v1/backups/{job_id}")
+        if resp.status_code == 200:
+            body = resp.json()
+            last_status = body.get("status")
+            if last_status in TERMINAL_JOB_STATUSES:
+                return body
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"job {job_id!r} did not reach a terminal state within "
+                f"{timeout}s (last status: {last_status or 'not found'})"
+            )
+        time.sleep(poll)
+
+
+class AutoWaitTestClient(TestClient):
+    """``TestClient`` that waits for each backup job it creates to finish.
+
+    #27 moved backup dispatch off FastAPI ``BackgroundTasks`` (which
+    ``TestClient`` ran synchronously before the next request) onto a
+    dedicated background executor, so a ``POST /api/v1/backups`` now returns
+    while the job is still ``pending``.  This subclass polls the created job
+    to a terminal state right after a successful backups POST, restoring the
+    pre-#27 "the job has finished by the next request" timing the existing
+    tests were written against — without each test needing an explicit
+    :func:`wait_for_job` call.  The response returned is the original
+    (``pending``) POST body, so a test asserting the POST itself is
+    ``pending`` still passes; only the *timing* is restored.
+
+    Use this in place of ``TestClient`` for any client that POSTs backups and
+    then reads the job / its side effects.  Do NOT use it for a client whose
+    job is deliberately held non-terminal (e.g. the runner is stubbed so the
+    job stays ``pending``) — the post-POST poll would then hit its timeout.
+    """
+
+    def post(self, url, *args, **kwargs):
+        resp = super().post(url, *args, **kwargs)
+        # Only a successful create against the backups *collection* endpoint
+        # spawns a job to wait on (not GET /{id}, not a 422/400 rejection,
+        # not a POST to some other resource).
+        if resp.status_code == 202 and url.rstrip("/").endswith("/api/v1/backups"):
+            try:
+                job_id = resp.json().get("id")
+            except Exception:  # non-JSON / unexpected body — nothing to wait on
+                job_id = None
+            if job_id:
+                wait_for_job(self, job_id)
+        return resp
 
 
 # ---------------------------------------------------------------------------

--- a/tests/desktop/test_backups_juniper_desktop.py
+++ b/tests/desktop/test_backups_juniper_desktop.py
@@ -31,12 +31,17 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from netcanon.collectors.base import BaseCollector
 from netcanon.config import Settings
 from netcanon.definitions import LIBRARY_DIR
 from netcanon.main import create_app
+
+# #27: backup dispatch is now async on a dedicated executor, so a POST returns
+# before the job finishes.  Alias the auto-waiting client (polls each created
+# backup job to completion) to TestClient so the POST-then-GET smoke assertions
+# keep their pre-#27 semantics.
+from tests.conftest import AutoWaitTestClient as TestClient
 
 pytestmark = pytest.mark.desktop
 

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -661,12 +661,35 @@ class MigratePage:
 # ---------------------------------------------------------------------------
 
 
+def _wait_for_job(page: Page, job_id: str, *, timeout: float = 15.0) -> None:
+    """Poll ``GET /api/v1/backups/{job_id}`` until the job is terminal.
+
+    Since #27, backups run on a dedicated background executor on the live
+    server, so ``POST /api/v1/backups`` returns before the job — and its
+    stored config file — is done.  Seeding helpers must wait for completion
+    before reading ``/api/v1/configs/`` or the config may not exist yet.
+    """
+    import time as _time
+
+    terminal = {"completed", "partial", "failed"}
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        resp = page.request.get(f"/api/v1/backups/{job_id}")
+        if resp.ok and resp.json().get("status") in terminal:
+            return
+        _time.sleep(0.05)
+    raise AssertionError(
+        f"e2e: backup job {job_id} did not finish within {timeout}s"
+    )
+
+
 def ensure_cisco_config(page: Page) -> str:
     """Make sure at least one Cisco config exists, then return its filename.
 
-    Posts a backup via the API (FakeCollector returns canned Cisco output).
+    Posts a backup via the API (FakeCollector returns canned Cisco output)
+    and waits for the job to finish before reading the config list (#27).
     """
-    page.request.post(
+    resp = page.request.post(
         "/api/v1/backups/",
         data={
             "devices": [
@@ -678,6 +701,7 @@ def ensure_cisco_config(page: Page) -> str:
             ]
         },
     )
+    _wait_for_job(page, resp.json()["id"])
     resp = page.request.get("/api/v1/configs/")
     assert resp.ok
     records = resp.json()
@@ -690,9 +714,14 @@ def ensure_n_configs_of_type(
     page: Page, type_key: str, count: int
 ) -> list[str]:
     """Create *count* configs of the given type via the live API and
-    return their filenames (newest-first)."""
+    return their filenames (newest-first).
+
+    Each backup job is polled to completion before the config list is read,
+    since backups now run asynchronously on a dedicated executor (#27).
+    """
+    job_ids: list[str] = []
     for i in range(count):
-        page.request.post(
+        resp = page.request.post(
             "/api/v1/backups/",
             data={
                 "devices": [
@@ -704,6 +733,9 @@ def ensure_n_configs_of_type(
                 ]
             },
         )
+        job_ids.append(resp.json()["id"])
+    for jid in job_ids:
+        _wait_for_job(page, jid)
     records = page.request.get("/api/v1/configs/").json()
     files = [
         r["filename"] for r in records if r["device_type"] == type_key

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,9 +5,15 @@ These fixtures build on the root ``tests/conftest.py`` fixtures to provide a
 ``TestClient`` connected to a fully initialised FastAPI application.  SSH
 collection is mocked by patching ``get_collector`` before any request is made.
 
-Because FastAPI's ``TestClient`` runs ``BackgroundTasks`` synchronously
-(before returning the response), integration tests see a *completed* backup
-job immediately after ``POST /api/v1/backups`` — no polling required.
+Backup dispatch runs on a dedicated background executor since #27 (no longer
+FastAPI ``BackgroundTasks``), so a ``POST /api/v1/backups`` returns while the
+job is still ``pending``.  The ``client`` fixture below wraps ``TestClient``
+so it automatically polls each newly-created backup job to completion — this
+restores the pre-#27 "the job has finished by the next request" behaviour the
+existing tests were written against, without every test needing an explicit
+``wait_for_job`` call.  Tests that build their own ``TestClient`` (custom
+collector / settings) must call ``wait_for_job`` from ``tests/conftest.py``
+themselves.
 """
 from __future__ import annotations
 
@@ -16,7 +22,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from tests.conftest import CISCO_FAKE_OUTPUT, FakeCollector
+from tests.conftest import CISCO_FAKE_OUTPUT, AutoWaitTestClient, FakeCollector
 
 
 @pytest.fixture()
@@ -28,13 +34,16 @@ def client(test_app) -> TestClient:
     a ``FakeCollector`` for every ``get_collector(definition)`` call, regardless
     of the definition's strategy or type_key.
 
-    The ``TestClient`` is used as a context manager so the app lifespan runs
-    (loading definitions, creating the FileConfigStore) before the first
-    request and tears down cleanly after the last.
+    The client is an :class:`~tests.conftest.AutoWaitTestClient` so a
+    ``POST /api/v1/backups`` blocks until the created job is terminal (see the
+    module docstring) — the default ``FakeCollector`` finishes in
+    milliseconds.  Used as a context manager so the app lifespan runs (loading
+    definitions, creating the FileConfigStore) before the first request and
+    tears down cleanly after.
     """
     fake = FakeCollector(output=CISCO_FAKE_OUTPUT)
     with patch(
         "netcanon.api.routes.backups.get_collector",
         return_value=fake,
-    ), TestClient(test_app, raise_server_exceptions=True) as c:
+    ), AutoWaitTestClient(test_app, raise_server_exceptions=True) as c:
         yield c

--- a/tests/integration/test_backup_probe_wiring.py
+++ b/tests/integration/test_backup_probe_wiring.py
@@ -26,7 +26,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from netcanon.collectors.base import BaseCollector
 from netcanon.definitions import LIBRARY_DIR
@@ -34,6 +33,12 @@ from netcanon.definitions.schema import DeviceDefinition
 from netcanon.main import create_app
 from netcanon.models.device import DeviceTarget
 from tests.conftest import CISCO_FAKE_OUTPUT
+
+# #27: backup dispatch is now async on a dedicated executor, so a POST returns
+# before the job finishes.  Alias the auto-waiting client (polls each created
+# backup job to completion) to TestClient so the POST-then-GET probe-wiring
+# assertions keep their pre-#27 semantics.
+from tests.conftest import AutoWaitTestClient as TestClient
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_backups_api.py
+++ b/tests/integration/test_backups_api.py
@@ -1,11 +1,13 @@
 """
 Integration tests for ``/api/v1/backups/`` endpoints.
 
-Key property of TestClient + BackgroundTasks:
-FastAPI's ``TestClient`` executes background tasks **synchronously** before
-returning the HTTP response.  This means the backup job is always in
-``completed`` state by the time the ``POST /api/v1/backups`` response arrives —
-no polling or sleep required in tests.
+Dispatch model (#27): backup jobs run on a dedicated background executor, so
+a ``POST /api/v1/backups`` returns while the job is still ``pending`` — the
+job is NOT run synchronously before the response.  These tests use the
+auto-waiting client (``TestClient`` here is aliased to
+``tests.conftest.AutoWaitTestClient``, which polls each created job to
+completion after the POST), so the POST-then-GET assertions read the terminal
+state without an explicit ``wait_for_job`` call.
 """
 from __future__ import annotations
 
@@ -42,9 +44,10 @@ def _post_backup(client, devices: list[dict] | None = None) -> dict:
 def _post_and_get(client, devices: list[dict] | None = None) -> dict:
     """POST a backup job and return the final job state via GET.
 
-    Background tasks run synchronously in TestClient but AFTER the POST
-    response body is serialized.  The POST response always shows
-    ``status: pending``; a subsequent GET reflects the completed state.
+    The POST response always shows ``status: pending`` (the job runs in the
+    background on a dedicated executor, #27).  With the auto-waiting client,
+    the POST blocks until the job is terminal, so the subsequent GET reflects
+    the completed state.
     """
     post_resp = _post_backup(client, devices)
     assert post_resp.status_code == 202
@@ -67,12 +70,13 @@ class TestCreateBackup:
         assert "id" in resp.json()
 
     def test_post_returns_pending(self, client):
-        """POST response is serialised before background tasks run → always pending."""
+        """POST body is a frozen pending snapshot (#27) — the live job runs in
+        the background, but the response is always ``pending``."""
         resp = _post_backup(client)
         assert resp.json()["status"] == "pending"
 
     def test_job_completed_after_get(self, client):
-        """Background task runs synchronously; GET reflects completed state."""
+        """Job runs in the background; after the auto-wait, GET is completed."""
         job = _post_and_get(client)
         assert job["status"] == "completed"
 
@@ -173,7 +177,7 @@ class TestJobTerminalStatus:
     def _run(self, test_app, fail_hosts: set[str], hosts: list[str]) -> dict:
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         collector = _SelectiveFailCollector(fail_hosts)
         with patch(
@@ -253,7 +257,7 @@ class TestDeviceStatusLifecycle:
         """While device N is being collected, N is 'running' and N+1..end are 'queued'."""
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         collector = _ObservingCollector(test_app)
         with patch(
@@ -357,7 +361,7 @@ class TestBackupConcurrency:
         """Barrier(3) only opens if 3 workers arrive simultaneously."""
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         app = _build_parallel_app(test_settings, concurrency=3)
         collector = _BarrierCollector(parties=3)
@@ -406,7 +410,7 @@ class TestBackupConcurrency:
         import time
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         app = _build_parallel_app(test_settings, concurrency=5)
 
@@ -462,7 +466,7 @@ class TestBackupConcurrency:
         import threading
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
         thread_names: list[str] = []
 
         class ThreadNameCollector:
@@ -481,8 +485,79 @@ class TestBackupConcurrency:
             )
 
         assert len(thread_names) == 1
-        # Serial path runs in the caller's thread, not a "backup-…" worker.
-        assert not thread_names[0].startswith("backup-")
+        # #27: the job runs on the dedicated backup-job executor, and a
+        # single-device job takes the serial fast-path — the collect runs
+        # directly on that job-executor thread ("backup-job_N"), NOT in a
+        # per-job sub-pool worker (which would be named "backup-<jobid8>_N").
+        assert thread_names[0].startswith("backup-job"), thread_names[0]
+
+
+# ---------------------------------------------------------------------------
+# #27 — background dispatch contract (POST returns before the job finishes)
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundDispatchContract:
+    """The manual POST dispatches to the dedicated backup-job executor, not
+    FastAPI ``BackgroundTasks``: it returns a frozen ``pending`` snapshot while
+    the job is *still running* in the background (#27)."""
+
+    def test_post_returns_while_job_still_running_on_dedicated_executor(
+        self, test_app
+    ):
+        """POST returns 202 + ``pending`` while a deliberately-blocked collector
+        is mid-run — proof the dispatch is async, not synchronous.  The collect
+        also runs on a ``backup-job`` executor thread.
+
+        Negative control: under the pre-#27 ``BackgroundTasks`` dispatch this
+        POST blocked until the whole job finished, so it could not return while
+        the collector was still gated, the body serialised as ``completed`` /
+        ``running`` (not a frozen ``pending``), and the collector ran on an
+        anyio worker thread — every assertion below would fail.
+        """
+        import threading
+        from unittest.mock import patch
+
+        # Plain client: do NOT auto-wait — we assert on the in-flight state.
+        from fastapi.testclient import TestClient
+
+        from tests.conftest import wait_for_job
+
+        started = threading.Event()
+        release = threading.Event()
+        thread_names: list[str] = []
+
+        class _GatedCollector:
+            def collect(self, device, definition):
+                thread_names.append(threading.current_thread().name)
+                started.set()
+                # Block so the job is unambiguously mid-run when POST returns.
+                release.wait(timeout=10)
+                return "! config"
+
+        try:
+            with patch(
+                "netcanon.api.routes.backups.get_collector",
+                return_value=_GatedCollector(),
+            ), TestClient(test_app, raise_server_exceptions=True) as c:
+                resp = c.post(
+                    "/api/v1/backups",
+                    json={"devices": [_device_payload(host="1.1.1.1")]},
+                )
+                assert resp.status_code == 202
+                # Frozen pending snapshot — not the racy live status.
+                assert resp.json()["status"] == "pending"
+                # The job started on the executor while POST already returned.
+                assert started.wait(timeout=10), "job never started"
+                assert thread_names[0].startswith("backup-job"), thread_names[0]
+                # Let the job finish, then confirm terminal state.
+                release.set()
+                job = wait_for_job(c, resp.json()["id"])
+                assert job["status"] == "completed"
+        finally:
+            # Ensure the gated collector is always released (even on assert
+            # failure) so the executor thread can exit and teardown is clean.
+            release.set()
 
 
 # ---------------------------------------------------------------------------
@@ -606,7 +681,7 @@ class TestServerSideCredentialResolution:
     def test_profile_backup_resolves_credentials_server_side(self, test_app):
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         collector = _CredCapturingCollector()
         with patch(
@@ -700,7 +775,7 @@ class TestEgressAllowlist:
     def test_loopback_target_rejected_when_enabled(self, test_settings):
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         app = self._strict_app(test_settings)
         with patch(
@@ -717,7 +792,7 @@ class TestEgressAllowlist:
     def test_metadata_endpoint_rejected_when_enabled(self, test_settings):
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         app = self._strict_app(test_settings)
         with patch(
@@ -733,7 +808,7 @@ class TestEgressAllowlist:
     def test_public_target_allowed_when_enabled(self, test_settings):
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         app = self._strict_app(test_settings)
         with patch(

--- a/tests/integration/test_backups_arista.py
+++ b/tests/integration/test_backups_arista.py
@@ -21,11 +21,16 @@ import shutil
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from netcanon.config import Settings
 from netcanon.definitions import LIBRARY_DIR
 from netcanon.main import create_app
+
+# #27: backup dispatch is now async on a dedicated executor, so a POST returns
+# before the job finishes.  Alias the auto-waiting client (polls each created
+# backup job to completion) to TestClient so the POST-then-GET happy-path
+# assertions keep their pre-#27 semantics.
+from tests.conftest import AutoWaitTestClient as TestClient
 from tests.conftest import FakeCollector
 
 pytestmark = pytest.mark.integration

--- a/tests/integration/test_backups_aruba.py
+++ b/tests/integration/test_backups_aruba.py
@@ -21,11 +21,16 @@ import shutil
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from netcanon.config import Settings
 from netcanon.definitions import LIBRARY_DIR
 from netcanon.main import create_app
+
+# #27: backup dispatch is now async on a dedicated executor, so a POST returns
+# before the job finishes.  Alias the auto-waiting client (polls each created
+# backup job to completion) to TestClient so the POST-then-GET happy-path
+# assertions keep their pre-#27 semantics.
+from tests.conftest import AutoWaitTestClient as TestClient
 from tests.conftest import FakeCollector
 
 pytestmark = pytest.mark.integration

--- a/tests/integration/test_backups_juniper.py
+++ b/tests/integration/test_backups_juniper.py
@@ -18,8 +18,9 @@ seam is ``get_collector``, the single factory used by the backup
 route.
 
 POST/GET sequence rationale (AGENTS.md hard rule): the POST response
-is serialised before the BackgroundTask runs and always shows
-``status: pending``.  Always GET the job by ID for the final state.
+always shows ``status: pending`` (the job runs in the background on a
+dedicated executor since #27).  Poll GET the job by ID for the final
+state — the auto-waiting client aliased below does this after each POST.
 """
 
 from __future__ import annotations
@@ -27,12 +28,17 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from netcanon.collectors.base import BaseCollector
 from netcanon.config import Settings
 from netcanon.definitions import LIBRARY_DIR
 from netcanon.main import create_app
+
+# #27: backup dispatch is now async on a dedicated executor, so a POST returns
+# before the job finishes.  Alias the auto-waiting client (polls each created
+# backup job to completion) to TestClient so the POST-then-GET happy-path
+# assertions keep their pre-#27 semantics.
+from tests.conftest import AutoWaitTestClient as TestClient
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_configs_api.py
+++ b/tests/integration/test_configs_api.py
@@ -22,9 +22,10 @@ pytestmark = pytest.mark.integration
 def _seed_config(client, host: str = "192.168.1.1") -> str:
     """Run a backup job and return the saved filename.
 
-    Background tasks run synchronously in TestClient but AFTER the POST
-    response body is serialised (so POST always returns ``status: pending``).
-    We GET the job immediately after to read the completed state.
+    The POST always returns ``status: pending`` (the job runs in the
+    background on a dedicated executor, #27).  With the auto-waiting ``client``
+    fixture the POST blocks until the job is terminal, so the config file has
+    landed and the GET below reads the completed state.
     """
     post_resp = client.post(
         "/api/v1/backups",
@@ -149,10 +150,14 @@ class TestOpenConfig:
         """TestClient with ``open_in_editor=True`` and SSH mocked out."""
         from unittest.mock import patch
 
-        from fastapi.testclient import TestClient
-
         from netcanon.main import create_app
         from tests.conftest import CISCO_FAKE_OUTPUT, FakeCollector
+
+        # #27: seeding a config POSTs a backup that now runs async on a
+        # dedicated executor, so use the auto-waiting client (aliased to
+        # TestClient) — it blocks until the seed job finishes and the config
+        # file has landed.
+        from tests.conftest import AutoWaitTestClient as TestClient
 
         settings = Settings(
             definitions_dir=sample_definitions_dir,

--- a/tests/integration/test_load_and_memory.py
+++ b/tests/integration/test_load_and_memory.py
@@ -39,10 +39,17 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient as _PlainTestClient
 
 from netcanon.models.backup import BackupJob
 from netcanon.storage.job_registry import BackupJobRegistry
+
+# #27: most load tests assert on terminal job state / the LRU cap, which now
+# requires the async backup job to finish first — alias the auto-waiting client
+# to TestClient so those POST-then-assert tests keep their semantics.  The one
+# test that deliberately holds a job ``pending`` (stubbed dispatch) uses
+# ``_PlainTestClient`` so its post-POST poll doesn't time out.
+from tests.conftest import AutoWaitTestClient as TestClient
 from tests.conftest import FakeCollector
 
 pytestmark = pytest.mark.integration
@@ -183,9 +190,12 @@ class TestSustainedLoad:
         so the first job stays ``pending``; a second submission would normally
         evict the LRU entry, but the non-terminal protection keeps it resident.
         It is reachable either way (cache OR the creation-time disk persist)."""
+        # Stub the dispatch seam so the job is created + persisted but never
+        # runs (stays ``pending``).  Use the PLAIN client — the auto-waiting
+        # one would poll a job that never completes and hit its timeout.
         with patch(
-            "netcanon.api.routes.backups.run_backup_job",
-        ), TestClient(test_app) as c:
+            "netcanon.api.routes.backups.submit_backup_job",
+        ), _PlainTestClient(test_app) as c:
             original_registry = _swap_registry(test_app, max_memory_jobs=1)
             try:
                 first = c.post(

--- a/tests/integration/test_ui_routes.py
+++ b/tests/integration/test_ui_routes.py
@@ -14,10 +14,15 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from netcanon.main import create_app
 from tests.conftest import CISCO_FAKE_OUTPUT, FakeCollector
+
+# #27: backup dispatch is now async on a dedicated executor, so a POST returns
+# before the job finishes.  Alias the auto-waiting client (polls each created
+# backup job to completion) to TestClient so the POST-then-GET UI assertions
+# keep their pre-#27 semantics.
+from tests.conftest import AutoWaitTestClient as TestClient
 
 pytestmark = pytest.mark.integration
 


### PR DESCRIPTION
## What

Completes 2026-07-06 review **MEDIUM #27** — the contract-changing half. Follows [#333](https://github.com/netcanon/netcanon/pull/333) (executor infra + scheduled path). The manual `POST /api/v1/backups` path now dispatches to the dedicated backup-job executor (`submit_backup_job`) instead of FastAPI `BackgroundTasks`.

## Why

`BackgroundTasks` ran the minutes-long, blocking `run_backup_job` on one of anyio's ~40 shared worker-thread tokens — the same pool that serves every synchronous route — so ~40 in-flight jobs froze the whole sync API while async `/health` stayed green. Now both entry points (manual + scheduled) run whole jobs off the shared pools with an explicit concurrent-job cap.

**Contract change:** the job runs *truly* in the background, so the POST returns while it is still `pending` rather than being executed synchronously before the response (the pre-#27 behaviour `TestClient` reproduced). This is why it's a separate PR from #333.

## Source

- **`backups.py`**: `background_tasks.add_task(run_backup_job, …)` → `submit_backup_job(…)`; drop the `BackgroundTasks` param/import. Return a **`pending` snapshot** (`job.model_copy(deep=True)`) taken *before* dispatch — the worker flips `job.status` to `running` the instant it's scheduled, possibly before FastAPI serialises the response, so returning the live object would race a nondeterministic status into the POST body. The registry + disk hold the LIVE object (`GET /{id}` is real-time); the response is a frozen `pending` acknowledgement, preserving the documented "POST always returns pending" contract.
- Docstrings (`backups.py`, `backup_runner.py`) + **`AGENTS.md:284`**: describe the async dispatch + poll-for-terminal contract.

## Test infrastructure (why this is its own PR)

- **`tests/conftest.py`**: `wait_for_job(client, job_id)` polls `GET /{id}` to terminal; **`AutoWaitTestClient`** (a `TestClient` subclass) polls each created job to completion after a 202 backups POST — restoring the pre-#27 "job finished by the next request" timing **without** editing every POST-then-read assertion.
- Integration `client` fixture uses `AutoWaitTestClient`; the vendor / probe / UI / configs / load fixtures + inline clients alias it as `TestClient`. The one test that deliberately holds a job `pending` (stubbed dispatch) keeps a plain client and switches its patch target `run_backup_job` → `submit_backup_job`.
- `test_single_device_job_uses_serial_fast_path`: assertion updated — the serial fast-path collect now runs directly on the `backup-job` executor thread (was asserting `not backup-…`, which described the old per-job-pool naming).
- **New `TestBackgroundDispatchContract`**: a gated collector proves the POST returns 202 + frozen `pending` while the job is *still mid-run* on a `backup-job` thread — the direct regression test for the async swap (pre-#27 the POST blocked until completion; both the thread-name and pending assertions would fail).
- **`tests/e2e/helpers.py`**: seed helpers poll each job to completion before reading `/configs` (the live e2e server runs backups async too).

## Verification

Full unit + integration + desktop suites green locally; mesh-flat (no codec touched); cross-mesh CI guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
