### PR TITLE
feat(vyos): infer IPv6 link-local scope from the fe80::/10 prefix (promotion #10)

### DIFF
--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -135,6 +135,7 @@ class VyOSCodec(CodecBase):
             "/interfaces/interface/ipv4/address/prefix-length",
             "/interfaces/interface/ipv6/address/ip",
             "/interfaces/interface/ipv6/address/prefix-length",
+            "/interfaces/interface/ipv6/address/scope",   # re-inferred from the fe80::/10 prefix on parse
             "/interfaces/interface/dhcp-client",
             "/interfaces/interface/dhcp-client-v6",
             # Static routes (default VRF)
@@ -174,17 +175,6 @@ class VyOSCodec(CodecBase):
                     "so the mac-vrf vs vrf instance-type discriminator downgrades "
                     "to vrf on render. Declared lossy so validate_against surfaces "
                     "the loss instead of reporting severity:ok (audit e5b77d7, PR-2c)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
-                path="/interfaces/interface/ipv6/address/scope",
-                reason=(
-                    "Renders the IPv6 address but parse hardcodes scope=global "
-                    "(never re-infers link-local from the fe80::/10 prefix), so the "
-                    "link-local vs global discriminator is lost. Declared lossy so "
-                    "validate_against surfaces the loss instead of reporting "
-                    "severity:ok (audit e5b77d7, PR-2c)."
                 ),
                 severity="warn",
             ),

--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -103,6 +103,7 @@ from ...canonical.intent import (
     CanonicalStaticRoute,
     CanonicalVxlan,
 )
+from .._helpers import _is_link_local_v6
 from .._input_shape import detect_input_shape
 from ..base import ParseError
 
@@ -883,7 +884,6 @@ def _apply_iface_leaf(sc: dict, key: str, value: str) -> None:
 
 def _build_iface(sc: dict) -> CanonicalInterface:
     """Convert an interface scratch dict into a CanonicalInterface."""
-    scope_v6 = "global"
     return CanonicalInterface(
         name=sc["name"],
         description=sc.get("description", ""),
@@ -894,8 +894,18 @@ def _build_iface(sc: dict) -> CanonicalInterface:
             for a in sc.get("ipv4", [])
         ],
         ipv6_addresses=[
+            # Scope is a pure function of the address bytes: VyOS has no
+            # ``link-local`` keyword (the ``address fe80::.../64`` line is
+            # identical to a global one), so re-infer it from the fe80::/10
+            # prefix (RFC 4291 §2.4) rather than hardcoding ``global``.
+            # Without this a cross-vendor target (cisco/arista/nxos) renders
+            # the fe80 address WITHOUT the mandatory ``link-local`` keyword —
+            # invalid CLI on the target.  Same inference already shipped for
+            # cisco_iosxe_cli + aruba_aoscx.
             CanonicalIPv6Address(
-                ip=a["ip"], prefix_length=a["prefix_length"], scope=scope_v6,
+                ip=a["ip"],
+                prefix_length=a["prefix_length"],
+                scope="link-local" if _is_link_local_v6(a["ip"]) else "global",
             )
             for a in sc.get("ipv6", [])
         ],

--- a/tests/unit/migration/test_singleton_subfield_walk_expansion.py
+++ b/tests/unit/migration/test_singleton_subfield_walk_expansion.py
@@ -69,11 +69,13 @@ _EXPECTED: dict[str, dict[str, str]] = {
         )
     ),
     # scope: codecs that re-infer link-local from the fe80::/10 prefix on parse
-    # round-trip the scope and stay supported; FortiGate / VyOS hardcode
-    # scope=global on parse and the NETCONF stub emits no scope -> lossy (the
-    # IPv6 address itself still renders, so this is a downgrade, not unsupported).
+    # round-trip the scope and stay supported (cisco_iosxe_cli, aruba_aoscx, and
+    # now VyOS via the shared ``_is_link_local_v6`` helper — promotion #10);
+    # FortiGate still hardcodes scope=global on parse and the NETCONF stub emits
+    # no scope -> lossy (the IPv6 address itself still renders, so this is a
+    # downgrade, not unsupported).
     _V6 + "scope": dict.fromkeys(
-        ("cisco_iosxe", "fortigate_cli", "vyos"), "lossy",
+        ("cisco_iosxe", "fortigate_cli"), "lossy",
     ),
 }
 

--- a/tests/unit/migration/test_vyos.py
+++ b/tests/unit/migration/test_vyos.py
@@ -355,6 +355,41 @@ def test_parse_loopback_dual_stack(codec: VyOSCodec) -> None:
     assert lo.ipv6_addresses[0].ip == "2001:db8::1"
 
 
+def test_ipv6_link_local_scope_inferred(codec: VyOSCodec) -> None:
+    """VyOS has no ``link-local`` keyword, so scope is re-inferred from the
+    fe80::/10 prefix (promotion #6-batch, was declared lossy). Pre-fix parse
+    hardcoded scope='global', so a cross-vendor target rendered the fe80
+    address WITHOUT the mandatory ``link-local`` keyword — invalid CLI."""
+    cfg = (
+        "interfaces {\n"
+        "    ethernet eth0 {\n"
+        "        address 2001:db8::1/64\n"
+        "        address fe80::1/64\n"
+        "    }\n"
+        "}\n"
+    )
+    eth0 = next(i for i in codec.parse(cfg).interfaces if i.name == "eth0")
+    by_ip = {a.ip: a.scope for a in eth0.ipv6_addresses}
+    assert by_ip == {"2001:db8::1": "global", "fe80::1": "link-local"}
+
+
+def test_ipv6_link_local_round_trips_and_cross_renders(codec: VyOSCodec) -> None:
+    """Same-vendor round-trip re-infers the scope; a cisco target emits the
+    ``link-local`` keyword the scope now carries."""
+    cfg = (
+        "interfaces {\n"
+        "    ethernet eth0 {\n"
+        "        address fe80::1/64\n"
+        "    }\n"
+        "}\n"
+    )
+    intent = codec.parse(cfg)
+    rp = codec.parse(codec.render(intent))
+    assert next(a.scope for i in rp.interfaces for a in i.ipv6_addresses) == "link-local"
+    cisco = get_codec("cisco_iosxe_cli").render(intent)
+    assert "ipv6 address fe80::1/64 link-local" in cisco
+
+
 def test_parse_disable_sets_admin_down(codec: VyOSCodec) -> None:
     dum0 = next(i for i in codec.parse(_SAMPLE).interfaces if i.name == "dum0")
     assert dum0.enabled is False


### PR DESCRIPTION
Graduates `/interfaces/interface/ipv6/address/scope` on **vyos** from `lossy` → `supported` — promotion candidate **#10** from the 2026-07-06 review (verifier CONFIRMED). Completes declared debt: the `LossyPath` reason named this exact gap.

### The bug
VyOS has no `link-local` keyword — `address fe80::1/64` is byte-identical to a global address line — so parse stamped **every** IPv6 address `scope=global`. A cross-vendor target (cisco/arista/nxos) then rendered the fe80 address **without** the mandatory `link-local` keyword → **invalid CLI on the target**.

### The fix
Re-infer scope from the address bytes via the shared `_is_link_local_v6` helper (already used by cisco_iosxe_cli + aruba_aoscx): `fe80::/10` → `link-local`, everything else → `global`. Because scope is a **pure function of the bytes**, the flip **cannot reintroduce silent loss**. Render needs no change (the grammar carries no scope keyword; reparse re-infers). Matrix flips `lossy` → `supported`; the PR-2c walk-expansion disposition pin drops vyos from the scope `lossy` set.

### Verification (verify-first)
- parse: `fe80::1` → `link-local`, `2001:db8::1` → `global`
- same-vendor render→reparse re-infers correctly
- `vyos fe80 → cisco render` now emits `ipv6 address fe80::1/64 link-local` (the invalid-CLI fix)

### Mesh
**Mesh-flat** — no committed vyos fixture carries an fe80 address, so the cross-mesh baseline is unchanged (no re-baseline). Full unit suite 5272 passed / 80 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
