### PR TITLE
fix(arista): kill polynomial ReDoS in the VRF description regex (CodeQL #151)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -189,7 +189,13 @@ _VRF_INSTANCE_RE = re.compile(
 # route-target IOS-style in the stanza body; the header-only harvest dropped
 # them.  ``route-target`` accepts the optional EOS ``evpn`` keyword.
 _VRF_RD_RE = re.compile(r"^\s+rd\s+(\S+)\s*$")
-_VRF_DESC_RE = re.compile(r"^\s+description\s+(.+?)\s*$")
+# Capture is anchored ``\S.*`` (value starts non-space, run to EOL) rather than
+# a lazy ``(.+?)\s*$``: the lazy quantifier competing with the trailing ``\s*``
+# over the same whitespace is a polynomial-ReDoS — a ``description a<many
+# spaces>!`` line backtracks O(n^2) (CodeQL py/polynomial-redos).  ``\s+`` and
+# ``\S`` are disjoint classes so there is exactly one split; the ``.strip()``
+# on the captured group still trims any trailing whitespace ``.*`` absorbed.
+_VRF_DESC_RE = re.compile(r"^\s+description\s+(\S.*)$")
 _VRF_RT_RE = re.compile(
     r"^\s+route-target\s+(import|export|both)\s+(?:evpn\s+)?(\S+)\s*$"
 )

--- a/tests/unit/migration/test_redos_hardening.py
+++ b/tests/unit/migration/test_redos_hardening.py
@@ -1,5 +1,6 @@
-"""ReDoS hardening guard for the five parse.py regexes CodeQL flagged
-(``py/polynomial-redos`` alerts #124-#128).
+"""ReDoS hardening guard for the parse.py regexes CodeQL flagged
+(``py/polynomial-redos`` alerts #124-#128, plus #151 — the arista_eos VRF
+description regex that #327 reintroduced with the same lazy shape).
 
 Each pattern paired a ``\\s+`` separator (or a greedy ``(\\S+)`` next-hop) with a
 value group whose character class OVERLAPPED it (``.+`` / ``.+?`` / ``.*`` all
@@ -22,7 +23,12 @@ import time
 
 import pytest
 
-from netcanon.migration.codecs.arista_eos.parse import _DHCP_DNS_SERVER_RE
+from netcanon.migration.codecs.arista_eos.parse import (
+    _DHCP_DNS_SERVER_RE,
+)
+from netcanon.migration.codecs.arista_eos.parse import (
+    _VRF_DESC_RE as _ARISTA_VRF_DESC_RE,
+)
 from netcanon.migration.codecs.aruba_aoscx.parse import _VLAN_TRUNK_ALLOWED_RE
 from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
     _STATIC_ROUTE_RE,
@@ -64,7 +70,13 @@ def test_vlan_trunk_allowed_still_captures():
 
 
 def test_vrf_description_still_captures():
-    for rx in (_NXOS_VRF_DESCRIPTION_RE, _IOSXE_VRF_DESCRIPTION_RE):
+    # arista_eos joined this set in #151 — #327 reintroduced the lazy
+    # ``(.+?)\\s*$`` shape the #124-#128 pass had eliminated everywhere else.
+    for rx in (
+        _NXOS_VRF_DESCRIPTION_RE,
+        _IOSXE_VRF_DESCRIPTION_RE,
+        _ARISTA_VRF_DESC_RE,
+    ):
         assert rx.match("  description   Uplink to core  ").group(1).strip() == "Uplink to core"
 
 
@@ -91,8 +103,13 @@ def test_static_route_still_captures_and_keeps_trailing_tokens():
         (_NXOS_VRF_DESCRIPTION_RE, "   description " + "  " * _REPS),     # #126
         (_IOSXE_VRF_DESCRIPTION_RE, "   description " + "  " * _REPS),    # #127
         (_STATIC_ROUTE_RE, "ip route 9.9.9.9 9.9.9.9 !" + "!!" * _REPS),  # #128
+        # arista lazy ``(.+?)\s*$`` blows up specifically when the value
+        # STARTS with a non-space so the greedy ``\s+`` can't absorb the run;
+        # the trailing ``!`` defeats ``\s*$`` and forces the O(n^2) rescan.
+        (_ARISTA_VRF_DESC_RE, "   description a" + " " * _REPS + "!"),    # #151
     ],
-    ids=["dns-server", "vlan-trunk", "nxos-desc", "iosxe-desc", "static-route"],
+    ids=["dns-server", "vlan-trunk", "nxos-desc", "iosxe-desc", "static-route",
+         "arista-desc"],
 )
 def test_attack_string_is_linear_time(rx, attack):
     _m, elapsed = _timed_match(rx, attack)


### PR DESCRIPTION
## What

Fixes **CodeQL alert #151** (`py/polynomial-redos`, **HIGH**) in `arista_eos/parse.py`.

`#327`'s `vrf definition` body harvest introduced `_VRF_DESC_RE = ^\s+description\s+(.+?)\s*$` — the lazy `(.+?)` competing with the trailing `\s*$` over the same whitespace is a polynomial ReDoS, the very shape the earlier #124–#128 pass had eliminated on every other value-capturing parse regex.

## Impact

A `description a<many spaces>!` line backtracks **O(n²)**: 38 ms → 158 ms → 618 ms as the space run doubles (4× per 2×). At the 10 MB `/plan` upload cap a single crafted line pins a worker for ~hours. Reachable **unauthenticated** via `/plan` + `/detect` (both parse pasted config text).

## Fix

Anchor the capture on a disjoint class: `^\s+description\s+(\S.*)$`. `\s+` and `\S` can't both match the same char, so there's exactly one split (no backtracking) — and it's **behaviour-identical** because the consumer already `.strip()`s the group. The attack string now matches in microseconds.

## Verification

- **Verify-first / negative control:** reproduced the O(n²) blowup on the actual source regex (git-stashed the fix → 38→158→618 ms; ~92 s at the test's attack size vs the 1 s budget).
- **Behaviour preserved:** identical captured value on representative real lines (`description Core uplink to spine`, padded, single-char).
- **Regression test:** `arista_eos` added to `test_redos_hardening.py` — both the "still captures" set and a `#151` attack-string case (its own triggering shape).
- **Mesh-flat:** cross-mesh CI guard green (functionally identical on real config); full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
