### PR TITLE
feat(arista_eos): wire interface next-hop static routes (Null0/iface) (promotion #18)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -120,6 +120,7 @@ class AristaEOSCodec(CodecBase):
             "/vlans/vlan/name",
             "/routing/static-route",
             "/routing/static-route/vrf",   # per-VRF ``ip route vrf X ...`` (donor: cisco_iosxe_cli #24)
+            "/routing/static-route/interface",   # interface next-hop ``ip route <dest> Null0`` (donor: cisco_iosxe_cli)
             "/snmp/community",
             "/snmp/location",
             "/snmp/contact",
@@ -336,13 +337,6 @@ class AristaEOSCodec(CodecBase):
                     "This codec does not model EOS per-port voice VLAN "
                     "(``switchport phone``); dropped on render (blind-audit "
                     "65f9c01 #11)."
-                ),
-            ),
-            UnsupportedPath(
-                path="/routing/static-route/interface",
-                reason=(
-                    "No interface-nexthop (connected) static-route form; a "
-                    "gateway-less / interface-only route is dropped (run3)."
                 ),
             ),
             # ── Tier-1 surfaces this codec drops on render — declared so the

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -476,14 +476,18 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         intent.ntp_servers.append(ntp_m.group(1))
     for route_m in _IP_ROUTE_RE.finditer(raw):
         vrf, ip, prefix, next_hop = route_m.groups()
-        # Skip interface-form next hops (``Null0``, ``Ethernet1``) —
-        # treat as non-routable for canonical; parse-ignore keeps
-        # the canonical tree clean while preserving round-trip for
-        # IP-form routes.
+        # A next hop is either an IP literal (gateway) or an interface name
+        # (``Null0``, ``Ethernet1`` — an interface/connected route, ubiquitous
+        # as a BGP aggregate anchor ``ip route <agg> Null0``).  Route it to the
+        # right canonical field instead of dropping the interface form (donor:
+        # the identical cisco_iosxe_cli branch).
+        gateway = ""
+        interface = ""
         try:
             ipaddress.IPv4Address(next_hop)
+            gateway = next_hop
         except ipaddress.AddressValueError:
-            continue
+            interface = next_hop
         # The optional ``vrf <name>`` infix lands on ``route.vrf`` — NOT a
         # routing-instance.  Harvesting a per-VRF route must never conjure a
         # phantom ``CanonicalRoutingInstance`` (that surface comes only from
@@ -491,22 +495,24 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         # global-table routes byte-identical.
         intent.static_routes.append(CanonicalStaticRoute(
             destination=f"{ip}/{prefix}",
-            gateway=next_hop,
-            interface="",
+            gateway=gateway,
+            interface=interface,
             vrf=vrf or "",
         ))
     for route_m in _IPV6_ROUTE_RE.finditer(raw):
         vrf, dest, next_hop = route_m.groups()
-        # Same interface-form skip as the v4 branch: only IP next hops
-        # round-trip cleanly onto the canonical gateway.
+        # Same gateway-or-interface split as the v4 branch.
+        gateway = ""
+        interface = ""
         try:
             ipaddress.IPv6Address(next_hop)
+            gateway = next_hop
         except ipaddress.AddressValueError:
-            continue
+            interface = next_hop
         intent.static_routes.append(CanonicalStaticRoute(
             destination=dest,
-            gateway=next_hop,
-            interface="",
+            gateway=gateway,
+            interface=interface,
             vrf=vrf or "",
         ))
 

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -934,7 +934,12 @@ def render_intent(tree: Any) -> str:  # noqa: C901
     if tree.static_routes:
         has_v4 = has_v6 = False
         for route in tree.static_routes:
-            if not route.gateway:
+            # The next hop is a gateway IP OR an interface (``Null0`` /
+            # ``Ethernet1`` — an interface/connected route).  EOS emits both
+            # as ``ip route <dest> <next-hop>``.  Skip only when NEITHER is
+            # populated (never emit a dangling ``ip route <dest>``).
+            target = route.gateway or route.interface
+            if not target:
                 continue
             # Per-VRF routes carry the ``vrf <name>`` qualifier between the
             # ``ip route`` / ``ipv6 route`` keyword and the destination.
@@ -946,12 +951,12 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             # use ``ipv6 route`` (emitting ``ip route <v6>`` is invalid CLI).
             if ":" in (route.destination or ""):
                 out.append(
-                    f"ipv6 route {vrf_prefix}{route.destination} {route.gateway}"
+                    f"ipv6 route {vrf_prefix}{route.destination} {target}"
                 )
                 has_v6 = True
             else:
                 out.append(
-                    f"ip route {vrf_prefix}{route.destination} {route.gateway}"
+                    f"ip route {vrf_prefix}{route.destination} {target}"
                 )
                 has_v4 = True
         out.append("!")

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -101,18 +101,42 @@ class TestParseScalars:
         assert intent.static_routes[0].destination == "0.0.0.0/0"
         assert intent.static_routes[0].gateway == "10.0.0.1"
 
-    def test_interface_form_next_hop_ignored(self):
-        """``ip route 10.0.0.0/8 Null0`` — interface-form next hops
-        aren't IPs; parser drops them rather than store 'Null0' as a
-        gateway."""
+    def test_interface_form_next_hop_harvested(self):
+        """``ip route 10.0.0.0/8 Null0`` — an interface-form next hop lands
+        on ``route.interface`` (gateway empty), not dropped (promotion #18).
+        EOS ``ip route <dest> Null0`` is ubiquitous as a BGP aggregate anchor.
+        """
         raw = (
             "hostname sw1\n"
             "ip route 10.0.0.0/8 Null0\n"
             "ip route 0.0.0.0/0 10.0.0.1\n"
+            "ip route 172.16.0.0/12 Ethernet1\n"
         )
-        intent = AristaEOSCodec().parse(raw)
-        assert len(intent.static_routes) == 1
-        assert intent.static_routes[0].gateway == "10.0.0.1"
+        routes = {r.destination: r for r in AristaEOSCodec().parse(raw).static_routes}
+        assert len(routes) == 3
+        assert routes["10.0.0.0/8"].interface == "Null0"
+        assert routes["10.0.0.0/8"].gateway == ""
+        assert routes["0.0.0.0/0"].gateway == "10.0.0.1"
+        assert routes["172.16.0.0/12"].interface == "Ethernet1"
+
+    def test_interface_form_next_hop_round_trips(self):
+        """render emits ``ip route <dest> <iface>``; reparse preserves it."""
+        raw = (
+            "ip route 10.99.0.0/16 Null0\n"
+            "ipv6 route 2001:db8::/48 Null0\n"
+        )
+        codec = AristaEOSCodec()
+        intent = codec.parse(raw)
+        rendered = codec.render(intent)
+        assert "ip route 10.99.0.0/16 Null0" in rendered
+        assert "ipv6 route 2001:db8::/48 Null0" in rendered
+        reparsed = codec.parse(rendered)
+        assert [(r.destination, r.interface) for r in reparsed.static_routes] == \
+               [(r.destination, r.interface) for r in intent.static_routes]
+
+    def test_static_route_interface_classified_supported(self):
+        assert AristaEOSCodec().capabilities.classify(
+            "/routing/static-route/interface") == "supported"
 
     def test_ipv6_static_route_parsed(self):
         """EOS keys the AF off the keyword: ``ipv6 route <prefix> <nh>``."""

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -670,13 +670,18 @@ def test_static_route_subfield_and_secondary_drops_are_declared(name: str):
     )
 
 
-@pytest.mark.parametrize("name", ["arista_eos", "juniper_junos", "opnsense"])
+@pytest.mark.parametrize("name", ["juniper_junos", "opnsense"])
 def test_connected_route_loss_blocks_on_vanishing_codecs(name: str):
     """A gateway-less (interface-only / connected) static route is dropped
     ENTIRELY by these codecs — its destination vanishes from the render, a
     real reachability loss.  The live validation report must surface that as
     a block via the ``/routing/static-route/interface`` unsupported
-    declaration, not a silent ``severity: ok`` (run3)."""
+    declaration, not a silent ``severity: ok`` (run3).
+
+    ``arista_eos`` was in this list until it graduated interface next-hop
+    routes (``ip route <dest> Null0``, promotion #18) — it now PRESERVES the
+    interface form, so it is covered by the round-trip test in
+    ``test_arista_eos.py`` instead."""
     src = get_codec("cisco_iosxe_cli")
     tree = CanonicalIntent(
         hostname="r1",


### PR DESCRIPTION
Graduates `/routing/static-route/interface` on **arista_eos** from `unsupported` → `supported` — promotion candidate **#18** (verifier CONFIRMED).

### The bug
An interface-form next hop — `ip route 10.99.0.0/16 Null0` (a BGP aggregate anchor, ubiquitous in real networks) or an egress interface like `ip route 172.16.0.0/12 Ethernet1` — was **parse-dropped**: the loop did `ipaddress.IPv4Address(next_hop)` and `continue`d on the error, so the whole route vanished. The matrix honestly declared it unsupported (the loss surfaced as a block), but the route need not be dropped at all.

### The fix (mirrors the cisco_iosxe_cli branch)
- Parse: on `AddressValueError`, land the token on `route.interface` (gateway="") instead of dropping (v4 + v6).
- Render: emit `ip route <dest> <next-hop>` for a gateway **or** an interface; skip only when **neither** is populated (never a dangling `ip route <dest>`).
- Matrix flips `unsupported` → `supported`.

### Verification (verify-first)
`Null0` + egress-interface routes harvest onto `route.interface`; render→reparse round-trips; classify == supported. Test updates: `test_interface_form_next_hop_ignored` → `_harvested`; `test_connected_route_loss_blocks_on_vanishing_codecs` drops arista (it no longer vanishes — junos/opnsense still do and stay guarded).

### Mesh
**Mesh-flat** — no committed fixture produces an interface next-hop route rendered to arista, so the cross-mesh baseline is unchanged. Full unit 5273 passed + integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
