### PR TITLE
ci(security): harden release workflows — pin cosign identity, drop tag-build cache, fix zizmor input

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -272,8 +272,17 @@ jobs:
           # excluded from the Docker context per .dockerignore).
           build-args: |
             SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NETCANON=${{ steps.meta.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No build cache on the release path (deliberately no cache-from /
+          # cache-to).  `type=gha` is a mutable, cross-run-writable scope;
+          # importing it into the image we then sign (cosign), SBOM-attest
+          # (syft) and push as :latest would let a poisoned cache layer
+          # launder into a signed, attested release (GHA cache-poisoning).
+          # This workflow only ever runs on a version tag — the "Refuse a
+          # non-tag ref" guard above rejects every other ref — so there is no
+          # PR-build cache to preserve here; the release simply builds clean
+          # from source.  zizmor does not model cache-poisoning, so this is a
+          # human-review invariant, not a tool-enforced one: do not re-add a
+          # `type=gha` (or any writable shared) cache to this build step.
           provenance: true
           sbom: false   # we generate via syft below for richer SPDX output
 
@@ -365,13 +374,24 @@ jobs:
       - name: Verify signature (post-publish smoke test)
         env:
           IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          # The keyless signer identity (Fulcio cert SAN) is fully
+          # deterministic for a tag-triggered run of THIS workflow: the
+          # workflow file path at the exact triggering ref.  github.ref is
+          # refs/tags/vX.Y.Z here, so the SAN is
+          # https://github.com/<repo>/.github/workflows/docker-publish.yml@refs/tags/vX.Y.Z.
+          # Both github.repository and github.ref are trusted contexts mapped
+          # into env (never `${{ }}` in the run: block) so there is no
+          # template-injection surface.
+          EXPECTED_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/docker-publish.yml@${{ github.ref }}
         run: |
-          # The identity regexp is passed to Go's regexp (substring match,
-          # NO implicit anchors), so it MUST be anchored + dot-escaped +
-          # fully qualified to this workflow file — otherwise a SAN like
-          # https://github.com/netcanon/netcanon-attacker/... would also
-          # match (run3).  The keyless signer identity for a tag-triggered
-          # run is .../.github/workflows/docker-publish.yml@refs/tags/vX.Y.Z.
+          # Pin the signer identity EXACTLY (not a regexp).  The prior
+          # --certificate-identity-regexp was head-anchored but had NO tail
+          # anchor ("...@refs/tags/v"), so it accepted a signature minted by
+          # ANY version tag's run of this workflow — a cross-version
+          # substitution hole (verify vX.Y.Z's digest against v0.0.1's
+          # signature).  The identity is fully known at run time, so match it
+          # verbatim: this closes both the different-repo-suffix case the old
+          # regexp guarded and the different-version case it did not.
           cosign verify "${IMAGE_DIGEST}" \
-            --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/docker-publish\.yml@refs/tags/v" \
+            --certificate-identity "${EXPECTED_IDENTITY}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,8 +8,8 @@ name: zizmor — GHA workflow security scan
 #
 # Findings land in Security → Code scanning alongside CodeQL alerts.
 # A red CI run here is informational, not blocking — review the
-# Security tab.  Bump `advisory-level` to `low` or add an explicit
-# `exit-code` if you want hard CI gating later.
+# Security tab.  Loosen `min-severity` (e.g. to `low`) to surface the
+# long-tail style findings once the current wave is triaged.
 
 on:
   pull_request:
@@ -63,7 +63,14 @@ jobs:
         # ecosystem).
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa  # v0.5.7
         with:
-          # `medium` is the conservative starting baseline.  Drop to
+          # `medium` is the conservative starting baseline.  Loosen to
           # `low` once the initial finding wave is triaged to surface
           # the long-tail style issues.
-          advisory-level: medium
+          #
+          # NOTE: the input is `min-severity`, NOT `advisory-level`.  The
+          # action defines no `advisory-level` input (verified against
+          # v0.5.7's action.yml), so the old key was silently ignored —
+          # meaning zizmor ran with its default (no severity floor,
+          # reporting everything) rather than the intended medium baseline.
+          # This makes the config actually take effect.
+          min-severity: medium


### PR DESCRIPTION
Three CI supply-chain hardening fixes to the release workflows. Config / comment only — no change to the happy release path. Same family as #337/#338.

### 1. `docker-publish.yml` — pin the cosign identity exactly (HIGH)
The post-publish smoke-test verified the signature with:
```
--certificate-identity-regexp "^https://github\.com/<repo>/\.github/workflows/docker-publish\.yml@refs/tags/v"
```
That regexp is **head-anchored but has no tail anchor**, so it accepts a signature minted by *any* version tag's run of this workflow — it would verify `vX.Y.Z`'s digest against a signature whose SAN ends `@refs/tags/v0.0.1` (cross-version substitution).

The signer identity is fully deterministic at run time — the workflow file path at the exact triggering ref (`github.ref` = `refs/tags/vX.Y.Z`) — so it's now pinned **exactly** with `--certificate-identity`. This closes both the different-repo-suffix case the old head anchor guarded *and* the different-version case it did not. `EXPECTED_IDENTITY` is composed in the step `env:` (trusted `github.repository` / `github.ref`, never `${{ }}` in the `run:` block) so there's no template-injection surface.

> ⚠️ This step only executes on a real tag push, so PR CI cannot exercise it. The exact-match string was validated offline against the known SAN format; it is **verified live at the next release**.

### 2. `docker-publish.yml` — no build cache on the signed release path
The build imported/exported a `type=gha` cache. `type=gha` is a mutable, cross-run-writable scope; importing it into the image we then cosign-sign, syft-attest and push as `:latest` lets a poisoned cache layer launder into a **signed, attested** release (GHA cache-poisoning). This workflow only ever runs on a version tag (the "Refuse a non-tag ref" guard rejects every other ref), so there's no PR-build cache to preserve — both cache lines dropped; the release builds clean from source. A comment marks this as a human-review invariant (zizmor does not model cache-poisoning).

### 3. `zizmor.yml` — `advisory-level: medium` is a no-op → `min-severity: medium`
`zizmorcore/zizmor-action@v0.5.7` defines **no** `advisory-level` input (verified against that tag's `action.yml`); the key was silently ignored, so zizmor ran with its default (no severity floor, reporting everything) rather than the intended medium baseline. Renamed to the real input, `min-severity: medium`, so the config takes effect as documented. Two stale comments citing the non-existent `advisory-level`/`exit-code` keys were corrected.

### Verification
- Both workflow YAML files parse.
- Editing `.github/workflows/**` re-triggers the zizmor scan on this PR; the change is expected to be zizmor-clean (tightening `min-severity` can only report fewer findings, never more).
- No required-check jobs added/renamed (ruleset gate unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
