### PR TITLE
fix(fortigate_cli): parse the nested FortiOS 7.x config ipv6 interface address (promotion #2)

### DIFF
--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -384,7 +384,23 @@ def _apply_system_interface(  # noqa: C901
         # FortiOS native).  ``set ip6-address ::/0`` is "no IPv6
         # address" — drop the all-zero placeholder rather than emit
         # a canonical record for it.
+        #
+        # FortiOS 6.x puts ``set ip6-address`` directly on the interface
+        # edit; FortiOS 7.x nests it under a ``config ipv6`` sub-block
+        # (``edit port1 / config ipv6 / set ip6-address .../64 / end``).
+        # Read the direct form first, then the nested block if the direct
+        # form was absent — a real config carries the address in exactly
+        # one place, so this never double-appends (promotion #2: the path
+        # is declared supported, so a dropped nested address was a
+        # fail-open silent loss).  Only ``ip6-address`` is harvested from
+        # the nested block; nested ``ip6-mode`` is a separate surface left
+        # untouched here.
         ip6_tokens = edit.settings.get("ip6-address")
+        if not (ip6_tokens and ip6_tokens[0]):
+            for sub in edit.sub_blocks:
+                if sub.config_path == "ipv6":
+                    ip6_tokens = sub.settings.get("ip6-address")
+                    break
         if ip6_tokens and ip6_tokens[0]:
             v6_token = ip6_tokens[0]
             if "/" in v6_token:

--- a/tests/unit/migration/test_ipv6_wire_through.py
+++ b/tests/unit/migration/test_ipv6_wire_through.py
@@ -402,6 +402,59 @@ class TestFortiGateIPv6:
         assert first.interfaces[0].ipv6_addresses == \
                second.interfaces[0].ipv6_addresses
 
+    def test_parse_nested_config_ipv6(self):
+        """FortiOS 7.x nests the interface IPv6 address under a ``config
+        ipv6`` sub-block (promotion #2).  Parsing only the legacy direct form
+        silently dropped it while the matrix declared it supported —
+        fail-open silent loss."""
+        raw = (
+            "config system interface\n"
+            '    edit "port1"\n'
+            "        config ipv6\n"
+            "            set ip6-address 2001:db8:1::1/64\n"
+            "            set ip6-mode static\n"
+            "        end\n"
+            "    next\n"
+            "end\n"
+        )
+        iface = FortiGateCLICodec().parse(raw).interfaces[0]
+        assert [(a.ip, a.prefix_length, a.scope) for a in iface.ipv6_addresses] == \
+               [("2001:db8:1::1", 64, "global")]
+        # Only ip6-address is harvested from the nested block — ip6-mode is a
+        # separate surface (left untouched so the mesh stays flat).
+        assert iface.dhcp_client_v6 == ""
+
+    def test_nested_placeholder_filtered(self):
+        raw = (
+            "config system interface\n"
+            '    edit "port1"\n'
+            "        config ipv6\n"
+            "            set ip6-address ::/0\n"
+            "        end\n"
+            "    next\n"
+            "end\n"
+        )
+        assert FortiGateCLICodec().parse(raw).interfaces[0].ipv6_addresses == []
+
+    def test_nested_round_trips_via_direct_render(self):
+        """The nested-parsed address round-trips through the existing direct
+        render form (render is unchanged by this promotion)."""
+        c = FortiGateCLICodec()
+        raw = (
+            "config system interface\n"
+            '    edit "port1"\n'
+            "        config ipv6\n"
+            "            set ip6-address 2001:db8:1::1/64\n"
+            "        end\n"
+            "    next\n"
+            "end\n"
+        )
+        first = c.parse(raw)
+        assert "set ip6-address 2001:db8:1::1/64" in c.render(first)
+        second = c.parse(c.render(first))
+        assert first.interfaces[0].ipv6_addresses == \
+               second.interfaces[0].ipv6_addresses
+
 
 # ---------------------------------------------------------------------------
 # MikroTik RouterOS


### PR DESCRIPTION
Closes a **fail-open silent loss** on fortigate_cli — promotion candidate **#2** (verifier re-vetted **GO**, mesh-flat, parse-only).

### The bug
The interface IPv6-address path is declared **supported**, but parse read `set ip6-address` only from the legacy 6.x **direct** form. FortiOS 7.x nests it under a `config ipv6` sub-block (`edit port1 / config ipv6 / set ip6-address …/64 / end`) — which parse never descended into. So a real nested address dropped to `ipv6_addresses == []` with **no Tier-3 flag** and classify() still reporting supported (the worst class — the honesty machinery says "ok" while data is discarded).

### The fix (parse-only)
Read `ip6-address` from the direct form first, then fall back to the nested `config ipv6` block (`edit.sub_blocks` where `config_path == "ipv6"`, `sub.settings['ip6-address']` — same machinery ntp/vrrp/secondaryip use). Reuses the existing `::/0` filter + `scope="global"`; read from exactly one place (never double-appended). **Only** `ip6-address` is harvested — nested `ip6-mode` is deliberately left untouched (that would move the mesh — a separate dhcp-client-v6 promotion).

Render + matrix **unchanged**: render already emits the direct form (round-trips), and the path was already declared supported — this just makes the declaration honest.

### Mesh — FLAT
The 2 committed fixtures using `config ipv6` (kevinguenay, fg100e) carry only the `::/0` placeholder in all 29 nested blocks (filtered anyway) → canonical tree and cross-mesh baseline don't move. Verified before/after. No re-baseline.

### Tests
Nested parse → one `CanonicalIPv6Address(scope=global)` + `ip6-mode` not harvested; nested `::/0` filtered; nested round-trip via the existing direct render. Full unit 5287 + integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
