### PR TITLE
feat(cisco_nxos): wire management plane — domain/DNS/NTP/syslog (promotion #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,9 @@ across vendors.  Full per-codec matrix is in
   renders these fully (the experimental `cisco_iosxe` NETCONF stub
   excepted — it renders interfaces only).  DNS / NTP servers translate
   on most codecs; `syslog` servers translate on `juniper_junos`,
-  `cisco_iosxe_cli`, and `arista_eos` (`logging host <ip>` /
-  `set system syslog host <ip>`), while `timezone` is wired on no codec
+  `cisco_iosxe_cli`, `arista_eos` (`logging host <ip>` /
+  `set system syslog host <ip>`) and `cisco_nxos` (`logging server
+  <ip>`), while `timezone` is wired on no codec
   — check the per-codec matrices in
   [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md), and note that where a
   codec doesn't wire a field the source-side value is currently dropped

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -90,11 +90,12 @@ names the canonical surface, not a blanket guarantee.
   `description`; plus per-VRF `vrf` discriminator (v0.2.0 Wave A —
   see Tier 2 ship-before-wire note below)
 * `dns_servers`, `ntp_servers` — wired on most codecs (not all: e.g.
-  cisco_nxos / cisco_iosxr render-drop the management plane); plus
-  `syslog_servers` and `timezone`, which are wired on only a
-  **subset** of codecs: `timezone` on none as of this release;
-  `syslog_servers` on juniper_junos, cisco_iosxe_cli, and arista_eos
-  (`logging host <ip>` harvest + render, promotions #1/#11).  These are
+  cisco_iosxr still render-drops the management plane; cisco_nxos now
+  wires it — promotion #4); plus `syslog_servers` and `timezone`, which
+  are wired on only a **subset** of codecs: `timezone` on none as of
+  this release; `syslog_servers` on juniper_junos, cisco_iosxe_cli,
+  arista_eos (`logging host <ip>`, promotions #1/#11) and cisco_nxos
+  (`logging server <ip>`, promotion #4).  These are
   Tier-1 by data shape but NOT yet a cross-vendor guarantee — the §A
   per-codec panels are authoritative, and an unwired field is dropped
   on parse (with a banner where the codec declares it unsupported,

--- a/docs/vendors/cisco_nxos.md
+++ b/docs/vendors/cisco_nxos.md
@@ -44,12 +44,13 @@ translatable with caveats:
   VTEP (source-interface, UDP port, multicast group, flood list), and
   the symmetric-IRB **L3VNI** (`vrf context X / vni N`)
 
-> **Management-plane caveat.**  When NX-OS is the **target**, the
-> codec renders no `ip domain-name` / `ip name-server` / `ntp server`
-> / `logging server` / `ip dhcp` / `radius-server` config — those
-> Tier-1/2 surfaces are declared `unsupported` (the live validation
-> report flags the loss rather than reporting `severity: ok`).  See
-> [What we don't do](#what-we-dont-do).
+> **Management-plane caveat.**  When NX-OS is the **target**, the codec
+> now renders `ip domain-name` / `ip name-server` / `ntp server` /
+> `logging server` (promotion #4 — domain / DNS / NTP / syslog
+> round-trip), but still emits no `ip dhcp` / `radius-server` / `clock
+> timezone` config — those surfaces stay declared `unsupported` (the
+> live validation report flags the loss rather than reporting
+> `severity: ok`).  See [What we don't do](#what-we-dont-do).
 
 ## L3 redundancy: HSRP + IPv4 Distributed Anycast Gateway
 
@@ -136,7 +137,8 @@ identical IPv6-anycast deferral).
 **Management-plane Tier-1/2 surfaces NX-OS render drops** (declared
 `unsupported` so the loss is visible, not silent):
 
-- `domain`, `timezone`, DNS / NTP / syslog servers
+- `timezone` (`domain`, DNS, NTP and syslog servers now round-trip —
+  promotion #4)
 - DHCP server pools
 - RADIUS servers (host + shared secret)
 - IPv6 anycast-gateway
@@ -187,9 +189,10 @@ source are the highest-value contributions — see
 - **`nve1` is the VTEP, not a routed port.**  The codec intercepts
   `interface nve1` as the VXLAN tunnel-endpoint container (`tunnel`
   kind), not an L3 interface.
-- **Management services don't carry.**  DNS / NTP / syslog / DHCP /
-  RADIUS / domain / timezone are render-dropped on an NX-OS target —
-  re-apply them on the device.  The validation panel flags each.
+- **Some management services don't carry.**  DHCP / RADIUS / timezone
+  are render-dropped on an NX-OS target — re-apply them on the device.
+  The validation panel flags each.  (DNS / NTP / syslog / domain now
+  round-trip — promotion #4.)
 - **`feature` lines are regenerated.**  The renderer derives `feature
   interface-vlan` / `feature lacp` / `feature hsrp` etc. from the
   canonical shape; it does not preserve arbitrary source `feature`

--- a/netcanon/migration/canonical/README.md
+++ b/netcanon/migration/canonical/README.md
@@ -194,8 +194,9 @@ and the codec's `CapabilityMatrix` declarations:
   bug, not a gap.  `dns_servers` / `ntp_servers` are wired on most
   codecs; `timezone` and `syslog_servers` are wired on only a subset
   (`timezone` on none as of this release; `syslog_servers` on
-  `juniper_junos`, `cisco_iosxe_cli`, and `arista_eos` — `logging host
-  <ip>` / `set system syslog host <ip>`, promotions #1/#11) — for these
+  `juniper_junos`, `cisco_iosxe_cli`, `arista_eos` — `logging host
+  <ip>` / `set system syslog host <ip>`, promotions #1/#11 — and
+  `cisco_nxos` `logging server <ip>`, promotion #4) — for these
   two, an unwired codec is a known gap (declared `unsupported` in its
   `CapabilityMatrix` where the drop should raise the cross-vendor
   banner, otherwise dropped silently on parse), not a bug.  Per-codec

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -856,7 +856,8 @@ class CanonicalIntent(BaseModel):
             (parse harvest + render emit + declared-``supported``) on
             ``juniper_junos`` (``set system syslog host <ip>``),
             ``cisco_iosxe_cli`` and ``arista_eos`` (``logging host <ip>``,
-            promotions #1/#11).  Other codecs still drop it — the ones
+            promotions #1/#11), and ``cisco_nxos`` (``logging server
+            <ip>``, promotion #4).  Other codecs still drop it — the ones
             that declare it ``unsupported`` surface the cross-vendor
             banner; the rest fall through to an implicit drop.  Not yet a
             universal round-trip guarantee — see docs/CAPABILITIES.md.

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -119,6 +119,14 @@ class CiscoNXOSCodec(CodecBase):
         supported=[
             # System
             "/system/hostname",
+            # Management plane — domain / DNS / NTP / syslog (promotion #4):
+            # parse harvest + render (`ip domain-name` / `ip name-server` /
+            # `ntp server` / `logging server`), grammar from the codec's own
+            # real fixtures.
+            "/system/domain",
+            "/system/dns-server",
+            "/system/ntp-server",
+            "/system/syslog-server",
             # Interfaces — name + basic L3
             "/interfaces/interface/name",
             "/interfaces/interface/config/description",
@@ -492,24 +500,8 @@ class CiscoNXOSCodec(CodecBase):
             #    live validation report flags the loss instead of reporting
             #    `severity: ok` (2026-06 adversarial review #9). ──
             UnsupportedPath(
-                path="/system/domain",
-                reason="Render emits no system domain-name; intent.domain is dropped on migration.",
-            ),
-            UnsupportedPath(
                 path="/system/timezone",
                 reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/dns-server",
-                reason="Render emits no name-server config; intent.dns_servers are dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/ntp-server",
-                reason="Render emits no NTP config; intent.ntp_servers are dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/syslog-server",
-                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
             ),
             UnsupportedPath(
                 path="/dhcp-servers/pool",

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -90,6 +90,27 @@ _HOSTNAME_RE = re.compile(r"^hostname\s+(\S+)", re.IGNORECASE | re.MULTILINE)
 #: after ``version`` is the NX-OS release string.
 _VERSION_RE = re.compile(r"^version\s+(\S+)", re.IGNORECASE | re.MULTILINE)
 
+# ── Management-plane globals (promotion #4) — NX-OS render-dropped these
+#    until this wire-up.  Grammar attested in the codec's own real fixtures:
+#    ``ip domain-name lab.karneliuk.com``, ``ntp server 10.1.1.1 use-vrf
+#    default`` / ``ntp server 10.2.2.2 prefer use-vrf default``,
+#    ``logging server 10.125.1.171 6 port 7008``. ──
+#: ``ip domain-name <fqdn>`` — NX-OS keeps the ``ip`` prefix (unlike IOS-XR).
+_DOMAIN_RE = re.compile(r"^ip\s+domain-name\s+(\S+)\s*$", re.IGNORECASE | re.MULTILINE)
+#: ``ip name-server [vrf <name>] <ip> [<ip> ...]`` — multiple resolvers per line.
+_NAME_SERVER_RE = re.compile(
+    r"^ip\s+name-server\s+(?:vrf\s+\S+\s+)?(.+)$", re.IGNORECASE | re.MULTILINE,
+)
+#: ``ntp server <ip> [prefer] [use-vrf <name>]`` — the address is the first
+#: token; the ``prefer`` / ``use-vrf`` tails follow and are dropped.
+_NTP_SERVER_RE = re.compile(r"^ntp\s+server\s+(\S+)", re.IGNORECASE | re.MULTILINE)
+#: Syslog destinations — NX-OS spells them ``logging server <ip> [severity]
+#: [port N] [use-vrf X]``, but ``logging`` also fronts non-destination
+#: sub-commands (``logging console``, ``logging monitor``, ``logging level``).
+#: Harvest the first IP-literal token per ``logging`` line and validate with
+#: :mod:`ipaddress` (mirrors cisco_iosxe_cli / arista_eos ``_SYSLOG_LINE_RE``).
+_SYSLOG_LINE_RE = re.compile(r"^\s*logging\s+(\S.*)$", re.IGNORECASE | re.MULTILINE)
+
 _IFACE_RE = re.compile(r"^interface\s+(\S+)", re.IGNORECASE)
 _DESC_RE = re.compile(r"^\s+description\s+(.+)", re.IGNORECASE)
 _SHUTDOWN_RE = re.compile(r"^\s+shutdown\s*$", re.IGNORECASE)
@@ -408,6 +429,9 @@ def parse_intent(raw: str) -> CanonicalIntent:
     intent.hostname = _extract_hostname(raw)
     intent.source_version = _extract_version(raw)
 
+    # Management-plane globals (domain / DNS / NTP / syslog) — promotion #4.
+    _parse_globals(raw, intent)
+
     # Distributed Anycast Gateway: the chassis-wide MAC (`fabric
     # forwarding anycast-gateway-mac`).  Per-SVI anycast-mode markers are
     # harvested in :func:`_parse_interfaces`.
@@ -484,6 +508,34 @@ def parse_intent(raw: str) -> CanonicalIntent:
 def _extract_hostname(raw: str) -> str:
     m = _HOSTNAME_RE.search(raw)
     return m.group(1) if m else ""
+
+
+def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
+    """Harvest the NX-OS management-plane globals (promotion #4) that the
+    codec render-dropped until this wire-up: ``ip domain-name`` → domain,
+    ``ip name-server`` → dns_servers, ``ntp server`` → ntp_servers,
+    ``logging server``/``logging <ip>`` → syslog_servers.  Mutates *intent*
+    in place (keeps :func:`parse_intent` a flat sequence of phase calls)."""
+    m = _DOMAIN_RE.search(raw)
+    if m:
+        intent.domain = m.group(1)
+    for m in _NAME_SERVER_RE.finditer(raw):
+        # ``ip name-server 1.1.1.1 8.8.8.8`` is two resolvers on one line.
+        for token in m.group(1).split():
+            intent.dns_servers.append(token)
+    for m in _NTP_SERVER_RE.finditer(raw):
+        intent.ntp_servers.append(m.group(1))
+    for m in _SYSLOG_LINE_RE.finditer(raw):
+        # First IP-literal token on the ``logging`` line is the syslog host;
+        # non-destination sub-commands carry no IP token.  De-dup, first-seen.
+        for token in m.group(1).split():
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                continue
+            if token not in intent.syslog_servers:
+                intent.syslog_servers.append(token)
+            break
 
 
 def _extract_version(raw: str) -> str:

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -71,6 +71,23 @@ _CANON_TO_NXOS_PRIV = {
 }
 
 
+def _render_management_plane(tree: CanonicalIntent) -> list[str]:
+    """Domain / DNS / NTP / syslog lines (promotion #4).  NX-OS render-dropped
+    these until the wire-up; grammar mirrors the codec's own real fixtures
+    (``ip domain-name`` / ``ip name-server`` / ``ntp server`` / ``logging
+    server``).  Parse harvests each back (see ``_parse_globals``).  Returns a
+    trailing ``""`` separator only when at least one line was emitted."""
+    out: list[str] = []
+    if tree.domain:
+        out.append(f"ip domain-name {tree.domain}")
+    out.extend(f"ip name-server {srv}" for srv in tree.dns_servers)
+    out.extend(f"ntp server {srv}" for srv in tree.ntp_servers)
+    out.extend(f"logging server {srv}" for srv in tree.syslog_servers)
+    if out:
+        out.append("")
+    return out
+
+
 def render_intent(tree: CanonicalIntent) -> str:
     """Render a :class:`CanonicalIntent` as Cisco NX-OS config text."""
     hostname = tree.hostname or "switch"
@@ -83,6 +100,9 @@ def render_intent(tree: CanonicalIntent) -> str:
     lines.append(f"hostname {hostname}")
     lines.append(f"vdc {hostname} id 1")
     lines.append("")
+
+    # ── Management plane — domain / DNS / NTP / syslog (promotion #4) ──
+    lines.extend(_render_management_plane(tree))
 
     # ── Render-derived feature block ──
     features = _derive_features(tree)

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-12T20:03:47+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T195055Z.json",
-  "mesh_run_started_utc": "2026-07-12T19:50:49+00:00",
+  "started_utc": "2026-07-12T20:34:45+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T203348Z.json",
+  "mesh_run_started_utc": "2026-07-12T20:33:42+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4201,7 +4201,7 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "cisco_nxos",
-      "drifted_total": 31
+      "drifted_total": 20
     },
     {
       "source_codec": "arista_eos",
@@ -4286,7 +4286,7 @@
     {
       "source_codec": "aruba_aoss",
       "target_codec": "cisco_nxos",
-      "drifted_total": 19
+      "drifted_total": 15
     },
     {
       "source_codec": "aruba_aoss",
@@ -4336,7 +4336,7 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "cisco_nxos",
-      "drifted_total": 33
+      "drifted_total": 25
     },
     {
       "source_codec": "cisco_iosxe_cli",
@@ -4376,7 +4376,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "cisco_nxos",
-      "drifted_total": 35
+      "drifted_total": 27
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4411,12 +4411,12 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 53
+      "drifted_total": 57
     },
     {
       "source_codec": "cisco_nxos",
       "target_codec": "aruba_aoss",
-      "drifted_total": 49
+      "drifted_total": 52
     },
     {
       "source_codec": "cisco_nxos",
@@ -4431,7 +4431,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 64
+      "drifted_total": 66
     },
     {
       "source_codec": "cisco_nxos",
@@ -4441,7 +4441,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "fortigate_cli",
-      "drifted_total": 57
+      "drifted_total": 58
     },
     {
       "source_codec": "cisco_nxos",
@@ -4451,17 +4451,17 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "mikrotik_routeros",
-      "drifted_total": 57
+      "drifted_total": 60
     },
     {
       "source_codec": "cisco_nxos",
       "target_codec": "opnsense",
-      "drifted_total": 56
+      "drifted_total": 58
     },
     {
       "source_codec": "cisco_nxos",
       "target_codec": "vyos",
-      "drifted_total": 61
+      "drifted_total": 62
     },
     {
       "source_codec": "fortigate_cli",
@@ -4476,7 +4476,7 @@
     {
       "source_codec": "fortigate_cli",
       "target_codec": "cisco_nxos",
-      "drifted_total": 28
+      "drifted_total": 22
     },
     {
       "source_codec": "fortigate_cli",
@@ -4501,7 +4501,7 @@
     {
       "source_codec": "juniper_junos",
       "target_codec": "cisco_nxos",
-      "drifted_total": 63
+      "drifted_total": 43
     },
     {
       "source_codec": "juniper_junos",
@@ -4526,7 +4526,7 @@
     {
       "source_codec": "mikrotik_routeros",
       "target_codec": "cisco_nxos",
-      "drifted_total": 23
+      "drifted_total": 19
     },
     {
       "source_codec": "mikrotik_routeros",
@@ -4551,7 +4551,7 @@
     {
       "source_codec": "opnsense",
       "target_codec": "cisco_nxos",
-      "drifted_total": 34
+      "drifted_total": 23
     },
     {
       "source_codec": "opnsense",
@@ -4596,7 +4596,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "cisco_nxos",
-      "drifted_total": 48
+      "drifted_total": 35
     },
     {
       "source_codec": "vyos",

--- a/tests/unit/migration/test_cisco_nxos_mgmt_plane.py
+++ b/tests/unit/migration/test_cisco_nxos_mgmt_plane.py
@@ -1,0 +1,79 @@
+"""Round-trip + matrix coverage for the cisco_nxos management-plane wire-up
+(promotion #4): ``/system/domain`` + ``/system/dns-server`` +
+``/system/ntp-server`` + ``/system/syslog-server``.
+
+NX-OS render-dropped all four until this change.  Grammar is attested in the
+codec's own real fixtures: ``ip domain-name``, ``ntp server <ip> [prefer]
+[use-vrf <name>]``, ``logging server <ip> <sev> [port N]``.  DNS
+(``ip name-server``) is grammar-grounded (no corpus line) but round-trips.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from netcanon.migration.codecs.registry import get_codec
+
+pytestmark = pytest.mark.unit
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "real" / "cisco_nxos"
+_NAUTOBOT = _FIXTURES / "nautobot_gc_nxos_snmp_spine01_nxos933.txt"
+
+
+class TestNxosManagementPlaneHarvest:
+    def test_parses_domain_ntp_syslog_from_real_fixture(self) -> None:
+        intent = get_codec("cisco_nxos").parse(_NAUTOBOT.read_text())
+        assert intent.domain == "infra.ntc.com"
+        # `ntp server 10.1.1.1 use-vrf default` + `... 10.2.2.2 prefer use-vrf`.
+        assert intent.ntp_servers == ["10.1.1.1", "10.2.2.2"]
+        # `logging server 10.125.1.171 6 port 7008` — first IP token only.
+        assert intent.syslog_servers == ["10.125.1.171"]
+
+    def test_syslog_ignores_non_destination_logging(self) -> None:
+        # `logging console`/`logging monitor`/`logging level` carry no IP.
+        intent = get_codec("cisco_nxos").parse(
+            "hostname h\nlogging console 5\nlogging monitor 6\n"
+            "logging server 10.9.9.9 6\n"
+        )
+        assert intent.syslog_servers == ["10.9.9.9"]
+
+    def test_render_emits_nxos_forms(self) -> None:
+        codec = get_codec("cisco_nxos")
+        intent = codec.parse(_NAUTOBOT.read_text())
+        rendered = codec.render(intent)
+        assert "ip domain-name infra.ntc.com" in rendered
+        assert "ntp server 10.1.1.1" in rendered
+        assert "logging server 10.125.1.171" in rendered
+
+    def test_same_vendor_round_trip_stable(self) -> None:
+        codec = get_codec("cisco_nxos")
+        intent = codec.parse(_NAUTOBOT.read_text())
+        reparsed = codec.parse(codec.render(intent))
+        assert reparsed.domain == intent.domain
+        assert reparsed.ntp_servers == intent.ntp_servers
+        assert reparsed.syslog_servers == intent.syslog_servers
+
+    def test_dns_round_trips_grammar_grounded(self) -> None:
+        # No `ip name-server` in the corpus, but the wire-up round-trips it.
+        codec = get_codec("cisco_nxos")
+        intent = codec.parse("hostname h\nip name-server 8.8.8.8 1.1.1.1\n")
+        assert intent.dns_servers == ["8.8.8.8", "1.1.1.1"]
+        assert codec.parse(codec.render(intent)).dns_servers == ["8.8.8.8", "1.1.1.1"]
+
+    def test_no_mgmt_config_renders_nothing(self) -> None:
+        codec = get_codec("cisco_nxos")
+        intent = codec.parse("hostname bare\n")
+        assert intent.ntp_servers == [] and intent.syslog_servers == []
+        assert intent.dns_servers == [] and intent.domain == ""
+        rendered = codec.render(intent)
+        assert "ntp server" not in rendered and "logging server" not in rendered
+
+    @pytest.mark.parametrize("path", [
+        "/system/domain", "/system/dns-server",
+        "/system/ntp-server", "/system/syslog-server",
+    ])
+    def test_classify_supported(self, path: str) -> None:
+        caps = get_codec("cisco_nxos").capabilities
+        assert caps.classify(path) == "supported"
+        assert path not in {u.path for u in caps.unsupported}

--- a/tests/unit/migration/test_syslog_harvest.py
+++ b/tests/unit/migration/test_syslog_harvest.py
@@ -105,7 +105,7 @@ class TestAristaSyslogHarvest:
 class TestCrossVendorSyslogPreserve:
     """A syslog host survives across each wired pair."""
 
-    @pytest.mark.parametrize("target", ["cisco_iosxe_cli", "arista_eos", "juniper_junos"])
+    @pytest.mark.parametrize("target", ["cisco_iosxe_cli", "arista_eos", "juniper_junos", "cisco_nxos"])
     def test_arista_source_preserves_to_wired_target(self, target: str) -> None:
         arista = get_codec("arista_eos")
         tgt = get_codec(target)

--- a/tests/unit/migration/test_tier1_wiring_honesty.py
+++ b/tests/unit/migration/test_tier1_wiring_honesty.py
@@ -61,8 +61,11 @@ def test_timezone_declared_unsupported_on_every_codec() -> None:
 # Codecs that genuinely round-trip syslog (parse harvest + render emit) and
 # therefore list `/system/syslog-server` in their EXPLICIT ``supported`` set.
 # juniper_junos: ``set system syslog host <ip>``.  cisco_iosxe_cli + arista_eos:
-# ``logging host <ip>`` (promotions #1/#11).
-_SYSLOG_WIRED = {"arista_eos", "cisco_iosxe_cli", "juniper_junos"}
+# ``logging host <ip>`` (promotions #1/#11).  cisco_nxos: ``logging server
+# <ip>`` (promotion #4 — part of the NX-OS management-plane wire-up).
+_SYSLOG_WIRED = {
+    "arista_eos", "cisco_iosxe_cli", "cisco_nxos", "juniper_junos",
+}
 
 
 def test_syslog_declared_supported_matches_wired_roster() -> None:


### PR DESCRIPTION
## Summary

Wires the **cisco_nxos management plane** — `/system/domain`, `/system/dns-server`, `/system/ntp-server`, `/system/syslog-server` — all four of which NX-OS render-dropped (declared unsupported). An arista/junos→nxos job silently lost DNS/NTP/syslog, and even same-vendor round-trips dropped the source's own lines.

This is the first half of the deferred syslog-family follow-up (**#4**); the cisco_iosxr twin (**#13**) follows as a separate PR.

## Grammar (from the codec's own real fixtures)

```
ip domain-name lab.karneliuk.com
ntp server 10.1.1.1 use-vrf default
ntp server 10.2.2.2 prefer use-vrf default
logging server 10.125.1.171 6 port 7008
```

## Changes

- **parse** — new `_parse_globals`: `ip domain-name`→domain, `ip name-server`→dns_servers, `ntp server <ip>`→ntp_servers (first token; drops `prefer`/`use-vrf` tails), and `logging server`/`logging <ip>`→syslog_servers via the first-IP-literal-token + `ipaddress` guard (so `logging console`/`monitor`/`level` are rejected structurally — the #1/#11 pattern).
- **render** — `_render_management_plane` emits the four NX-OS forms after the hostname/vdc wrapper, before the feature block (extracted to a helper to keep `render_intent` under the C901 ceiling).
- **matrix** — drop the 4 UnsupportedPaths; declare all 4 supported.

## Doc-truth + guard

- Add `cisco_nxos` to the `_SYSLOG_WIRED` roster in the Tier-1 honesty guard.
- Update the "cisco_nxos render-drops the management plane" claim across CAPABILITIES.md / README / canonical/README / intent.py / the cisco_nxos vendor page (domain/DNS/NTP/syslog now round-trip; timezone/DHCP/RADIUS still drop).

## Tests + cross-mesh baseline

- New `test_cisco_nxos_mgmt_plane.py` (real-fixture harvest, non-destination `logging` rejection, render forms, same-vendor round-trip, grammar-grounded DNS round-trip, negative control, classify) + `cisco_nxos` added to the syslog cross-vendor preserve test.
- Re-baselined: **CODEC_BUG stays 5, no new bug pair.** All cisco_nxos pairs are yaml-less (one of the 4 newest codecs), so the only effect is on raw mechanical drift — nxos-source pairs rise (mgmt-plane now carried, dropped by targets that don't support a given field; verified only `syslog` drifts on droppers, DNS/NTP/domain **preserve** on supporting targets) and X→nxos pairs fall sharply (e.g. `juniper_junos→cisco_nxos` 63→43, nxos now preserves the mgmt plane). Change is perfectly isolated to cisco_nxos pairs.

## Verification

- De-risk probe + real-codec verification: harvest, render, round-trip, classify, DNS synthetic, negative control all green.
- Full `tests/unit tests/integration` local run: green (incl. the cross-mesh CI guard + tier-1/registry honesty guards + round-trip harness). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
