### PR TITLE
feat(fortigate_cli): wire secondary interface IPs via config secondaryip (promotion #3)

### DIFF
--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -121,6 +121,9 @@ class FortiGateCLICodec(CodecBase):
             "/interfaces/interface/config/type",
             "/interfaces/interface/ipv4/address/ip",
             "/interfaces/interface/ipv4/address/prefix-length",
+            # Additional interface IPs via ``config secondaryip`` (promotion #3).
+            # The VLAN-SVI twin + the IPv6 twin stay unsupported (below).
+            "/interfaces/interface/ipv4/address/secondary-ip",
             "/interfaces/interface/ipv6/address/ip",         # GAP-EVPN-3
             "/interfaces/interface/ipv6/address/prefix-length",  # GAP-EVPN-3
             # Per-interface MTU — parse (`set mtu N` →
@@ -360,14 +363,6 @@ class FortiGateCLICodec(CodecBase):
                     "/anycast-gateway-mac), so a per-address virtual-gateway "
                     "MAC on a VLAN SVI is dropped. Declared unsupported "
                     "(blind-audit f92e97a T0-2)."
-                ),
-            ),
-            UnsupportedPath(
-                path="/interfaces/interface/ipv4/address/secondary-ip",
-                reason=(
-                    "Render emits one IPv4 address per interface; "
-                    "is_secondary addresses are dropped — a whole-subnet "
-                    "reachability loss (run3)."
                 ),
             ),
             UnsupportedPath(

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -347,6 +347,25 @@ def _apply_system_interface(  # noqa: C901
                 prefix_length=_mask_to_prefix(mask, vendor="fortigate_cli"),
             ))
 
+        # Additional interface IPs live in a nested ``config secondaryip``
+        # sub-table (``set secondary-IP enable`` gates it).  Without this
+        # every secondary subnet vanishes on parse — a whole-subnet
+        # reachability loss (promotion #3).  Harvest each ``set ip <ip>
+        # <mask>`` onto a secondary CanonicalIPv4Address.
+        for sub in edit.sub_blocks:
+            if sub.config_path != "secondaryip":
+                continue
+            for sec in sub.edits:
+                sec_tokens = sec.settings.get("ip")
+                if sec_tokens and len(sec_tokens) >= 2:
+                    iface.ipv4_addresses.append(CanonicalIPv4Address(
+                        ip=sec_tokens[0],
+                        prefix_length=_mask_to_prefix(
+                            sec_tokens[1], vendor="fortigate_cli",
+                        ),
+                        is_secondary=True,
+                    ))
+
         # IPv6 dynamic-address mode: ``set ip6-mode {static|dhcp|
         # delegated|pppoe}`` on FortiOS.  The ``dhcp`` value populates
         # the canonical ``dhcp_client_v6`` field.  Other modes

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -605,6 +605,26 @@ def render_intent(tree: Any) -> str:  # noqa: C901
                 mask = _prefix_to_mask(addr.prefix_length)
                 out.append(f"        set ip {addr.ip} {mask}")
                 out.append("        set mode static")
+                # Additional interface IPs → FortiOS ``config secondaryip``
+                # table (whole-subnet reachability that used to vanish —
+                # promotion #3).  Skip rows with no real IP: a VARP virtual-
+                # gateway anycast row carries ip='' + virtual_gateway_address,
+                # and emitting ``set ip  <mask>`` would be invalid CLI.
+                secondaries = [
+                    a for a in iface.ipv4_addresses[1:]
+                    if a.ip and not a.virtual_gateway_address
+                ]
+                if secondaries:
+                    out.append("        set secondary-IP enable")
+                    out.append("        config secondaryip")
+                    for i, sec in enumerate(secondaries, start=1):
+                        sec_mask = _prefix_to_mask(sec.prefix_length)
+                        out.append(f"            edit {i}")
+                        out.append(
+                            f"                set ip {sec.ip} {sec_mask}"
+                        )
+                        out.append("            next")
+                    out.append("        end")
             elif iface.dhcp_client:
                 # Finding 20 (``user_smoke_findings.md``): foreign
                 # DHCP-client interfaces (OPNsense ``<ipaddr>dhcp

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -14,15 +14,15 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 |---|---:|---|
 | ALIGNED | 1581 | ok |
 | CODEC_BUG | 5 | **high** |
-| EXPECTED_LOSSY | 1227 | ok |
+| EXPECTED_LOSSY | 1224 | ok |
 | EXPECTED_UNSUPPORTED | 729 | ok |
-| METHODOLOGY_ISSUE_under | 944 | low/medium |
+| METHODOLOGY_ISSUE_under | 947 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
 | STRUCTURAL_ONLY | 1194 | low |
 | TRIVIAL_EMPTY | 9515 | ok |
 | **Total field-cells classified** | **15220** | |
 
-Severity roll-up: 5 high, 111 medium, 2052 low, 13052 ok.
+Severity roll-up: 5 high, 111 medium, 2055 low, 13049 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-11T18:18:14+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260711T181813Z.json",
-  "mesh_run_started_utc": "2026-07-11T18:18:07+00:00",
+  "started_utc": "2026-07-11T19:20:46+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260711T192044Z.json",
+  "mesh_run_started_utc": "2026-07-11T19:20:30+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4136,17 +4136,17 @@
   "aggregate": {
     "ALIGNED": 1581,
     "CODEC_BUG": 5,
-    "EXPECTED_LOSSY": 1227,
+    "EXPECTED_LOSSY": 1224,
     "EXPECTED_UNSUPPORTED": 729,
-    "METHODOLOGY_ISSUE_under": 944,
+    "METHODOLOGY_ISSUE_under": 947,
     "METHODOLOGY_ISSUE_over": 25,
     "STRUCTURAL_ONLY": 1194,
     "TRIVIAL_EMPTY": 9515,
     "fields_total": 15220,
     "severity_high": 5,
     "severity_medium": 111,
-    "severity_low": 2052,
-    "severity_ok": 13052
+    "severity_low": 2055,
+    "severity_ok": 13049
   },
   "severity_matrix": {
     "arista_eos": {
@@ -4346,7 +4346,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "arista_eos",
-      "drifted_total": 31
+      "drifted_total": 28
     },
     {
       "source_codec": "cisco_iosxr",

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -476,6 +476,82 @@ end
         assert norm(first) == norm(second)
 
 
+class TestSecondaryIp:
+    """Promotion #3: additional interface IPs via ``config secondaryip``."""
+
+    _CFG = (
+        "config system interface\n"
+        '    edit "port1"\n'
+        "        set ip 10.0.0.1 255.255.255.0\n"
+        "        set secondary-IP enable\n"
+        "        config secondaryip\n"
+        "            edit 1\n"
+        "                set ip 10.0.1.1 255.255.255.0\n"
+        "            next\n"
+        "            edit 2\n"
+        "                set ip 10.0.2.1 255.255.255.0\n"
+        "            next\n"
+        "        end\n"
+        "    next\n"
+        "end\n"
+    )
+
+    def test_parse_harvests_secondaries(self):
+        iface = FortiGateCLICodec().parse(self._CFG).interfaces[0]
+        got = [(a.ip, a.is_secondary) for a in iface.ipv4_addresses]
+        assert got == [
+            ("10.0.0.1", False),
+            ("10.0.1.1", True),
+            ("10.0.2.1", True),
+        ]
+
+    def test_round_trips(self):
+        codec = FortiGateCLICodec()
+        intent = codec.parse(self._CFG)
+        rendered = codec.render(intent)
+        assert "config secondaryip" in rendered
+        reparsed = codec.parse(rendered)
+        assert [(a.ip, a.is_secondary) for a in reparsed.interfaces[0].ipv4_addresses] == \
+               [(a.ip, a.is_secondary) for a in intent.interfaces[0].ipv4_addresses]
+
+    def test_coequal_source_emits_secondaryip_table(self):
+        """A donor with co-equal (unflagged) additional IPs still renders the
+        secondaryip table — every subnet survives."""
+        tree = CanonicalIntent(interfaces=[CanonicalInterface(
+            name="port1",
+            ipv4_addresses=[
+                CanonicalIPv4Address(ip="10.0.0.1", prefix_length=24),
+                CanonicalIPv4Address(ip="10.0.9.1", prefix_length=24),
+            ],
+        )])
+        rendered = FortiGateCLICodec().render(tree)
+        assert "set secondary-IP enable" in rendered
+        assert "set ip 10.0.9.1 255.255.255.0" in rendered
+
+    def test_varp_row_not_emitted_as_secondary(self):
+        """A VARP anycast row (ip='' + virtual_gateway_address) must NOT emit
+        a ``set ip  <mask>`` line into the secondaryip table (invalid CLI)."""
+        tree = CanonicalIntent(interfaces=[CanonicalInterface(
+            name="vlan110",
+            ipv4_addresses=[
+                CanonicalIPv4Address(ip="10.1.1.1", prefix_length=24),
+                CanonicalIPv4Address(
+                    ip="", prefix_length=24,
+                    virtual_gateway_address="10.1.1.254",
+                ),
+            ],
+        )])
+        rendered = FortiGateCLICodec().render(tree)
+        assert "config secondaryip" not in rendered
+        assert "set ip  " not in rendered
+
+    def test_interface_v4_secondary_supported_twins_stay_unsupported(self):
+        caps = FortiGateCLICodec().capabilities
+        assert caps.classify("/interfaces/interface/ipv4/address/secondary-ip") == "supported"
+        assert caps.classify("/vlans/vlan/ipv4/address/secondary-ip") == "unsupported"
+        assert caps.classify("/interfaces/interface/ipv6/address/secondary-ip") == "unsupported"
+
+
 class TestRoundTrip:
     def test_roundtrip_minimal(self):
         codec = FortiGateCLICodec()

--- a/tests/unit/migration/test_multiaddress_cardinality_walk.py
+++ b/tests/unit/migration/test_multiaddress_cardinality_walk.py
@@ -134,8 +134,13 @@ class TestEndToEndLossSurfaces:
     """The flagless multi-address loss surfaces in the live validation
     report on a single-address target codec (was a silent ``ok``)."""
 
-    @pytest.mark.parametrize("target", ["opnsense", "fortigate_cli"])
-    def test_flagless_multiaddress_blocks_on_single_address_codec(self, target):
+    @pytest.mark.parametrize(
+        "target,expect_v4_unsup",
+        [("opnsense", True), ("fortigate_cli", False)],
+    )
+    def test_flagless_multiaddress_blocks_on_single_address_codec(
+        self, target, expect_v4_unsup,
+    ):
         tree = _intent(
             [_v4("10.0.0.1"), _v4("10.0.9.1")],
             [_v6("2001:db8::1"), _v6("2001:db8:9::1")],
@@ -144,6 +149,10 @@ class TestEndToEndLossSurfaces:
             tree, get_codec(target), source=get_codec("cisco_iosxe_cli"),
         )
         unsup = {u.path for u in report.unsupported_paths}
-        assert _V4_SEC in unsup
+        # fortigate_cli graduated the interface-mount v4 secondary-ip
+        # (promotion #3 — `config secondaryip`), so its v4 secondaries now
+        # round-trip; the v6 twin still drops, so the report stays
+        # incompatible via the v6 loss.  opnsense still drops both.
+        assert (_V4_SEC in unsup) is expect_v4_unsup
         assert _V6_SEC in unsup
         assert report.compatible is False


### PR DESCRIPTION
Graduates the interface-mount `/interfaces/interface/ipv4/address/secondary-ip` on **fortigate_cli** from `unsupported` → `supported` — promotion candidate **#3** (verifier CONFIRMED). Closes a **whole-subnet reachability loss**.

### The bug
FortiOS carries additional interface IPs in a nested `config secondaryip` sub-table (gated by `set secondary-IP enable`). Parse read only the primary `set ip` and never descended into that sub-block; render emitted only `ipv4_addresses[0]`. So **every secondary subnet vanished** on both parse and render (a cisco `ip address B secondary`, a junos multi-address loopback → all extra subnets lost crossing into FortiOS).

### The fix
- **Parse** iterates `edit.sub_blocks` for `config_path == "secondaryip"` (same machinery ntp/vrrp/dhcp use), harvesting each onto a secondary `CanonicalIPv4Address`.
- **Render** emits `set secondary-IP enable` + a `config secondaryip` edit table — **skipping** rows with no real IP (a VARP anycast row carries `ip='' + virtual_gateway_address`; emitting `set ip  <mask>` would be invalid CLI — the verifier's trap).
- **Matrix** flips only the interface-mount v4 entry; the VLAN-SVI twin and the IPv6 twin stay `unsupported`.
- **Guard**: `test_multiaddress_cardinality_walk` splits the single-address-target param — fortigate no longer expects v4 secondary-ip unsupported (it round-trips), while the v6 twin still drops so the report stays incompatible.

### Verification (verify-first)
Secondaries harvested + round-trip; co-equal donor emits the table; VARP row skipped (no invalid line); classify supported (twins stay unsupported). Full unit + integration green.

### Mesh
Re-baselined. **CODEC_BUG stays 5, cells_total 1224, codec-bug pairs identical.** Two explainable deltas: (1) 3 fortigate-target cells move `EXPECTED_LOSSY → METHODOLOGY_under` (secondaries now round-trip; their YAMLs still declare lossy = safe pessimism); (2) `cisco_iosxr→arista 31→28` — a **previously-unbaselined** improvement from #342 (arista interface routes) that the `<=` ratchet let ride un-ratcheted, locked in now. `is_secondary` is a documented cosmetic comparator subfield, so co-equal→secondary re-parse isn't scored as drift.

### Deferred (optional `[yaml]` follow-up)
Flip the 3 fortigate expectation-YAML `ipv4_addresses`/`secondary-ip` cells lossy→good to make future drift stricter (currently `METHODOLOGY_under` = safe pessimism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
