### PR TITLE
feat(arista_eos): wire per-VRF static routes — parse + render + matrix (promotion #6)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -119,6 +119,7 @@ class AristaEOSCodec(CodecBase):
             "/vlans/vlan/id",
             "/vlans/vlan/name",
             "/routing/static-route",
+            "/routing/static-route/vrf",   # per-VRF ``ip route vrf X ...`` (donor: cisco_iosxe_cli #24)
             "/snmp/community",
             "/snmp/location",
             "/snmp/contact",
@@ -395,18 +396,10 @@ class AristaEOSCodec(CodecBase):
                     "are Tier 3 — see `/access-list/extended`."
                 ),
             ),
-            # -- Ship-before-wire (v0.2.0) -- per-VRF static routes --
-            # (VRRP + anycast-gateway flipped to ``supported`` in
-            # Wave B/C — see the supported list above.)
-            UnsupportedPath(
-                path="/routing/static-route/vrf",
-                reason=(
-                    "Per-VRF static-route binding parses-and-ignores in "
-                    "v1.  Schema exists on CanonicalStaticRoute.vrf; "
-                    "wire-up scheduled for v0.2.0 (closes existing "
-                    "per-VRF static-route lossy declaration)."
-                ),
-            ),
+            # (Per-VRF static routes flipped to ``supported`` — see the
+            # supported list above — alongside VRRP + anycast-gateway in
+            # Wave B/C.  ``ip route vrf X ...`` now parses onto
+            # CanonicalStaticRoute.vrf and renders the ``vrf`` qualifier.)
         ],
     )
 

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -86,14 +86,19 @@ _NTP_SERVER_RE = re.compile(
     re.MULTILINE,
 )
 _IP_ROUTE_RE = re.compile(
-    # ``ip route 0.0.0.0/0 10.0.0.1`` or ``ip route 10.0.0.0/8 Null0``.
-    r"^ip route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)",
+    # ``ip route 0.0.0.0/0 10.0.0.1`` or ``ip route 10.0.0.0/8 Null0``,
+    # plus the per-VRF form ``ip route vrf MGMT 0.0.0.0/0 192.168.2.1``.
+    # The optional ``vrf <name>`` infix (group 1) lands on
+    # ``CanonicalStaticRoute.vrf`` and round-trips through render
+    # (mirrors the cisco_iosxe_cli graduation, PR #24).
+    r"^ip route\s+(?:vrf\s+(\S+)\s+)?(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)",
     re.MULTILINE,
 )
 _IPV6_ROUTE_RE = re.compile(
     # ``ipv6 route 2001:db8::/48 2001:db8::1`` — v6 uses the ``ipv6 route``
     # keyword with the prefix form (does not overlap ``^ip route``).
-    r"^ipv6 route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)",
+    # The optional ``vrf <name>`` infix mirrors the v4 form above.
+    r"^ipv6 route\s+(?:vrf\s+(\S+)\s+)?([0-9A-Fa-f:]+/\d+)\s+(\S+)",
     re.MULTILINE,
 )
 _SNMP_COMMUNITY_RE = re.compile(
@@ -470,7 +475,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     for ntp_m in _NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(ntp_m.group(1))
     for route_m in _IP_ROUTE_RE.finditer(raw):
-        ip, prefix, next_hop = route_m.groups()
+        vrf, ip, prefix, next_hop = route_m.groups()
         # Skip interface-form next hops (``Null0``, ``Ethernet1``) —
         # treat as non-routable for canonical; parse-ignore keeps
         # the canonical tree clean while preserving round-trip for
@@ -479,13 +484,19 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             ipaddress.IPv4Address(next_hop)
         except ipaddress.AddressValueError:
             continue
+        # The optional ``vrf <name>`` infix lands on ``route.vrf`` — NOT a
+        # routing-instance.  Harvesting a per-VRF route must never conjure a
+        # phantom ``CanonicalRoutingInstance`` (that surface comes only from
+        # ``vrf instance|definition`` stanzas); the empty-string default keeps
+        # global-table routes byte-identical.
         intent.static_routes.append(CanonicalStaticRoute(
             destination=f"{ip}/{prefix}",
             gateway=next_hop,
             interface="",
+            vrf=vrf or "",
         ))
     for route_m in _IPV6_ROUTE_RE.finditer(raw):
-        dest, next_hop = route_m.groups()
+        vrf, dest, next_hop = route_m.groups()
         # Same interface-form skip as the v4 branch: only IP next hops
         # round-trip cleanly onto the canonical gateway.
         try:
@@ -496,6 +507,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             destination=dest,
             gateway=next_hop,
             interface="",
+            vrf=vrf or "",
         ))
 
     # --- VARP system-wide MAC (Wave C) -------------------------------

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -936,13 +936,23 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         for route in tree.static_routes:
             if not route.gateway:
                 continue
+            # Per-VRF routes carry the ``vrf <name>`` qualifier between the
+            # ``ip route`` / ``ipv6 route`` keyword and the destination.
+            # Without this, a donor-carried ``route.vrf`` (e.g. a cisco
+            # ``ip route vrf MGMT ...`` source) rendered into the GLOBAL
+            # table — a wrong-VRF emission, worse than a drop.
+            vrf_prefix = f"vrf {route.vrf} " if route.vrf else ""
             # EOS keys the address family off the keyword: IPv6 destinations
             # use ``ipv6 route`` (emitting ``ip route <v6>`` is invalid CLI).
             if ":" in (route.destination or ""):
-                out.append(f"ipv6 route {route.destination} {route.gateway}")
+                out.append(
+                    f"ipv6 route {vrf_prefix}{route.destination} {route.gateway}"
+                )
                 has_v6 = True
             else:
-                out.append(f"ip route {route.destination} {route.gateway}")
+                out.append(
+                    f"ip route {vrf_prefix}{route.destination} {route.gateway}"
+                )
                 has_v4 = True
         out.append("!")
         if has_v4:

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -12,17 +12,17 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 
 | Variance class | Count | Severity |
 |---|---:|---|
-| ALIGNED | 1569 | ok |
+| ALIGNED | 1581 | ok |
 | CODEC_BUG | 5 | **high** |
-| EXPECTED_LOSSY | 1226 | ok |
-| EXPECTED_UNSUPPORTED | 732 | ok |
-| METHODOLOGY_ISSUE_under | 933 | low/medium |
+| EXPECTED_LOSSY | 1227 | ok |
+| EXPECTED_UNSUPPORTED | 729 | ok |
+| METHODOLOGY_ISSUE_under | 944 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
 | STRUCTURAL_ONLY | 1194 | low |
-| TRIVIAL_EMPTY | 9536 | ok |
+| TRIVIAL_EMPTY | 9515 | ok |
 | **Total field-cells classified** | **15220** | |
 
-Severity roll-up: 5 high, 111 medium, 2041 low, 13063 ok.
+Severity roll-up: 5 high, 111 medium, 2052 low, 13052 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-06-25T19:56:20+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260625T195601Z.json",
-  "mesh_run_started_utc": "2026-06-25T19:55:55+00:00",
+  "started_utc": "2026-07-11T18:18:14+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260711T181813Z.json",
+  "mesh_run_started_utc": "2026-07-11T18:18:07+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4134,19 +4134,19 @@
     }
   ],
   "aggregate": {
-    "ALIGNED": 1569,
+    "ALIGNED": 1581,
     "CODEC_BUG": 5,
-    "EXPECTED_LOSSY": 1226,
-    "EXPECTED_UNSUPPORTED": 732,
-    "METHODOLOGY_ISSUE_under": 933,
+    "EXPECTED_LOSSY": 1227,
+    "EXPECTED_UNSUPPORTED": 729,
+    "METHODOLOGY_ISSUE_under": 944,
     "METHODOLOGY_ISSUE_over": 25,
     "STRUCTURAL_ONLY": 1194,
-    "TRIVIAL_EMPTY": 9536,
+    "TRIVIAL_EMPTY": 9515,
     "fields_total": 15220,
     "severity_high": 5,
     "severity_medium": 111,
-    "severity_low": 2041,
-    "severity_ok": 13063
+    "severity_low": 2052,
+    "severity_ok": 13052
   },
   "severity_matrix": {
     "arista_eos": {
@@ -4191,7 +4191,7 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 28
+      "drifted_total": 30
     },
     {
       "source_codec": "arista_eos",
@@ -4206,7 +4206,7 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "vyos",
-      "drifted_total": 29
+      "drifted_total": 31
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4346,7 +4346,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "arista_eos",
-      "drifted_total": 32
+      "drifted_total": 31
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4406,7 +4406,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "arista_eos",
-      "drifted_total": 44
+      "drifted_total": 41
     },
     {
       "source_codec": "cisco_nxos",
@@ -4695,6 +4695,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -4717,6 +4718,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -4739,6 +4741,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -4771,6 +4774,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -4793,6 +4797,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -4815,6 +4820,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -5146,10 +5152,10 @@
           }
         },
         "static_routes": {
-          "actual": "trivially_preserved",
+          "actual": "preserved",
           "expected": "lossy",
-          "variance": "TRIVIAL_EMPTY",
-          "severity": "ok"
+          "variance": "METHODOLOGY_ISSUE_under",
+          "severity": "low"
         },
         "dhcp_servers": {
           "actual": "trivially_preserved",
@@ -5496,16 +5502,16 @@
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 4,
         "EXPECTED_UNSUPPORTED": 1,
-        "METHODOLOGY_ISSUE_under": 1,
+        "METHODOLOGY_ISSUE_under": 2,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
-        "TRIVIAL_EMPTY": 11,
+        "TRIVIAL_EMPTY": 10,
         "fields_total": 20,
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 1,
-        "severity_ok": 18
+        "severity_low": 2,
+        "severity_ok": 17
       }
     },
     {
@@ -5578,6 +5584,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -5600,6 +5607,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -5622,6 +5630,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -5654,6 +5663,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -5676,6 +5686,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -5698,6 +5709,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -6108,10 +6120,10 @@
           }
         },
         "static_routes": {
-          "actual": "trivially_preserved",
+          "actual": "preserved",
           "expected": "lossy",
-          "variance": "TRIVIAL_EMPTY",
-          "severity": "ok"
+          "variance": "METHODOLOGY_ISSUE_under",
+          "severity": "low"
         },
         "dhcp_servers": {
           "actual": "trivially_preserved",
@@ -6442,16 +6454,16 @@
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 4,
         "EXPECTED_UNSUPPORTED": 1,
-        "METHODOLOGY_ISSUE_under": 1,
+        "METHODOLOGY_ISSUE_under": 2,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
-        "TRIVIAL_EMPTY": 11,
+        "TRIVIAL_EMPTY": 10,
         "fields_total": 20,
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 1,
-        "severity_ok": 18
+        "severity_low": 2,
+        "severity_ok": 17
       }
     },
     {
@@ -8254,6 +8266,7 @@
                 ],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -8295,6 +8308,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -8317,6 +8331,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -8357,6 +8372,7 @@
                 ],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -8398,6 +8414,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,
@@ -8420,6 +8437,7 @@
                 "ipv6_addresses": [],
                 "switchport_mode": null,
                 "access_vlan": null,
+                "dot1q_vlan": null,
                 "trunk_allowed_vlans": [],
                 "trunk_native_vlan": null,
                 "voice_vlan": null,

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -128,6 +128,72 @@ class TestParseScalars:
             ("::/0", "fe80::1"),
         ]
 
+    def test_per_vrf_static_route_parsed(self):
+        """``ip route vrf MGMT ...`` harvests the VRF onto ``route.vrf``.
+
+        Pre-fix the ``vrf`` infix broke ``_IP_ROUTE_RE`` (the next token
+        after ``ip route`` was ``vrf``, not a digit), so the whole route
+        was silently dropped — a real management-default-route loss present
+        in 2 of the committed EOS fixtures.
+        """
+        raw = (
+            "hostname sw1\n"
+            "ip route 0.0.0.0/0 10.0.0.1\n"
+            "ip route vrf MGMT 0.0.0.0/0 192.168.2.1\n"
+            "ipv6 route vrf MGMT 2001:db8::/48 2001:db8::1\n"
+        )
+        intent = AristaEOSCodec().parse(raw)
+        by_vrf = sorted(
+            (r.destination, r.gateway, r.vrf) for r in intent.static_routes
+        )
+        assert by_vrf == [
+            ("0.0.0.0/0", "10.0.0.1", ""),
+            ("0.0.0.0/0", "192.168.2.1", "MGMT"),
+            ("2001:db8::/48", "2001:db8::1", "MGMT"),
+        ]
+        # A per-VRF route must NEVER conjure a phantom routing-instance —
+        # that surface comes only from ``vrf instance|definition`` stanzas.
+        assert intent.routing_instances == []
+
+    def test_per_vrf_static_route_round_trips(self):
+        """render emits the ``vrf <name>`` qualifier; reparse preserves it."""
+        raw = (
+            "ip route vrf MGMT 0.0.0.0/0 192.168.2.1\n"
+            "ipv6 route vrf RED 2001:db8::/48 2001:db8::1\n"
+        )
+        codec = AristaEOSCodec()
+        intent = codec.parse(raw)
+        rendered = codec.render(intent)
+        assert "ip route vrf MGMT 0.0.0.0/0 192.168.2.1" in rendered
+        assert "ipv6 route vrf RED 2001:db8::/48 2001:db8::1" in rendered
+        reparsed = codec.parse(rendered)
+        assert [(r.destination, r.gateway, r.vrf) for r in reparsed.static_routes] == \
+               [(r.destination, r.gateway, r.vrf) for r in intent.static_routes]
+
+    def test_donor_vrf_route_not_emitted_into_global_table(self):
+        """A donor-carried ``route.vrf`` must render WITH the ``vrf``
+        qualifier — never as a bare global-table route (wrong-VRF emission,
+        which is worse than a drop).
+        """
+        tree = CanonicalIntent(
+            static_routes=[
+                CanonicalStaticRoute(
+                    destination="10.9.0.0/16",
+                    gateway="192.168.9.1",
+                    vrf="RED",
+                ),
+            ],
+        )
+        rendered = AristaEOSCodec().render(tree)
+        assert "ip route vrf RED 10.9.0.0/16 192.168.9.1" in rendered
+        # The bare global-table line must NOT appear.
+        assert "\nip route 10.9.0.0/16 192.168.9.1" not in rendered
+
+    def test_static_route_vrf_classified_supported(self):
+        """The matrix flip: ``/routing/static-route/vrf`` is now supported."""
+        caps = AristaEOSCodec().capabilities
+        assert caps.classify("/routing/static-route/vrf") == "supported"
+
 
 # ---------------------------------------------------------------------------
 # Parse — SNMP

--- a/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
+++ b/tests/unit/migration/test_canonical_vrrp_anycast_schema.py
@@ -383,12 +383,16 @@ class TestShipBeforeWireUnsupportedDeclarations:
         # Wave B + C — see commit feat(arista_eos): wire VRRP +
         # VARP.  Per-IP virtual-gateway-mac is ``lossy`` (Arista
         # only has chassis-wide ``ip virtual-router mac-address``;
-        # per-IP override doesn't exist).
+        # per-IP override doesn't exist).  Per-VRF static routes
+        # graduated to ``supported`` — ``ip route vrf <NAME> <dest>
+        # <gw>`` round-trips through parse + render (donor: the
+        # cisco_iosxe_cli graduation, PR #24).
         "arista_eos": {
             "/interfaces/interface/vrrp-groups/group",
             "/interfaces/interface/ipv4/address/virtual-gateway-address",
             "/interfaces/interface/ipv6/address/virtual-gateway-address",
             "/anycast-gateway-mac",
+            "/routing/static-route/vrf",
             # GAP 7 — routed sub-interface `encapsulation dot1q vlan N`.
             "/interfaces/interface/dot1q-vlan",
         },


### PR DESCRIPTION
Graduates `/routing/static-route/vrf` on **arista_eos** from `unsupported` → `supported` — promotion candidate **#6** from the 2026-07-06 review (verifier CONFIRMED, payoff HIGH). Closes a **two-sided** per-VRF static-route bug.

### The bug
- **Parse — silent source loss.** `_IP_ROUTE_RE` expected a dotted-quad right after `ip route`, so `ip route vrf MGMT 0.0.0.0/0 192.168.2.1` (next token is `vrf`) failed the regex and the **whole route was dropped**. The management default route silently vanished from the migrated tree — present in **2 of the committed EOS fixtures**.
- **Render — wrong-VRF emission.** The emitter ignored `route.vrf`, so a donor-carried per-VRF route (e.g. a cisco `ip route vrf MGMT …` source) rendered into the **global table** — arguably worse than a drop.

### The fix (mirrors the cisco_iosxe_cli graduation, #24)
- Optional `vrf\s+(\S+)` infix on the v4 + v6 route regexes → harvested onto `CanonicalStaticRoute.vrf`.
- Render emits the `vrf <name>` qualifier between the keyword and the destination.
- Per the standing **phantom-instance** rule, a per-VRF route lands **only** on `route.vrf` — it never conjures a `CanonicalRoutingInstance` (that surface comes only from `vrf instance|definition` stanzas).
- Matrix flip `unsupported` → `supported`; the two-sided ship-before-wire invariant (`_WIRED_UP_BY_CODEC`) updated.

### Verification (verify-first, negative controls)
New tests in `test_arista_eos.py`: per-VRF v4+v6 parse with vrf harvested and **no phantom instance**; render+reparse round-trip; a donor tree renders **with** the vrf qualifier and **not** into the global table; classify == supported.

### Mesh baseline
Re-baselined `latest.json` + `PHASE4_RECONCILIATION.md`. **CODEC_BUG stays 5, cells_total 1224, no new codec-bug pair.** Four YAML-less pairs move — all arista-related, all explained by this change:
- `arista → {aruba_aoscx, vyos}` **+2** each: the now-captured MGMT route honestly drops at targets that declare per-VRF static routes unsupported — a silent **source** loss becomes a **declared target** loss (visible > silent).
- `{cisco_nxos, cisco_iosxr} → arista` **−1 / −3**: donor VRF routes now round-trip to arista instead of being globalized (the render half paying off).

### Deferred (separate `[yaml]` truth-maintenance — promotion #8/#9)
Several arista-source expectation YAMLs still carry stale reason prose ("per-VRF parses-and-ignores", "CanonicalStaticRoute lacks a vrf field") — some already stale since #24. Their `lossy` dispositions remain safe pessimism; flipping them changes reconciliation classification and belongs in the YAML batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
