### PR TITLE
feat(codecs): wire static-route metric (admin distance) for arista/mikrotik/fortigate/iosxr (promotion #7)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -218,14 +218,6 @@ class AristaEOSCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
-                path="/routing/static-route/metric",
-                reason=(
-                    "Render emits destination + next-hop only; the static-"
-                    "route administrative distance (metric) is dropped (run3)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
                 path="/routing/static-route/description",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -91,14 +91,18 @@ _IP_ROUTE_RE = re.compile(
     # The optional ``vrf <name>`` infix (group 1) lands on
     # ``CanonicalStaticRoute.vrf`` and round-trips through render
     # (mirrors the cisco_iosxe_cli graduation, PR #24).
-    r"^ip route\s+(?:vrf\s+(\S+)\s+)?(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)",
+    # A trailing integer (group 5) is the administrative distance
+    # (``ip route <prefix> <next-hop> <distance>``, 1-255) — lands on
+    # ``CanonicalStaticRoute.metric``; the optional group keeps distance-
+    # less routes byte-identical.
+    r"^ip route\s+(?:vrf\s+(\S+)\s+)?(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)(?:\s+(\d+))?",
     re.MULTILINE,
 )
 _IPV6_ROUTE_RE = re.compile(
     # ``ipv6 route 2001:db8::/48 2001:db8::1`` — v6 uses the ``ipv6 route``
     # keyword with the prefix form (does not overlap ``^ip route``).
     # The optional ``vrf <name>`` infix mirrors the v4 form above.
-    r"^ipv6 route\s+(?:vrf\s+(\S+)\s+)?([0-9A-Fa-f:]+/\d+)\s+(\S+)",
+    r"^ipv6 route\s+(?:vrf\s+(\S+)\s+)?([0-9A-Fa-f:]+/\d+)\s+(\S+)(?:\s+(\d+))?",
     re.MULTILINE,
 )
 _SNMP_COMMUNITY_RE = re.compile(
@@ -475,7 +479,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
     for ntp_m in _NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(ntp_m.group(1))
     for route_m in _IP_ROUTE_RE.finditer(raw):
-        vrf, ip, prefix, next_hop = route_m.groups()
+        vrf, ip, prefix, next_hop, distance = route_m.groups()
         # A next hop is either an IP literal (gateway) or an interface name
         # (``Null0``, ``Ethernet1`` — an interface/connected route, ubiquitous
         # as a BGP aggregate anchor ``ip route <agg> Null0``).  Route it to the
@@ -497,10 +501,11 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             destination=f"{ip}/{prefix}",
             gateway=gateway,
             interface=interface,
+            metric=int(distance) if distance else 0,
             vrf=vrf or "",
         ))
     for route_m in _IPV6_ROUTE_RE.finditer(raw):
-        vrf, dest, next_hop = route_m.groups()
+        vrf, dest, next_hop, distance = route_m.groups()
         # Same gateway-or-interface split as the v4 branch.
         gateway = ""
         interface = ""
@@ -513,6 +518,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             destination=dest,
             gateway=gateway,
             interface=interface,
+            metric=int(distance) if distance else 0,
             vrf=vrf or "",
         ))
 

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -947,16 +947,22 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             # ``ip route vrf MGMT ...`` source) rendered into the GLOBAL
             # table — a wrong-VRF emission, worse than a drop.
             vrf_prefix = f"vrf {route.vrf} " if route.vrf else ""
+            # The administrative distance trails the next-hop (``ip route
+            # <dest> <next-hop> <distance>``).  Emitted only when the
+            # canonical metric is set, so distance-less routes stay clean.
+            metric_suffix = f" {route.metric}" if route.metric else ""
             # EOS keys the address family off the keyword: IPv6 destinations
             # use ``ipv6 route`` (emitting ``ip route <v6>`` is invalid CLI).
             if ":" in (route.destination or ""):
                 out.append(
-                    f"ipv6 route {vrf_prefix}{route.destination} {target}"
+                    f"ipv6 route {vrf_prefix}{route.destination} "
+                    f"{target}{metric_suffix}"
                 )
                 has_v6 = True
             else:
                 out.append(
-                    f"ip route {vrf_prefix}{route.destination} {target}"
+                    f"ip route {vrf_prefix}{route.destination} "
+                    f"{target}{metric_suffix}"
                 )
                 has_v4 = True
         out.append("!")

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -227,14 +227,6 @@ class CiscoIOSXRCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
-                path="/routing/static-route/metric",
-                reason=(
-                    "Render emits destination + next-hop only; the static-"
-                    "route administrative distance (metric) is dropped (run3)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
                 path="/routing/static-route/description",
                 reason=(
                     "Render emits destination + next-hop only; the static-"

--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -658,15 +658,24 @@ def _parse_static_leaf(
     dest = m.group(1)
     gateway = ""
     iface = ""
+    metric = 0
     for tok in m.group(2).split():
         try:
             ipaddress.ip_address(tok)  # IPv4 or IPv6 next-hop
             gateway = tok
         except ValueError:
-            if not iface:
+            if tok.isdigit():
+                # A bare integer trailing the next-hop is the administrative
+                # distance (metric).  IOS-XR interface names are never bare
+                # digits, so this is unambiguous — without it the distance
+                # was mis-filed as the egress interface and re-rendered as
+                # ``<dest> <distance> <gw>`` (invalid CLI).
+                metric = int(tok)
+            elif not iface:
                 iface = tok
     return CanonicalStaticRoute(
-        destination=dest, gateway=gateway, interface=iface, vrf=vrf,
+        destination=dest, gateway=gateway, interface=iface,
+        metric=metric, vrf=vrf,
     )
 
 

--- a/netcanon/migration/codecs/cisco_iosxr/render.py
+++ b/netcanon/migration/codecs/cisco_iosxr/render.py
@@ -212,13 +212,20 @@ def _render_bgp_rd(instances: list[CanonicalRoutingInstance]) -> list[str]:
 
 
 def _static_route_line(route) -> str:
-    """Format one static-route leaf: ``<dest> [<interface>] [<gateway>]``.
+    """Format one static-route leaf: ``<dest> [<interface>] [<gateway>] [<distance>]``.
 
     Empty components drop out (interface-only for ``Null0`` / blackhole;
-    gateway-only for a plain next-hop).
+    gateway-only for a plain next-hop).  The administrative distance
+    (metric) trails the next-hop and is emitted only when set; it is
+    clamped to 254 (IOS-XR's maximum installable distance — 255 marks a
+    route unreachable) so a donor-carried out-of-range value stays valid
+    CLI.
     """
-    nexthop = " ".join(t for t in (route.interface, route.gateway) if t)
-    return f"{route.destination} {nexthop}".rstrip()
+    parts = [route.destination]
+    parts.extend(t for t in (route.interface, route.gateway) if t)
+    if route.metric:
+        parts.append(str(min(route.metric, 254)))
+    return " ".join(parts).rstrip()
 
 
 def _render_router_static(routes: list) -> list[str]:

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -236,15 +236,6 @@ class FortiGateCLICodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
-                path="/routing/static-route/metric",
-                reason=(
-                    "Render emits destination + next-hop + device only; the "
-                    "static-route administrative distance (metric) is "
-                    "dropped (run3)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
                 path="/interfaces/interface/config/description",
                 reason=(
                     "FortiOS limits alias to 25 characters; longer "

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -728,10 +728,15 @@ def _apply_router_static(
         # FortiGate -> FortiGate (or any source -> FortiGate) pipe.
         # Ref: https://docs.fortinet.com/document/fortigate/7.4.0/cli-reference/522620/config-router-static
         comment_tokens = edit.settings.get("comment") or [""]
+        # FortiOS ``set distance <n>`` (admin distance, default 10).  Landed
+        # on CanonicalStaticRoute.metric so a floating static round-trips.
+        distance_tokens = edit.settings.get("distance") or [""]
+        metric = int(distance_tokens[0]) if distance_tokens[0].isdigit() else 0
         intent.static_routes.append(CanonicalStaticRoute(
             destination=destination,
             gateway=gateway_tokens[0],
             interface=device_tokens[0],
+            metric=metric,
             description=comment_tokens[0],
         ))
 
@@ -753,10 +758,13 @@ def _apply_router_static6(
         gateway_tokens = edit.settings.get("gateway") or [""]
         device_tokens = edit.settings.get("device") or [""]
         comment_tokens = edit.settings.get("comment") or [""]
+        distance_tokens = edit.settings.get("distance") or [""]
+        metric = int(distance_tokens[0]) if distance_tokens[0].isdigit() else 0
         intent.static_routes.append(CanonicalStaticRoute(
             destination=destination,
             gateway=gateway_tokens[0],
             interface=device_tokens[0],
+            metric=metric,
             description=comment_tokens[0],
         ))
 

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -992,6 +992,10 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             out.append(f"        set gateway {route.gateway}")
         if route.interface:
             out.append(f'        set device "{route.interface}"')
+        if route.metric:
+            # FortiOS admin distance (default 10); emit only when the
+            # canonical metric is set so ordinary routes stay clean.
+            out.append(f"        set distance {route.metric}")
         if route.description:
             # FortiOS uses ``set comment`` (singular) on static-route
             # entries; max 255 chars.

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -142,6 +142,7 @@ class MikroTikRouterOSCodec(CodecBase):
             "/routing/static-route",
             "/routing/static-route/gateway",      # audit e5b77d7 — next-hop round-trips
             "/routing/static-route/description",  # run3 — `comment=...`
+            "/routing/static-route/metric",       # #7 — `distance=<n>` admin distance
             # Tier 2 — SNMP
             "/snmp/community",
             "/snmp/location",
@@ -279,15 +280,6 @@ class MikroTikRouterOSCodec(CodecBase):
                     "renders, so a non-default lease_time is not emitted and "
                     "re-parses as the 86400 default — a 2h lease policy "
                     "silently becomes 1 day.  Declared lossy (#24)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
-                path="/routing/static-route/metric",
-                reason=(
-                    "Render emits destination + gateway + comment only; the "
-                    "static-route administrative distance (metric) is "
-                    "dropped (run3)."
                 ),
                 severity="warn",
             ),

--- a/netcanon/migration/codecs/mikrotik_routeros/parse.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/parse.py
@@ -1287,6 +1287,11 @@ def _parse_ip_route(lines: list[str], intent: CanonicalIntent) -> None:
         if not dest:
             continue
         gateway_raw = kv.get("gateway", "")
+        # RouterOS admin distance (``distance=<n>``, default 1).  Landed on
+        # CanonicalStaticRoute.metric so a floating static (e.g.
+        # ``distance=250``) round-trips instead of silently reparsing to 0.
+        distance_raw = kv.get("distance", "")
+        metric = int(distance_raw) if distance_raw.isdigit() else 0
         # (#9) RouterOS combines an IP next-hop and an egress interface
         # into one ``gateway=<ip>%<iface>`` argument (also the shape of an
         # IPv6 link-local scoped next-hop, ``fe80::1%ether1``).  render.py
@@ -1301,6 +1306,7 @@ def _parse_ip_route(lines: list[str], intent: CanonicalIntent) -> None:
                 destination=dest,
                 gateway=gw,
                 interface=egress,
+                metric=metric,
                 description=kv.get("comment", ""),
             )
         else:
@@ -1309,6 +1315,7 @@ def _parse_ip_route(lines: list[str], intent: CanonicalIntent) -> None:
             route = CanonicalStaticRoute(
                 destination=dest,
                 gateway=gateway_raw,
+                metric=metric,
                 description=kv.get("comment", ""),
             )
         intent.static_routes.append(route)

--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -628,6 +628,10 @@ def render_intent(tree: Any) -> str:  # noqa: C901
                 parts.append(f"gateway={route.gateway}")
             elif route.interface:
                 parts.append(f"gateway={route.interface}")
+            if route.metric:
+                # RouterOS admin distance (default 1); emit only when the
+                # canonical metric is set so ordinary routes stay clean.
+                parts.append(f"distance={route.metric}")
             lines.append(" ".join(parts))
         lines.append("")
 

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -12,17 +12,17 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 
 | Variance class | Count | Severity |
 |---|---:|---|
-| ALIGNED | 1581 | ok |
+| ALIGNED | 1620 | ok |
 | CODEC_BUG | 5 | **high** |
 | EXPECTED_LOSSY | 1224 | ok |
 | EXPECTED_UNSUPPORTED | 729 | ok |
-| METHODOLOGY_ISSUE_under | 947 | low/medium |
+| METHODOLOGY_ISSUE_under | 908 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
 | STRUCTURAL_ONLY | 1194 | low |
 | TRIVIAL_EMPTY | 9515 | ok |
 | **Total field-cells classified** | **15220** | |
 
-Severity roll-up: 5 high, 111 medium, 2055 low, 13049 ok.
+Severity roll-up: 5 high, 107 medium, 2020 low, 13088 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-11T20:01:10+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260711T200109Z.json",
-  "mesh_run_started_utc": "2026-07-11T20:01:03+00:00",
+  "started_utc": "2026-07-12T08:55:54+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T085547Z.json",
+  "mesh_run_started_utc": "2026-07-12T08:55:41+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4134,19 +4134,19 @@
     }
   ],
   "aggregate": {
-    "ALIGNED": 1581,
+    "ALIGNED": 1620,
     "CODEC_BUG": 5,
     "EXPECTED_LOSSY": 1224,
     "EXPECTED_UNSUPPORTED": 729,
-    "METHODOLOGY_ISSUE_under": 947,
+    "METHODOLOGY_ISSUE_under": 908,
     "METHODOLOGY_ISSUE_over": 25,
     "STRUCTURAL_ONLY": 1194,
     "TRIVIAL_EMPTY": 9515,
     "fields_total": 15220,
     "severity_high": 5,
-    "severity_medium": 111,
-    "severity_low": 2055,
-    "severity_ok": 13049
+    "severity_medium": 107,
+    "severity_low": 2020,
+    "severity_ok": 13088
   },
   "severity_matrix": {
     "arista_eos": {
@@ -4211,7 +4211,7 @@
     {
       "source_codec": "aruba_aoscx",
       "target_codec": "arista_eos",
-      "drifted_total": 30
+      "drifted_total": 29
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4236,7 +4236,7 @@
     {
       "source_codec": "aruba_aoscx",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 37
+      "drifted_total": 36
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4246,7 +4246,7 @@
     {
       "source_codec": "aruba_aoscx",
       "target_codec": "fortigate_cli",
-      "drifted_total": 28
+      "drifted_total": 27
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4256,7 +4256,7 @@
     {
       "source_codec": "aruba_aoscx",
       "target_codec": "mikrotik_routeros",
-      "drifted_total": 27
+      "drifted_total": 26
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4406,7 +4406,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "arista_eos",
-      "drifted_total": 41
+      "drifted_total": 40
     },
     {
       "source_codec": "cisco_nxos",
@@ -4431,7 +4431,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 65
+      "drifted_total": 64
     },
     {
       "source_codec": "cisco_nxos",
@@ -4471,7 +4471,7 @@
     {
       "source_codec": "fortigate_cli",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 30
+      "drifted_total": 28
     },
     {
       "source_codec": "fortigate_cli",
@@ -4566,7 +4566,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "arista_eos",
-      "drifted_total": 27
+      "drifted_total": 26
     },
     {
       "source_codec": "vyos",
@@ -4591,7 +4591,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 46
+      "drifted_total": 45
     },
     {
       "source_codec": "vyos",
@@ -4601,7 +4601,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "fortigate_cli",
-      "drifted_total": 31
+      "drifted_total": 30
     },
     {
       "source_codec": "vyos",
@@ -4611,7 +4611,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "mikrotik_routeros",
-      "drifted_total": 24
+      "drifted_total": 23
     },
     {
       "source_codec": "vyos",
@@ -4654,9 +4654,9 @@
         },
         "ntp_servers": {
           "actual": "preserved",
-          "expected": "lossy",
-          "variance": "METHODOLOGY_ISSUE_under",
-          "severity": "low"
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
         },
         "timezone": {
           "actual": "trivially_preserved",
@@ -5498,11 +5498,11 @@
         }
       },
       "summary": {
-        "ALIGNED": 2,
+        "ALIGNED": 3,
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 4,
         "EXPECTED_UNSUPPORTED": 1,
-        "METHODOLOGY_ISSUE_under": 2,
+        "METHODOLOGY_ISSUE_under": 1,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
         "TRIVIAL_EMPTY": 10,
@@ -5510,8 +5510,8 @@
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 2,
-        "severity_ok": 17
+        "severity_low": 1,
+        "severity_ok": 18
       }
     },
     {
@@ -5543,9 +5543,9 @@
         },
         "ntp_servers": {
           "actual": "preserved",
-          "expected": "lossy",
-          "variance": "METHODOLOGY_ISSUE_under",
-          "severity": "low"
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
         },
         "timezone": {
           "actual": "trivially_preserved",
@@ -6450,11 +6450,11 @@
         }
       },
       "summary": {
-        "ALIGNED": 2,
+        "ALIGNED": 3,
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 4,
         "EXPECTED_UNSUPPORTED": 1,
-        "METHODOLOGY_ISSUE_under": 2,
+        "METHODOLOGY_ISSUE_under": 1,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
         "TRIVIAL_EMPTY": 10,
@@ -6462,8 +6462,8 @@
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 2,
-        "severity_ok": 17
+        "severity_low": 1,
+        "severity_ok": 18
       }
     },
     {
@@ -6495,7 +6495,7 @@
         },
         "ntp_servers": {
           "actual": "trivially_preserved",
-          "expected": "lossy",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
@@ -6757,9 +6757,9 @@
         },
         "static_routes": {
           "actual": "preserved",
-          "expected": "lossy",
-          "variance": "METHODOLOGY_ISSUE_under",
-          "severity": "low"
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
         },
         "dhcp_servers": {
           "actual": "preserved",
@@ -7239,11 +7239,11 @@
         }
       },
       "summary": {
-        "ALIGNED": 4,
+        "ALIGNED": 5,
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 3,
         "EXPECTED_UNSUPPORTED": 2,
-        "METHODOLOGY_ISSUE_under": 6,
+        "METHODOLOGY_ISSUE_under": 5,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
         "TRIVIAL_EMPTY": 40,
@@ -7251,8 +7251,8 @@
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 6,
-        "severity_ok": 49
+        "severity_low": 5,
+        "severity_ok": 50
       }
     },
     {

--- a/tests/unit/migration/test_static_route_metric.py
+++ b/tests/unit/migration/test_static_route_metric.py
@@ -1,0 +1,96 @@
+"""Static-route administrative-distance (metric) round-trip — promotion #7.
+
+A floating static route (a backup default with a raised admin distance) must
+carry its distance token through render and reparse; without it the backup
+silently becomes co-equal with the primary and failover is destroyed.  This
+graduated four codecs from ``/routing/static-route/metric`` lossy -> supported:
+arista_eos, mikrotik_routeros, fortigate_cli, cisco_iosxr.  The four donor
+codecs (cisco_iosxe_cli, cisco_nxos, vyos, aruba_aoscx) already supported it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalStaticRoute,
+)
+from netcanon.migration.codecs.arista_eos.codec import AristaEOSCodec
+from netcanon.migration.codecs.cisco_iosxr.codec import CiscoIOSXRCodec
+from netcanon.migration.codecs.fortigate_cli.codec import FortiGateCLICodec
+from netcanon.migration.codecs.mikrotik_routeros.codec import (
+    MikroTikRouterOSCodec,
+)
+
+_GRADUATED = [
+    pytest.param(AristaEOSCodec, id="arista_eos"),
+    pytest.param(MikroTikRouterOSCodec, id="mikrotik_routeros"),
+    pytest.param(FortiGateCLICodec, id="fortigate_cli"),
+    pytest.param(CiscoIOSXRCodec, id="cisco_iosxr"),
+]
+
+
+def _round_trip(codec, routes):
+    intent = CanonicalIntent(hostname="rt", static_routes=routes)
+    reparsed = codec.parse(codec.render(intent))
+    return {r.destination: r for r in reparsed.static_routes}
+
+
+@pytest.mark.parametrize("codec_cls", _GRADUATED)
+def test_metric_is_supported(codec_cls):
+    assert codec_cls().capabilities.classify(
+        "/routing/static-route/metric"
+    ) == "supported"
+
+
+@pytest.mark.parametrize("codec_cls", _GRADUATED)
+def test_floating_default_metric_round_trips(codec_cls):
+    """A metric-250 backup default survives; the metric-0 primary stays 0."""
+    codec = codec_cls()
+    by_dest = _round_trip(codec, [
+        CanonicalStaticRoute(destination="10.0.0.0/24", gateway="192.0.2.1"),
+        CanonicalStaticRoute(
+            destination="0.0.0.0/0", gateway="192.0.2.254", metric=250,
+        ),
+    ])
+    assert by_dest["0.0.0.0/0"].metric == 250
+    # Distance-less routes must not gain a spurious metric.
+    assert by_dest["10.0.0.0/24"].metric == 0
+
+
+@pytest.mark.parametrize("codec_cls", _GRADUATED)
+def test_metric_zero_emits_no_distance_token(codec_cls):
+    """Negative control: metric 0 renders no distance keyword."""
+    codec = codec_cls()
+    rendered = codec.render(CanonicalIntent(
+        hostname="rt",
+        static_routes=[CanonicalStaticRoute(
+            destination="10.0.0.0/24", gateway="192.0.2.1",
+        )],
+    ))
+    assert "set distance" not in rendered  # fortigate
+    assert "distance=" not in rendered      # mikrotik
+    # arista/iosxr trailing-int distance: the only tokens are dest + next-hop.
+    for line in rendered.splitlines():
+        if "192.0.2.1" in line and "route" in line.lower():
+            assert not line.rstrip().split()[-1].isdigit(), line
+
+
+def test_cisco_iosxr_clamps_metric_to_254():
+    """IOS-XR max installable distance is 254 (255 = unreachable)."""
+    codec = CiscoIOSXRCodec()
+    by_dest = _round_trip(codec, [CanonicalStaticRoute(
+        destination="0.0.0.0/0", gateway="192.0.2.254", metric=255,
+    )])
+    assert by_dest["0.0.0.0/0"].metric == 254
+
+
+def test_arista_interface_nexthop_carries_metric():
+    """An aggregate anchor (``ip route <agg> Null0 250``) keeps its distance."""
+    codec = AristaEOSCodec()
+    by_dest = _round_trip(codec, [CanonicalStaticRoute(
+        destination="10.99.0.0/16", interface="Null0", metric=250,
+    )])
+    route = by_dest["10.99.0.0/16"]
+    assert route.interface == "Null0"
+    assert route.metric == 250


### PR DESCRIPTION
## What

Graduates **`/routing/static-route/metric`** (static-route administrative distance) from `lossy → supported` on four codecs: **arista_eos, mikrotik_routeros, fortigate_cli, cisco_iosxr**.

### The bug

A *floating* static route — a backup default carrying a raised admin distance (e.g. `metric 250`) — rendered with **no distance token** and re-parsed as `metric=0` on all four. The backup silently became co-equal with the primary and **failover was destroyed**. Reproduced live at HEAD on all four before touching anything.

### Parse + render per codec

| Codec | Parse | Render | Note |
|-------|-------|--------|------|
| **arista_eos** | `_IP_ROUTE_RE`/`_IPV6_ROUTE_RE` gain an optional trailing `(?:\s+(\d+))?` distance group | append `<distance>` after next-hop | disjoint char classes, no ReDoS; also the `Null0` aggregate-anchor form |
| **mikrotik_routeros** | read the already-tokenised `distance=` kv | append `distance=<n>` | explicit `supported` entry (has a strict walker-vs-matrix test + a `distance=1` fixture) |
| **fortigate_cli** | read `set distance` (v4 + static6) | emit `set distance <n>` | FortiOS default AD is 10 |
| **cisco_iosxr** | **token-loop fix**: a bare trailing integer is the admin distance, not the egress interface | append distance **clamped to 254** | the sharp one — see below |

**IOS-XR trap:** `_parse_static_leaf` greedily filed a bare trailing integer as the *interface*, so a distance re-rendered as `<dest> <distance> <gw>` — invalid CLI. IOS-XR interface names are never bare digits, so a digit token is now recognised as the metric. Render clamps to 254 (IOS-XR's max installable distance; 255 marks a route unreachable) so a donor-carried out-of-range value stays valid.

Every render emits the distance **only when `metric>0`**, so distance-less routes stay byte-identical. The four donor codecs (`cisco_iosxe_cli`, `cisco_nxos`, `vyos`, `aruba_aoscx`) already supported metric. `juniper_junos` and `aruba_aoss` stay lossy (their sketches need a redesign — junos per-next-hop `qualified-next-hop preference`, aoss default-route has no distance grammar).

### Matrix

Removed the `/routing/static-route/metric` `LossyPath` from all four (supported-by-default via `classify()`, matching the donors); added the explicit `supported` entry for mikrotik. The capability-honesty guard (`test_static_route_subfield_and_secondary_drops_are_declared`, `metric=250`) enforces the wiring — a `LossyPath` may be removed only once 250 actually round-trips.

## Mesh re-baseline

`latest.json` + `PHASE4_RECONCILIATION.md` regenerated. **CODEC_BUG flat at 5**, `cells_total` 1224, no new codec-bug pair. **39 cells** move `METHODOLOGY_ISSUE_under → ALIGNED` as donor sources (aoscx/nxos/vyos/fortigate + YAML-covered iosxe_cli) with metric'd routes now round-trip through the four fixed targets. **11 YAML-less pairs decreased, ZERO increased**, every one targeting one of the four codecs.

## Verified

- New `tests/unit/migration/test_static_route_metric.py` — round-trip + metric-0 negative control + iosxr 254-clamp + arista Null0-anchor
- Full `tests/unit` + `tests/integration` (incl. the cross-mesh CI guard against the new baseline) — green
- `ruff` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
