### PR TITLE
feat(cisco_iosxr): wire DNS/NTP/syslog management plane (promotion #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ across vendors.  Full per-codec matrix is in
   excepted — it renders interfaces only).  DNS / NTP servers translate
   on most codecs; `syslog` servers translate on `juniper_junos`,
   `cisco_iosxe_cli`, `arista_eos` (`logging host <ip>` /
-  `set system syslog host <ip>`) and `cisco_nxos` (`logging server
-  <ip>`), while `timezone` is wired on no codec
-  — check the per-codec matrices in
+  `set system syslog host <ip>`), `cisco_nxos` (`logging server <ip>`)
+  and `cisco_iosxr` (bare `logging <ip>`), while `timezone` is wired on
+  no codec — check the per-codec matrices in
   [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md), and note that where a
   codec doesn't wire a field the source-side value is currently dropped
   without a banner.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -89,13 +89,14 @@ names the canonical surface, not a blanket guarantee.
 * `static_routes` — `destination`, `gateway`, `interface`, `metric`,
   `description`; plus per-VRF `vrf` discriminator (v0.2.0 Wave A —
   see Tier 2 ship-before-wire note below)
-* `dns_servers`, `ntp_servers` — wired on most codecs (not all: e.g.
-  cisco_iosxr still render-drops the management plane; cisco_nxos now
-  wires it — promotion #4); plus `syslog_servers` and `timezone`, which
-  are wired on only a **subset** of codecs: `timezone` on none as of
-  this release; `syslog_servers` on juniper_junos, cisco_iosxe_cli,
-  arista_eos (`logging host <ip>`, promotions #1/#11) and cisco_nxos
-  (`logging server <ip>`, promotion #4).  These are
+* `dns_servers`, `ntp_servers` — wired on most codecs (the two Cisco
+  SP/DC codecs cisco_nxos and cisco_iosxr, which historically render-
+  dropped the management plane, now wire it — promotions #4/#13); plus
+  `syslog_servers` and `timezone`, which are wired on only a **subset**
+  of codecs: `timezone` on none as of this release; `syslog_servers` on
+  juniper_junos, cisco_iosxe_cli, arista_eos (`logging host <ip>`,
+  promotions #1/#11), cisco_nxos (`logging server <ip>`, #4) and
+  cisco_iosxr (bare `logging <ip>`, #13).  These are
   Tier-1 by data shape but NOT yet a cross-vendor guarantee — the §A
   per-codec panels are authoritative, and an unwired field is dropped
   on parse (with a banner where the codec declares it unsupported,

--- a/docs/vendors/cisco_iosxr.md
+++ b/docs/vendors/cisco_iosxr.md
@@ -43,12 +43,13 @@ translatable with caveats:
 - Local users — `username` block (group → role + secret hash),
   form-preserving
 
-> **Management-plane caveat.**  When IOS-XR is the **target**, the
-> codec renders no `clock timezone` / `domain name-server` / `ntp` /
-> `logging` / `dhcp` / `radius-server` / SNMP config — those surfaces
-> are declared `unsupported` (the live validation report flags the
-> loss rather than reporting `severity: ok`).  See
-> [What we don't do](#what-we-dont-do).
+> **Management-plane caveat.**  When IOS-XR is the **target**, the codec
+> now renders `domain name-server` / `ntp` / `logging <ip>` (promotion
+> #13 — DNS / NTP / syslog round-trip, alongside the pre-existing
+> `domain name`), but still emits no `clock timezone` / `dhcp` /
+> `radius-server` / SNMP config — those surfaces stay declared
+> `unsupported` (the live validation report flags the loss rather than
+> reporting `severity: ok`).  See [What we don't do](#what-we-dont-do).
 
 ## Lossy paths
 
@@ -87,8 +88,9 @@ is visible, not silent):
 - **L2 switchport** — IOS-XR has no Cisco-style access/trunk model
   (VLANs are dot1q sub-interfaces); switchport mode / access-VLAN /
   trunk allowed-list / native VLAN / voice-VLAN all drop on render
-- **Management plane** — `timezone`, DNS / NTP / syslog servers, DHCP
-  server pools, RADIUS servers (host + secret)
+- **Management plane** — `timezone`, DHCP server pools, RADIUS servers
+  (host + secret).  (DNS / NTP / syslog servers now round-trip —
+  promotion #13.)
 - **SNMP** — parse + render is out of the v1 XR scope
 
 Deliberately deferred to [Tier

--- a/netcanon/migration/canonical/README.md
+++ b/netcanon/migration/canonical/README.md
@@ -195,8 +195,9 @@ and the codec's `CapabilityMatrix` declarations:
   codecs; `timezone` and `syslog_servers` are wired on only a subset
   (`timezone` on none as of this release; `syslog_servers` on
   `juniper_junos`, `cisco_iosxe_cli`, `arista_eos` — `logging host
-  <ip>` / `set system syslog host <ip>`, promotions #1/#11 — and
-  `cisco_nxos` `logging server <ip>`, promotion #4) — for these
+  <ip>` / `set system syslog host <ip>`, promotions #1/#11 — plus
+  `cisco_nxos` `logging server <ip>` (#4) and `cisco_iosxr` bare
+  `logging <ip>` (#13)) — for these
   two, an unwired codec is a known gap (declared `unsupported` in its
   `CapabilityMatrix` where the drop should raise the cross-vendor
   banner, otherwise dropped silently on parse), not a bug.  Per-codec

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -856,8 +856,9 @@ class CanonicalIntent(BaseModel):
             (parse harvest + render emit + declared-``supported``) on
             ``juniper_junos`` (``set system syslog host <ip>``),
             ``cisco_iosxe_cli`` and ``arista_eos`` (``logging host <ip>``,
-            promotions #1/#11), and ``cisco_nxos`` (``logging server
-            <ip>``, promotion #4).  Other codecs still drop it — the ones
+            promotions #1/#11), ``cisco_nxos`` (``logging server <ip>``,
+            #4) and ``cisco_iosxr`` (bare ``logging <ip>``, #13).  Other
+            codecs still drop it — the ones
             that declare it ``unsupported`` surface the cross-vendor
             banner; the rest fall through to an implicit drop.  Not yet a
             universal round-trip guarantee — see docs/CAPABILITIES.md.

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -122,6 +122,12 @@ class CiscoIOSXRCodec(CodecBase):
         supported=[
             # System
             "/system/hostname",
+            # Management plane — DNS / NTP / syslog (promotion #13): parse
+            # harvest + render (`domain name-server` / `ntp` block / `logging
+            # <ip>`).  `/system/domain` was already wired (classify-default).
+            "/system/dns-server",
+            "/system/ntp-server",
+            "/system/syslog-server",
             # Interfaces — name + basic L3
             "/interfaces/interface/name",
             "/interfaces/interface/config/description",
@@ -402,18 +408,6 @@ class CiscoIOSXRCodec(CodecBase):
             UnsupportedPath(
                 path="/system/timezone",
                 reason="Render emits no clock/timezone stanza; intent.timezone is dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/dns-server",
-                reason="Render emits no name-server config; intent.dns_servers are dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/ntp-server",
-                reason="Render emits no NTP config; intent.ntp_servers are dropped on migration.",
-            ),
-            UnsupportedPath(
-                path="/system/syslog-server",
-                reason="Render emits no logging/syslog config; intent.syslog_servers are dropped on migration.",
             ),
             UnsupportedPath(
                 path="/dhcp-servers/pool",

--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -103,6 +103,31 @@ _DOMAIN_RE = re.compile(
     r"^domain\s+name\s+(\S+)", re.IGNORECASE | re.MULTILINE,
 )
 
+# ── Management-plane globals (promotion #13) — XR render-dropped DNS / NTP /
+#    syslog until this wire-up (``/system/domain`` was already wired). ──
+#: ``domain name-server <ip>`` — disjoint from ``domain name <fqdn>`` above
+#: (``name-server`` has no whitespace after ``name``, so ``_DOMAIN_RE`` can't
+#: match it, and vice-versa).
+_NAMESERVER_RE = re.compile(
+    r"^domain\s+name-server\s+(\S+)", re.IGNORECASE | re.MULTILINE,
+)
+#: NTP is a block: ``ntp`` on its own line, then indented ``server <ip>
+#: [maxpoll N] [prefer]`` / ``source <iface>`` / ``update-calendar`` leaves.
+#: Capture the indented body, then pull ``server`` leaves from it (the
+#: ``source`` / ``update-calendar`` tails carry no ``server`` keyword).
+_NTP_BLOCK_RE = re.compile(
+    r"^ntp[ \t]*\r?\n((?:[ \t]+.*\r?\n)+)", re.IGNORECASE | re.MULTILINE,
+)
+_NTP_SERVER_LINE_RE = re.compile(
+    r"^[ \t]+server\s+(\S+)", re.IGNORECASE | re.MULTILINE,
+)
+#: Syslog destinations — XR spells them bare ``logging <ip>``, but ``logging``
+#: also fronts non-destination sub-commands (``logging console debugging``,
+#: ``logging monitor``, ``logging trap``).  Harvest the first IP-literal token
+#: per ``logging`` line, validated with :mod:`ipaddress` (mirrors the sibling
+#: Cisco codecs' ``_SYSLOG_LINE_RE``).
+_SYSLOG_LINE_RE = re.compile(r"^\s*logging\s+(\S.*)$", re.IGNORECASE | re.MULTILINE)
+
 _IFACE_RE = re.compile(r"^interface\s+(\S+)", re.IGNORECASE)
 _DESC_RE = re.compile(r"^\s+description\s+(.+)", re.IGNORECASE)
 _SHUTDOWN_RE = re.compile(r"^\s+shutdown\s*$", re.IGNORECASE)
@@ -264,6 +289,9 @@ def parse_intent(raw: str) -> CanonicalIntent:
     intent.domain = _extract_domain(raw)
     intent.source_version = _extract_version(raw)
 
+    # Management-plane globals (DNS / NTP / syslog) — promotion #13.
+    _parse_globals(raw, intent)
+
     intent.interfaces = _parse_interfaces(raw)
 
     # VRF declarations (top-level ``vrf <name>`` stanzas: description +
@@ -305,6 +333,30 @@ def _extract_hostname(raw: str) -> str:
 def _extract_domain(raw: str) -> str:
     m = _DOMAIN_RE.search(raw)
     return m.group(1) if m else ""
+
+
+def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
+    """Harvest the XR management-plane globals DNS / NTP / syslog (promotion
+    #13) that the codec render-dropped until this wire-up (``domain`` is
+    handled by :func:`_extract_domain`).  Mutates *intent* in place."""
+    for m in _NAMESERVER_RE.finditer(raw):
+        intent.dns_servers.append(m.group(1))
+    for block in _NTP_BLOCK_RE.finditer(raw):
+        # ``server <ip>`` leaves inside the ``ntp`` block; drop the
+        # ``maxpoll`` / ``prefer`` tails and the ``source`` / ``update-
+        # calendar`` sibling lines (no ``server`` keyword).
+        intent.ntp_servers.extend(_NTP_SERVER_LINE_RE.findall(block.group(1)))
+    for m in _SYSLOG_LINE_RE.finditer(raw):
+        # First IP-literal token on a ``logging`` line is the syslog host;
+        # non-destination sub-commands carry no IP token.  De-dup, first-seen.
+        for token in m.group(1).split():
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                continue
+            if token not in intent.syslog_servers:
+                intent.syslog_servers.append(token)
+            break
 
 
 def _extract_version(raw: str) -> str:

--- a/netcanon/migration/codecs/cisco_iosxr/render.py
+++ b/netcanon/migration/codecs/cisco_iosxr/render.py
@@ -72,6 +72,22 @@ _CANON_TO_IOSXR_BUNDLE_MODE = {
 _FALLBACK_BGP_ASN = "65000"
 
 
+def _render_ntp_syslog(tree: CanonicalIntent) -> list[str]:
+    """NTP block + syslog lines (promotion #13).  XR render-dropped these
+    until the wire-up; the NTP block mirrors the real fixture (``ntp`` /
+    indented ``server <ip>``), syslog is the bare ``logging <ip>`` form.
+    (DNS ``domain name-server`` is emitted inline with the domain line.)"""
+    out: list[str] = []
+    if tree.ntp_servers:
+        out.append("ntp")
+        out.extend(f" server {srv}" for srv in tree.ntp_servers)
+        out.append("!")
+    if tree.syslog_servers:
+        out.extend(f"logging {srv}" for srv in tree.syslog_servers)
+        out.append("!")
+    return out
+
+
 def render_intent(tree: CanonicalIntent) -> str:
     """Render a :class:`CanonicalIntent` as Cisco IOS-XR config text."""
     hostname = tree.hostname or "Router"
@@ -83,7 +99,9 @@ def render_intent(tree: CanonicalIntent) -> str:
     lines.append(f"hostname {hostname}")
     if tree.domain:
         lines.append(f"domain name {tree.domain}")
+    lines.extend(f"domain name-server {srv}" for srv in tree.dns_servers)
     lines.append("!")
+    lines.extend(_render_ntp_syslog(tree))
 
     # ── Local users (Phase 2) ──
     for user in tree.local_users:

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-12T20:34:45+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T203348Z.json",
-  "mesh_run_started_utc": "2026-07-12T20:33:42+00:00",
+  "started_utc": "2026-07-12T20:48:43+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T204824Z.json",
+  "mesh_run_started_utc": "2026-07-12T20:48:18+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4196,7 +4196,7 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 35
+      "drifted_total": 26
     },
     {
       "source_codec": "arista_eos",
@@ -4281,7 +4281,7 @@
     {
       "source_codec": "aruba_aoss",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 28
+      "drifted_total": 24
     },
     {
       "source_codec": "aruba_aoss",
@@ -4331,7 +4331,7 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 35
+      "drifted_total": 30
     },
     {
       "source_codec": "cisco_iosxe_cli",
@@ -4351,7 +4351,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 36
+      "drifted_total": 37
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4396,7 +4396,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "opnsense",
-      "drifted_total": 27
+      "drifted_total": 28
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4431,7 +4431,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 66
+      "drifted_total": 64
     },
     {
       "source_codec": "cisco_nxos",
@@ -4471,7 +4471,7 @@
     {
       "source_codec": "fortigate_cli",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 28
+      "drifted_total": 23
     },
     {
       "source_codec": "fortigate_cli",
@@ -4496,7 +4496,7 @@
     {
       "source_codec": "juniper_junos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 76
+      "drifted_total": 58
     },
     {
       "source_codec": "juniper_junos",
@@ -4521,7 +4521,7 @@
     {
       "source_codec": "mikrotik_routeros",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 25
+      "drifted_total": 21
     },
     {
       "source_codec": "mikrotik_routeros",
@@ -4546,7 +4546,7 @@
     {
       "source_codec": "opnsense",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 32
+      "drifted_total": 28
     },
     {
       "source_codec": "opnsense",
@@ -4591,7 +4591,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "cisco_iosxr",
-      "drifted_total": 45
+      "drifted_total": 33
     },
     {
       "source_codec": "vyos",

--- a/tests/unit/migration/test_cisco_iosxr_mgmt_plane.py
+++ b/tests/unit/migration/test_cisco_iosxr_mgmt_plane.py
@@ -1,0 +1,99 @@
+"""Round-trip + matrix coverage for the cisco_iosxr management-plane wire-up
+(promotion #13): ``/system/dns-server`` + ``/system/ntp-server`` +
+``/system/syslog-server`` (``/system/domain`` was already wired).
+
+XR render-dropped DNS / NTP / syslog until this change.  NTP is a *block*
+(``ntp`` / indented ``server <ip> [maxpoll N] [prefer]`` / ``source`` /
+``update-calendar``); DNS is ``domain name-server <ip>`` (disjoint from the
+``domain name <fqdn>`` line); syslog is the bare ``logging <ip>`` form.  The
+one real XR fixture's ntp block is the corpus anchor; dns/syslog are
+grammar-grounded but round-trip.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from netcanon.migration.codecs.registry import get_codec
+
+pytestmark = pytest.mark.unit
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "real" / "cisco_iosxr"
+_XR = _FIXTURES / "iosxr_design_cst_pa3_xr752.cfg"
+
+
+class TestXrNtpBlockHarvest:
+    def test_parses_ntp_block_from_real_fixture(self) -> None:
+        # `ntp` / ` server 198.51.100.118 maxpoll 8 prefer` / ` server 192.0.2.3`
+        # / ` source MgmtEth0/RP0/CPU0/0` / ` update-calendar`.
+        intent = get_codec("cisco_iosxr").parse(_XR.read_text())
+        assert intent.ntp_servers == ["198.51.100.118", "192.0.2.3"]
+
+    def test_ntp_block_skips_non_server_leaves(self) -> None:
+        intent = get_codec("cisco_iosxr").parse(
+            "ntp\n server 10.0.0.1\n source Loopback0\n update-calendar\n!\n"
+        )
+        assert intent.ntp_servers == ["10.0.0.1"]
+
+
+class TestXrSyslogHarvest:
+    def test_ignores_non_destination_logging(self) -> None:
+        # The real fixture carries `logging console debugging` (no IP).
+        intent = get_codec("cisco_iosxr").parse(_XR.read_text())
+        assert intent.syslog_servers == []
+
+    def test_harvests_bare_logging_ip(self) -> None:
+        intent = get_codec("cisco_iosxr").parse(
+            "logging 10.9.9.9\nlogging console debugging\nlogging trap warnings\n"
+        )
+        assert intent.syslog_servers == ["10.9.9.9"]
+
+
+class TestXrDnsDisjointFromDomain:
+    def test_name_server_and_domain_dont_shadow(self) -> None:
+        codec = get_codec("cisco_iosxr")
+        intent = codec.parse(
+            "domain name example.com\ndomain name-server 8.8.8.8\n"
+            "domain name-server 1.1.1.1\n"
+        )
+        assert intent.domain == "example.com"
+        assert intent.dns_servers == ["8.8.8.8", "1.1.1.1"]
+
+
+class TestXrManagementPlaneRoundTrip:
+    _SRC = (
+        "hostname r1\ndomain name lab.local\ndomain name-server 8.8.8.8\n"
+        "ntp\n server 10.0.0.1\n server 10.0.0.2\n source Loopback0\n!\n"
+        "logging 10.9.9.9\n"
+    )
+
+    def test_render_emits_xr_forms(self) -> None:
+        codec = get_codec("cisco_iosxr")
+        rendered = codec.render(codec.parse(self._SRC))
+        assert "domain name-server 8.8.8.8" in rendered
+        assert "ntp" in rendered and " server 10.0.0.1" in rendered
+        assert "logging 10.9.9.9" in rendered
+
+    def test_round_trip_stable(self) -> None:
+        codec = get_codec("cisco_iosxr")
+        intent = codec.parse(self._SRC)
+        reparsed = codec.parse(codec.render(intent))
+        assert reparsed.dns_servers == ["8.8.8.8"]
+        assert reparsed.ntp_servers == ["10.0.0.1", "10.0.0.2"]
+        assert reparsed.syslog_servers == ["10.9.9.9"]
+        assert reparsed.domain == "lab.local"
+
+    def test_no_mgmt_config_renders_nothing(self) -> None:
+        codec = get_codec("cisco_iosxr")
+        rendered = codec.render(codec.parse("hostname bare\n"))
+        assert "domain name-server" not in rendered
+        assert "\nntp\n" not in rendered and "logging" not in rendered
+
+    @pytest.mark.parametrize("path", [
+        "/system/dns-server", "/system/ntp-server", "/system/syslog-server",
+    ])
+    def test_classify_supported(self, path: str) -> None:
+        caps = get_codec("cisco_iosxr").capabilities
+        assert caps.classify(path) == "supported"
+        assert path not in {u.path for u in caps.unsupported}

--- a/tests/unit/migration/test_syslog_harvest.py
+++ b/tests/unit/migration/test_syslog_harvest.py
@@ -105,7 +105,9 @@ class TestAristaSyslogHarvest:
 class TestCrossVendorSyslogPreserve:
     """A syslog host survives across each wired pair."""
 
-    @pytest.mark.parametrize("target", ["cisco_iosxe_cli", "arista_eos", "juniper_junos", "cisco_nxos"])
+    @pytest.mark.parametrize("target", [
+        "cisco_iosxe_cli", "arista_eos", "juniper_junos", "cisco_nxos", "cisco_iosxr",
+    ])
     def test_arista_source_preserves_to_wired_target(self, target: str) -> None:
         arista = get_codec("arista_eos")
         tgt = get_codec(target)

--- a/tests/unit/migration/test_tier1_wiring_honesty.py
+++ b/tests/unit/migration/test_tier1_wiring_honesty.py
@@ -62,9 +62,11 @@ def test_timezone_declared_unsupported_on_every_codec() -> None:
 # therefore list `/system/syslog-server` in their EXPLICIT ``supported`` set.
 # juniper_junos: ``set system syslog host <ip>``.  cisco_iosxe_cli + arista_eos:
 # ``logging host <ip>`` (promotions #1/#11).  cisco_nxos: ``logging server
-# <ip>`` (promotion #4 — part of the NX-OS management-plane wire-up).
+# <ip>`` (promotion #4).  cisco_iosxr: bare ``logging <ip>`` (promotion #13 —
+# both #4 and #13 wire the whole Cisco management plane, not just syslog).
 _SYSLOG_WIRED = {
-    "arista_eos", "cisco_iosxe_cli", "cisco_nxos", "juniper_junos",
+    "arista_eos", "cisco_iosxe_cli", "cisco_iosxr", "cisco_nxos",
+    "juniper_junos",
 }
 
 


### PR DESCRIPTION
## Summary

The IOS-XR twin of #4 — wires `/system/dns-server`, `/system/ntp-server` and `/system/syslog-server` on **cisco_iosxr** (all three were render-dropped / declared unsupported). `/system/domain` was already wired. This **completes the deferred syslog-family follow-up** (#4 + #13); the whole family (#1/#4/#11/#13) is now shipped.

## Grammar (ntp block anchored in the real XR fixture)

```
ntp
 server 198.51.100.118 maxpoll 8 prefer
 server 192.0.2.3
 source MgmtEth0/RP0/CPU0/0
 update-calendar
```

## Changes

- **parse** — `_parse_globals`: `domain name-server <ip>`→dns_servers (disjoint from the existing `domain name <fqdn>` regex — `name-server` has no whitespace after `name`), the `ntp` **block**→ntp_servers (`_NTP_BLOCK_RE` grabs the indented body, `_NTP_SERVER_LINE_RE` pulls the `server <ip>` leaves and skips `source`/`update-calendar`/`maxpoll`/`prefer`), and bare `logging <ip>`→syslog_servers via the first-IP-literal-token + `ipaddress` guard (so `logging console debugging` is rejected structurally).
- **render** — `domain name-server` inline with the domain line; new `_render_ntp_syslog` helper emits the `ntp` block + bare `logging <ip>` (extracted to keep `render_intent` simple).
- **matrix** — drop the 3 UnsupportedPaths; declare all 3 supported.

## Doc-truth + guard

- Add `cisco_iosxr` to `_SYSLOG_WIRED` — the syslog roster is now the five codecs that wire it: `arista_eos` / `cisco_iosxe_cli` / `cisco_iosxr` / `cisco_nxos` / `juniper_junos`.
- Update the "cisco_iosxr render-drops the management plane" claim across CAPABILITIES.md / README / canonical/README / intent.py / the cisco_iosxr vendor page (DNS/NTP/syslog now round-trip; timezone/DHCP/RADIUS/SNMP still drop).

## Tests + cross-mesh baseline

- New `test_cisco_iosxr_mgmt_plane.py` (ntp-block harvest incl. non-`server`-leaf skip, syslog IP-guard, DNS/domain disjointness, full round-trip, negative control, classify) + `cisco_iosxr` added to the syslog cross-vendor preserve test.
- Re-baselined: **CODEC_BUG stays 5, no new bug pair, change isolated to cisco_iosxr pairs.** All cisco_iosxr pairs are yaml-less (one of the 4 newest codecs), so the only effect is raw mechanical drift — iosxr-source rises only +1 on aoscx/opnsense (verified: `ntp_servers`, which aruba_aoscx deliberately discards) and X→iosxr falls sharply (e.g. `juniper_junos→cisco_iosxr` 76→58, iosxr now preserves the mgmt plane).

## Verification

- De-risk probe + real-codec verification: ntp-block/dns/syslog harvest, render forms, round-trip, classify, negative control all green.
- Full `tests/unit tests/integration` local run: green (incl. the cross-mesh CI guard + tier-1/registry honesty guards + round-trip harness). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
