### PR TITLE
fix(matrix): promote proven-clean ntp/dhcp/static-route cells + correct aoscx lag reason (promotions #8/#9/#14/#19)

### DIFF
--- a/netcanon/migration/codecs/aruba_aoscx/codec.py
+++ b/netcanon/migration/codecs/aruba_aoscx/codec.py
@@ -155,7 +155,8 @@ class ArubaAOSCXCodec(CodecBase):
             "/lags/lag/name",
             "/lags/lag/members",
             # /lags/lag/mode is LOSSY, not supported — see the lossy list
-            # below (passive re-parses as static; audit bb47f21 T0-1).
+            # below (cross-vendor render gap: a foreign-named LAG with no
+            # kind-`lag` interface re-parses as static; audit bb47f21 T0-1).
             # ── Phase 2: local users (`user X group G password ciphertext`) ──
             "/local-users/user/name",
             "/local-users/user/role",
@@ -178,10 +179,14 @@ class ArubaAOSCXCodec(CodecBase):
             LossyPath(
                 path="/lags/lag/mode",
                 reason=(
-                    "AOS-CX renders the LAG `lacp mode`, but a `passive` LACP "
-                    "bundle re-parses as `static` -- the passive mode is not "
-                    "preserved (audit bb47f21 T0-1, verified by round-trip "
-                    "probe)."
+                    "AOS-CX emits the LAG `lacp mode` only for a kind-`lag` "
+                    "interface present in the tree, so a same-vendor bundle "
+                    "round-trips cleanly. The loss is cross-vendor: a source "
+                    "whose LAG lives only in `tree.lags` under a foreign name "
+                    "(e.g. `Port-Channel1`) has no matching AOS-CX `interface "
+                    "lag N` stanza, so no `lacp mode` line is rendered and the "
+                    "mode re-parses as `static` from the surviving member "
+                    "`lag N` reference (audit bb47f21 T0-1)."
                 ),
                 severity="warn",
             ),

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
@@ -164,15 +164,17 @@ per_field_expectation:
     references: [system_services]
 
   ntp_servers:
-    disposition: lossy
-    reason: >
-      Canonical model stores ``ntp_servers: list[str]`` (bare
-      addresses only).  Per-server options (``prefer``, ``iburst``,
-      ``key``, ``source``) are not modelled and drop on round-trip.
-      Address list itself is preserved.  Notable on this direction:
-      Arista's default-on ``iburst`` is silently dropped on the
-      Cisco target, which means the migrated device takes longer to
-      converge time after a reboot until an operator re-adds it.
+    disposition: good
+    note: >
+      The address list is preserved cleanly.  Canonical model stores
+      ``ntp_servers: list[str]`` (bare addresses only), so per-server
+      options (``prefer``, ``iburst``, ``key``, ``source``) are
+      pre-canonical loss the comparator never observes rather than a
+      cross-vendor drop.  Behavioural nuance on this direction
+      (invisible to the canonical comparator): Arista's default-on
+      ``iburst`` is dropped on the Cisco target, so the migrated
+      device takes longer to converge time after a reboot until an
+      operator re-adds it.
     references: [system_services]
 
   timezone:

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__fortigate_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__fortigate_cli.yaml
@@ -162,15 +162,16 @@ per_field_expectation:
     references: [system_services, system_services_fortios]
 
   ntp_servers:
-    disposition: lossy
-    reason: >
-      Address list itself is preserved, but Arista's per-server
-      ``prefer`` / ``iburst`` / ``key <id>`` / ``source <iface>``
-      modifiers are not modelled in canonical and drop on round-
-      trip.  FortiGate emits the list under ``config system ntp /
-      config ntpserver`` with sequential edit IDs.  FortiOS
-      additionally requires ``set ntpsync enable`` and ``set type
-      custom`` outside the per-server table; these are codec
+    disposition: good
+    note: >
+      The address list is preserved cleanly — FortiGate emits every
+      server under ``config system ntp / config ntpserver`` with
+      sequential edit IDs (no cap).  Arista's per-server ``prefer`` /
+      ``iburst`` / ``key <id>`` / ``source <iface>`` modifiers are
+      not modelled in canonical, so they are pre-canonical loss the
+      comparator never observes rather than a cross-vendor drop.
+      FortiOS additionally requires ``set ntpsync enable`` and ``set
+      type custom`` outside the per-server table; these are codec
       defaults rather than canonical-tree fields.
     references: [system_services, system_services_fortios]
 

--- a/tests/fixtures/cross_vendor_expectations/fortigate_cli__arista_eos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/fortigate_cli__arista_eos.yaml
@@ -258,20 +258,21 @@ per_field_expectation:
   # ── Tier 2 — auto-translate with review ──
 
   dhcp_servers:
-    disposition: unsupported
-    reason: >
-      FortiGate-source ``config system dhcp server`` populates
-      CanonicalDHCPPool records cleanly on parse.  The arista_eos
-      codec does NOT advertise ``/dhcp/pool`` in its supported
-      set — Arista DC leafs typically don't host DHCP servers
-      (DHCP is a relay-only role on Arista DC deployments via
-      ``ip helper-address``).  Cross-vendor render therefore
-      drops the pool config entirely; operators migrating a
-      FortiGate edge to an Arista DC role must redirect DHCP-
-      server duties to a separate appliance.  Promote to ``lossy``
-      when the arista_eos codec wires DHCP-pool render (uncommon
-      in practice).
-    references: [interfaces]
+    disposition: good
+    note: >
+      The arista_eos codec now advertises ``/dhcp-servers/pool`` in
+      its supported set (Cluster E.1-A wire-up: render emits ``ip
+      dhcp pool <name>`` with network / range / default-router /
+      dns-server / domain-name / lease, and parse harvests them
+      back).  FortiGate-source ``config system dhcp server`` pools
+      therefore round-trip cleanly — verified byte-model-equal on
+      the 6-pool ``user_contrib_fg100e`` fixture (interface /
+      network / start_ip / end_ip / gateway / dns_servers /
+      lease_time / domain_name all preserved).  FortiGate-only
+      advanced pool options (vci-match, ntp-service) never enter
+      CanonicalDHCPPool, so they are pre-canonical loss the
+      comparator cannot observe rather than a cross-vendor drop.
+    references: [system_services]
 
   snmp:
     disposition: lossy
@@ -492,11 +493,6 @@ per_field_expectation:
 #     pass when canonical schema gains vendor-id translation
 #     tables.  Even when wired, integer-VRF -> Arista named-VRF
 #     migration will require operator-curated mappings.
-#
-#   * Arista codec wire-up for ``/dhcp/pool`` render — currently
-#     unsupported; would promote dhcp_servers to ``lossy`` (with
-#     model-divergence caveats around Arista's typical relay-
-#     only DC role).
 #
 #   * IPv6 static routes — not currently wired through the
 #     canonical static_routes list on FortiOS source side

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__cisco_iosxe_cli.yaml
@@ -267,11 +267,14 @@ per_field_expectation:
     references: [junos-initial-config, cisco-fundamentals]
 
   ntp_servers:
-    disposition: lossy
-    reason: >
-      Address list round-trips.  Per-server options (``prefer``,
-      ``iburst``, ``key``, ``boot-server``, ``source``) are not
-      modelled canonically and drop on cross-vendor round-trip.
+    disposition: good
+    note: >
+      The address list round-trips cleanly (verified across the
+      corpus, including a 12-server Junos fixture).  Per-server
+      options (``prefer``, ``iburst``, ``key``, ``boot-server``,
+      ``source``) are not modelled canonically, so they are
+      pre-canonical loss the canonical-vs-canonical comparator never
+      observes rather than a cross-vendor drop it can score.
     references: [junos-initial-config, cisco-fundamentals]
 
   timezone:
@@ -485,16 +488,23 @@ per_field_expectation:
   # ── Tier 1 — static routes ──
 
   static_routes:
-    disposition: lossy
-    reason: >
-      Default-VRF static routes round-trip cleanly.  Per-VRF
-      static routes (``set routing-instances X routing-options
-      static route ...``) are parse-and-ignore in v1
-      (CanonicalStaticRoute lacks a ``vrf`` field).  Junos's
-      ``preference`` and Cisco's "AD" are vendor-specific scalars
-      not 1:1; canonical metric is the operator-visible metric.
-      Junos's ``qualified-next-hop`` flattens to multiple canonical
-      entries on Cisco render.
+    disposition: good
+    note: >
+      Default-VRF AND per-VRF static routes round-trip cleanly.
+      CanonicalStaticRoute carries a ``vrf`` field (since v0.2.0)
+      that Junos parse harvests (``set routing-instances X
+      routing-options static route ...``, without materialising a
+      phantom routing-instance) and Cisco render emits (``ip route
+      vrf X ...`` / ``ipv6 route vrf X ...``).  Verified across the
+      full corpus: 8/8 Junos fixtures with static routes are
+      byte-model-preserved through iosxe_cli, three of them carrying
+      VRF-bound routes.  Two residuals stay comparator-invisible —
+      they never enter the canonical model, so the harness cannot
+      observe them and both codecs are honest about the on-device
+      loss: Junos ``preference`` is parse-and-ignored (canonical
+      ``metric`` stays 0), and ``qualified-next-hop`` floating
+      routes are parse-and-ignored (Junos parse handles only
+      ``next-hop``).
     references: [junos-static-routing, cisco-static-routes]
 
   # ── Tier 2 — DHCP server ──
@@ -784,9 +794,6 @@ per_field_expectation:
 #     families.  Lossy with confidence.
 #
 # Deferred items:
-#
-#   * Per-VRF static routes — schema gap on CanonicalStaticRoute
-#     (no vrf field).  Lands alongside Cisco VRF wire-up.
 #
 #   * NTP per-server options / qualified-next-hop preservation —
 #     canonical model is host-list-only / single-NH-only.

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__fortigate_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__fortigate_cli.yaml
@@ -271,13 +271,15 @@ per_field_expectation:
     references: [junos-initial-config, fortios-cli-reference]
 
   ntp_servers:
-    disposition: lossy
-    reason: >
-      Address list itself is preserved.  Junos's per-server options
-      (``prefer`` / ``key`` / ``boot-server`` / ``source-address``)
-      are not modelled in canonical and drop on round-trip.
-      FortiGate emits the list under ``config system ntp / config
-      ntpserver`` with sequential edit IDs.
+    disposition: good
+    note: >
+      The address list is preserved cleanly — the FortiGate codec
+      emits every server under ``config system ntp / config
+      ntpserver`` with sequential edit IDs (no cap, unlike its
+      two-slot DNS render).  Junos's per-server options (``prefer``
+      / ``key`` / ``boot-server`` / ``source-address``) are not
+      modelled in canonical, so they are pre-canonical loss the
+      comparator never observes rather than a cross-vendor drop.
     references: [junos-initial-config, fortios-cli-reference]
 
   timezone:

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__mikrotik_routeros.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__mikrotik_routeros.yaml
@@ -285,14 +285,19 @@ per_field_expectation:
     references: [junos-initial-config, mikrotik-identity]
 
   ntp_servers:
-    disposition: lossy
-    reason: >
+    disposition: good
+    note: >
       Bare-address list round-trips cleanly (Junos ``set system ntp
       server X`` -> RouterOS ``/system ntp client / set servers=X,...``).
-      Junos per-server modifiers (``prefer`` / ``key`` / ``iburst``
-      / ``source``) drop on canonical round-trip — canonical model
+      A juniper_junos source always renders the unbounded RouterOS-7
+      comma-separated form — the truncating RouterOS-6 two-slot
+      ``primary-ntp``/``secondary-ntp`` dialect gates on
+      ``source_vendor == 'mikrotik_routeros'`` and never fires
+      cross-vendor.  Junos per-server modifiers (``prefer`` /
+      ``key`` / ``iburst`` / ``source``) are not modelled (canonical
       stores ``list[str]`` only, and RouterOS exposes no per-server
-      options.
+      options), so they are pre-canonical loss the comparator never
+      observes.
     references: [junos-initial-config, mikrotik-identity]
 
   timezone:

--- a/tests/unit/migration/test_aruba_aoscx.py
+++ b/tests/unit/migration/test_aruba_aoscx.py
@@ -643,9 +643,11 @@ def test_matrix_supported(codec: ArubaAOSCXCodec, path: str) -> None:
 
 @pytest.mark.parametrize("path", [
     "/interfaces/interface/config/type",
-    # audit bb47f21 T0-1: AOS-CX renders the LAG `lacp mode` but a `passive`
-    # bundle re-parses as `static`, so the mode is lossy (was wrongly listed
-    # supported — the value-corruption the LAG-mode fidelity guard now pins).
+    # audit bb47f21 T0-1: AOS-CX emits the LAG `lacp mode` only for a
+    # kind-`lag` interface, so a same-vendor bundle round-trips clean, but a
+    # cross-vendor LAG (living only in tree.lags under a foreign name) renders
+    # no `interface lag N` stanza and the mode re-parses as `static` — declared
+    # lossy, pinned by the LAG-mode fidelity guard.
     "/lags/lag/mode",
     "/local-users/user/privilege-level",
     "/snmp/v3-user/auth-passphrase",


### PR DESCRIPTION
## What

A batch of **codec-fidelity honesty corrections** from the 2026-07-06 Fable review's promotion candidates (#8, #9, #14, #19). Each cell was adversarially re-vetted against `HEAD` with a live round-trip probe before flipping — all four premises reproduced (none stale), all flips proven clean, zero new CODEC_BUG.

| # | Cell | Change | Proof |
|---|------|--------|-------|
| **#8** | `fortigate_cli → arista_eos` `dhcp_servers` | `unsupported → good` | arista now renders/parses `/dhcp-servers/pool` (Cluster E.1-A); 6-pool `user_contrib_fg100e` fixture round-trips byte-model-equal |
| **#9** | `juniper_junos → cisco_iosxe_cli` `static_routes` | `lossy → good` | `CanonicalStaticRoute.vrf` exists since v0.2.0 and both codecs wire it; 8/8 junos fixtures preserved (3 VRF-carrying) |
| **#14** | 5 `ntp_servers` cells | `lossy → good` | junos→{iosxe_cli, fortigate, mikrotik} + arista→{iosxe_cli, fortigate}; address list preserved on every fixture (incl. a 12-server junos stress fixture) |
| **#19** | `aruba_aoscx` `/lags/lag/mode` | reason text only (**stays lossy**) | the "passive re-parses as static same-vendor" claim reproduced **clean** same-vendor; the real gap is cross-vendor-only |

## Why these and not the rest

The flips are scoped to what the vet **proved**; the sharp traps it flagged are deliberately excluded:

- **#14** does **not** flip the 3 fortigate-target `dns_servers` cells (fortigate render caps at `set primary`/`set secondary` — a real 3+-resolver truncation that would mint a false CODEC_BUG on `cisco_iosxe_cli__fortigate_cli` *today*), nor the 2 aoss-target `ntp` cells (aoss emits every server at `priority 1`, an on-device replace the harness can't see).
- **#9** flips only the one proven cell; the ~20 sibling pair files carrying the same stale "lacks a vrf field" text are **reason-text-only** territory for 7 non-vrf-wiring target codecs (flipping their disposition would mint false CODEC_BUGs) — left as a follow-up sweep.
- **#19** keeps the disposition **lossy** — the render-half (synthesize `interface lag N` from `tree.lags`) is deferred design work, and the LAG-mode fidelity guard correctly still requires the declaration. Only the false reason text + two comments are corrected.

Every flip makes drift detection **stricter**: a preserved cell that was `lossy`/`unsupported` (swallowed as METHODOLOGY-under / EXPECTED_UNSUPPORTED) becomes `good`, so any *future* genuine asymmetry surfaces as a high-severity CODEC_BUG instead of hiding.

## No mesh re-baseline

This is a pure reconciliation-classification shift with **zero mechanical mesh movement** — the committed `latest.json` slim `cells` and `pair_drift_yaml_less` are byte-identical; only the derived `aggregate` counts move (METHODOLOGY-under down, ALIGNED up, CODEC_BUG stays 5). The cross-mesh CI guard is green because every ratchet is one-directional; the cosmetic `aggregate` slack is absorbed at the next mechanical re-baseline (a code-promotion PR).

## Verified

- `tests/unit/migration`, `tests/unit/audit`, `tests/unit/tools` — green
- `tests/integration/test_cross_mesh_ci_guard.py` (full in-process mesh regen) — green
- `test_lag_mode_fidelity.py` + `test_registry_capability_honesty.py` — green (confirm #19 still honestly declared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
