### PR TITLE
docs(readme): fix backslashed CAPABILITIES.md link on the public front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ across vendors.  Full per-codec matrix is in
   excepted — it renders interfaces only).  DNS / NTP servers translate
   on most codecs; `syslog` servers and `timezone` are wired on only a
   subset — check the per-codec matrices in
-  [`docs\CAPABILITIES.md`](docs\CAPABILITIES.md), and note that where a
+  [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md), and note that where a
   codec doesn't wire a field the source-side value is currently dropped
   without a banner.
 * **Tier 2 — translatable with caveats.**  SNMP (incl. SNMPv3 USM),


### PR DESCRIPTION
Line 291 of `README.md` linked `CAPABILITIES.md` with a **Windows-style backslash path** (`docs\CAPABILITIES.md`) in both the link text and the href, while the file's three other references use `docs/CAPABILITIES.md`. The backslash href doesn't resolve as a repo-relative link on GitHub — and since `netcanon` is a user account whose flagship repo is named after it, this README is *also* the github.com/netcanon **profile page**, so the broken link + Windows-path text is doubly visible on public surfaces.

One-line fix: forward slash, matching the file's own convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
