### PR TITLE
feat(vyos): wire system domain-name + name-server (promotion #12)

### DIFF
--- a/netcanon/migration/codecs/vyos/codec.py
+++ b/netcanon/migration/codecs/vyos/codec.py
@@ -125,6 +125,11 @@ class VyOSCodec(CodecBase):
         supported=[
             # System
             "/system/hostname",
+            # ── Promotion #12: system domain-name + name-server ──
+            # (system-level only; a dhcp-server subnet's leaves feed the
+            # DHCP pool, not these scalars; non-IP name-servers are filtered).
+            "/system/domain",
+            "/system/dns-server",
             # Interfaces — name + basic L3 (Phase 1; incl. vif VLAN
             # sub-interfaces modelled as ethN.<vid> interfaces).
             "/interfaces/interface/name",
@@ -485,16 +490,8 @@ class VyOSCodec(CodecBase):
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
             UnsupportedPath(
-                path="/system/domain",
-                reason="Render emits no system domain-name; intent.domain is dropped on migration.",
-            ),
-            UnsupportedPath(
                 path="/system/timezone",
                 reason="Render emits no time-zone stanza; intent.timezone is dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/dns-server",
-                reason="Render emits no name-server config; intent.dns_servers are dropped on migration.",
             ),
             UnsupportedPath(
                 path="/system/syslog-server",

--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -87,6 +87,7 @@ single-device SVD ``vlan-to-vni``, per-VRF static routes (``vrf name
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import re
 
@@ -592,6 +593,37 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             and value
         ):
             intent.hostname = value
+            continue
+
+        # system domain-name (single scalar).  PATH-GUARDED to the top-level
+        # ``system {}`` block (stack depth 1) — a dhcp-server subnet's
+        # ``domain-name`` leaf lives deeper and feeds CanonicalDHCPPool, NOT
+        # this system scalar (promotion #12).
+        if (
+            len(stack) == 1
+            and stack[0][0] == "system"
+            and key == "domain-name"
+            and value
+        ):
+            intent.domain = value
+            continue
+
+        # system name-server (multi-value), same system-level path-guard.
+        # ``name-server eth0`` is legal VyOS ("use eth0's DHCP-obtained
+        # resolvers") but not a real server — skip any non-IP value so a
+        # cross-vendor target never renders an invalid ``ip name-server eth0``.
+        if (
+            len(stack) == 1
+            and stack[0][0] == "system"
+            and key == "name-server"
+            and value
+        ):
+            try:
+                ipaddress.ip_address(value)
+            except ValueError:
+                continue
+            if value not in intent.dns_servers:
+                intent.dns_servers.append(value)
             continue
 
         # static-route metric (distance) inside the open next-hop block

--- a/netcanon/migration/codecs/vyos/render.py
+++ b/netcanon/migration/codecs/vyos/render.py
@@ -103,8 +103,14 @@ def render_intent(tree: CanonicalIntent) -> str:
     # ``system`` always carries at least the host-name; Phase 2 adds the
     # ``login`` (local users) and ``ntp`` sub-blocks.
     lines.append("system {")
+    # VyOS orders system children alphabetically: domain-name, host-name,
+    # login, name-server, ntp (promotion #12 wired domain-name + name-server).
+    if tree.domain:
+        lines.append(f"    domain-name {tree.domain}")
     lines.append(f"    host-name {tree.hostname or 'vyos'}")
     lines.extend(_render_login(tree.local_users))
+    for _ns in tree.dns_servers:
+        lines.append(f"    name-server {_ns}")
     lines.extend(_render_ntp(tree.ntp_servers))
     lines.append("}")
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-11T19:20:46+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260711T192044Z.json",
-  "mesh_run_started_utc": "2026-07-11T19:20:30+00:00",
+  "started_utc": "2026-07-11T20:01:10+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260711T200109Z.json",
+  "mesh_run_started_utc": "2026-07-11T20:01:03+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4206,7 +4206,7 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "vyos",
-      "drifted_total": 31
+      "drifted_total": 25
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4291,7 +4291,7 @@
     {
       "source_codec": "aruba_aoss",
       "target_codec": "vyos",
-      "drifted_total": 23
+      "drifted_total": 20
     },
     {
       "source_codec": "cisco_iosxe",
@@ -4341,7 +4341,7 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "vyos",
-      "drifted_total": 34
+      "drifted_total": 30
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4401,7 +4401,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "vyos",
-      "drifted_total": 43
+      "drifted_total": 35
     },
     {
       "source_codec": "cisco_nxos",
@@ -4486,7 +4486,7 @@
     {
       "source_codec": "fortigate_cli",
       "target_codec": "vyos",
-      "drifted_total": 31
+      "drifted_total": 26
     },
     {
       "source_codec": "juniper_junos",
@@ -4511,7 +4511,7 @@
     {
       "source_codec": "juniper_junos",
       "target_codec": "vyos",
-      "drifted_total": 66
+      "drifted_total": 58
     },
     {
       "source_codec": "mikrotik_routeros",
@@ -4536,7 +4536,7 @@
     {
       "source_codec": "mikrotik_routeros",
       "target_codec": "vyos",
-      "drifted_total": 18
+      "drifted_total": 17
     },
     {
       "source_codec": "opnsense",
@@ -4561,7 +4561,7 @@
     {
       "source_codec": "opnsense",
       "target_codec": "vyos",
-      "drifted_total": 31
+      "drifted_total": 20
     },
     {
       "source_codec": "vyos",
@@ -4571,12 +4571,12 @@
     {
       "source_codec": "vyos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 41
+      "drifted_total": 43
     },
     {
       "source_codec": "vyos",
       "target_codec": "aruba_aoss",
-      "drifted_total": 31
+      "drifted_total": 32
     },
     {
       "source_codec": "vyos",
@@ -4591,17 +4591,17 @@
     {
       "source_codec": "vyos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 45
-    },
-    {
-      "source_codec": "vyos",
-      "target_codec": "cisco_nxos",
       "drifted_total": 46
     },
     {
       "source_codec": "vyos",
+      "target_codec": "cisco_nxos",
+      "drifted_total": 48
+    },
+    {
+      "source_codec": "vyos",
       "target_codec": "fortigate_cli",
-      "drifted_total": 30
+      "drifted_total": 31
     },
     {
       "source_codec": "vyos",
@@ -4611,7 +4611,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "mikrotik_routeros",
-      "drifted_total": 23
+      "drifted_total": 24
     },
     {
       "source_codec": "vyos",

--- a/tests/unit/migration/test_vyos.py
+++ b/tests/unit/migration/test_vyos.py
@@ -286,6 +286,69 @@ def test_parse_hostname(codec: VyOSCodec) -> None:
     assert codec.parse(_SAMPLE).hostname == "vyos-sample"
 
 
+def test_parse_system_dns_and_domain(codec: VyOSCodec) -> None:
+    """Promotion #12: ``system domain-name`` + ``system name-server`` harvest.
+    A non-IP name-server (``eth0`` = use-DHCP-resolvers) is filtered."""
+    cfg = (
+        "system {\n"
+        "    domain-name example.com\n"
+        "    host-name r1\n"
+        "    name-server 8.8.8.8\n"
+        "    name-server 1.1.1.1\n"
+        "    name-server eth0\n"
+        "}\n"
+    )
+    intent = codec.parse(cfg)
+    assert intent.domain == "example.com"
+    assert intent.dns_servers == ["8.8.8.8", "1.1.1.1"]  # eth0 filtered
+
+
+def test_dns_domain_round_trip(codec: VyOSCodec) -> None:
+    cfg = (
+        "system {\n"
+        "    domain-name corp.local\n"
+        "    host-name r1\n"
+        "    name-server 9.9.9.9\n"
+        "}\n"
+    )
+    intent = codec.parse(cfg)
+    rendered = codec.render(intent)
+    assert "domain-name corp.local" in rendered
+    assert "name-server 9.9.9.9" in rendered
+    reparsed = codec.parse(rendered)
+    assert reparsed.domain == "corp.local"
+    assert reparsed.dns_servers == ["9.9.9.9"]
+
+
+def test_dhcp_subnet_dns_domain_not_harvested_to_system(codec: VyOSCodec) -> None:
+    """A dhcp-server subnet's ``name-server`` / ``domain-name`` leaves feed the
+    DHCP pool — the system-level path-guard keeps them off the system scalars."""
+    cfg = (
+        "service {\n"
+        "    dhcp-server {\n"
+        "        shared-network-name LAN {\n"
+        "            subnet 192.168.1.0/24 {\n"
+        "                domain-name vyos.net\n"
+        "                name-server 192.168.1.5\n"
+        "            }\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+        "system {\n"
+        "    host-name r2\n"
+        "}\n"
+    )
+    intent = codec.parse(cfg)
+    assert intent.domain == ""
+    assert intent.dns_servers == []
+
+
+def test_system_dns_domain_classified_supported(codec: VyOSCodec) -> None:
+    caps = codec.capabilities
+    assert caps.classify("/system/domain") == "supported"
+    assert caps.classify("/system/dns-server") == "supported"
+
+
 def test_source_version_release_comment(codec: VyOSCodec) -> None:
     """The OS release is captured from the ``// Release version:`` trailer."""
     raw = _SAMPLE + "// Release version: 1.4-rolling-202307070317\n"


### PR DESCRIPTION
Graduates `/system/domain` + `/system/dns-server` on **vyos** from `unsupported` → `supported` — promotion candidate **#12** (re-vetted CAUTION; landed with both guards the verifier required). Both leaves were parse-ignore *and* render-drop, so a VyOS device's DNS config vanished both directions.

### The fix
- **Parse** harvests `system domain-name` + `system name-server` at the top-level `system {}` block, with **two guards**:
  - **(a) path-guard** to stack-depth 1 under `system` — a dhcp-server subnet's `domain-name`/`name-server` leaves live deeper and feed `CanonicalDHCPPool`, **not** these system scalars.
  - **(b) non-IP filter** — `name-server eth0` ("use eth0's DHCP resolvers") is legal VyOS but not a real server; skipping it stops a cross-vendor target rendering invalid `ip name-server eth0`.
- **Render** emits `domain-name` + `name-server` in the `system {}` block (VyOS-alphabetical order).
- **Matrix** flips both `unsupported` → `supported`.

### Verified against BOTH real fixtures that carry these keys
- **scottlaird-vyos-parser**: system `domain-name` + 3 `name-server` IPs → all harvested ✓
- **houdev_vyos_dhcpv6_pd_client**: system `name-server eth0` **filtered** + a dhcp-subnet `name-server`/`domain-name` correctly **path-guarded** off the system scalars ✓

Plus synthetic parse / round-trip / path-guard / classify tests.

### Mesh
Re-baselined (`latest.json` only — the report md is byte-identical since every moved pair is YAML-less). **CODEC_BUG flat 5, cells 1224, no new codec-bug pair.** All moved pairs are vyos-involved and explained: **X→vyos decreased** (render now emits dns/domain → sources round-trip instead of dropping: junos→vyos 66→58, opnsense→vyos 31→20…); **vyos→X increased** (scottlaird now captures dns/domain that honestly drifts on non-supporting targets — silent source loss → visible target loss). Full unit 5292 + integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
