### PR TITLE
feat(juniper_junos): parse static (non-LACP) LAG bundles as static, not active (promotion #5)

### DIFF
--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -153,6 +153,10 @@ class JunosCodec(CodecBase):
             "/vxlan-vnis/udp-port",              # GAP-EVPN-2
             "/routing-instances/instance",       # GAP 6
             "/dhcp-servers/pool",                # Cluster E.1-B
+            # LACP mode round-trips: active/passive emit a `lacp` line, and a
+            # static (non-LACP) bundle emits none + re-parses as static
+            # (promotion #5 — a bundle with no lacp line is static, not active).
+            "/lags/lag/mode",
             # -- v0.2.0 Wave B: classic FHRP redundancy groups --
             "/interfaces/interface/vrrp-groups/group",
             # -- v0.2.0 Wave C: anycast-gateway companions --
@@ -162,17 +166,6 @@ class JunosCodec(CodecBase):
             "/interfaces/interface/ipv6/address/virtual-gateway-mac",
         ],
         lossy=[
-            LossyPath(
-                path="/lags/lag/mode",
-                reason=(
-                    "Junos renders LACP `active`/`passive` faithfully, but a "
-                    "`static` (non-LACP) aggregate carries no `lacp` statement "
-                    "and re-parses as `active` -- the static/LACP distinction "
-                    "is dropped (audit bb47f21 T0-1, verified by round-trip "
-                    "probe)."
-                ),
-                severity="warn",
-            ),
             LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(

--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -543,7 +543,13 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     lags_by_name: dict[str, CanonicalLAG] = {lag.name: lag for lag in intent.lags}
     for ae_name, lag_entry in lag_state.items():
         members = list(lag_entry.get("members", []))
-        mode = lag_entry.get("mode", "active") or "active"
+        # A Junos aggregate with NO ``aggregated-ether-options lacp
+        # active|passive`` line is a STATIC (non-LACP) bundle — NOT active.
+        # Defaulting to ``active`` invented ``set … lacp active`` on re-render,
+        # which taken to a static-bonded peer brings the bundle DOWN
+        # (protocol-changing loss).  ``static`` round-trips (render emits no
+        # lacp line for it) — promotion #5.
+        mode = lag_entry.get("mode", "static") or "static"
         # Don't accumulate duplicates if the same LAG already exists
         # (defensive for groups + apply-groups composition).
         existing = lags_by_name.get(ae_name)
@@ -1363,10 +1369,15 @@ def _apply_interfaces(  # noqa: C901
     ):
         ae_name = name
         mode = tokens[3]
-        if mode not in ("active", "passive"):
-            mode = "active"
-        entry = lag_state.setdefault(ae_name, {"members": [], "mode": "active"})
-        entry["mode"] = mode
+        entry = lag_state.setdefault(ae_name, {"members": [], "mode": "static"})
+        # Only an explicit ``lacp active`` / ``lacp passive`` sets the mode.
+        # Other ``aggregated-ether-options lacp <sub>`` lines — notably
+        # ``lacp periodic <interval>`` — do NOT enable/disable LACP and must
+        # NOT clobber an already-seen ``passive`` (nor promote a static bundle
+        # to active).  The prior code coerced ``periodic`` → ``active`` and
+        # overwrote, corrupting a real ``lacp passive`` that preceded it.
+        if mode in ("active", "passive"):
+            entry["mode"] = mode
         return
 
     # --- Phase 4 rank-4: LAG member binding ---
@@ -1378,7 +1389,11 @@ def _apply_interfaces(  # noqa: C901
     ):
         ae_name = tokens[3]
         state["lag_member_of"] = ae_name
-        entry = lag_state.setdefault(ae_name, {"members": [], "mode": "active"})
+        # Members join via ``ether-options 802.3ad ae<N>`` with no mode of
+        # their own — a bundle seen ONLY through its members (no lacp line) is
+        # static, so seed the default ``static`` (an explicit lacp line, if
+        # present, overwrites it above).
+        entry = lag_state.setdefault(ae_name, {"members": [], "mode": "static"})
         if name not in entry["members"]:
             entry["members"].append(name)
         return

--- a/tests/unit/migration/test_juniper_junos.py
+++ b/tests/unit/migration/test_juniper_junos.py
@@ -19,6 +19,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalInterface,
     CanonicalIPv4Address,
     CanonicalIPv6Address,
+    CanonicalLAG,
     CanonicalLocalUser,
     CanonicalSNMP,
     CanonicalStaticRoute,
@@ -257,6 +258,52 @@ class TestParseStaticRoutes:
         )
         intent = JunosCodec().parse(raw)
         assert len(intent.static_routes) == 2
+
+
+# ---------------------------------------------------------------------------
+# Parse — LAG mode (promotion #5)
+# ---------------------------------------------------------------------------
+
+
+class TestParseLagMode:
+    def test_static_bundle_is_static_not_active(self):
+        """A bundle seen only through its members (no ``lacp active|passive``
+        line) is STATIC — not active.  Defaulting to active invented
+        ``lacp active`` on re-render, which downs a static-bonded peer."""
+        raw = (
+            "set interfaces ge-0/0/0 ether-options 802.3ad ae0\n"
+            "set interfaces ge-0/0/1 ether-options 802.3ad ae0\n"
+        )
+        lags = JunosCodec().parse(raw).lags
+        assert [(lag.name, lag.mode) for lag in lags] == [("ae0", "static")]
+
+    def test_lacp_periodic_does_not_clobber_passive(self):
+        """``lacp periodic <interval>`` does not enable/disable LACP and must
+        not overwrite an explicit ``lacp passive`` that precedes it."""
+        raw = (
+            "set interfaces ge-0/0/0 ether-options 802.3ad ae1\n"
+            "set interfaces ae1 aggregated-ether-options lacp passive\n"
+            "set interfaces ae1 aggregated-ether-options lacp periodic fast\n"
+        )
+        lags = JunosCodec().parse(raw).lags
+        assert lags[0].mode == "passive"
+
+    @pytest.mark.parametrize("mode", ["active", "passive", "static"])
+    def test_lag_mode_round_trips(self, mode):
+        """render→reparse preserves every mode; active/passive emit a ``lacp``
+        line, static emits none (and re-parses as static)."""
+        codec = JunosCodec()
+        tree = CanonicalIntent(
+            interfaces=[CanonicalInterface(name="ge-0/0/0", lag_member_of="ae0")],
+            lags=[CanonicalLAG(name="ae0", members=["ge-0/0/0"], mode=mode)],
+        )
+        rendered = codec.render(tree)
+        assert ("lacp" in rendered) == (mode in ("active", "passive"))
+        reparsed = codec.parse(rendered)
+        assert reparsed.lags[0].mode == mode
+
+    def test_lag_mode_classified_supported(self):
+        assert JunosCodec().capabilities.classify("/lags/lag/mode") == "supported"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Graduates `/lags/lag/mode` on **juniper_junos** from `lossy` → `supported` — promotion candidate **#5** (verifier CONFIRMED, and stronger than filed). Fixes a **protocol-changing** loss.

### Bug 1 — static bundle migrates as active LACP
A Junos aggregate with **no** `aggregated-ether-options lacp active|passive` line is a **static** (non-LACP) bundle, but parse defaulted its mode to `active`. Same-vendor re-render then **invented** `set interfaces ae0 aggregated-ether-options lacp active` — deploying that against a static-bonded peer renegotiates and **takes the bundle down**. Two parse sites seeded the `active` default; both now default `static`.

### Bug 2 — `lacp periodic` clobbers an explicit `passive` (verifier-added)
`lacp periodic <interval>` doesn't enable/disable LACP, but the parser coerced any non-active/passive token to `active` and **overwrote** the mode — so `lacp passive` followed by `lacp periodic fast` (a real Junos emit order) re-parsed as `active`. Now only an explicit `lacp active`/`lacp passive` sets the mode.

### Why it's a pure junos-parse fix
Render already emits a `lacp` line only for active/passive (nothing for static), so all three modes round-trip. The `static` canonical value is long-established — arista/aoscx/aoss/cisco/nxos/iosxr all parse `on`/`trunk`/`fec` → `static` and every render maps it — so there is **no cross-codec change**. Matrix flips the `LossyPath` to a supported declaration.

### Verification (verify-first)
Member-only bundle → static; passive+periodic → passive; active/passive/static each render→reparse faithfully; classify == supported. The reachability-based T0-1 fidelity guard now passes for junos with no loss to declare.

### Mesh
**Mesh-flat** — committed junos fixtures use explicit `lacp active`, so the baseline is unchanged. Full unit 5279 passed + integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
