### PR TITLE
feat(opnsense): harvest static routes on parse (default route + <staticroutes>) (promotion #15)

### DIFF
--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -274,11 +274,13 @@ class OPNsenseCodec(CodecBase):
                 # block below.)
                 path="/routing/static-route",
                 reason=(
-                    "OPNsense's config.xml renderer emits no "
-                    "<staticroutes>/<route> block, so the entire static route "
-                    "(destination + next-hop) is dropped on render. Declared "
-                    "lossy so validate_against surfaces the loss instead of "
-                    "reporting severity:ok (audit f92e97a T0-1)."
+                    "Parse harvests routes (the <gateways> default route + "
+                    "<staticroutes>/<route> entries, resolving named gateways "
+                    "to their IP; promotion #15), but the config.xml renderer "
+                    "emits no <staticroutes>/<route> block, so the route is "
+                    "dropped on render. Declared lossy so validate_against "
+                    "surfaces the render loss instead of reporting severity:ok "
+                    "(audit f92e97a T0-1)."
                 ),
                 severity="warn",
             ),

--- a/netcanon/migration/codecs/opnsense/parse.py
+++ b/netcanon/migration/codecs/opnsense/parse.py
@@ -64,6 +64,7 @@ swallow XML errors silently.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -90,6 +91,7 @@ from ...canonical.intent import (
     CanonicalLocalUser,
     CanonicalRADIUSServer,
     CanonicalSNMP,
+    CanonicalStaticRoute,
     CanonicalVlan,
     CanonicalVRRPGroup,
 )
@@ -490,6 +492,9 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
                 or snmp.trap_hosts):
             intent.snmp = snmp
 
+    # ----- static routes (<gateways> default route + <staticroutes>) -----
+    _parse_static_routes(root, intent)
+
     logger.debug(
         "opnsense parsed: hostname=%r ifaces=%d vlans=%d "
         "routes=%d lags=%d users=%d snmp=%s (input=%d chars)",
@@ -503,6 +508,118 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         len(raw),
     )
     return intent
+
+
+# ---------------------------------------------------------------------------
+# Static-route harvest (default route + <staticroutes>)
+# ---------------------------------------------------------------------------
+
+
+def _is_ip(value: str) -> bool:
+    """Is *value* a parseable IPv4/IPv6 literal (not a name / empty)?"""
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _iter_by_tag(root: ET.Element, name: str):
+    """Yield every element whose tag matches *name* case-insensitively.
+
+    OPNsense 25+ relocates several config sections from the historical
+    lowercase root elements (``<gateways>``) into a capitalised
+    model-plugin container nested under ``<OPNsense>``
+    (``<OPNsense><Gateways>…``).  A case-insensitive whole-tree walk finds
+    both shapes; without it a lowercase-only lookup misses a
+    ``<Gateways>``-model config's default gateway entirely.
+    """
+    target = name.lower()
+    for el in root.iter():
+        if el.tag.lower() == target:
+            yield el
+
+
+def _gateway_name_to_ip(root: ET.Element) -> dict[str, str]:
+    """Map each named ``<gateway_item>`` to its literal next-hop IP.
+
+    Only items whose ``<gateway>`` is an IP literal are recorded — a
+    dynamic/DHCP gateway (empty ``<gateway/>``) is omitted so a named
+    static route pointing at it resolves to nothing rather than a bogus
+    literal next-hop.
+    """
+    name_to_ip: dict[str, str] = {}
+    for item in _iter_by_tag(root, "gateway_item"):
+        if (item.findtext("disabled") or "").strip() == "1":
+            continue
+        name = (item.findtext("name") or "").strip()
+        gw = (item.findtext("gateway") or "").strip()
+        if name and _is_ip(gw):
+            name_to_ip[name] = gw
+    return name_to_ip
+
+
+def _parse_static_routes(root: ET.Element, intent: CanonicalIntent) -> None:
+    """Harvest the box default route + explicit static routes.
+
+    Two sources feed :class:`CanonicalStaticRoute`.  OPNsense render still
+    emits no ``<staticroutes>`` block (declared lossy), so this closes a
+    *source* silent-loss — opnsense-as-source previously dropped its
+    default route entirely — rather than delivering a round-trip.
+
+      * ``<gateway_item defaultgw=1>`` synthesises the default route
+        (``0.0.0.0/0`` / ``::/0`` keyed off the gateway's address family),
+        which lives nowhere in the parsed tree today.
+      * ``<staticroutes><route>`` carries a ``<network>`` destination and a
+        ``<gateway>`` that is EITHER a literal IP OR a gateway_item name.
+
+    Guards: skip disabled items and routes missing network/gateway; and —
+    the load-bearing one — apply the IP check to the RESOLVED next-hop, so
+    an unresolvable gateway name or a dynamic/DHCP gateway is dropped
+    rather than emitted as an invalid literal next-hop that would
+    round-trip as a stable-but-invalid string past every fidelity guard.
+    """
+    name_to_ip = _gateway_name_to_ip(root)
+    seen: set[tuple[str, str]] = set()
+
+    def _add(destination: str, gateway: str, description: str = "") -> None:
+        key = (destination, gateway)
+        if key in seen:
+            return
+        seen.add(key)
+        intent.static_routes.append(CanonicalStaticRoute(
+            destination=destination, gateway=gateway, description=description,
+        ))
+
+    # Default route(s): one per enabled defaultgw gateway_item with a real IP.
+    for item in _iter_by_tag(root, "gateway_item"):
+        if (item.findtext("disabled") or "").strip() == "1":
+            continue
+        if (item.findtext("defaultgw") or "").strip() != "1":
+            continue
+        gw = (item.findtext("gateway") or "").strip()
+        if not _is_ip(gw):
+            continue  # dynamic / DHCP-assigned default gateway — nothing to emit
+        destination = (
+            "::/0" if ipaddress.ip_address(gw).version == 6 else "0.0.0.0/0"
+        )
+        _add(destination, gw)
+
+    # Explicit <staticroutes><route> entries (a named gateway is resolved).
+    for container in _iter_by_tag(root, "staticroutes"):
+        for route_el in container:
+            if route_el.tag.lower() != "route":
+                continue
+            if (route_el.findtext("disabled") or "").strip() == "1":
+                continue
+            network = (route_el.findtext("network") or "").strip()
+            gw_raw = (route_el.findtext("gateway") or "").strip()
+            if not network or not gw_raw:
+                continue
+            next_hop = gw_raw if _is_ip(gw_raw) else name_to_ip.get(gw_raw, "")
+            if not _is_ip(next_hop):
+                continue  # unresolvable name / dynamic gateway — skip
+            _add(network, next_hop, (route_el.findtext("descr") or "").strip())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/cross_vendor_expectations/opnsense__arista_eos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__arista_eos.yaml
@@ -418,17 +418,15 @@ per_field_expectation:
   static_routes:
     disposition: lossy
     reason: >
-      OPNsense's two-block model (``<gateways>/<gateway_item>`` +
-      ``<staticroutes>/<route>``) requires a JOIN to resolve named
-      gateway references to bare next-hop IPs.  The opnsense
-      codec capability matrix lists ``/staticroutes/route`` as
-      supported in the kitchen-sink XML but parser wire-up is
-      incomplete; cross-pair render emits nothing on the Arista
-      target until parse lands.  The OPNsense default-route idiom
-      (implicit ``<gateway>`` on the WAN zone) requires
-      synthesising a ``0.0.0.0/0`` canonical record on parse —
-      currently not done.  Arista target accepts ``ip route
-      0.0.0.0/0 <gw>`` natively when canonical surfaces it.
+      OPNsense parse now resolves the two-block model — the default
+      route from ``<gateway_item defaultgw=1>`` and each
+      ``<staticroutes>/<route>`` with its named gateway JOINed to a
+      next-hop IP (#15) — so Arista renders ``ip route 0.0.0.0/0
+      <gw>`` and the destination + next-hop round-trip.  Kept lossy:
+      Arista drops the per-route description (declared lossy on the
+      Arista codec), so a route carrying ``<descr>`` drifts on the
+      round-trip.  An unresolvable / dynamic-DHCP gateway is dropped
+      on parse rather than emitted as a bogus next-hop.
     references: [opnsense-gateways, arista-routing-cg]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/opnsense__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__aruba_aoss.yaml
@@ -423,15 +423,14 @@ per_field_expectation:
   static_routes:
     disposition: lossy
     reason: >
-      OPNsense's two-block model (``<gateways>/<gateway_item>`` +
-      ``<staticroutes>/<route>``) requires a JOIN to resolve named
-      gateway references to bare next-hop IPs.  The opnsense codec
-      capability matrix lists ``/staticroutes/route`` as supported
-      in the kitchen-sink XML but parser wire-up is incomplete;
-      cross-pair render emits nothing on the Aruba target until
-      parse lands.  The OPNsense default-route idiom (implicit
-      ``<gateway>`` on the WAN zone) requires synthesising a
-      ``0.0.0.0/0`` canonical record on parse — currently not done.
+      OPNsense parse now resolves the two-block model — the default
+      route from ``<gateway_item defaultgw=1>`` and each
+      ``<staticroutes>/<route>`` with its named gateway JOINed to a
+      next-hop IP (#15) — so the destination + next-hop round-trip on
+      the Aruba target.  Kept lossy: AOS-S drops the per-route
+      description, so a route carrying ``<descr>`` drifts on the
+      round-trip.  An unresolvable / dynamic-DHCP gateway is dropped
+      on parse rather than emitted as a bogus next-hop.
     references: [opnsense-gateways, aruba-static-routes]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/opnsense__cisco_iosxe.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__cisco_iosxe.yaml
@@ -394,14 +394,16 @@ per_field_expectation:
     references: [opnsense-vlans]
 
   static_routes:
-    disposition: not_applicable
-    note: >
-      OPNsense parser doesn't currently parse `<gateways>` or
-      `<staticroutes>` into intent.static_routes — the codec
-      hasn't wired the two-block model into canonical.  cisco_iosxe
-      target render also doesn't walk
-      `<network-instances>/<protocols>/<protocol identifier=STATIC>`
-      regardless.  Doubly gated.
+    disposition: lossy
+    reason: >
+      OPNsense parse now harvests the default route (from
+      `<gateway_item defaultgw=1>`) and `<staticroutes>/<route>`
+      entries, resolving named gateways to next-hop IPs (#15).  The
+      cisco_iosxe (structured/OpenConfig) target render does not walk
+      `<network-instances>/<protocols>/<protocol identifier=STATIC>`,
+      so the harvested route is dropped on render.  Declared lossy so
+      validate_against surfaces the render loss (was not_applicable
+      when parse produced nothing).
     references: [oc-network-instance]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/opnsense__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__cisco_iosxe_cli.yaml
@@ -363,14 +363,15 @@ per_field_expectation:
   static_routes:
     disposition: lossy
     reason: >
-      OPNsense splits static-route declaration into ``<gateways>``
-      (named gateways with bound interface) and ``<staticroutes>``
-      (routes referencing named gateways).  The OPNsense codec does
-      not currently parse either block into the canonical
-      ``static_routes`` list; Cisco target therefore emits no
-      ``ip route`` lines from an OPNsense source.  Lands when
-      OPNsense parse wire-up completes and the gateway-name
-      indirection is resolved to bare next-hop IPs.
+      OPNsense parse now resolves the two-block model
+      (``<gateways>`` named gateways JOINed to ``<staticroutes>``
+      routes, plus the ``<gateway_item defaultgw=1>`` default route)
+      into the canonical ``static_routes`` list (#15), so the Cisco
+      target emits ``ip route`` lines and the destination + next-hop
+      round-trip.  Kept lossy: IOS drops the per-route description,
+      so a route carrying ``<descr>`` drifts on the round-trip.  An
+      unresolvable / dynamic-DHCP gateway is dropped on parse rather
+      than emitted as a bogus next-hop.
     references: [opnsense-gateways]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/opnsense__fortigate_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__fortigate_cli.yaml
@@ -463,17 +463,16 @@ per_field_expectation:
   static_routes:
     disposition: lossy
     reason: >
-      OPNsense's two-block model (``<gateways>/<gateway_item>`` +
-      ``<staticroutes>/<route>``) requires a JOIN to resolve named
-      gateway references to bare next-hop IPs.  The opnsense codec
-      capability matrix lists ``/staticroutes/route`` in the
-      kitchen-sink XML but parser wire-up is incomplete; cross-pair
-      render emits nothing on the FortiGate target until parse
-      lands.  The OPNsense default-route idiom (implicit
-      ``<gateway>`` on the WAN zone) requires synthesising a
-      ``0.0.0.0/0`` canonical record on parse — currently not done.
-      Description / interface-name fields are lossy through the
-      rename mesh on the interface pointer.
+      OPNsense parse now resolves the two-block model — the default
+      route from ``<gateway_item defaultgw=1>`` and each
+      ``<staticroutes>/<route>`` with its named gateway JOINed to a
+      next-hop IP (#15) — so the FortiGate target emits ``config
+      router static`` entries and destination + next-hop + comment
+      round-trip (FortiOS ``set comment`` preserves the route
+      description).  Kept lossy: the interface-name pointer is lossy
+      through the rename mesh.  An unresolvable / dynamic-DHCP
+      gateway is dropped on parse rather than emitted as a bogus
+      next-hop.
     references: [opn-static-routes, fgt-static-routes]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/opnsense__juniper_junos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__juniper_junos.yaml
@@ -466,15 +466,16 @@ per_field_expectation:
   static_routes:
     disposition: lossy
     reason: >
-      OPNsense codec does not currently parse ``<staticroutes>`` /
-      ``<gateways>`` blocks into the canonical static_routes list;
-      structural mapping IS sound (each ``<staticroutes>/<route>``
-      becomes one Junos ``set routing-options static route X/N
-      next-hop Y`` once wire-up lands), but currently the cross-pair
-      delivers an empty list.  Default route synthesis: OPNsense's
-      WAN-gateway default-flag has no direct Junos analogue; the
-      canonical model would need to synthesise ``0.0.0.0/0 →
-      wan_gw_ip`` to round-trip.
+      OPNsense parse now harvests ``<staticroutes>`` / ``<gateways>``
+      into the canonical static_routes list (#15): each
+      ``<staticroutes>/<route>`` becomes one Junos ``set
+      routing-options static route X/N next-hop Y``, and a
+      ``<gateway_item defaultgw=1>`` synthesises ``0.0.0.0/0 →
+      wan_gw_ip``.  Destination + next-hop round-trip.  Kept lossy:
+      Junos render drops the per-route description, so a route
+      carrying ``<descr>`` drifts on the round-trip.  An unresolvable
+      / dynamic-DHCP gateway is dropped on parse rather than emitted
+      as a bogus next-hop.
     references: [opnsense-gateways, junos-static-routing]
 
   # ── Tier 2 — DHCP server ──

--- a/tests/fixtures/cross_vendor_expectations/opnsense__mikrotik_routeros.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__mikrotik_routeros.yaml
@@ -427,17 +427,16 @@ per_field_expectation:
   static_routes:
     disposition: lossy
     reason: >
-      OPNsense splits static-route declaration into ``<gateways>``
-      (named gateways with bound interface) and ``<staticroutes>``
-      (routes referencing named gateways).  The OPNsense codec does
-      not currently parse either block into the canonical
-      ``static_routes`` list; RouterOS target therefore emits no
-      ``/ip route add`` lines from an OPNsense source.  Lands when
-      OPNsense parse wire-up resolves the gateway-name indirection
-      to bare next-hop IPs.  Default route (``0.0.0.0/0``) on
-      OPNsense is the WAN-zone ``<gateway>`` attribute, not a
-      ``<staticroutes>`` entry — operator-curated mapping to
-      RouterOS's ``dst-address=0.0.0.0/0`` form.
+      OPNsense parse now resolves the two-block model into the
+      canonical ``static_routes`` list (#15): the gateway-name
+      indirection in ``<staticroutes>`` is JOINed to bare next-hop
+      IPs, and the ``<gateway_item defaultgw=1>`` default route
+      synthesises ``0.0.0.0/0`` — so RouterOS emits ``/ip route add
+      dst-address=... gateway=...`` and destination + next-hop +
+      comment round-trip (RouterOS ``comment=`` preserves the route
+      description).  Kept lossy as safe pessimism pending the
+      OPNsense render half.  An unresolvable / dynamic-DHCP gateway
+      is dropped on parse rather than emitted as a bogus next-hop.
     references: [opnsense-gateways, mikrotik_ip_routing]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -14,15 +14,15 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 |---|---:|---|
 | ALIGNED | 1620 | ok |
 | CODEC_BUG | 5 | **high** |
-| EXPECTED_LOSSY | 1224 | ok |
+| EXPECTED_LOSSY | 1231 | ok |
 | EXPECTED_UNSUPPORTED | 729 | ok |
-| METHODOLOGY_ISSUE_under | 908 | low/medium |
+| METHODOLOGY_ISSUE_under | 922 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
 | STRUCTURAL_ONLY | 1194 | low |
-| TRIVIAL_EMPTY | 9515 | ok |
+| TRIVIAL_EMPTY | 9494 | ok |
 | **Total field-cells classified** | **15220** | |
 
-Severity roll-up: 5 high, 107 medium, 2020 low, 13088 ok.
+Severity roll-up: 5 high, 107 medium, 2034 low, 13074 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-12T08:55:54+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T085547Z.json",
-  "mesh_run_started_utc": "2026-07-12T08:55:41+00:00",
+  "started_utc": "2026-07-12T10:08:08+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T100358Z.json",
+  "mesh_run_started_utc": "2026-07-12T10:03:52+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4136,17 +4136,17 @@
   "aggregate": {
     "ALIGNED": 1620,
     "CODEC_BUG": 5,
-    "EXPECTED_LOSSY": 1224,
+    "EXPECTED_LOSSY": 1231,
     "EXPECTED_UNSUPPORTED": 729,
-    "METHODOLOGY_ISSUE_under": 908,
+    "METHODOLOGY_ISSUE_under": 922,
     "METHODOLOGY_ISSUE_over": 25,
     "STRUCTURAL_ONLY": 1194,
-    "TRIVIAL_EMPTY": 9515,
+    "TRIVIAL_EMPTY": 9494,
     "fields_total": 15220,
     "severity_high": 5,
     "severity_medium": 107,
-    "severity_low": 2020,
-    "severity_ok": 13088
+    "severity_low": 2034,
+    "severity_ok": 13074
   },
   "severity_matrix": {
     "arista_eos": {
@@ -4541,27 +4541,27 @@
     {
       "source_codec": "opnsense",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 34
+      "drifted_total": 35
     },
     {
       "source_codec": "opnsense",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 31
+      "drifted_total": 32
     },
     {
       "source_codec": "opnsense",
       "target_codec": "cisco_nxos",
-      "drifted_total": 33
+      "drifted_total": 34
     },
     {
       "source_codec": "opnsense",
       "target_codec": "opnsense",
-      "drifted_total": 0
+      "drifted_total": 3
     },
     {
       "source_codec": "opnsense",
       "target_codec": "vyos",
-      "drifted_total": 20
+      "drifted_total": 21
     },
     {
       "source_codec": "vyos",

--- a/tests/unit/migration/test_opnsense_static_route_harvest.py
+++ b/tests/unit/migration/test_opnsense_static_route_harvest.py
@@ -1,0 +1,96 @@
+"""OPNsense static-route parse harvest — promotion #15.
+
+Parse now harvests the box default route (from ``<gateway_item
+defaultgw=1>``) plus explicit ``<staticroutes><route>`` entries, resolving
+a named gateway through the ``<gateways>`` map.  The matrix stays LOSSY —
+render still emits no ``<staticroutes>`` block — so this closes an
+opnsense-as-source silent loss, not a round-trip.  The load-bearing guard
+applies the IP check to the RESOLVED next-hop so an unresolvable name or a
+dynamic/DHCP gateway is dropped rather than emitted as a bogus next-hop.
+"""
+from __future__ import annotations
+
+import pathlib
+
+from netcanon.migration.codecs.opnsense.codec import OPNsenseCodec
+
+_FIXTURES = pathlib.Path(__file__).parents[2] / "fixtures" / "real" / "opnsense"
+
+
+def _parse(raw: str):
+    return {r.destination: r for r in OPNsenseCodec().parse(raw).static_routes}
+
+
+def test_real_ha_master_synthesises_default_route():
+    raw = (_FIXTURES / "opnsense_docs_carp_ha_master.xml").read_text(
+        encoding="utf-8",
+    )
+    routes = _parse(raw)
+    assert "0.0.0.0/0" in routes
+    assert routes["0.0.0.0/0"].gateway == "172.18.0.250"
+
+
+def test_supergate_capital_gateways_dhcp_default_is_skipped():
+    """A capital-<Gateways> (OPNsense 25 model) defaultgw with an empty
+    DHCP <gateway/> resolves to nothing — not a bogus next-hop."""
+    raw = (_FIXTURES / "user_contrib_supergate_opn25.xml").read_text(
+        encoding="utf-8",
+    )
+    assert _parse(raw) == {}
+
+
+def _wrap(body: str) -> str:
+    return f"<?xml version='1.0'?>\n<opnsense>{body}</opnsense>"
+
+
+def test_named_gateway_resolves_unresolvable_and_dynamic_are_dropped():
+    raw = _wrap(
+        """
+        <gateways>
+          <gateway_item>
+            <name>WAN_GW</name><interface>wan</interface>
+            <ipprotocol>inet</ipprotocol><gateway>203.0.113.1</gateway>
+          </gateway_item>
+          <gateway_item>
+            <name>DHCP_GW</name><interface>opt1</interface>
+            <ipprotocol>inet</ipprotocol><gateway></gateway>
+          </gateway_item>
+        </gateways>
+        <staticroutes>
+          <route><network>10.1.0.0/16</network><gateway>WAN_GW</gateway></route>
+          <route><network>10.2.0.0/16</network><gateway>DHCP_GW</gateway></route>
+          <route><network>10.3.0.0/16</network><gateway>GHOST</gateway></route>
+          <route><network>10.4.0.0/16</network><gateway>198.51.100.9</gateway></route>
+        </staticroutes>
+        """
+    )
+    routes = _parse(raw)
+    # WAN_GW resolves to its IP; a literal next-hop passes through.
+    assert routes["10.1.0.0/16"].gateway == "203.0.113.1"
+    assert routes["10.4.0.0/16"].gateway == "198.51.100.9"
+    # DHCP_GW (empty gateway) and GHOST (undefined name) are dropped.
+    assert "10.2.0.0/16" not in routes
+    assert "10.3.0.0/16" not in routes
+
+
+def test_ipv6_defaultgw_synthesises_v6_default_and_disabled_skipped():
+    raw = _wrap(
+        """
+        <gateways>
+          <gateway_item>
+            <name>WAN6</name><interface>wan</interface>
+            <ipprotocol>inet6</ipprotocol><gateway>2001:db8::1</gateway>
+            <defaultgw>1</defaultgw>
+          </gateway_item>
+          <gateway_item>
+            <name>OLD</name><interface>opt2</interface>
+            <ipprotocol>inet</ipprotocol><gateway>10.9.9.9</gateway>
+            <defaultgw>1</defaultgw><disabled>1</disabled>
+          </gateway_item>
+        </gateways>
+        """
+    )
+    routes = _parse(raw)
+    assert routes["::/0"].gateway == "2001:db8::1"
+    # The disabled defaultgw must not synthesise a v4 default route.
+    assert "0.0.0.0/0" not in routes

--- a/tests/unit/migration/test_real_captures.py
+++ b/tests/unit/migration/test_real_captures.py
@@ -345,6 +345,15 @@ def test_real_capture_round_trips_stable(
         # version are excluded — both are metadata about the input,
         # not canonical config data.
         d.pop("dropped_tier3_sections", None)
+        # A codec that declares /routing/static-route non-supported (e.g.
+        # opnsense: parse harvests the <gateways> default route +
+        # <staticroutes> entries (#15) but render emits no <staticroutes>
+        # block — declared lossy) cannot round-trip the field: the first
+        # parse yields routes, render drops them, the re-parse yields none.
+        # Exclude it so the round-trip stability check still covers every
+        # field the codec CAN render.
+        if codec.capabilities.classify("/routing/static-route") != "supported":
+            d.pop("static_routes", None)
         # Sort collections by natural identity key.
         for key, id_key in [
             ("interfaces", "name"),

--- a/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
+++ b/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
@@ -111,6 +111,15 @@ _KNOWN_ROUNDTRIP_GAPS: dict[str, tuple[str, frozenset[str]]] = {
         "TODO on mikrotik_routeros codec",
         frozenset({"interfaces[0].description", "interfaces[1].description"}),
     ),
+    # opnsense: parse now harvests <staticroutes>/<gateways> (#15) but the
+    # renderer emits no <staticroutes> block (declared lossy on the
+    # opnsense codec), so the single harvested route (172.16.0.0/12) is
+    # dropped on render and the re-parse sees an empty list.
+    "opnsense::kitchen_sink.xml": (
+        "static routes harvested on parse but not re-emitted on render — "
+        "declared lossy on the opnsense codec (render half pending)",
+        frozenset({"static_routes"}),
+    ),
 }
 
 

--- a/tests/unit/migration/test_synthetic_opnsense_kitchen_sink.py
+++ b/tests/unit/migration/test_synthetic_opnsense_kitchen_sink.py
@@ -211,6 +211,18 @@ def test_populates_every_expected_canonical_field(raw_xml: str) -> None:
     # SNMPv3 is intentionally absent — config.xml doesn't store it.
     assert intent.snmp.v3_users == []
 
+    # ── Tier 1 — static routes (promotion #15: parse harvests; render drops) ──
+    # <staticroutes> carries two <route> entries: one via a literal
+    # next-hop IP (harvested) and one via the gateway NAME ``WAN_GW`` that
+    # is defined nowhere in this fixture (no <gateways> block), so the
+    # resolved-next-hop guard drops it rather than emitting a bogus literal
+    # next-hop.  There is no defaultgw gateway_item here, so no default
+    # route is synthesised.
+    routes = {r.destination: r for r in intent.static_routes}
+    assert list(routes) == ["172.16.0.0/12"]
+    assert routes["172.16.0.0/12"].gateway == "10.0.0.254"
+    assert routes["172.16.0.0/12"].description == "Corporate transit"
+
 
 # ---------------------------------------------------------------------------
 # Test 3 — within-vendor round-trip stability.


### PR DESCRIPTION
## What

Closes an **opnsense-as-source silent loss**: parse harvested no static routes, so the box's default route (and any `<staticroutes>` entry) vanished before the walker ever saw it — no declaration fired at all. This is a **parse-half promotion**: the matrix stays **lossy** (the renderer still emits no `<staticroutes>` block), so the loss is now surfaced honestly rather than silently dropped.

## Parse

- **Default route** synthesised from each `<gateway_item defaultgw=1>` with a real `<gateway>` IP (`0.0.0.0/0` or `::/0`, keyed off the gateway's address family).
- **`<staticroutes>/<route>`** harvested: destination from `<network>`, next-hop from `<gateway>` — a literal IP passes through; a gateway **name** is JOINed through the gateway_item map to its IP.
- Gateway containers are matched **case-insensitively across the whole tree**, so both the legacy lowercase `<gateways>` (root) and the OPNsense-25 model-plugin `<OPNsense><Gateways>` shape resolve (a lowercase-only lookup misses the latter — verified against the `user_contrib_supergate` fixture).

### The load-bearing guard

The IP check is applied to the **resolved** next-hop, not the raw `<gateway>` value:

- An **unresolvable gateway name** (defined nowhere — e.g. the kitchen-sink's `WAN_GW`) is **dropped**, not emitted as a bogus literal next-hop. Without this, 10/12 target codecs would render `ip route <dst> WAN_GW` etc., which round-trips as a *stable-but-invalid* string past every fidelity guard while shipping semantically invalid config.
- A **dynamic/DHCP gateway** (empty `<gateway/>`, e.g. supergate's DHCP default) resolves to nothing.

Disabled entries are skipped; default routes are deduped.

## Matrix + pair-file truth-maintenance

Dispositions **unchanged** (render still drops → the whole route stays lossy):
- `codec.py` `/routing/static-route` reason → "parse harvests; render pending".
- The 7 `opnsense__*.yaml` static_routes reasons rewritten (they claimed *"OPNsense codec does not currently parse …"*, now false). `opnsense → cisco_iosxe` flipped `not_applicable → lossy` — parse now produces a route the structured target genuinely drops, which was a fresh over-claim.

## Mesh re-baseline

`CODEC_BUG` flat at **5**, `cells_total` **1224**. The default-route cells **preserve** on the six CLI targets → `METHODOLOGY_under`; `kitchen_sink` **drifts** only where the target drops the route *description* → `EXPECTED_LOSSY`. Dispositions were kept lossy **deliberately** — a blanket good-flip would mint a false CODEC_BUG on that description drift. The yaml-less pair-drift increases are all opnsense-source and benign (`opnsense→opnsense` +3 = same-vendor render drop; `opnsense→{aoscx,iosxr,nxos,vyos}` +1 = kitchen_sink description drop); **zero non-opnsense pair regressed**.

## Round-trip harness

opnsense parse now yields more than render can emit, so same-vendor round-trip drops `static_routes`. `test_real_captures::_compare` excludes the field for a codec that declares `/routing/static-route` non-supported (still covers every other field); the synthetic harness gets a field-targeted (#37) gap entry pinned to exactly `{static_routes}`.

## Verified

- New `tests/unit/migration/test_opnsense_static_route_harvest.py` — default-route synthesis, capital-`<Gateways>` DHCP skip, name resolution + unresolvable/dynamic drop, inet6 default, disabled skip
- Kitchen-sink coverage assertion added
- Full `tests/unit` + `tests/integration` (incl. cross-mesh CI guard) + `ruff` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
