### PR TITLE
feat(codecs): harvest /system/syslog-server on cisco_iosxe_cli + arista_eos (promotions #1/#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,10 @@ across vendors.  Full per-codec matrix is in
   VRF binding), VLANs, static routes.  Every shipped codec parses +
   renders these fully (the experimental `cisco_iosxe` NETCONF stub
   excepted — it renders interfaces only).  DNS / NTP servers translate
-  on most codecs; `syslog` servers and `timezone` are wired on only a
-  subset — check the per-codec matrices in
+  on most codecs; `syslog` servers translate on `juniper_junos`,
+  `cisco_iosxe_cli`, and `arista_eos` (`logging host <ip>` /
+  `set system syslog host <ip>`), while `timezone` is wired on no codec
+  — check the per-codec matrices in
   [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md), and note that where a
   codec doesn't wire a field the source-side value is currently dropped
   without a banner.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -91,12 +91,14 @@ names the canonical surface, not a blanket guarantee.
   see Tier 2 ship-before-wire note below)
 * `dns_servers`, `ntp_servers` — wired on most codecs (not all: e.g.
   cisco_nxos / cisco_iosxr render-drop the management plane); plus
-  `syslog_servers` and `timezone`, which are schema slots wired on only
-  a **subset** of codecs (`timezone` on none as of this release;
-  `syslog_servers` on juniper_junos).  These two are Tier-1 by data
-  shape but NOT a cross-vendor guarantee — the §A per-codec panels are
-  authoritative, and an unwired field is currently dropped silently on
-  parse.
+  `syslog_servers` and `timezone`, which are wired on only a
+  **subset** of codecs: `timezone` on none as of this release;
+  `syslog_servers` on juniper_junos, cisco_iosxe_cli, and arista_eos
+  (`logging host <ip>` harvest + render, promotions #1/#11).  These are
+  Tier-1 by data shape but NOT yet a cross-vendor guarantee — the §A
+  per-codec panels are authoritative, and an unwired field is dropped
+  on parse (with a banner where the codec declares it unsupported,
+  silently otherwise).
 * `interfaces[].vrrp_groups` (v0.2.0 Wave B — classic FHRP
   redundancy, mode discriminator `vrrp` / `hsrp` / `carp`) — wired
   across the bidirectional codecs.  See

--- a/docs/vendors/arista_eos.md
+++ b/docs/vendors/arista_eos.md
@@ -19,9 +19,10 @@ corpus yet — operator captures from EOS 4.27+ are welcome (see
 
 [Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable):
 
-- `hostname`, `domain`, DNS / NTP servers (`syslog_servers` and
-  `timezone` are declared **unsupported** on this codec — see the
-  capability matrix; they do not round-trip)
+- `hostname`, `domain`, DNS / NTP / `syslog_servers` (`logging host
+  <ip>` harvest + render, promotion #11).  `timezone` is declared
+  **unsupported** on this codec — see the capability matrix; it does
+  not round-trip.
 - Interfaces — `Ethernet<N>` and QSFP-breakout `Ethernet<N>/<M>`,
   Loopback, Management1; descriptions, IPv4 + IPv6, VRF binding
 - VLANs — ID, name, tagged/untagged member lists

--- a/docs/vendors/cisco_iosxe.md
+++ b/docs/vendors/cisco_iosxe.md
@@ -24,10 +24,11 @@ vendors (or vice versa), use `cisco_iosxe_cli`.
 [Tier 1](../CAPABILITIES.md#tier-1--auto-translatable-cross-vendor-stable)
 — auto-translatable:
 
-- `hostname`, `domain`, DNS / NTP servers (`syslog_servers` and
-  `timezone` are declared **unsupported** in the capability matrix and
-  do not round-trip; the NETCONF `cisco_iosxe` stub renders interfaces
-  only, so the rest of this list applies to `cisco_iosxe_cli`)
+- `hostname`, `domain`, DNS / NTP / `syslog_servers` (`logging host
+  <ip>` harvest + render, promotion #1 — applies to `cisco_iosxe_cli`).
+  `timezone` is declared **unsupported** in the capability matrix and
+  does not round-trip; the NETCONF `cisco_iosxe` stub renders interfaces
+  only, so the rest of this list applies to `cisco_iosxe_cli`.
 - Interfaces — name, description, enabled state, IPv4 + IPv6
   addresses, MTU, VRF binding, `kind` override
 - VLANs — ID, name, tagged/untagged port lists, SVI L3 (via

--- a/netcanon/migration/canonical/README.md
+++ b/netcanon/migration/canonical/README.md
@@ -192,12 +192,14 @@ and the codec's `CapabilityMatrix` declarations:
   `domain`, `interfaces`, `vlans`, `static_routes` — are wired on every
   bidirectional codec, and a codec that fails to wire one of these is a
   bug, not a gap.  `dns_servers` / `ntp_servers` are wired on most
-  codecs; `timezone` and `syslog_servers` are Tier-1 *schema slots* that
-  are wired on only a subset (`timezone` on none as of this release;
-  `syslog_servers` on `juniper_junos`) — for these two, an unwired codec
-  is a known gap declared `unsupported` in its `CapabilityMatrix`, not a
-  bug, and the source-side value is currently dropped on parse without a
-  banner.  Per-codec truth lives in the `CapabilityMatrix` tables.
+  codecs; `timezone` and `syslog_servers` are wired on only a subset
+  (`timezone` on none as of this release; `syslog_servers` on
+  `juniper_junos`, `cisco_iosxe_cli`, and `arista_eos` — `logging host
+  <ip>` / `set system syslog host <ip>`, promotions #1/#11) — for these
+  two, an unwired codec is a known gap (declared `unsupported` in its
+  `CapabilityMatrix` where the drop should raise the cross-vendor
+  banner, otherwise dropped silently on parse), not a bug.  Per-codec
+  truth lives in the `CapabilityMatrix` tables.
 * **Tier 2 — auto-translate with review.**  Common enough to model;
   vendor mappings are partially lossy.  Fields: `dhcp_servers`,
   `snmp` (community + v3 users), `lags`, `local_users`,

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -852,10 +852,14 @@ class CanonicalIntent(BaseModel):
             ``/system/timezone`` unsupported); a source-side value is
             currently dropped on parse.  Kept Tier-1 by data shape, not
             a cross-vendor round-trip guarantee — see docs/CAPABILITIES.md.
-        syslog_servers: Tier 1 *schema slot* — syslog destination IPs /
-            hostnames.  NOTE: wired on ``juniper_junos`` only as of this
-            release; other codecs declare it unsupported and drop it on
-            parse.  Tier-1 by data shape, not a universal guarantee.
+        syslog_servers: Tier 1 — syslog destination IPs.  Wired
+            (parse harvest + render emit + declared-``supported``) on
+            ``juniper_junos`` (``set system syslog host <ip>``),
+            ``cisco_iosxe_cli`` and ``arista_eos`` (``logging host <ip>``,
+            promotions #1/#11).  Other codecs still drop it — the ones
+            that declare it ``unsupported`` surface the cross-vendor
+            banner; the rest fall through to an implicit drop.  Not yet a
+            universal round-trip guarantee — see docs/CAPABILITIES.md.
         interfaces: Tier 1 — per-interface configuration records.
         vlans: Tier 1 — VLAN definitions with port membership.
         static_routes: Tier 1 — static route entries.

--- a/netcanon/migration/codecs/arista_eos/codec.py
+++ b/netcanon/migration/codecs/arista_eos/codec.py
@@ -105,6 +105,7 @@ class AristaEOSCodec(CodecBase):
             "/system/hostname",
             "/system/dns-server",
             "/system/ntp-server",
+            "/system/syslog-server",   # promotion #11 — `logging host <ip>` harvest + render
             "/interfaces/interface/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
@@ -337,10 +338,6 @@ class AristaEOSCodec(CodecBase):
             UnsupportedPath(
                 path="/system/timezone",
                 reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/syslog-server",
-                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
             ),
             UnsupportedPath(
                 path="/routing/bgp",

--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -85,6 +85,14 @@ _NTP_SERVER_RE = re.compile(
     r"^ntp server\s+(?:vrf\s+\S+\s+)?(\S+)",
     re.MULTILINE,
 )
+# Syslog destinations.  EOS spells these ``logging host <ip>`` /
+# ``logging vrf <name> host <ip>``, but ``logging`` also fronts a large family
+# of NON-destination sub-commands (``logging buffered``, ``logging trap``,
+# ``logging level``, ``logging format`` …).  Harvest the FIRST IP-literal token
+# on any ``logging`` line and validate it with :mod:`ipaddress` — a numeric
+# sub-command argument is never a valid IPv4/IPv6 literal, so the guard rejects
+# the noise structurally (mirrors cisco_iosxe_cli ``_SYSLOG_LINE_RE``).
+_SYSLOG_LINE_RE = re.compile(r"^\s*logging\s+(\S.*)$", re.IGNORECASE | re.MULTILINE)
 _IP_ROUTE_RE = re.compile(
     # ``ip route 0.0.0.0/0 10.0.0.1`` or ``ip route 10.0.0.0/8 Null0``,
     # plus the per-VRF form ``ip route vrf MGMT 0.0.0.0/0 192.168.2.1``.
@@ -478,6 +486,17 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         intent.domain = m.group(1)
     for ntp_m in _NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(ntp_m.group(1))
+    for syslog_m in _SYSLOG_LINE_RE.finditer(raw):
+        # First IP-literal token on the ``logging`` line is the syslog host;
+        # non-destination sub-commands carry no IP token.  De-dup, first-seen.
+        for token in syslog_m.group(1).split():
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                continue
+            if token not in intent.syslog_servers:
+                intent.syslog_servers.append(token)
+            break
     for route_m in _IP_ROUTE_RE.finditer(raw):
         vrf, ip, prefix, next_hop, distance = route_m.groups()
         # A next hop is either an IP literal (gateway) or an interface name

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -205,6 +205,10 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         for ntp in tree.ntp_servers:
             out.append(f"ntp server {ntp}")
         out.append("!")
+    if tree.syslog_servers:
+        for syslog in tree.syslog_servers:
+            out.append(f"logging host {syslog}")
+        out.append("!")
 
     if tree.snmp is not None:
         if tree.snmp.community:

--- a/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/codec.py
@@ -110,6 +110,7 @@ class CiscoIOSXECLICodec(CodecBase):
         device_classes=[DeviceClass.router, DeviceClass.switch],
         supported=[
             "/system/hostname",
+            "/system/syslog-server",   # promotion #1 — `logging host <ip>` harvest + render
             "/interfaces/interface/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
@@ -365,10 +366,6 @@ class CiscoIOSXECLICodec(CodecBase):
             UnsupportedPath(
                 path="/system/timezone",
                 reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/syslog-server",
-                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
             ),
             UnsupportedPath(
                 path="/interfaces/interface/subinterfaces/subinterface/ipv6",

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -407,6 +407,20 @@ _TOP_NTP_SERVER_RE = re.compile(
     r"^ntp\s+server\s+(?:vrf\s+\S+\s+)?(\S+)",
     re.IGNORECASE | re.MULTILINE,
 )
+# Syslog destinations.  The IOS / IOS-XE / IOS-XR / NX-OS families all spell
+# the target host differently — ``logging <ip>`` (classic / IOS-XR),
+# ``logging host <ip>``, ``logging host {ipv4|ipv6|<vrf>} <ip>``,
+# ``logging vrf <name> host <ip>``, ``logging server <ip>`` (NX-OS) — and the
+# very same ``logging`` keyword introduces a large family of NON-destination
+# sub-commands (``logging buffered 5000``, ``logging trap 6``, ``logging
+# console 3``, ``logging facility local0``, ``logging message 1222444`` …).
+# Rather than enumerate every sub-command, harvest the FIRST IP-literal token
+# on any ``logging`` line and validate it with :mod:`ipaddress` (see
+# :func:`_parse_globals`): a numeric sub-command argument (buffer size,
+# severity level, message id, UDP port) is never a valid IPv4/IPv6 literal, so
+# the guard rejects the noise structurally.  Mirrors the opnsense resolved-
+# next-hop IP guard.
+_SYSLOG_LINE_RE = re.compile(r"^\s*logging\s+(\S.*)$", re.IGNORECASE | re.MULTILINE)
 
 # ``vrf definition <name>`` opens a VRF stanza; sub-commands include
 # ``description X``, ``rd <rd>``, ``route-target {import|export|both}
@@ -663,6 +677,12 @@ def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
     * ``ntp server [vrf <name>] <ip>`` →
       :attr:`CanonicalIntent.ntp_servers`.  One server per line
       (unlike name-server).  Mirrors arista_eos prior art.
+    * ``logging <ip>`` / ``logging host [ipv4|ipv6|<vrf>] <ip>`` /
+      ``logging vrf <name> host <ip>`` / ``logging server <ip>`` →
+      :attr:`CanonicalIntent.syslog_servers`.  See :data:`_SYSLOG_LINE_RE`
+      for why the harvest is an IP-literal guard rather than a keyword
+      grammar — the ``logging`` keyword also introduces dozens of non-
+      destination sub-commands.  De-duplicated, first-seen order preserved.
 
     The helper mutates ``intent`` in place — keeps :func:`parse_intent`
     a flat sequence of phase calls.
@@ -677,6 +697,19 @@ def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
         intent.domain = m.group(1)
     for m in _TOP_NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(m.group(1))
+    for m in _SYSLOG_LINE_RE.finditer(raw):
+        # Harvest the first token on the ``logging`` line that is a valid
+        # IPv4/IPv6 literal — that is the destination host.  Non-destination
+        # sub-commands (buffer sizes, severities, message ids) carry no IP
+        # token, so they contribute nothing.  De-dup, first-seen order.
+        for token in m.group(1).split():
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                continue
+            if token not in intent.syslog_servers:
+                intent.syslog_servers.append(token)
+            break
 
 
 def _parse_routing_instances(raw: str) -> list[CanonicalRoutingInstance]:

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -121,6 +121,9 @@ class JunosCodec(CodecBase):
         device_classes=[DeviceClass.switch, DeviceClass.router],
         supported=[
             "/system/hostname",
+            # `set system syslog host <ip>` — parse+render; was implicit-
+            # supported, declared explicit alongside promotions #1/#11.
+            "/system/syslog-server",
             "/interfaces/interface/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__aruba_aoss.yaml
@@ -168,11 +168,11 @@ per_field_expectation:
     references: [system_services]
 
   syslog_servers:
-    disposition: good
-    note: >
-      Arista ``logging host <addr>`` -> Aruba ``logging <addr>``.
-      Both vendors round-trip the host list cleanly.  Severity /
-      facility tokens drop (canonical surface is host-list-only).
+    disposition: unsupported
+    reason: >
+      aruba_aoss declares ``/system/syslog-server`` unsupported and its
+      render emits no logging/syslog stanza, so the source host list
+      drops on migration and the cross-vendor unsupported banner fires.
     references: [system_services]
 
   interfaces:

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__juniper_junos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__juniper_junos.yaml
@@ -109,8 +109,14 @@ per_field_expectation:
     reason: "Both vendors accept Olson timezone names but Arista accepts both abbreviations (PST/EST) and Olson IDs while Junos requires Olson IDs (America/Los_Angeles). Round-trip of operator-typed PST -> Junos requires translation; canonical model preserves the source string verbatim so operator may need to adjust."
 
   syslog_servers:
-    disposition: lossy
-    reason: "Junos requires explicit per-host facility/severity filters via 'set system syslog host X any info'; Arista's 'logging host X' has implicit any-any. Basic mapping works; per-severity filters drift."
+    disposition: good
+    reason: >
+      Both endpoints carry the syslog destination host LIST -- the only
+      syslog surface the canonical model represents -- so it round-trips
+      cleanly (promotions #1/#11).  Per-host severity/facility filters
+      (Junos ``any info`` vs the Cisco/Arista device-global ``logging
+      trap`` level) are NOT modelled canonically; that nuance is out of
+      scope for this cell, not a loss of the modelled surface.
     references: [junos-iface-fundamentals]
 
   # ── Tier 1 — interfaces ──

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__aruba_aoss.yaml
@@ -157,12 +157,11 @@ per_field_expectation:
     references: [system_services]
 
   syslog_servers:
-    disposition: good
-    note: >
-      Cisco ``logging host <addr>`` -> Aruba ``logging <addr>``.
-      Both vendors round-trip the host list cleanly.  Severity /
-      facility tokens (``logging trap informational``, ``logging
-      facility local6``) are not modelled — drop on round-trip.
+    disposition: unsupported
+    reason: >
+      aruba_aoss declares ``/system/syslog-server`` unsupported and its
+      render emits no logging/syslog stanza, so the source host list
+      drops on migration and the cross-vendor unsupported banner fires.
     references: [system_services]
 
   interfaces:

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__juniper_junos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__juniper_junos.yaml
@@ -277,12 +277,14 @@ per_field_expectation:
     references: [cisco-fundamentals, junos-initial-config]
 
   syslog_servers:
-    disposition: lossy
+    disposition: good
     reason: >
-      Cisco's ``logging host X`` (implicit any-severity) maps to
-      Junos's ``set system syslog host X any info`` (severity
-      required).  Host list round-trips; per-facility / severity
-      filters are not modelled canonically.
+      Both endpoints carry the syslog destination host LIST -- the only
+      syslog surface the canonical model represents -- so it round-trips
+      cleanly (promotions #1/#11).  Per-host severity/facility filters
+      (Junos ``any info`` vs the Cisco/Arista device-global ``logging
+      trap`` level) are NOT modelled canonically; that nuance is out of
+      scope for this cell, not a loss of the modelled surface.
     references: [cisco-fundamentals, junos-syslog-overview]
 
   # ── Tier 1 — interfaces ──

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__arista_eos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__arista_eos.yaml
@@ -234,8 +234,14 @@ per_field_expectation:
     references: [junos-initial-config, arista-system-management]
 
   syslog_servers:
-    disposition: lossy
-    reason: "Junos's 'set system syslog host X any info' carries per-host facility / severity filters; Arista's 'logging host X' has implicit any-any with severity gating at the device-global 'logging trap' level. Host list survives; per-host facility map drops on canonical layer."
+    disposition: good
+    reason: >
+      Both endpoints carry the syslog destination host LIST -- the only
+      syslog surface the canonical model represents -- so it round-trips
+      cleanly (promotions #1/#11).  Per-host severity/facility filters
+      (Junos ``any info`` vs the Cisco/Arista device-global ``logging
+      trap`` level) are NOT modelled canonically; that nuance is out of
+      scope for this cell, not a loss of the modelled surface.
     references: [junos-syslog-overview, arista-system-management]
 
   # ── Tier 1 — interfaces ──

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__cisco_iosxe_cli.yaml
@@ -289,12 +289,14 @@ per_field_expectation:
     references: [junos-initial-config, cisco-fundamentals]
 
   syslog_servers:
-    disposition: lossy
+    disposition: good
     reason: >
-      Junos's ``set system syslog host X any info`` (severity
-      required) maps to Cisco's ``logging host X`` (severity
-      implicit).  Host list round-trips; per-facility / severity
-      filters are not modelled canonically.
+      Both endpoints carry the syslog destination host LIST -- the only
+      syslog surface the canonical model represents -- so it round-trips
+      cleanly (promotions #1/#11).  Per-host severity/facility filters
+      (Junos ``any info`` vs the Cisco/Arista device-global ``logging
+      trap`` level) are NOT modelled canonically; that nuance is out of
+      scope for this cell, not a loss of the modelled surface.
     references: [junos-syslog-overview, cisco-fundamentals]
 
   # ── Tier 1 — interfaces ──

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -12,14 +12,14 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 
 | Variance class | Count | Severity |
 |---|---:|---|
-| ALIGNED | 1658 | ok |
+| ALIGNED | 1678 | ok |
 | CODEC_BUG | 5 | **high** |
 | EXPECTED_LOSSY | 1229 | ok |
-| EXPECTED_UNSUPPORTED | 724 | ok |
+| EXPECTED_UNSUPPORTED | 732 | ok |
 | METHODOLOGY_ISSUE_under | 925 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
 | STRUCTURAL_ONLY | 1179 | low |
-| TRIVIAL_EMPTY | 9554 | ok |
+| TRIVIAL_EMPTY | 9526 | ok |
 | **Total field-cells classified** | **15299** | |
 
 Severity roll-up: 5 high, 107 medium, 2022 low, 13165 ok.

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-12T17:00:43+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T164327Z.json",
-  "mesh_run_started_utc": "2026-07-12T16:43:21+00:00",
+  "started_utc": "2026-07-12T20:03:47+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T195055Z.json",
+  "mesh_run_started_utc": "2026-07-12T19:50:49+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4134,14 +4134,14 @@
     }
   ],
   "aggregate": {
-    "ALIGNED": 1658,
+    "ALIGNED": 1678,
     "CODEC_BUG": 5,
     "EXPECTED_LOSSY": 1229,
-    "EXPECTED_UNSUPPORTED": 724,
+    "EXPECTED_UNSUPPORTED": 732,
     "METHODOLOGY_ISSUE_under": 925,
     "METHODOLOGY_ISSUE_over": 25,
     "STRUCTURAL_ONLY": 1179,
-    "TRIVIAL_EMPTY": 9554,
+    "TRIVIAL_EMPTY": 9526,
     "fields_total": 15299,
     "severity_high": 5,
     "severity_medium": 107,
@@ -4191,22 +4191,22 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 30
+      "drifted_total": 31
     },
     {
       "source_codec": "arista_eos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 34
+      "drifted_total": 35
     },
     {
       "source_codec": "arista_eos",
       "target_codec": "cisco_nxos",
-      "drifted_total": 30
+      "drifted_total": 31
     },
     {
       "source_codec": "arista_eos",
       "target_codec": "vyos",
-      "drifted_total": 25
+      "drifted_total": 26
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4321,7 +4321,7 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 37
+      "drifted_total": 40
     },
     {
       "source_codec": "cisco_iosxe_cli",
@@ -4331,17 +4331,17 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 32
+      "drifted_total": 35
     },
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "cisco_nxos",
-      "drifted_total": 30
+      "drifted_total": 33
     },
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "vyos",
-      "drifted_total": 30
+      "drifted_total": 33
     },
     {
       "source_codec": "cisco_iosxr",
@@ -6377,7 +6377,7 @@
         },
         "syslog_servers": {
           "actual": "trivially_preserved",
-          "expected": "lossy",
+          "expected": "good",
           "variance": "TRIVIAL_EMPTY",
           "severity": "ok"
         },

--- a/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
+++ b/tests/unit/migration/codecs/cisco_iosxe_cli/test_walk_canonical_coverage.py
@@ -53,7 +53,7 @@ def _kitchen_sink() -> CanonicalIntent:
         dns_servers=["10.0.0.53"],
         ntp_servers=["10.0.0.123"],
         timezone="UTC",
-        syslog_servers=["10.0.0.514"],
+        syslog_servers=["10.0.5.14"],
         interfaces=[
             CanonicalInterface(
                 name="GigabitEthernet1/0/1",

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -185,7 +185,7 @@ def _maximal_intent() -> CanonicalIntent:
     return CanonicalIntent(
         hostname="h", domain="d.test", dns_servers=["10.0.0.53"],
         ntp_servers=["10.0.0.123"], timezone="UTC",
-        syslog_servers=["10.0.0.514"],
+        syslog_servers=["10.0.5.14"],  # valid IPv4 (octets <=255); iosxe_cli/arista IP-guard reparse it
         interfaces=[iface, iface2],
         vlans=[CanonicalVlan(
             id=10, name="V", description="desc",

--- a/tests/unit/migration/test_syslog_harvest.py
+++ b/tests/unit/migration/test_syslog_harvest.py
@@ -1,0 +1,127 @@
+"""Round-trip + honesty coverage for the ``/system/syslog-server`` harvest
+(promotions #1 cisco_iosxe_cli, #11 arista_eos).
+
+The three codecs that genuinely wire syslog — ``juniper_junos``
+(``set system syslog host <ip>``), ``cisco_iosxe_cli`` and ``arista_eos``
+(``logging host <ip>``) — must:
+
+* harvest the destination host out of the vendor ``logging`` grammar,
+  IGNORING the large family of non-destination ``logging`` sub-commands
+  (buffer sizes, severities, message ids, UDP ports …) via an IP-literal
+  guard;
+* round-trip that host back on render (same-vendor stability);
+* classify ``/system/syslog-server`` as ``supported`` (explicit list).
+
+The adversarial ``batfish_cisco_logging.txt`` fixture is the minefield: a
+``logging <everything>`` dump where the true destinations are buried among
+dozens of look-alike sub-commands.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from netcanon.migration.codecs.registry import get_codec
+
+pytestmark = pytest.mark.unit
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "real"
+_BATFISH = _FIXTURES / "cisco_iosxe" / "batfish_cisco_logging.txt"
+_KSATOR = _FIXTURES / "arista_eos" / "ksator_dcs_7150s64_eos4224.txt"
+
+# The six distinct true destinations in the batfish minefield, first-seen order.
+_BATFISH_HOSTS = [
+    "1.2.3.4", "dead:beef::1", "10.246.131.130",
+    "10.246.131.138", "1.1.1.1", "11.2.3.4",
+]
+# Non-destination numeric arguments that MUST NOT be harvested as "servers".
+_BATFISH_NOISE = {
+    "5000", "5", "100000", "512", "6", "3", "0", "100", "9", "10", "25",
+    "1222444", "1233334", "1111234", "32000", "12345", "514", "50000",
+}
+
+
+class TestIosxeCliSyslogHarvest:
+    def test_harvests_only_true_hosts_from_minefield(self) -> None:
+        codec = get_codec("cisco_iosxe_cli")
+        got = codec.parse(_BATFISH.read_text()).syslog_servers
+        assert got == _BATFISH_HOSTS
+
+    def test_no_noise_token_leaks(self) -> None:
+        codec = get_codec("cisco_iosxe_cli")
+        got = set(codec.parse(_BATFISH.read_text()).syslog_servers)
+        assert not (_BATFISH_NOISE & got)
+
+    def test_same_vendor_round_trip_is_stable(self) -> None:
+        codec = get_codec("cisco_iosxe_cli")
+        intent = codec.parse(_BATFISH.read_text())
+        reparsed = codec.parse(codec.render(intent))
+        assert reparsed.syslog_servers == _BATFISH_HOSTS
+
+    def test_render_emits_logging_host(self) -> None:
+        codec = get_codec("cisco_iosxe_cli")
+        rendered = codec.render(codec.parse("logging host 10.9.9.9\n"))
+        assert "logging host 10.9.9.9" in rendered
+
+    def test_classify_supported(self) -> None:
+        caps = get_codec("cisco_iosxe_cli").capabilities
+        assert caps.classify("/system/syslog-server") == "supported"
+        assert "/system/syslog-server" in set(caps.supported)
+
+
+class TestAristaSyslogHarvest:
+    def test_harvests_host_from_ksator(self) -> None:
+        codec = get_codec("arista_eos")
+        got = codec.parse(_KSATOR.read_text()).syslog_servers
+        assert got == ["10.83.28.52"]
+
+    def test_render_emits_logging_host(self) -> None:
+        codec = get_codec("arista_eos")
+        rendered = codec.render(codec.parse("logging host 10.83.28.52\n"))
+        assert "logging host 10.83.28.52" in rendered
+
+    def test_same_vendor_round_trip_is_stable(self) -> None:
+        codec = get_codec("arista_eos")
+        intent = codec.parse(_KSATOR.read_text())
+        reparsed = codec.parse(codec.render(intent))
+        assert reparsed.syslog_servers == ["10.83.28.52"]
+
+    def test_classify_supported(self) -> None:
+        caps = get_codec("arista_eos").capabilities
+        assert caps.classify("/system/syslog-server") == "supported"
+        assert "/system/syslog-server" in set(caps.supported)
+
+    def test_noise_only_config_harvests_nothing(self) -> None:
+        # A `logging` config with NO host destination must yield an empty list
+        # and render no `logging host` line.
+        codec = get_codec("arista_eos")
+        noise = "logging buffered 5000\nlogging trap informational\n"
+        intent = codec.parse(noise)
+        assert intent.syslog_servers == []
+        assert "logging host" not in codec.render(intent)
+
+
+class TestCrossVendorSyslogPreserve:
+    """A syslog host survives across each wired pair."""
+
+    @pytest.mark.parametrize("target", ["cisco_iosxe_cli", "arista_eos", "juniper_junos"])
+    def test_arista_source_preserves_to_wired_target(self, target: str) -> None:
+        arista = get_codec("arista_eos")
+        tgt = get_codec(target)
+        intent = arista.parse(_KSATOR.read_text())
+        # Render to the target, then read it back with the target's own parser.
+        reparsed = tgt.parse(tgt.render(intent))
+        assert "10.83.28.52" in reparsed.syslog_servers
+
+
+class TestInvalidIpRejected:
+    """The IP-literal guard rejects tokens that are not valid IPv4/IPv6 — this
+    is why a bare-hostname syslog target is a known (documented) gap and why
+    an out-of-range dotted quad (``10.0.0.514``) is not mistaken for a host."""
+
+    @pytest.mark.parametrize("codec_name", ["cisco_iosxe_cli", "arista_eos"])
+    def test_out_of_range_quad_not_harvested(self, codec_name: str) -> None:
+        codec = get_codec(codec_name)
+        got = codec.parse("logging host 10.0.0.514\n").syslog_servers
+        assert got == []

--- a/tests/unit/migration/test_tier1_wiring_honesty.py
+++ b/tests/unit/migration/test_tier1_wiring_honesty.py
@@ -2,17 +2,20 @@
 
 The 2026-07-06 Fable review found the Tier-1 promise (README, CAPABILITIES.md,
 canonical/README.md, intent.py, several vendor pages) claimed ``timezone`` and
-``syslog_servers`` round-trip on every shipped codec, while ``timezone`` is
-wired on **none** and ``syslog_servers`` is declared-supported on **none**
-(juniper_junos renders it via a fail-open undeclared path).  The docs were
-corrected to say so.
+``syslog_servers`` round-trip on every shipped codec, while ``timezone`` was
+wired on **none** and ``syslog_servers`` on only ``juniper_junos`` (via a
+fail-open undeclared path).  The docs were corrected to say so.
 
-These guards pin the underlying matrix facts so a future codec that wires
-either field trips the test — forcing the Tier-1 docs to be updated in
-lockstep rather than silently drifting back into the over-promise.  They also
-lock the honesty property that ``timezone``'s drop is *declared* (so the
-cross-vendor unsupported banner fires) rather than undeclared (fail-open =
-silent loss).
+Since then the syslog surface graduated on two more codecs — ``cisco_iosxe_cli``
+and ``arista_eos`` now parse-harvest + render ``logging host <ip>`` (promotions
+#1/#11), and ``juniper_junos``'s existing round-trip was declared explicit — so
+the roster is now ``{arista_eos, cisco_iosxe_cli, juniper_junos}``.
+
+These guards pin the underlying matrix facts so a codec that wires (or
+regresses) either field trips the test — forcing the Tier-1 docs to be updated
+in lockstep rather than silently drifting.  They also lock the honesty property
+that ``timezone``'s drop is *declared* (so the cross-vendor unsupported banner
+fires) rather than undeclared (fail-open = silent loss).
 """
 
 from __future__ import annotations
@@ -55,16 +58,25 @@ def test_timezone_declared_unsupported_on_every_codec() -> None:
     )
 
 
-def test_syslog_not_declared_supported_on_any_codec() -> None:
-    """No codec lists `/system/syslog-server` under ``supported`` — the docs
-    say it is wired narrowly (juniper_junos, via a fail-open undeclared
-    path), not a cross-vendor Tier-1 guarantee.  If a codec adds it to
-    ``supported``, update the Tier-1 docs alongside."""
-    offenders = [
+# Codecs that genuinely round-trip syslog (parse harvest + render emit) and
+# therefore list `/system/syslog-server` in their EXPLICIT ``supported`` set.
+# juniper_junos: ``set system syslog host <ip>``.  cisco_iosxe_cli + arista_eos:
+# ``logging host <ip>`` (promotions #1/#11).
+_SYSLOG_WIRED = {"arista_eos", "cisco_iosxe_cli", "juniper_junos"}
+
+
+def test_syslog_declared_supported_matches_wired_roster() -> None:
+    """`/system/syslog-server` is declared ``supported`` on EXACTLY the codecs
+    that parse + render it.  Any drift from this roster means the Tier-1 docs
+    (README / CAPABILITIES.md / canonical/README.md / intent.py / vendor pages)
+    are stale — update them in the same change that moves a codec in or out."""
+    declared = {
         c for c in _REAL_CODECS
         if _status(c, "/system/syslog-server") == "supported"
-    ]
-    assert not offenders, (
-        f"/system/syslog-server is now 'supported' on {offenders} — update the "
-        f"Tier-1 docs to reflect the broader wiring."
+    }
+    assert declared == _SYSLOG_WIRED, (
+        f"syslog explicit-supported roster is {sorted(declared)}, expected "
+        f"{sorted(_SYSLOG_WIRED)} — update the Tier-1 docs (README / "
+        f"CAPABILITIES.md / canonical/README.md / intent.py / vendor pages) in "
+        f"lockstep with this roster change."
     )


### PR DESCRIPTION
## Summary

Wires `/system/syslog-server` harvest on **cisco_iosxe_cli** (#1) and **arista_eos** (#11) so syslog destinations round-trip cross-vendor instead of triggering a false validation BLOCK. Both codecs already emit (iosxe_cli) or now emit (arista) `logging host <ip>`, but parse never read it back — so the matrix declared the path `unsupported` and a `junos → iosxe/arista` migration carrying syslog was flagged as dropped even though the rendered config was correct.

This is the corpus-grounded pilot from the held syslog family; **#4 (cisco_nxos bundle)** and **#13 (cisco_iosxr)** remain a follow-up.

## The harvest

Picks the **first IPv4/IPv6-literal token** on any `logging` line and validates it with `ipaddress`. The `logging <everything>` grammar (`logging buffered 5000`, `logging trap 6`, `logging console 3`, `logging facility local0`, …) is rejected **structurally** — a numeric sub-command argument is never a valid IP literal — rather than by an unmaintainable keyword blacklist.

Verified against the adversarial batfish `cisco_logging.txt` minefield (6 true hosts harvested incl. an IPv6 dest, **zero** noise tokens leaked) and the arista `ksator` capture (`logging host 10.83.28.52` → `['10.83.28.52']`, the exact asymmetry that motivated #11, where the same fixture's `ntp server 10.83.28.52` already parsed).

## Codec changes

- **cisco_iosxe_cli** — parse `_SYSLOG_LINE_RE` + harvest in `_parse_globals`; drop the stale `UnsupportedPath`; declare supported. (render already emitted `logging host`.)
- **arista_eos** — both halves: parse harvest + `logging host <ip>` render; drop the `UnsupportedPath`; declare supported.
- **juniper_junos** — declare `/system/syslog-server` explicit-supported. It already parses+renders `set system syslog host <ip>` via classify's implicit-default, so this is a declaration-only change (zero behaviour/mesh impact) that makes the roster coherent.

## Doc-truth + honesty guard (coupled)

The Tier-1 honesty guard deliberately pinned "syslog is declared-supported on no codec", so a flip requires updating it and the docs it guards in the same change:

- Rewrote `test_syslog_not_declared_supported_on_any_codec` → `test_syslog_declared_supported_matches_wired_roster`, pinning the exact roster `{arista_eos, cisco_iosxe_cli, juniper_junos}` (a future codec that wires — or regresses — syslog trips it). The **timezone** sibling guard is untouched.
- Updated the Tier-1 docs it references: `README.md`, `docs/CAPABILITIES.md`, `canonical/README.md`, `intent.py` `syslog_servers` docstring, and the `arista_eos` + `cisco_iosxe` vendor pages.

## Tests + cross-mesh baseline

- New `tests/unit/migration/test_syslog_harvest.py`: minefield harvest, no-noise negative control, same-vendor round-trip, cross-vendor preserve to each wired target, invalid-IP rejection.
- Fixed the shared kitchen-sink `syslog_servers` seed `10.0.0.514` → `10.0.5.14` (`10.0.0.514` is an **invalid** IPv4 — octet > 255 — that the loose junos parser tolerated but the new IP-guard correctly rejects).
- Re-baselined the cross-mesh: **CODEC_BUG stays 5, no new bug pair.** 6 expectation YAMLs corrected — `aruba_aoss` `good`→`unsupported` (it declares syslog unsupported and renders nothing), and `junos ↔ arista/iosxe` `lossy`→`good` (the host list round-trips; only un-modelled per-host severity differs). Regenerated `latest.json` + `PHASE4_RECONCILIATION.md`; the only yaml-less drift increase is syslog dropping on the 4 codecs that correctly don't support it (nxos/iosxr/aoscx/vyos).

## Verification

- De-risk probe + real-codec verification: harvest, classify, round-trips, cross-vendor preserve, negative controls all green.
- `tests/unit tests/integration` full local run: green (incl. the cross-mesh CI guard, tier-1 + registry honesty guards, round-trip harness).
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
