### PR TITLE
ci(zizmor): pin exact action versions in comments + ignore MSI-attach note

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -183,7 +183,7 @@ jobs:
           exit 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       # Resolve whether the optional Docker Hub mirror is configured.  The
       # `secrets` context is NOT available in a step-level `if:`, so we map
@@ -201,7 +201,7 @@ jobs:
           fi
 
       - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -214,14 +214,14 @@ jobs:
       # there — login runs exactly as before (run3 dockerhub-login-unguarded).
       - name: Log in to Docker Hub
         if: steps.mirror.outputs.enabled == 'true'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Compute image metadata + tags
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           # Two images = same tag patterns applied to both registries.
           # The build-push-action below pushes a single image manifest
@@ -258,7 +258,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           push: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,3 +19,16 @@ rules:
         "actions/*": ref-pin   # GitHub-owned, force-push protected
         "github/*": ref-pin    # GitHub-owned
         "*": hash-pin          # third-party publishers: SHA required
+
+  # `superfluous-actions` (note) flags the MSI-publish "Attach MSI to
+  # GitHub Release" step for using softprops/action-gh-release where a
+  # `gh release` script would also work.  Kept intentionally: the action
+  # gives create-page-if-missing + idempotent asset append + prerelease
+  # sorting in one SHA-pinned step; a hand-rolled `gh release create/upload`
+  # equivalent is more error-prone on the release-critical path (the MSI is
+  # already double-saved as a 30-day artifact, but we don't want the attach
+  # itself flaky).  Suppress the note rather than destabilise a verified
+  # publish step.
+  superfluous-actions:
+    ignore:
+      - desktop-msi-publish.yml


### PR DESCRIPTION
## What

Resolves the **6 open zizmor code-scanning alerts**.

### `ref-version-mismatch` (5, `docker-publish.yml`) — real fix

The SHA-pinned `docker/*` actions carried floating-major version comments (`# v4`/`# v6`/`# v7`) that no longer match the tag the pinned SHA points to, so zizmor couldn't verify the pin. Corrected each comment to the **exact release the SHA is** (SHA pins unchanged, resolved via the actions' tag API):

| action | SHA | `# v4` → |
|---|---|---|
| setup-buildx-action | `d7f5e7f5` | **v4.1.0** |
| login-action (×2) | `650006c6` | **v4.2.0** |
| metadata-action | `80c7e94d` | **v6.1.0** |
| build-push-action | `f9f3042f` | **v7.2.0** |

### `superfluous-actions` (1, note, `desktop-msi-publish.yml:295`) — documented ignore

The "Attach MSI to GitHub Release" step uses `softprops/action-gh-release` where a `gh release` script would also work. Kept intentionally and ignored in `.github/zizmor.yml` (matching the repo's existing config-driven zizmor curation): the action gives create-page-if-missing + idempotent asset append + prerelease sorting in one SHA-pinned step; a hand-rolled `gh release create/upload` equivalent is more error-prone on the release-critical path (which just shipped v0.5.5 clean).

Comment-only + config — **no behaviour change**; both YAML files parse. The zizmor scan re-runs on this PR (workflow watches `.github/workflows/**`) and reconciles all six alerts on merge.

## Not in this PR

The 2 remaining `py/paramiko-missing-host-key-validation` HIGHs are handled separately (by-design `auto_add` opt-out + TOFU-with-loaded-store; dismissed with rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
