### PR TITLE
feat(cisco_iosxe_cli): parse + render VXLAN-EVPN nve1 (promotion #16)

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -152,6 +152,18 @@ class CiscoIOSXECLICodec(CodecBase):
             # anycast MAC.  Round-trips between Cisco dotted-triplet
             # wire form and canonical colon-hex.
             "/anycast-gateway-mac",
+            # VXLAN-EVPN (promotion #16) — L2 VLAN↔VNI + VTEP source +
+            # per-VNI multicast group.  Parse intercepts ``interface nve1``
+            # (mirrors cisco_nxos) and correlates the ``vlan configuration N
+            # / member [evpn-instance M] vni V`` bindings; render re-emits
+            # both.  The L3VNI→VRF binding (``member vni V vrf <name>``) rides
+            # /routing-instances/instance/l3-vni.  Head-end static ingress-
+            # replication (/vxlan-vnis/flood-list) + a custom VXLAN UDP port
+            # (/vxlan-vnis/udp-port) are declared lossy below.
+            "/vxlan-vnis/vni",
+            "/vxlan-vnis/source-interface",
+            "/vxlan-vnis/mcast-group",
+            "/routing-instances/instance/l3-vni",
         ],
         lossy=[
             LossyPath(
@@ -271,6 +283,35 @@ class CiscoIOSXECLICodec(CodecBase):
                 ),
                 severity="warn",
             ),
+            # VXLAN-EVPN sub-field losses (promotion #16).  The NVE render
+            # emits the VTEP + per-VNI ``member vni`` bindings, so the VNI
+            # identity + multicast group survive; these two sub-details do
+            # not (mirrors the cisco_nxos declarations).
+            LossyPath(
+                path="/vxlan-vnis/udp-port",
+                reason=(
+                    "The IOS-XE NVE render emits the VTEP source-interface + "
+                    "per-VNI `member vni` bindings but no `vxlan udp-port` "
+                    "override, so a non-default VXLAN UDP port (e.g. the "
+                    "legacy 8472) is dropped on render and re-parses as the "
+                    "IANA default 4789.  The VNI binding survives; only the "
+                    "custom port is lost (mirrors cisco_nxos MTX-1)."
+                ),
+                severity="warn",
+            ),
+            LossyPath(
+                path="/vxlan-vnis/flood-list",
+                reason=(
+                    "IOS-XE EVPN relies on BGP-EVPN head-end auto-discovery "
+                    "(`host-reachability protocol bgp`); the NVE render emits "
+                    "multicast flood-and-learn (`member vni N mcast-group`) "
+                    "when set, but has no per-VNI static ingress-replication "
+                    "peer-list grammar, so an explicit flood_list of VTEP peer "
+                    "IPs is dropped on render while the VNI identity survives "
+                    "(promotion #16)."
+                ),
+                severity="warn",
+            ),
             LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/address-family",
                 reason=(
@@ -332,33 +373,6 @@ class CiscoIOSXECLICodec(CodecBase):
             UnsupportedPath(
                 path="/interfaces/interface/subinterfaces/subinterface/ipv6",
                 reason="Phase 0.5 scope — IPv4 only.",
-            ),
-            UnsupportedPath(
-                path="/vxlan-vnis/vni",
-                reason=(
-                    "IOS-XE VXLAN mappings (`interface nve1 / member "
-                    "vni <N> associate vrf <name>`) parse-and-ignore "
-                    "in v1.  CanonicalVxlan schema exists; wire-up "
-                    "deferred until demand arrives for Catalyst-to-"
-                    "Arista migrations."
-                ),
-            ),
-            UnsupportedPath(
-                path="/vxlan-vnis/source-interface",
-                reason=(
-                    "IOS-XE VXLAN source-interface (`interface nve1 / "
-                    "source-interface Loopback<N>`) parse-and-ignore "
-                    "in v1.  Same scope as /vxlan-vnis/vni — both "
-                    "land when Catalyst VXLAN demand arrives."
-                ),
-            ),
-            UnsupportedPath(
-                path="/vxlan-vnis/udp-port",
-                reason=(
-                    "IOS-XE VXLAN UDP port (`interface nve1 / vxlan "
-                    "udp-port <N>`) parse-and-ignore in v1.  Same "
-                    "scope as /vxlan-vnis/vni."
-                ),
             ),
             # ── ACL / firewall / NAT (Tier 3 — not auto-translatable) ──
             UnsupportedPath(

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -58,6 +58,7 @@ from ...canonical.intent import (
     CanonicalStaticRoute,
     CanonicalVlan,
     CanonicalVRRPGroup,
+    CanonicalVxlan,
 )
 from .._helpers import (
     _is_link_local_v6,
@@ -268,6 +269,33 @@ _HOSTNAME_RE = re.compile(r"^hostname\s+(\S+)", re.IGNORECASE | re.MULTILINE)
 _VERSION_RE = re.compile(r"^version\s+(\S+)", re.IGNORECASE | re.MULTILINE)
 _VLAN_RE = re.compile(r"^vlan\s+(\d+)", re.IGNORECASE)
 _VLAN_NAME_RE = re.compile(r"^\s+name\s+(.+)", re.IGNORECASE)
+
+# ── VXLAN / EVPN overlay (promotion #16) ──
+#: ``vlan configuration <N>`` opens the L2/L3 VNI binding block (distinct
+#: from the ``vlan <N>`` VLAN-database stanza — ``_VLAN_RE`` deliberately
+#: won't match it because ``configuration`` is not a digit).
+_VLAN_CONFIG_RE = re.compile(r"^vlan\s+configuration\s+(\d+)\s*$", re.IGNORECASE)
+#: ``member [evpn-instance <M>] vni <V>`` inside ``vlan configuration`` →
+#: the VLAN↔VNI binding.  The optional ``evpn-instance <M>`` marks an L2
+#: VNI; a bare ``member vni <V>`` marks the L3VNI core VLAN.  Both spellings
+#: carry the same canonical ``vlan_id → vni`` mapping; the L2-vs-L3VNI
+#: distinction is taken from the ``interface nve1`` member line instead.
+_VLAN_CONFIG_MEMBER_RE = re.compile(
+    r"^\s+member\s+(?:evpn-instance\s+\d+\s+)?vni\s+(\d+)\s*$", re.IGNORECASE,
+)
+#: ``source-interface <name>`` inside ``interface nve1`` → the switch-level
+#: VTEP source, broadcast onto every L2 CanonicalVxlan record.
+_NVE_SOURCE_IF_RE = re.compile(r"^\s+source-interface\s+(\S+)\s*$", re.IGNORECASE)
+#: ``member vni <V> [mcast-group <ip>] | [vrf <name>]`` inside ``interface
+#: nve1``.  Group 2 (mcast-group) marks an L2 VNI's flood-and-learn group;
+#: group 3 (vrf) marks an L3VNI bound to a VRF (harvested onto
+#: CanonicalRoutingInstance.l3_vni).  A bare ``member vni <V>`` is an L2 VNI
+#: with head-end (BGP-EVPN) replication.
+_NVE_MEMBER_VNI_RE = re.compile(
+    r"^\s+member\s+vni\s+(\d+)"
+    r"(?:\s+mcast-group\s+(\d+\.\d+\.\d+\.\d+)|\s+vrf\s+(\S+))?\s*$",
+    re.IGNORECASE,
+)
 _STATIC_ROUTE_RE = re.compile(
     r"^ip\s+route\s+(?:vrf\s+(\S+)\s+)?"
     r"(\d+\.\d+\.\d+\.\d+)\s+(\d+\.\d+\.\d+\.\d+)\s+(\S+)"
@@ -519,6 +547,16 @@ def parse_intent(raw: str) -> CanonicalIntent:
     # "KNOWN DATA-LOSS BUGS / BUG 1".
     _synthesize_vlans_from_svis(intent)
 
+    # VXLAN-EVPN overlay (promotion #16).  ``interface nve1`` was
+    # intercepted by _parse_interfaces (no generic CanonicalInterface);
+    # its overlay body + the ``vlan configuration`` VLAN↔VNI bindings are
+    # harvested here.  L3VNIs land on the matching routing_instance's
+    # l3_vni (parsed just above), so this must run after routing_instances.
+    intent.vxlan_vnis, _l3vni_by_vrf = _parse_vxlan(raw)
+    for ri in intent.routing_instances:
+        if ri.name in _l3vni_by_vrf:
+            ri.l3_vni = _l3vni_by_vrf[ri.name]
+
     # Static routes
     intent.static_routes = _parse_static_routes(raw)
 
@@ -709,10 +747,95 @@ def _parse_routing_instances(raw: str) -> list[CanonicalRoutingInstance]:
     )
 
 
+def _parse_vxlan(raw: str) -> tuple[list[CanonicalVxlan], dict[str, int]]:
+    """Harvest the IOS-XE EVPN-VXLAN overlay (promotion #16).
+
+    Returns ``(l2_records, l3vni_by_vrf)``:
+
+    * ``l2_records`` — one :class:`CanonicalVxlan` per L2 VLAN↔VNI binding.
+      The ``vlan_id → vni`` mapping comes from ``vlan configuration <N> /
+      member [evpn-instance <M>] vni <V>``; the VTEP ``source-interface``
+      and per-VNI ``mcast-group`` come from ``interface nve1``.
+    * ``l3vni_by_vrf`` — ``{vrf_name: l3vni}`` from the ``interface nve1``
+      ``member vni <V> vrf <name>`` lines (the L3VNI→VRF binding, wired onto
+      :attr:`CanonicalRoutingInstance.l3_vni` by the caller).
+
+    ``interface nve1`` itself is intercepted in :func:`_parse_interfaces`
+    (``_open`` returns ``None``) so it never materialises as a generic
+    interface; this function is the sole consumer of its overlay body.
+    """
+    # Pass 1: vni → vlan_id from ``vlan configuration <N> / member ... vni``.
+    vlan_by_vni: dict[int, int] = {}
+    current_vlan: int | None = None
+    for line in raw.splitlines():
+        cm = _VLAN_CONFIG_RE.match(line)
+        if cm:
+            current_vlan = int(cm.group(1))
+            continue
+        if current_vlan is not None:
+            mm = _VLAN_CONFIG_MEMBER_RE.match(line)
+            if mm:
+                vlan_by_vni[int(mm.group(1))] = current_vlan
+                continue
+            if line and not line[0].isspace():
+                current_vlan = None
+
+    # Pass 2: ``interface nve1`` — VTEP source, L2 mcast, L3VNI→VRF.
+    source_iface = ""
+    l2_vnis: list[int] = []
+    mcast_by_vni: dict[int, str] = {}
+    l3vni_by_vrf: dict[str, int] = {}
+    in_nve = False
+    for line in raw.splitlines():
+        im = _IFACE_RE.match(line)
+        if im:
+            in_nve = im.group(1).lower().startswith("nve")
+            continue
+        if line and not line[0].isspace():
+            in_nve = False
+            continue
+        if not in_nve:
+            continue
+        sm = _NVE_SOURCE_IF_RE.match(line)
+        if sm:
+            source_iface = sm.group(1)
+            continue
+        vm = _NVE_MEMBER_VNI_RE.match(line)
+        if vm:
+            vni = int(vm.group(1))
+            if vm.group(3):  # ``member vni N vrf <name>`` → L3VNI binding
+                l3vni_by_vrf[vm.group(3)] = vni
+            else:            # L2 member (bare or inline ``mcast-group``)
+                l2_vnis.append(vni)
+                if vm.group(2):
+                    mcast_by_vni[vni] = vm.group(2)
+
+    records = [
+        CanonicalVxlan(
+            vlan_id=vlan_by_vni[vni],
+            vni=vni,
+            source_interface=source_iface,
+            mcast_group=mcast_by_vni.get(vni, ""),
+        )
+        for vni in l2_vnis
+        if vni in vlan_by_vni
+    ]
+    return records, l3vni_by_vrf
+
+
 def _parse_interfaces(raw: str) -> list[CanonicalInterface]:  # noqa: C901
     """Extract interface stanzas from IOS config text."""
-    def _open(m: re.Match[str]) -> dict[str, Any]:
+    def _open(m: re.Match[str]) -> dict[str, Any] | None:
         iface_name = m.group(1)
+        # VTEP (``interface nve1``) is a VXLAN-EVPN overlay container, not a
+        # routed/switched port: its source-interface + member-vni sub-commands
+        # are harvested by :func:`_parse_vxlan`.  Returning None leaves the
+        # stanza open-but-unmaterialised (``scan_stanzas`` skips its indented
+        # body while ``current is None``) so it does NOT become a generic
+        # CanonicalInterface — mirrors cisco_nxos's nve1 interception
+        # (promotion #16).
+        if iface_name.lower().startswith("nve"):
+            return None
         return {
             "name": iface_name,
             "description": "",

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -546,6 +546,42 @@ def render_intent(tree: Any) -> str:  # noqa: C901
     if tree.vlans:
         out.append("!")
 
+    # --- VXLAN / EVPN overlay (promotion #16) ---
+    # L2 VLAN↔VNI bindings render as ``vlan configuration <vlan_id> /
+    # member evpn-instance 1 vni <vni>`` (the ``evpn-instance`` number is
+    # not carried canonically — 1 matches the single ``l2vpn evpn instance
+    # 1`` most IOS-XE EVPN leaves declare, and re-parse maps it back to the
+    # same vlan_id).  The VTEP source-interface, per-VNI multicast group,
+    # and L3VNI→VRF bindings render under ``interface nve1`` — the same
+    # stanza the parser intercepts.  Mirrors the cisco_nxos VTEP emitter.
+    l3vnis = sorted(
+        (ri.l3_vni, ri.name)
+        for ri in tree.routing_instances
+        if ri.l3_vni is not None and ri.name
+    )
+    ordered_vx = sorted(tree.vxlan_vnis, key=lambda x: x.vni)
+    if ordered_vx or l3vnis:
+        for vx in ordered_vx:
+            out.append(f"vlan configuration {vx.vlan_id}")
+            out.append(f" member evpn-instance 1 vni {vx.vni}")
+        if ordered_vx:
+            out.append("!")
+        source_iface = next(
+            (x.source_interface for x in ordered_vx if x.source_interface), "",
+        ) or "Loopback0"
+        out.append("interface nve1")
+        out.append(" no ip address")
+        out.append(f" source-interface {source_iface}")
+        out.append(" host-reachability protocol bgp")
+        for vx in ordered_vx:
+            if vx.mcast_group:
+                out.append(f" member vni {vx.vni} mcast-group {vx.mcast_group}")
+            else:
+                out.append(f" member vni {vx.vni}")
+        for l3vni, vrf_name in l3vnis:
+            out.append(f" member vni {l3vni} vrf {vrf_name}")
+        out.append("!")
+
     # --- static routes ---
     for route in tree.static_routes:
         tail = ""

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
@@ -307,22 +307,35 @@ per_field_expectation:
   # ── Tier 2 (ship-before-wire) — EVPN-VXLAN fabric schema ──
 
   vxlan_vnis:
-    disposition: unsupported
-    reason: >
-      Arista EOS codec capability matrix lists ``/vxlan-vnis/vni``,
-      ``/vxlan-vnis/source-interface``, and ``/vxlan-vnis/udp-port``
-      as supported (parses interface Vxlan1 + vxlan source-interface
-      + vxlan udp-port + vxlan vlan N vni X mappings into
-      CanonicalVxlan records).  Cisco IOS-XE codec capability
-      matrix lists the same xpaths under unsupported with rationale
-      "IOS-XE VXLAN mappings (interface nve1 / member vni <N>
-      associate vrf <name>) parse-and-ignore in v1.  CanonicalVxlan
-      schema exists; wire-up deferred until demand arrives for
-      Catalyst-to-Arista migrations."  This direction is
-      asymmetrically lossy: Arista source carries the data, Cisco
-      target silently drops it on render (no NVE / VLAN-config /
-      l2vpn-evpn render block in cisco_iosxe_cli/render.py).
+    disposition: good
+    note: >
+      Promotion #16 wired the IOS-XE target render: cisco_iosxe_cli now
+      emits the ``vlan configuration N / member evpn-instance 1 vni V``
+      bindings + the ``interface nve1`` VTEP (source-interface, per-VNI
+      ``member vni N mcast-group``), so an Arista source's VLAN↔VNI
+      mappings + VTEP source + multicast group survive to IOS-XE.  Only
+      head-end static ingress-replication + a custom UDP port drop (see
+      the flood_list / udp_port sub-cells).
     references: [vxlan]
+
+  vxlan_vnis[].vlan_id:
+    disposition: good
+
+  vxlan_vnis[].vni:
+    disposition: good
+
+  vxlan_vnis[].mcast_group:
+    disposition: good
+
+  vxlan_vnis[].source_interface:
+    disposition: good
+
+  vxlan_vnis[].flood_list:
+    disposition: lossy
+    reason: >
+      The IOS-XE NVE render has no per-VNI static ingress-replication
+      peer-list grammar (declared lossy on the codec), so an Arista
+      ``vxlan flood vtep`` head-end peer list drops on the IOS-XE render.
 
   evpn_type5_routes:
     disposition: unsupported

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__arista_eos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__arista_eos.yaml
@@ -258,16 +258,39 @@ per_field_expectation:
   # ── Tier 2 (ship-before-wire) — EVPN-VXLAN fabric schema ──
 
   vxlan_vnis:
-    disposition: unsupported
+    disposition: lossy
     reason: >
-      Cisco IOS-XE codec capability matrix lists
-      ``/vxlan-vnis/vni`` as unsupported with rationale "IOS-XE
-      VXLAN mappings (``interface nve1 / member vni <N> associate
-      vrf <name>``) parse-and-ignore in v1.  CanonicalVxlan schema
-      exists; wire-up deferred until demand arrives for Catalyst-
-      to-Arista migrations."  Arista EOS codec advertises
-      ``/vxlan-vnis/vni`` as supported but Cisco-side parse is
-      empty, so the cross-pair drops to unsupported.
+      Promotion #16 wired IOS-XE VXLAN-EVPN: the codec now intercepts
+      ``interface nve1`` and correlates the ``vlan configuration N /
+      member [evpn-instance M] vni V`` bindings, so the L2 VLAN↔VNI
+      mapping + VTEP source-interface survive to Arista ``vlan N vxlan
+      vni X`` inside ``interface Vxlan1``.  The one sub-detail that drops
+      on this direction is the per-VNI multicast group (dropped by the
+      Arista render), so the field is lossy overall (see
+      vxlan_vnis[].mcast_group).
+
+  vxlan_vnis[].vlan_id:
+    disposition: good
+
+  vxlan_vnis[].vni:
+    disposition: good
+
+  vxlan_vnis[].source_interface:
+    disposition: good
+
+  vxlan_vnis[].mcast_group:
+    disposition: lossy
+    reason: >
+      IOS-XE ``member vni N mcast-group <addr>`` maps to Arista ``vlan N
+      multicast-group <addr>``, but the Arista render currently drops the
+      per-VNI multicast group, so it does not survive the cross-pair.
+
+  vxlan_vnis[].flood_list:
+    disposition: lossy
+    reason: >
+      Head-end static ingress-replication peer IPs have no per-VNI nve1
+      grammar on the IOS-XE side (declared lossy on the codec), so an
+      explicit flood_list drops on the IOS-XE source render.
 
   evpn_type5_routes:
     disposition: unsupported

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__aruba_aoss.yaml
@@ -285,11 +285,11 @@ per_field_expectation:
   vxlan_vnis:
     disposition: unsupported
     reason: >
-      cisco_iosxe_cli capability matrix lists /vxlan-vnis/vni
-      under unsupported ("IOS-XE VXLAN mappings parse-and-ignore in
-      v1") and aruba_aoss capability matrix also lists the path
-      under unsupported ("VXLAN not modelled — AOS-S is a campus
-      L2/L3 codec").  Both ends explicitly absent.
+      cisco_iosxe_cli now parses + renders VXLAN-EVPN (promotion #16 —
+      ``interface nve1`` interception + ``vlan configuration`` binding),
+      but aruba_aoss lists /vxlan-vnis/vni under unsupported ("VXLAN not
+      modelled — AOS-S is a campus L2/L3 codec"), so the overlay drops on
+      the AOS-S render.  Target-driven unsupported.
 
   evpn_type5_routes:
     disposition: unsupported

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__cisco_iosxe.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__cisco_iosxe.yaml
@@ -481,12 +481,12 @@ per_field_expectation:
   vxlan_vnis:
     disposition: unsupported
     reason: >
-      Both codecs declare every `/vxlan-vnis/*` path as `unsupported`
-      in their capability matrices: "VXLAN not modelled in this
-      NETCONF/OpenConfig stub codec.  CLI sibling defers VXLAN wire-
-      up until Catalyst demand arrives; NETCONF stays in lockstep."
-      CanonicalVxlan schema exists; cross-pair drops vxlan_vnis
-      entirely.
+      The CLI sibling (cisco_iosxe_cli) now parses + renders VXLAN-EVPN
+      (promotion #16 — ``interface nve1`` interception), but the
+      cisco_iosxe NETCONF/OpenConfig stub target still declares every
+      `/vxlan-vnis/*` path `unsupported` ("VXLAN not modelled in this
+      stub codec"), so the overlay drops on the NETCONF render.  Target-
+      driven unsupported.
     references: [iosxe-vxlan-cg, oc-evpn]
 
   evpn_type5_routes:

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__fortigate_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__fortigate_cli.yaml
@@ -290,11 +290,10 @@ per_field_expectation:
   vxlan_vnis:
     disposition: unsupported
     reason: >
-      Cisco IOS-XE codec capability matrix lists ``/vxlan-vnis/vni``
-      as unsupported.  FortiGate codec capability matrix lists
-      ``/vxlan-vnis/vni`` as unsupported with rationale "VXLAN not
-      modelled - FortiGate is a firewall codec".  Both codecs
-      parse-and-ignore VXLAN intent on this cross-pair.
+      cisco_iosxe_cli now parses + renders VXLAN-EVPN (promotion #16),
+      but the FortiGate codec lists ``/vxlan-vnis/vni`` as unsupported
+      ("VXLAN not modelled - FortiGate is a firewall codec"), so the
+      overlay drops on the FortiGate render.  Target-driven unsupported.
     references: [vrf]
 
   evpn_type5_routes:

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__juniper_junos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__juniper_junos.yaml
@@ -583,47 +583,41 @@ per_field_expectation:
   # ── Tier 2 (ship-before-wire) — EVPN-VXLAN ──
 
   vxlan_vnis:
-    disposition: unsupported
+    disposition: lossy
     reason: >
-      Cisco IOS-XE codec capability matrix lists
-      ``/vxlan-vnis/vni`` under unsupported with rationale "IOS-XE
-      VXLAN mappings (``interface nve1 / member vni <N>``) parse-
-      and-ignore in v1.  CanonicalVxlan schema exists; wire-up
-      deferred until demand arrives for Catalyst-to-Arista (or
-      Catalyst-to-Junos) migrations."  Junos codec advertises
-      ``/vxlan-vnis/vni`` as supported, so the cross-pair drops to
-      unsupported.
+      Promotion #16 wired IOS-XE VXLAN-EVPN: the codec now intercepts
+      ``interface nve1`` and correlates the ``vlan configuration N /
+      member [evpn-instance M] vni V`` bindings, so the L2 VLAN↔VNI
+      mapping + VTEP source-interface survive to Junos ``set vlans <name>
+      vxlan vni X`` + ``vtep-source-interface``.  The one sub-detail that
+      drops on this direction is the per-VNI multicast group — Junos uses
+      BGP-EVPN ingress replication — so the field is lossy overall (see
+      vxlan_vnis[].mcast_group).  Mirrors arista_eos__juniper_junos.
     references: [cisco-evpn-vxlan-cg, junos-evpn-overview, junos-evpn-irb-example]
 
   vxlan_vnis[].vlan_id:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco parse-and-ignore in v1)."
+    disposition: good
 
   vxlan_vnis[].vni:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco parse-and-ignore in v1)."
+    disposition: good
 
   vxlan_vnis[].mcast_group:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco parse-and-ignore in v1)."
+    disposition: lossy
+    reason: >
+      IOS-XE ``member vni N mcast-group <addr>`` has no direct Junos
+      EVPN-VXLAN data-plane equivalent (Junos uses BGP-EVPN signalled
+      ingress replication by default), so the canonical mcast_group is
+      dropped on the Junos render.  Mirrors arista_eos__juniper_junos.
 
   vxlan_vnis[].flood_list:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco parse-and-ignore in v1)."
+    disposition: lossy
+    reason: >
+      Head-end static ingress-replication peer IPs have no per-VNI nve1
+      grammar on the IOS-XE side (declared lossy on the codec) and Junos
+      derives them from BGP-EVPN — the explicit flood_list drops.
 
   vxlan_vnis[].source_interface:
-    disposition: unsupported
-    reason: >
-      Cisco IOS-XE codec capability matrix lists
-      ``/vxlan-vnis/source-interface`` under unsupported.  Same
-      scope as ``/vxlan-vnis/vni`` — both land when Catalyst VXLAN
-      demand arrives.
-
-  vxlan_vnis[].udp_port:
-    disposition: unsupported
-    reason: >
-      Cisco IOS-XE codec capability matrix lists
-      ``/vxlan-vnis/udp-port`` under unsupported.
+    disposition: good
 
   evpn_type5_routes:
     disposition: unsupported
@@ -687,12 +681,11 @@ per_field_expectation:
   routing_instances[].l3_vni:
     disposition: good
     note: >
-      Same as routing_instances — Wave 10β re-flip.  l3_vni is None
-      on every populated fixture; the field round-trips by being
-      uniformly absent.  Flips back to ``lossy`` if a future fixture
-      exercises a populated L3 VNI on a Cisco source against the
-      Junos render path (which currently doesn't emit
-      ``vrf-target ... l3vni``).
+      Promotion #16 wired the L3VNI both ways: the IOS-XE source now
+      harvests ``member vni N vrf <name>`` under nve1 onto
+      CanonicalRoutingInstance.l3_vni, and the Junos render carries it.
+      The ciscolive EVPN-leaf fixture exercises a populated L3 VNI
+      (cml_demo → 100200) and it round-trips on this pair.
 
   # ── Tier 3 — informational only ──
 

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__mikrotik_routeros.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__mikrotik_routeros.yaml
@@ -305,15 +305,11 @@ per_field_expectation:
   vxlan_vnis:
     disposition: unsupported
     reason: >
-      Cisco IOS-XE codec capability matrix lists ``/vxlan-vnis/vni``
-      as unsupported with rationale "IOS-XE VXLAN mappings (`interface
-      nve1 / member vni <N> associate vrf <name>`) parse-and-ignore in
-      v1.  CanonicalVxlan schema exists; wire-up deferred until demand
-      arrives for Catalyst-to-Arista migrations."  The MikroTik codec
-      capability matrix also lists ``/vxlan-vnis/vni`` as unsupported
-      ("RouterOS VXLAN exists but is rare in canonical scope and not
-      modelled in v1.").  Cross-pair drops to unsupported on both
-      sides.
+      cisco_iosxe_cli now parses + renders VXLAN-EVPN (promotion #16 —
+      ``interface nve1`` interception), but the MikroTik codec lists
+      ``/vxlan-vnis/vni`` as unsupported ("RouterOS VXLAN exists but is
+      rare in canonical scope and not modelled in v1."), so the overlay
+      drops on the RouterOS render.  Target-driven unsupported.
 
   evpn_type5_routes:
     disposition: unsupported

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
@@ -495,11 +495,10 @@ per_field_expectation:
   vxlan_vnis:
     disposition: unsupported
     reason: >
-      OPNsense codec capability matrix lists ``/vxlan-vnis/vni``
-      under unsupported with rationale "VXLAN not modelled —
-      OPNsense is a firewall codec."  Cisco IOS-XE codec also
-      lists ``/vxlan-vnis/vni`` as unsupported pending Catalyst
-      VXLAN demand.  Cross-pair drops VXLAN entirely.
+      cisco_iosxe_cli now parses + renders VXLAN-EVPN (promotion #16),
+      but the OPNsense codec lists ``/vxlan-vnis/vni`` under unsupported
+      ("VXLAN not modelled — OPNsense is a firewall codec"), so the
+      overlay drops on the OPNsense render.  Target-driven unsupported.
 
   evpn_type5_routes:
     disposition: unsupported

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__cisco_iosxe_cli.yaml
@@ -608,42 +608,34 @@ per_field_expectation:
   # ── Tier 2 (ship-before-wire) — EVPN-VXLAN ──
 
   vxlan_vnis:
-    disposition: unsupported
-    reason: >
-      Junos codec capability matrix lists ``/vxlan-vnis/vni``,
-      ``/vxlan-vnis/source-interface``, and ``/vxlan-vnis/udp-port``
-      under supported (GAP 6 + GAP-EVPN-2).  Cisco IOS-XE codec
-      capability matrix lists the same paths under unsupported
-      with rationale "IOS-XE VXLAN mappings (``interface nve1 /
-      member vni <N> associate vrf <name>``) parse-and-ignore in
-      v1.  CanonicalVxlan schema exists; wire-up deferred."
-      Cross-pair therefore emits no ``interface nve1`` blocks on
-      the Cisco target.
+    disposition: good
+    note: >
+      Promotion #16 wired the IOS-XE target render: cisco_iosxe_cli now
+      emits the ``vlan configuration N / member evpn-instance 1 vni V``
+      bindings + the ``interface nve1`` VTEP, so a Junos source's
+      ``set vlans <name> vxlan vni X`` + ``vtep-source-interface`` VLAN↔VNI
+      mappings survive to IOS-XE.  Only head-end static ingress-replication
+      + a custom UDP port drop (see the flood_list / udp_port sub-cells).
     references: [junos-evpn-overview, junos-evpn-irb-example, cisco-evpn-vxlan-cg]
 
   vxlan_vnis[].vlan_id:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco render-side wire-up deferred)."
+    disposition: good
 
   vxlan_vnis[].vni:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco render-side wire-up deferred)."
+    disposition: good
 
   vxlan_vnis[].mcast_group:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco render-side wire-up deferred)."
+    disposition: good
 
   vxlan_vnis[].flood_list:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco render-side wire-up deferred)."
+    disposition: lossy
+    reason: >
+      The IOS-XE NVE render has no per-VNI static ingress-replication
+      peer-list grammar (declared lossy on the codec), so an explicit
+      head-end flood_list drops on the IOS-XE render.
 
   vxlan_vnis[].source_interface:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco render-side wire-up deferred)."
-
-  vxlan_vnis[].udp_port:
-    disposition: unsupported
-    reason: "Same as vxlan_vnis (Cisco render-side wire-up deferred)."
+    disposition: good
 
   evpn_type5_routes:
     disposition: unsupported
@@ -711,13 +703,13 @@ per_field_expectation:
     reason: "Same as routing_instances (Cisco render-side wire-up deferred)."
 
   routing_instances[].l3_vni:
-    disposition: lossy
-    reason: >
+    disposition: good
+    note: >
       Junos's ``protocols evpn ip-prefix-routes vni N`` under the
       routing-instance maps to canonical
-      ``CanonicalRoutingInstance.l3_vni``.  Cisco's equivalent
-      (``member vni N vrf X`` under nve1) is parse-and-ignore in
-      v1; cross-pair render drops the L3 VNI.
+      ``CanonicalRoutingInstance.l3_vni``.  Promotion #16 wired the
+      IOS-XE render (``member vni N vrf X`` under nve1), so the L3 VNI
+      now round-trips on this cross-pair.
     references: [junos-evpn-irb-example, cisco-evpn-vxlan-cg]
 
   # ── Tier 3 — informational only ──

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -12,17 +12,17 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 
 | Variance class | Count | Severity |
 |---|---:|---|
-| ALIGNED | 1620 | ok |
+| ALIGNED | 1658 | ok |
 | CODEC_BUG | 5 | **high** |
-| EXPECTED_LOSSY | 1231 | ok |
-| EXPECTED_UNSUPPORTED | 729 | ok |
-| METHODOLOGY_ISSUE_under | 922 | low/medium |
+| EXPECTED_LOSSY | 1229 | ok |
+| EXPECTED_UNSUPPORTED | 724 | ok |
+| METHODOLOGY_ISSUE_under | 925 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
-| STRUCTURAL_ONLY | 1194 | low |
-| TRIVIAL_EMPTY | 9494 | ok |
-| **Total field-cells classified** | **15220** | |
+| STRUCTURAL_ONLY | 1179 | low |
+| TRIVIAL_EMPTY | 9554 | ok |
+| **Total field-cells classified** | **15299** | |
 
-Severity roll-up: 5 high, 107 medium, 2034 low, 13074 ok.
+Severity roll-up: 5 high, 107 medium, 2022 low, 13165 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-12T10:08:08+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T100358Z.json",
-  "mesh_run_started_utc": "2026-07-12T10:03:52+00:00",
+  "started_utc": "2026-07-12T17:00:43+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T164327Z.json",
+  "mesh_run_started_utc": "2026-07-12T16:43:21+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4134,19 +4134,19 @@
     }
   ],
   "aggregate": {
-    "ALIGNED": 1620,
+    "ALIGNED": 1658,
     "CODEC_BUG": 5,
-    "EXPECTED_LOSSY": 1231,
-    "EXPECTED_UNSUPPORTED": 729,
-    "METHODOLOGY_ISSUE_under": 922,
+    "EXPECTED_LOSSY": 1229,
+    "EXPECTED_UNSUPPORTED": 724,
+    "METHODOLOGY_ISSUE_under": 925,
     "METHODOLOGY_ISSUE_over": 25,
-    "STRUCTURAL_ONLY": 1194,
-    "TRIVIAL_EMPTY": 9494,
-    "fields_total": 15220,
+    "STRUCTURAL_ONLY": 1179,
+    "TRIVIAL_EMPTY": 9554,
+    "fields_total": 15299,
     "severity_high": 5,
     "severity_medium": 107,
-    "severity_low": 2034,
-    "severity_ok": 13074
+    "severity_low": 2022,
+    "severity_ok": 13165
   },
   "severity_matrix": {
     "arista_eos": {
@@ -4331,12 +4331,12 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 31
+      "drifted_total": 32
     },
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "cisco_nxos",
-      "drifted_total": 31
+      "drifted_total": 30
     },
     {
       "source_codec": "cisco_iosxe_cli",
@@ -4426,7 +4426,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "cisco_iosxe_cli",
-      "drifted_total": 39
+      "drifted_total": 33
     },
     {
       "source_codec": "cisco_nxos",
@@ -4586,7 +4586,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "cisco_iosxe_cli",
-      "drifted_total": 18
+      "drifted_total": 21
     },
     {
       "source_codec": "vyos",
@@ -5274,43 +5274,40 @@
           "severity": "ok"
         },
         "vxlan_vnis": {
-          "actual": "drifted",
-          "expected": "unsupported",
-          "variance": "EXPECTED_UNSUPPORTED",
-          "severity": "ok",
-          "drift_detail": {
-            "source": [
-              {
-                "vlan_id": 110,
-                "vni": 10110,
-                "mcast_group": "",
-                "flood_list": [],
-                "source_interface": "Loopback1",
-                "udp_port": 4789
-              },
-              {
-                "vlan_id": 111,
-                "vni": 10111,
-                "mcast_group": "",
-                "flood_list": [],
-                "source_interface": "Loopback1",
-                "udp_port": 4789
-              },
-              {
-                "vlan_id": 210,
-                "vni": 10210,
-                "mcast_group": "",
-                "flood_list": [],
-                "source_interface": "Loopback1",
-                "udp_port": 4789
-              },
-              "... and 3 more"
-            ],
-            "target": [],
-            "drift": "all 6 vxlan_vnis dropped",
-            "source_count": 6,
-            "target_count": 0
-          }
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].vlan_id": {
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].vni": {
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].mcast_group": {
+          "actual": "trivially_preserved",
+          "expected": "good",
+          "variance": "TRIVIAL_EMPTY",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].source_interface": {
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].flood_list": {
+          "actual": "trivially_preserved",
+          "expected": "lossy",
+          "variance": "TRIVIAL_EMPTY",
+          "severity": "ok"
         },
         "evpn_type5_routes": {
           "actual": "trivially_preserved",
@@ -5383,7 +5380,7 @@
                   "50101:50101"
                 ],
                 "description": "",
-                "l3_vni": null
+                "l3_vni": 50101
               },
               {
                 "name": "Tenant_A_OPZone_1",
@@ -5401,12 +5398,6 @@
               "... and 7 more"
             ],
             "drift": {
-              "routing_instances[1] {'name': 'Tenant_A_OPZone'}": {
-                "l3_vni": {
-                  "source": 50101,
-                  "target": null
-                }
-              },
               "routing_instances[2] {'name': 'Tenant_A_OPZone_1'}": {
                 "instance_type": {
                   "source": "mac-vrf",
@@ -5419,12 +5410,6 @@
                   "target": "vrf"
                 }
               },
-              "routing_instances[4] {'name': 'Tenant_B_OPZone'}": {
-                "l3_vni": {
-                  "source": 50201,
-                  "target": null
-                }
-              },
               "routing_instances[5] {'name': 'Tenant_B_OPZone_1'}": {
                 "instance_type": {
                   "source": "mac-vrf",
@@ -5435,12 +5420,6 @@
                 "instance_type": {
                   "source": "mac-vrf",
                   "target": "vrf"
-                }
-              },
-              "routing_instances[7] {'name': 'Tenant_C_OPZone'}": {
-                "l3_vni": {
-                  "source": 50301,
-                  "target": null
                 }
               },
               "routing_instances[8] {'name': 'Tenant_C_OPZone_1'}": {
@@ -5498,20 +5477,20 @@
         }
       },
       "summary": {
-        "ALIGNED": 3,
+        "ALIGNED": 7,
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 4,
-        "EXPECTED_UNSUPPORTED": 1,
+        "EXPECTED_UNSUPPORTED": 0,
         "METHODOLOGY_ISSUE_under": 1,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
-        "TRIVIAL_EMPTY": 10,
-        "fields_total": 20,
+        "TRIVIAL_EMPTY": 12,
+        "fields_total": 25,
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
         "severity_low": 1,
-        "severity_ok": 18
+        "severity_ok": 23
       }
     },
     {
@@ -6256,43 +6235,40 @@
           "severity": "ok"
         },
         "vxlan_vnis": {
-          "actual": "drifted",
-          "expected": "unsupported",
-          "variance": "EXPECTED_UNSUPPORTED",
-          "severity": "ok",
-          "drift_detail": {
-            "source": [
-              {
-                "vlan_id": 110,
-                "vni": 10110,
-                "mcast_group": "",
-                "flood_list": [],
-                "source_interface": "Loopback1",
-                "udp_port": 4789
-              },
-              {
-                "vlan_id": 111,
-                "vni": 10111,
-                "mcast_group": "",
-                "flood_list": [],
-                "source_interface": "Loopback1",
-                "udp_port": 4789
-              },
-              {
-                "vlan_id": 120,
-                "vni": 10120,
-                "mcast_group": "",
-                "flood_list": [],
-                "source_interface": "Loopback1",
-                "udp_port": 4789
-              },
-              "... and 6 more"
-            ],
-            "target": [],
-            "drift": "all 9 vxlan_vnis dropped",
-            "source_count": 9,
-            "target_count": 0
-          }
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].vlan_id": {
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].vni": {
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].mcast_group": {
+          "actual": "trivially_preserved",
+          "expected": "good",
+          "variance": "TRIVIAL_EMPTY",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].source_interface": {
+          "actual": "preserved",
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
+        },
+        "vxlan_vnis[].flood_list": {
+          "actual": "trivially_preserved",
+          "expected": "lossy",
+          "variance": "TRIVIAL_EMPTY",
+          "severity": "ok"
         },
         "evpn_type5_routes": {
           "actual": "trivially_preserved",
@@ -6301,116 +6277,10 @@
           "severity": "ok"
         },
         "routing_instances": {
-          "actual": "drifted",
+          "actual": "preserved",
           "expected": "lossy",
-          "variance": "EXPECTED_LOSSY",
-          "severity": "ok",
-          "drift_detail": {
-            "source": [
-              {
-                "name": "MGMT",
-                "instance_type": "vrf",
-                "route_distinguisher": "",
-                "rt_imports": [],
-                "rt_exports": [],
-                "description": "",
-                "l3_vni": null
-              },
-              {
-                "name": "Tenant_A_APP_Zone",
-                "instance_type": "vrf",
-                "route_distinguisher": "192.168.255.4:15003",
-                "rt_imports": [
-                  "15003:15003"
-                ],
-                "rt_exports": [
-                  "15003:15003"
-                ],
-                "description": "",
-                "l3_vni": 15003
-              },
-              {
-                "name": "Tenant_A_DB_Zone",
-                "instance_type": "vrf",
-                "route_distinguisher": "192.168.255.4:15004",
-                "rt_imports": [
-                  "15004:15004"
-                ],
-                "rt_exports": [
-                  "15004:15004"
-                ],
-                "description": "",
-                "l3_vni": 15004
-              },
-              "... and 2 more"
-            ],
-            "target": [
-              {
-                "name": "MGMT",
-                "instance_type": "vrf",
-                "route_distinguisher": "",
-                "rt_imports": [],
-                "rt_exports": [],
-                "description": "",
-                "l3_vni": null
-              },
-              {
-                "name": "Tenant_A_APP_Zone",
-                "instance_type": "vrf",
-                "route_distinguisher": "192.168.255.4:15003",
-                "rt_imports": [
-                  "15003:15003"
-                ],
-                "rt_exports": [
-                  "15003:15003"
-                ],
-                "description": "",
-                "l3_vni": null
-              },
-              {
-                "name": "Tenant_A_DB_Zone",
-                "instance_type": "vrf",
-                "route_distinguisher": "192.168.255.4:15004",
-                "rt_imports": [
-                  "15004:15004"
-                ],
-                "rt_exports": [
-                  "15004:15004"
-                ],
-                "description": "",
-                "l3_vni": null
-              },
-              "... and 2 more"
-            ],
-            "drift": {
-              "routing_instances[1] {'name': 'Tenant_A_APP_Zone'}": {
-                "l3_vni": {
-                  "source": 15003,
-                  "target": null
-                }
-              },
-              "routing_instances[2] {'name': 'Tenant_A_DB_Zone'}": {
-                "l3_vni": {
-                  "source": 15004,
-                  "target": null
-                }
-              },
-              "routing_instances[3] {'name': 'Tenant_A_OP_Zone'}": {
-                "l3_vni": {
-                  "source": 15001,
-                  "target": null
-                }
-              },
-              "routing_instances[4] {'name': 'Tenant_A_WEB_Zone'}": {
-                "l3_vni": {
-                  "source": 15002,
-                  "target": null
-                }
-              }
-            },
-            "source_count": 5,
-            "target_count": 5
-          }
+          "variance": "METHODOLOGY_ISSUE_under",
+          "severity": "low"
         },
         "raw_sections": {
           "actual": "trivially_preserved",
@@ -6450,20 +6320,20 @@
         }
       },
       "summary": {
-        "ALIGNED": 3,
+        "ALIGNED": 7,
         "CODEC_BUG": 1,
-        "EXPECTED_LOSSY": 4,
-        "EXPECTED_UNSUPPORTED": 1,
-        "METHODOLOGY_ISSUE_under": 1,
+        "EXPECTED_LOSSY": 3,
+        "EXPECTED_UNSUPPORTED": 0,
+        "METHODOLOGY_ISSUE_under": 2,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
-        "TRIVIAL_EMPTY": 10,
-        "fields_total": 20,
+        "TRIVIAL_EMPTY": 12,
+        "fields_total": 25,
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 1,
-        "severity_ok": 18
+        "severity_low": 2,
+        "severity_ok": 22
       }
     },
     {
@@ -6817,43 +6687,37 @@
         },
         "vxlan_vnis": {
           "actual": "trivially_preserved",
-          "expected": "unsupported",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
         "vxlan_vnis[].vlan_id": {
           "actual": "trivially_preserved",
-          "expected": "unsupported",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
         "vxlan_vnis[].vni": {
           "actual": "trivially_preserved",
-          "expected": "unsupported",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
         "vxlan_vnis[].mcast_group": {
           "actual": "trivially_preserved",
-          "expected": "unsupported",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
         "vxlan_vnis[].flood_list": {
           "actual": "trivially_preserved",
-          "expected": "unsupported",
+          "expected": "lossy",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
         "vxlan_vnis[].source_interface": {
           "actual": "trivially_preserved",
-          "expected": "unsupported",
-          "variance": "TRIVIAL_EMPTY",
-          "severity": "ok"
-        },
-        "vxlan_vnis[].udp_port": {
-          "actual": "trivially_preserved",
-          "expected": "unsupported",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
@@ -7018,7 +6882,7 @@
         },
         "routing_instances[].l3_vni": {
           "actual": "trivially_preserved",
-          "expected": "lossy",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },
@@ -7246,13 +7110,13 @@
         "METHODOLOGY_ISSUE_under": 5,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
-        "TRIVIAL_EMPTY": 40,
-        "fields_total": 56,
+        "TRIVIAL_EMPTY": 39,
+        "fields_total": 55,
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
         "severity_low": 5,
-        "severity_ok": 50
+        "severity_ok": 49
       }
     },
     {

--- a/tests/unit/migration/codecs/cisco_iosxe_cli/test_capability_matrix_acl_unsupported.py
+++ b/tests/unit/migration/codecs/cisco_iosxe_cli/test_capability_matrix_acl_unsupported.py
@@ -106,11 +106,14 @@ class TestExistingDeclarationsPreserved:
         # invariant.
         caps = CiscoIOSXECLICodec().capabilities
         unsupported_paths = {up.path for up in caps.unsupported}
+        # NB: the three ``/vxlan-vnis/*`` paths were historically pinned here
+        # but graduated in promotion #16 — the codec now parses ``interface
+        # nve1`` + renders the VTEP, so /vxlan-vnis/{vni,source-interface} are
+        # supported and /vxlan-vnis/udp-port is lossy.  See
+        # ``test_capability_matrix_vrf_lossy.py::TestVxlanNveSupported`` for the
+        # corrected invariant.  This test now only pins the ACL-era survivor.
         for required in (
             "/interfaces/interface/subinterfaces/subinterface/ipv6",
-            "/vxlan-vnis/vni",
-            "/vxlan-vnis/source-interface",
-            "/vxlan-vnis/udp-port",
         ):
             assert required in unsupported_paths, (
                 f"existing UnsupportedPath {required!r} dropped — "

--- a/tests/unit/migration/codecs/cisco_iosxe_cli/test_capability_matrix_vrf_lossy.py
+++ b/tests/unit/migration/codecs/cisco_iosxe_cli/test_capability_matrix_vrf_lossy.py
@@ -111,25 +111,37 @@ class TestRoutingInstancesDeclaredLossy:
                 break
 
 
-class TestVxlanStillUnsupported:
-    """VXLAN remains genuinely unsupported (no parse + no render in
-    `cisco_iosxe_cli`).  Pin that the W11-A-era declarations stay
-    in the `unsupported` set — they're correct, unlike the VRF one
-    that was stale."""
+class TestVxlanNveSupported:
+    """VXLAN-EVPN nve1 is genuinely supported (promotion #16).
 
-    def test_vxlan_paths_still_unsupported(self):
+    ``cisco_iosxe_cli`` now intercepts ``interface nve1`` on parse (mirrors
+    cisco_nxos), correlates the ``vlan configuration N / member
+    [evpn-instance M] vni V`` bindings, and re-emits the VTEP on render.  The
+    W11-A-era "still unsupported" pins were correct at the time but are now
+    stale — this class pins the graduated dispositions instead."""
+
+    def test_vni_and_source_interface_supported(self):
         codec = _build_codec()
-        unsupported_paths = {
-            entry.path for entry in codec.capabilities.unsupported
-        }
-        for path in (
-            "/vxlan-vnis/vni",
-            "/vxlan-vnis/source-interface",
-            "/vxlan-vnis/udp-port",
-        ):
-            assert path in unsupported_paths, (
-                f"{path} should remain unsupported — no VXLAN parse "
-                f"or render code exists in `cisco_iosxe_cli` "
-                f"(verified absence at commit `170a2c2` validation "
-                f"audit)."
+        supported = set(codec.capabilities.supported)
+        unsupported = {e.path for e in codec.capabilities.unsupported}
+        for path in ("/vxlan-vnis/vni", "/vxlan-vnis/source-interface",
+                     "/vxlan-vnis/mcast-group",
+                     "/routing-instances/instance/l3-vni"):
+            assert path in supported, (
+                f"{path} should be supported — promotion #16 wired "
+                f"parse (interface nve1 interception) + render (VTEP emit)."
             )
+            assert path not in unsupported, f"{path} must not be unsupported"
+
+    def test_udp_port_and_flood_list_lossy(self):
+        codec = _build_codec()
+        lossy = {e.path for e in codec.capabilities.lossy}
+        unsupported = {e.path for e in codec.capabilities.unsupported}
+        # udp-port: render emits no `vxlan udp-port` override (re-parses as
+        # 4789).  flood-list: no per-VNI static ingress-replication grammar.
+        for path in ("/vxlan-vnis/udp-port", "/vxlan-vnis/flood-list"):
+            assert path in lossy, (
+                f"{path} should be lossy — the NVE render keeps the VNI "
+                f"identity but drops this sub-detail (mirrors cisco_nxos)."
+            )
+            assert path not in unsupported, f"{path} must not be unsupported"

--- a/tests/unit/migration/test_cisco_iosxe_cli_vxlan_nve.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli_vxlan_nve.py
@@ -1,0 +1,191 @@
+"""cisco_iosxe_cli VXLAN-EVPN ``nve1`` harvest + render — promotion #16.
+
+Parse now intercepts ``interface nve1`` (mirrors cisco_nxos — the VTEP is
+an overlay container, not a routed/switched port) and correlates the
+``vlan configuration N / member [evpn-instance M] vni V`` bindings into
+``CanonicalVxlan`` records; render re-emits both.  The L3VNI (``member vni
+V vrf <name>``) lands on the matching ``CanonicalRoutingInstance.l3_vni``.
+
+Matrix: /vxlan-vnis/{vni,source-interface,mcast-group} +
+/routing-instances/instance/l3-vni are supported; /vxlan-vnis/udp-port +
+/vxlan-vnis/flood-list are lossy (the NVE render keeps the VNI identity but
+drops those sub-details).
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from netcanon.migration.canonical.intent import (
+    CanonicalIntent,
+    CanonicalRoutingInstance,
+    CanonicalVxlan,
+)
+from netcanon.migration.codecs.cisco_iosxe_cli.codec import CiscoIOSXECLICodec
+
+pytestmark = pytest.mark.unit
+
+_FIXTURE = (
+    pathlib.Path(__file__).parents[2]
+    / "fixtures" / "real" / "cisco_iosxe"
+    / "ciscolive_brkops1104_evpn_leaf_iosxe1715.txt"
+)
+
+
+def _codec() -> CiscoIOSXECLICodec:
+    return CiscoIOSXECLICodec()
+
+
+# ---------------------------------------------------------------------------
+# Real EVPN-leaf fixture
+# ---------------------------------------------------------------------------
+
+
+def test_real_fixture_harvests_l2_vni_and_intercepts_nve():
+    intent = _codec().parse(_FIXTURE.read_text(encoding="utf-8"))
+
+    # nve1 is intercepted — no generic CanonicalInterface materialises.
+    assert not any(i.name.lower().startswith("nve") for i in intent.interfaces)
+
+    # The one L2 VNI (VLAN 100 -> VNI 100100, multicast flood-and-learn).
+    assert len(intent.vxlan_vnis) == 1
+    vx = intent.vxlan_vnis[0]
+    assert vx.vlan_id == 100
+    assert vx.vni == 100100
+    assert vx.mcast_group == "239.0.0.100"
+    assert vx.source_interface == "Loopback2"
+
+    # The L3VNI (member vni 100200 vrf cml_demo) rides the routing instance.
+    by_vrf = {ri.name: ri for ri in intent.routing_instances}
+    assert by_vrf["cml_demo"].l3_vni == 100200
+    assert by_vrf["management"].l3_vni is None
+
+
+def test_real_fixture_round_trip_stable():
+    """parse -> render -> parse preserves the overlay (same-vendor lossless
+    on the wired surface).  The interception drops the iface count
+    identically on both parses, so the canonical tree is stable."""
+    codec = _codec()
+    a = codec.parse(_FIXTURE.read_text(encoding="utf-8"))
+    b = codec.parse(codec.render(a))
+
+    assert [(v.vlan_id, v.vni, v.mcast_group, v.source_interface)
+            for v in a.vxlan_vnis] == \
+           [(v.vlan_id, v.vni, v.mcast_group, v.source_interface)
+            for v in b.vxlan_vnis]
+    assert {ri.name: ri.l3_vni for ri in a.routing_instances} == \
+           {ri.name: ri.l3_vni for ri in b.routing_instances}
+    assert len(a.interfaces) == len(b.interfaces)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic round-trips (canonical -> render -> parse)
+# ---------------------------------------------------------------------------
+
+
+def _rt(intent: CanonicalIntent) -> CanonicalIntent:
+    codec = _codec()
+    return codec.parse(codec.render(intent))
+
+
+def test_l2_vni_multicast_round_trips():
+    src = CanonicalIntent(
+        hostname="leaf1",
+        vxlan_vnis=[CanonicalVxlan(
+            vlan_id=10, vni=10010, mcast_group="239.1.1.1",
+            source_interface="Loopback0")],
+    )
+    rp = _rt(src)
+    assert len(rp.vxlan_vnis) == 1
+    vx = rp.vxlan_vnis[0]
+    assert (vx.vlan_id, vx.vni, vx.mcast_group, vx.source_interface) == \
+           (10, 10010, "239.1.1.1", "Loopback0")
+
+
+def test_l2_vni_headend_bare_round_trips_vni_without_mcast():
+    """A head-end (BGP-EVPN) L2 VNI with no multicast group re-parses with an
+    empty mcast_group — the VNI identity survives, mcast simply isn't set."""
+    src = CanonicalIntent(
+        hostname="leaf1",
+        vxlan_vnis=[CanonicalVxlan(
+            vlan_id=20, vni=10020, source_interface="Loopback0")],
+    )
+    rp = _rt(src)
+    assert len(rp.vxlan_vnis) == 1
+    assert rp.vxlan_vnis[0].vni == 10020
+    assert rp.vxlan_vnis[0].mcast_group == ""
+
+
+def test_l3vni_round_trips_onto_routing_instance():
+    src = CanonicalIntent(
+        hostname="border1",
+        routing_instances=[CanonicalRoutingInstance(
+            name="TENANT_A", route_distinguisher="65000:1", l3_vni=50010)],
+        vxlan_vnis=[CanonicalVxlan(
+            vlan_id=30, vni=10030, source_interface="Loopback0")],
+    )
+    rp = _rt(src)
+    by_vrf = {ri.name: ri for ri in rp.routing_instances}
+    assert by_vrf["TENANT_A"].l3_vni == 50010
+
+
+def test_multiple_l2_vnis_round_trip():
+    src = CanonicalIntent(
+        hostname="leaf2",
+        vxlan_vnis=[
+            CanonicalVxlan(vlan_id=10, vni=10010, mcast_group="239.1.1.1",
+                           source_interface="Loopback0"),
+            CanonicalVxlan(vlan_id=20, vni=10020,
+                           source_interface="Loopback0"),
+        ],
+    )
+    rp = _rt(src)
+    got = sorted((v.vlan_id, v.vni, v.mcast_group) for v in rp.vxlan_vnis)
+    assert got == [(10, 10010, "239.1.1.1"), (20, 10020, "")]
+
+
+def test_flood_list_drops_but_vni_survives():
+    """Head-end static ingress-replication peers (flood_list) have no IOS-XE
+    nve1 grammar — declared lossy.  The VNI identity survives; the peers drop."""
+    src = CanonicalIntent(
+        hostname="leaf3",
+        vxlan_vnis=[CanonicalVxlan(
+            vlan_id=40, vni=10040, flood_list=["10.0.0.5", "10.0.0.6"],
+            source_interface="Loopback0")],
+    )
+    rp = _rt(src)
+    assert len(rp.vxlan_vnis) == 1
+    assert rp.vxlan_vnis[0].vni == 10040
+    assert rp.vxlan_vnis[0].flood_list == []
+
+
+# ---------------------------------------------------------------------------
+# Negative control — no overlay
+# ---------------------------------------------------------------------------
+
+
+def test_no_nve_config_yields_empty_vxlan():
+    raw = (
+        "hostname plain\n"
+        "!\n"
+        "interface GigabitEthernet0/1\n"
+        " ip address 10.0.0.1 255.255.255.0\n"
+        "!\n"
+        "vlan 10\n"
+        " name USERS\n"
+        "!\n"
+    )
+    intent = _codec().parse(raw)
+    assert intent.vxlan_vnis == []
+    assert all(ri.l3_vni is None for ri in intent.routing_instances)
+
+
+def test_matrix_dispositions():
+    caps = _codec().capabilities
+    assert caps.classify("/vxlan-vnis/vni") == "supported"
+    assert caps.classify("/vxlan-vnis/source-interface") == "supported"
+    assert caps.classify("/vxlan-vnis/mcast-group") == "supported"
+    assert caps.classify("/routing-instances/instance/l3-vni") == "supported"
+    assert caps.classify("/vxlan-vnis/udp-port") == "lossy"
+    assert caps.classify("/vxlan-vnis/flood-list") == "lossy"


### PR DESCRIPTION
## Promotion #16 — cisco_iosxe_cli VXLAN-EVPN `nve1`

Graduates `/vxlan-vnis/{vni,source-interface,mcast-group}` from **unsupported → supported** on the IOS-XE CLI codec by porting the proven `cisco_nxos` `nve1`-interception pattern.

### Before
On the committed EVPN-leaf fixture (`ciscolive_brkops1104_evpn_leaf_iosxe1715.txt`), `parse_intent(raw).vxlan_vnis == []`, `nve1` materialised as a generic `CanonicalInterface`, and a same-vendor re-render emitted a **gutted bare `interface nve1`** — every overlay line silently dropped.

### After
- **Parse** intercepts `interface nve1` in `_open` (returns `None`, mirroring `cisco_nxos`), so it never becomes a generic interface. `_parse_vxlan` correlates the `vlan configuration N / member [evpn-instance M] vni V` bindings with the `nve1` body to build `CanonicalVxlan` records (vlan_id + vni + source-interface + per-VNI mcast-group) and harvests the L3VNI (`member vni V vrf <name>`) onto `CanonicalRoutingInstance.l3_vni`.
- **Render** re-emits both the `vlan configuration` bindings and the `interface nve1` VTEP, so the overlay round-trips same-vendor.
- **Matrix**: `vni` / `source-interface` / `mcast-group` + `/routing-instances/instance/l3-vni` are supported; `udp-port` + `flood-list` are **lossy** (the NVE render keeps the VNI identity but has no `vxlan udp-port` override / head-end static ingress-replication grammar).

### Guard entanglements handled
- Rewrote the two HARD pins `test_capability_matrix_vrf_lossy::TestVxlanNveSupported` and `test_capability_matrix_acl_unsupported::test_existing_unsupported_paths_preserved` to the graduated dispositions.
- Registry honesty guards (`test_registry_capability_honesty`, `test_silent_loss_list_subfields`) pass: mcast-group round-trips, flood-list/udp-port are declared lossy, every emitted xpath is walkable and not-unsupported.

### Cross-vendor / mesh
- Re-baselined the Phase-4 reconciliation: **CODEC_BUG stays 5**, `cells_total == 1224`, no new codec-bug pairs, YAML coverage unchanged.
- Expectation truth-maintenance: `iosxe↔{arista,junos}` vxlan cells flip to `good`/`lossy` (they now preserve — top-level `lossy` on the source direction because the target drops mcast, avoiding a false CODEC_BUG); `junos↔iosxe` `l3_vni` → `good`; five `iosxe→target` full-drop reasons re-attributed to the target (disposition unchanged).

### Tests
New `test_cisco_iosxe_cli_vxlan_nve.py`: real-fixture harvest + interception, same-vendor round-trip, synthetic L2/L3VNI/multi-VNI round-trips, flood-list drop, and a no-overlay negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
