### PR TITLE
fix(cisco_nxos): render + parse gre/ipip tunnel encapsulation (promotion #17)

### DIFF
--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -300,12 +300,11 @@ class CiscoNXOSCodec(CodecBase):
             LossyPath(
                 path="/interfaces/interface/tunnel-type",
                 reason=(
-                    "Render emits `interface Tunnel<N>` with no `tunnel "
-                    "mode <kind>` sub-command, so the canonical tunnel_type "
-                    "(gre/ipip/ipsec) drops on render while the interface "
-                    "name survives.  NX-OS supports the `tunnel mode` "
-                    "grammar; this is a render-coverage gap (silent-loss "
-                    "guard, Bucket-C stage 3)."
+                    "`gre` and `ipip` round-trip via `tunnel mode gre ip` / "
+                    "`tunnel mode ipip` (with `feature tunnel`).  `ipsec` / "
+                    "`vxlan` / `eoip` have no clean NX-OS interface-encap "
+                    "equivalent and drop on render — the residual lossy "
+                    "surface (silent-loss guard, Bucket-C stage 3)."
                 ),
                 severity="warn",
             ),

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -95,6 +95,13 @@ _DESC_RE = re.compile(r"^\s+description\s+(.+)", re.IGNORECASE)
 _SHUTDOWN_RE = re.compile(r"^\s+shutdown\s*$", re.IGNORECASE)
 _NO_SHUTDOWN_RE = re.compile(r"^\s+no\s+shutdown\s*$", re.IGNORECASE)
 _MTU_RE = re.compile(r"^\s+mtu\s+(\d+)\s*$", re.IGNORECASE)
+# ``tunnel mode <encap>`` inside an ``interface Tunnel<N>`` stanza.  NX-OS
+# spells GRE ``tunnel mode gre ip`` and IP-in-IP ``tunnel mode ipip``;
+# ``ipv6ip`` (IPv6-over-IPv4) collapses to the canonical ``ipip``.  Ignored
+# on non-tunnel interfaces (the field is only meaningful there).
+_TUNNEL_MODE_RE = re.compile(
+    r"^\s+tunnel\s+mode\s+(gre|ipip|ipsec|vxlan|ipv6ip)\b", re.IGNORECASE,
+)
 #: ``ip address 10.10.10.1/24`` — CIDR form, NEVER dotted mask.  The
 #: optional ``secondary`` trailer is consumed but not modelled in Phase 1.
 _IP_CIDR_RE = re.compile(
@@ -348,6 +355,7 @@ _TYPE_HINTS: tuple[tuple[str, str], ...] = (
     ("vlan", "ianaift:l3ipvlan"),
     ("port-channel", "ianaift:ieee8023adLag"),
     ("nve", "ianaift:tunnel"),
+    ("tunnel", "ianaift:tunnel"),   # ``interface Tunnel<N>`` (GRE / IP-in-IP)
     ("mgmt", "ianaift:ethernetCsmacd"),
 )
 
@@ -620,6 +628,7 @@ def _new_iface_scratch(name: str) -> dict:
         "description": "",
         "enabled": True,
         "type": _infer_type(name),
+        "tunnel_type": "",
         "mtu": None,
         "ipv4": [],
         "ipv6": [],
@@ -734,6 +743,12 @@ def _parse_interfaces(raw: str) -> list[CanonicalInterface]:  # noqa: C901
                 current["mtu"] = int(mm.group(1))
             except ValueError:
                 pass
+            return
+
+        tmm = _TUNNEL_MODE_RE.match(line)
+        if tmm:
+            mode = tmm.group(1).lower()
+            current["tunnel_type"] = "ipip" if mode == "ipv6ip" else mode
             return
 
         im = _IP_CIDR_RE.match(line)
@@ -871,6 +886,7 @@ def _build_canonical_interface(raw: dict) -> CanonicalInterface:
         description=raw.get("description", ""),
         enabled=raw.get("enabled", True),
         interface_type=raw.get("type", ""),
+        tunnel_type=raw.get("tunnel_type", ""),
         mtu=raw.get("mtu"),
         ipv4_addresses=[
             CanonicalIPv4Address(

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -196,6 +196,12 @@ def _derive_features(tree: CanonicalIntent) -> list[str]:
     features: set[str] = set()
     if any(_is_svi(i.name) for i in tree.interfaces):
         features.add("interface-vlan")
+    # A bare ``interface Tunnel<N>`` is invalid on a real Nexus without
+    # ``feature tunnel``.  Gate on the ``Tunnel`` name prefix — NOT
+    # interface_type=="ianaift:tunnel", which also covers ``nve1`` (a VXLAN
+    # VTEP gated by ``feature nv overlay``, not ``feature tunnel``).
+    if any(i.name.lower().startswith("tunnel") for i in tree.interfaces):
+        features.add("tunnel")
     if tree.lags:
         features.add("lacp")
     if any(i.vrrp_groups for i in tree.interfaces):
@@ -442,6 +448,17 @@ def _render_interface(iface, lag_mode_by_name: dict) -> list[str]:
         block.append("  no shutdown")
     if iface.mtu is not None:
         block.append(f"  mtu {iface.mtu}")
+
+    # Tunnel encapsulation mode.  NX-OS spells GRE ``tunnel mode gre ip``
+    # and IP-in-IP ``tunnel mode ipip``.  Only gre/ipip have a clean NX-OS
+    # interface-encap equivalent; ipsec/vxlan/eoip carry no such line and
+    # stay dropped (declared lossy on /interfaces/interface/tunnel-type).
+    if iface.tunnel_type and iface.interface_type == "ianaift:tunnel":
+        _tt = iface.tunnel_type.lower()
+        if _tt == "gre":
+            block.append("  tunnel mode gre ip")
+        elif _tt == "ipip":
+            block.append("  tunnel mode ipip")
 
     block.extend(_render_switchport_lines(iface))
 

--- a/tests/unit/migration/test_dhcp_v6_and_tunnel_type_wire_through.py
+++ b/tests/unit/migration/test_dhcp_v6_and_tunnel_type_wire_through.py
@@ -41,6 +41,7 @@ from netcanon.migration.canonical.intent import (
 )
 from netcanon.migration.codecs.arista_eos import AristaEOSCodec
 from netcanon.migration.codecs.cisco_iosxe_cli import CiscoIOSXECLICodec
+from netcanon.migration.codecs.cisco_nxos import CiscoNXOSCodec
 from netcanon.migration.codecs.fortigate_cli import FortiGateCLICodec
 from netcanon.migration.codecs.juniper_junos import JunosCodec
 from netcanon.migration.codecs.mikrotik_routeros import MikroTikRouterOSCodec
@@ -473,3 +474,59 @@ class TestCrossVendorPreservation:
         out = MikroTikRouterOSCodec().render(intent)
         # Render must not raise.
         assert isinstance(out, str)
+
+
+class TestCiscoNxosTunnelType:
+    """Promotion #17: NX-OS gre/ipip tunnel encapsulation round-trips via
+    ``tunnel mode`` + ``feature tunnel``.  ipsec/vxlan stay declared lossy."""
+
+    def test_parse_gre_and_ipip(self):
+        raw = (
+            "interface Tunnel1\n"
+            "  tunnel mode gre ip\n"
+            "  no shutdown\n"
+            "interface Tunnel2\n"
+            "  tunnel mode ipip\n"
+        )
+        by_name = {i.name: i for i in CiscoNXOSCodec().parse(raw).interfaces}
+        assert by_name["Tunnel1"].interface_type == "ianaift:tunnel"
+        assert by_name["Tunnel1"].tunnel_type == "gre"
+        assert by_name["Tunnel2"].tunnel_type == "ipip"
+
+    def test_render_emits_mode_and_feature(self):
+        intent = CanonicalIntent(interfaces=[CanonicalInterface(
+            name="Tunnel1", interface_type="ianaift:tunnel", tunnel_type="gre")])
+        out = CiscoNXOSCodec().render(intent)
+        assert "feature tunnel" in out
+        assert "tunnel mode gre ip" in out
+
+    def test_round_trips(self):
+        codec = CiscoNXOSCodec()
+        for kind, line in (("gre", "tunnel mode gre ip"), ("ipip", "tunnel mode ipip")):
+            intent = CanonicalIntent(interfaces=[CanonicalInterface(
+                name="Tunnel1", interface_type="ianaift:tunnel", tunnel_type=kind)])
+            rendered = codec.render(intent)
+            assert line in rendered
+            assert codec.parse(rendered).interfaces[0].tunnel_type == kind
+
+    def test_nve_does_not_trigger_feature_tunnel(self):
+        """``nve1`` is also ianaift:tunnel but is a VXLAN VTEP — it must NOT
+        emit ``feature tunnel`` (it uses ``feature nv overlay``)."""
+        from netcanon.migration.canonical.intent import CanonicalVxlan
+        intent = CanonicalIntent(
+            interfaces=[CanonicalInterface(
+                name="nve1", interface_type="ianaift:tunnel")],
+            vxlan_vnis=[CanonicalVxlan(vni=10010, vlan_id=10)],
+        )
+        out = CiscoNXOSCodec().render(intent)
+        assert "feature tunnel" not in out
+        assert "feature nv overlay" in out
+
+    def test_ipsec_still_drops_and_declared_lossy(self):
+        intent = CanonicalIntent(interfaces=[CanonicalInterface(
+            name="Tunnel9", interface_type="ianaift:tunnel", tunnel_type="ipsec")])
+        out = CiscoNXOSCodec().render(intent)
+        assert "tunnel mode" not in out       # no clean NX-OS ipsec encap line
+        assert "feature tunnel" in out         # the interface itself is valid
+        assert CiscoNXOSCodec().capabilities.classify(
+            "/interfaces/interface/tunnel-type") == "lossy"


### PR DESCRIPTION
Closes an NX-OS tunnel **render-coverage gap** — promotion candidate **#17** (verifier re-vetted **GO**, mesh-flat). A *narrow* fidelity fix: gre/ipip now round-trip; ipsec/vxlan stay declared lossy.

### The bug
Render emitted a bare `interface Tunnel<N>` with **no** `tunnel mode` line and **no** `feature tunnel` — so the canonical `tunnel_type` dropped *and* the stanza was invalid on a real Nexus (a bare tunnel interface needs `feature tunnel`). Parse also discarded `tunnel mode` and typed `Tunnel<N>` as `ianaift:other`.

### The fix (mirrors the cisco_iosxe_cli donor)
- **Parse**: `("tunnel", "ianaift:tunnel")` name→ifType hint + a `tunnel mode (gre|ipip|ipsec|vxlan|ipv6ip)` rule onto `tunnel_type` (`ipv6ip`→`ipip`).
- **Render**: emit `tunnel mode gre ip` / `tunnel mode ipip` for gre/ipip; add `feature tunnel` gated on the `Tunnel` **name prefix** — *not* `interface_type`, which also covers `nve1` (a VXLAN VTEP using `feature nv overlay`; verified excluded).
- **Matrix**: `ipsec`/`vxlan`/`eoip` have no clean NX-OS interface-encap line and stay dropped — the LossyPath is **kept** (reason narrowed), not flipped to supported.

### Verification
Parse gre/ipip → `tunnel_type` + `ianaift:tunnel`; render emits mode + feature; gre/ipip round-trip; `nve1` does NOT emit `feature tunnel`; ipsec drops + stays lossy. The silent-loss subfield guard stays green (6 other codecs still demonstrate the drop case).

### Mesh — FLAT
No committed nxos fixture carries `interface Tunnel` / `tunnel mode` (verified) → baseline unchanged. Full unit + integration 5815 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
