### PR TITLE
fix(audit): treat snmp v3 passphrase hashes as cosmetic in cross-mesh comparator (#20, scoped)

### DIFF
--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -14,15 +14,15 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 |---|---:|---|
 | ALIGNED | 1678 | ok |
 | CODEC_BUG | 5 | **high** |
-| EXPECTED_LOSSY | 1229 | ok |
+| EXPECTED_LOSSY | 1228 | ok |
 | EXPECTED_UNSUPPORTED | 732 | ok |
-| METHODOLOGY_ISSUE_under | 925 | low/medium |
+| METHODOLOGY_ISSUE_under | 926 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
 | STRUCTURAL_ONLY | 1179 | low |
 | TRIVIAL_EMPTY | 9526 | ok |
 | **Total field-cells classified** | **15299** | |
 
-Severity roll-up: 5 high, 107 medium, 2022 low, 13165 ok.
+Severity roll-up: 5 high, 107 medium, 2023 low, 13164 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-12T20:48:43+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T204824Z.json",
-  "mesh_run_started_utc": "2026-07-12T20:48:18+00:00",
+  "started_utc": "2026-07-12T22:04:44+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T215945Z.json",
+  "mesh_run_started_utc": "2026-07-12T21:59:32+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4136,17 +4136,17 @@
   "aggregate": {
     "ALIGNED": 1678,
     "CODEC_BUG": 5,
-    "EXPECTED_LOSSY": 1229,
+    "EXPECTED_LOSSY": 1228,
     "EXPECTED_UNSUPPORTED": 732,
-    "METHODOLOGY_ISSUE_under": 925,
+    "METHODOLOGY_ISSUE_under": 926,
     "METHODOLOGY_ISSUE_over": 25,
     "STRUCTURAL_ONLY": 1179,
     "TRIVIAL_EMPTY": 9526,
     "fields_total": 15299,
     "severity_high": 5,
     "severity_medium": 107,
-    "severity_low": 2022,
-    "severity_ok": 13165
+    "severity_low": 2023,
+    "severity_ok": 13164
   },
   "severity_matrix": {
     "arista_eos": {
@@ -4246,7 +4246,7 @@
     {
       "source_codec": "aruba_aoscx",
       "target_codec": "fortigate_cli",
-      "drifted_total": 27
+      "drifted_total": 26
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4406,7 +4406,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "arista_eos",
-      "drifted_total": 40
+      "drifted_total": 37
     },
     {
       "source_codec": "cisco_nxos",
@@ -4416,7 +4416,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "aruba_aoss",
-      "drifted_total": 52
+      "drifted_total": 49
     },
     {
       "source_codec": "cisco_nxos",
@@ -4426,7 +4426,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "cisco_iosxe_cli",
-      "drifted_total": 33
+      "drifted_total": 30
     },
     {
       "source_codec": "cisco_nxos",
@@ -4446,7 +4446,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "juniper_junos",
-      "drifted_total": 57
+      "drifted_total": 54
     },
     {
       "source_codec": "cisco_nxos",
@@ -4461,7 +4461,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "vyos",
-      "drifted_total": 62
+      "drifted_total": 56
     },
     {
       "source_codec": "fortigate_cli",

--- a/tests/unit/audit/test_run_full_mesh.py
+++ b/tests/unit/audit/test_run_full_mesh.py
@@ -23,6 +23,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalIPv4Address,
     CanonicalLAG,
     CanonicalSNMP,
+    CanonicalSNMPv3User,
     CanonicalStaticRoute,
     CanonicalVlan,
     CanonicalVxlan,
@@ -230,6 +231,63 @@ def test_dropped_secondary_address_is_still_drift() -> None:
     )
     out = compute_field_disposition(src, tgt)
     assert out["interfaces"]["preserved"] is False
+
+
+def test_snmp_v3_passphrase_hash_is_cosmetic_cross_vendor() -> None:
+    """An ``snmp`` dict identical except for the v3 auth/priv PASSPHRASE
+    hashes must compare PRESERVED.
+
+    The passphrase is an opaque pre-hashed secret each vendor localises
+    into its own on-box digest / encryption envelope (Cisco ``ENC``-
+    prefixed, AOS-CX SHA-1, …), so the SAME logical credential never
+    ports byte-for-byte cross-vendor even when both codecs fully support
+    v3 — exactly the ``is_secondary`` situation (a rendering artifact,
+    not operator intent).  See ``_COSMETIC_SNMP_V3_SUBFIELDS`` (scoped
+    subset of promotion #20)."""
+    src = CanonicalIntent(snmp=CanonicalSNMP(
+        community="public",
+        v3_users=[CanonicalSNMPv3User(
+            name="admin", auth_protocol="sha", auth_passphrase="abc123hash",
+            priv_protocol="aes", priv_passphrase="def456hash",
+        )],
+    ))
+    tgt = CanonicalIntent(snmp=CanonicalSNMP(
+        community="public",
+        v3_users=[CanonicalSNMPv3User(
+            name="admin", auth_protocol="sha", auth_passphrase="ENC xyz789",
+            priv_protocol="aes", priv_passphrase="ENC uvw321",
+        )],
+    ))
+    out = compute_field_disposition(src, tgt)
+    assert out["snmp"]["preserved"], (
+        "snmp differing only in the opaque v3 passphrase hashes must "
+        "compare preserved (a per-vendor rendering artifact, not intent)"
+    )
+
+
+def test_snmp_non_passphrase_drift_is_still_detected() -> None:
+    """The passphrase-hash stripping must NOT hide real snmp drift: a
+    changed v3 ``group`` or a dropped ``trap_hosts`` entry must still
+    compare DRIFTED.  Guards against the cosmetic normalisation over-
+    reaching beyond the two passphrase fields."""
+    base_user = {
+        "name": "admin", "auth_protocol": "sha", "auth_passphrase": "h",
+        "priv_protocol": "aes", "priv_passphrase": "h",
+    }
+    # (a) v3 group drift
+    src = CanonicalIntent(snmp=CanonicalSNMP(
+        v3_users=[CanonicalSNMPv3User(group="netadmin", **base_user)],
+    ))
+    tgt = CanonicalIntent(snmp=CanonicalSNMP(
+        v3_users=[CanonicalSNMPv3User(group="", **base_user)],
+    ))
+    assert compute_field_disposition(src, tgt)["snmp"]["preserved"] is False
+    # (b) trap_hosts drop
+    src2 = CanonicalIntent(snmp=CanonicalSNMP(
+        community="public", trap_hosts=["10.0.0.1"],
+    ))
+    tgt2 = CanonicalIntent(snmp=CanonicalSNMP(community="public", trap_hosts=[]))
+    assert compute_field_disposition(src2, tgt2)["snmp"]["preserved"] is False
 
 
 def test_list_order_change_does_not_register_as_drift() -> None:

--- a/tools/run_full_mesh.py
+++ b/tools/run_full_mesh.py
@@ -258,6 +258,25 @@ _COSMETIC_LIST_SUBFIELDS: dict[str, dict[str, tuple[str, ...]]] = {
     },
 }
 
+#: The ``snmp`` dict carries a ``v3_users`` USM list whose ``auth_passphrase``
+#: / ``priv_passphrase`` are OPAQUE pre-hashed secrets — each vendor localises
+#: the credential into its own on-box digest / encryption envelope (Cisco
+#: ``ENC``-prefixed, AOS-CX SHA-1, MikroTik AES, …), so the SAME logical
+#: passphrase never ports byte-for-byte cross-vendor even when both codecs
+#: fully support v3.  Comparing the opaque hash false-flags drift on a
+#: credential the operator did not change — exactly the ``is_secondary``
+#: situation (a target-determined rendering artifact, not operator intent).
+#: The mesh only compares cross-vendor pairs, so the hash is never the carrier
+#: of real intent here.  Blanked on BOTH sides before the snmp-dict compare so
+#: a passphrase-only difference reads as preserved; any OTHER snmp drift
+#: (community / contact / location / trap_hosts / v3 group / protocols) still
+#: surfaces.  (Scoped subset of promotion #20 — the whole-``snmp``-dict flip
+#: stays blocked on those other, matrix-undeclared surfaces.)
+_COSMETIC_SNMP_V3_SUBFIELDS: tuple[str, ...] = (
+    "auth_passphrase",
+    "priv_passphrase",
+)
+
 
 def _strip_cosmetic_subfields(field: str, records: list[Any]) -> list[Any]:
     """Return a copy of *records* with target-determined cosmetic
@@ -283,6 +302,27 @@ def _strip_cosmetic_subfields(field: str, records: list[Any]) -> list[Any]:
                     for item in nested
                 ]
         out.append(rec)
+    return out
+
+
+def _strip_cosmetic_snmp(field: str, snmp: Any) -> Any:
+    """Return a copy of the ``snmp`` dict with each ``v3_users`` record's
+    opaque auth/priv passphrase hashes blanked (see
+    :data:`_COSMETIC_SNMP_V3_SUBFIELDS`).  No-op for any other field or a
+    non-dict value, so the caller can apply it unconditionally in the
+    dict-comparison branch."""
+    if field != "snmp" or not isinstance(snmp, dict):
+        return snmp
+    users = snmp.get("v3_users")
+    if not isinstance(users, list):
+        return snmp
+    out = dict(snmp)
+    out["v3_users"] = [
+        {k: ("" if k in _COSMETIC_SNMP_V3_SUBFIELDS else v)
+         for k, v in u.items()}
+        if isinstance(u, dict) else u
+        for u in users
+    ]
     return out
 
 
@@ -407,7 +447,12 @@ def compute_field_disposition(
                 record["source"] = _scalar_summary(src_disp)
                 record["target"] = _scalar_summary(tgt_disp)
         elif isinstance(src_val, dict) and isinstance(tgt_val, dict):
-            preserved = src_val == tgt_val
+            # Blank cosmetic opaque-hash subfields (snmp v3 passphrases) on
+            # both sides so a credential-hash-only difference reads preserved;
+            # real snmp drift still surfaces.  See _COSMETIC_SNMP_V3_SUBFIELDS.
+            cmp_src = _strip_cosmetic_snmp(field, src_val)
+            cmp_tgt = _strip_cosmetic_snmp(field, tgt_val)
+            preserved = cmp_src == cmp_tgt
             record["preserved"] = preserved
             record["source_count"] = len(src_val)
             record["target_count"] = len(tgt_val)
@@ -416,7 +461,11 @@ def compute_field_disposition(
                 # case above.  See Wave 10α.
                 record["trivially_preserved"] = True
             if not preserved:
-                record["drift"] = _dict_drift_summary(src_val, tgt_val)
+                # Use the cosmetic-normalised dicts (opaque v3 passphrase
+                # hashes blanked) so the drift summary + Phase 4's
+                # ``_subfield_drift_in_dict`` reflect real drift, not the
+                # per-vendor hash artifact.
+                record["drift"] = _dict_drift_summary(cmp_src, cmp_tgt)
                 # Store the FULL source/target dicts (not key-lists) so
                 # the Phase 4 reconciler's ``_subfield_drift_in_dict``
                 # can resolve per-attribute drift instead of bailing
@@ -429,8 +478,8 @@ def compute_field_disposition(
                 # (``_md_inline``) JSON-serialises and truncates dicts
                 # to 200 chars, so size impact on the matrix .md is
                 # bounded.
-                record["source"] = src_val
-                record["target"] = tgt_val
+                record["source"] = cmp_src
+                record["target"] = cmp_tgt
         else:
             # Scalar or None vs structured.  None-vs-empty is treated
             # as preserved (the canonical model uses None for "snmp


### PR DESCRIPTION
## Summary

The scoped, correct core of promotion **#20**. SNMPv3 `auth_passphrase` / `priv_passphrase` are **opaque pre-hashed secrets** — each vendor localises the credential into its own on-box digest / encryption envelope (Cisco `ENC`-prefixed, AOS-CX SHA-1, MikroTik AES, …), so the same logical passphrase never ports byte-for-byte cross-vendor even when both codecs fully support v3. The cross-mesh comparator was false-flagging drift on a credential the operator never changed — exactly the `is_secondary` situation (a target-determined rendering artifact, not intent).

## Change

`run_full_mesh`: new `_strip_cosmetic_snmp` blanks the two v3 passphrase fields on **both** sides of the snmp-dict comparison (and in the stored drift snapshot), mirroring the existing `_strip_cosmetic_subfields` / `is_secondary` pattern. A passphrase-hash-only difference now reads **preserved**; every other snmp drift (community / contact / location / trap_hosts / v3 group / protocols) still surfaces.

## Why only this scope (verify-first)

The full #20 — flip the ~22 `snmp: lossy` parents to `good` via a matrix-consulting reclassifier — stays **blocked**. An audit of the live mesh found **152** drifted-snmp cross-vendor cells, of which **102** carry residual drift the v3-hash strip does *not* cover:
- `trap_hosts` dropped on targets that don't declare `/snmp/trap-hosts` unsupported,
- `contact` quote-sanitised on vyos, which declares `/snmp/contact` **supported**,
- v3 `group`/passphrase undeclared on most targets.

Flipping the parents would leave ~102 false CODEC_BUGs, so this change deliberately does **not** flip them (the verifier's original "don't flip parents" caveat).

## Tests + cross-mesh baseline

- New guard tests in `tests/unit/audit/test_run_full_mesh.py` (passphrase-only diff is cosmetic/preserved; v3-`group` + `trap_hosts` drift still detected), mirroring the `is_secondary` pair.
- Re-baselined: **CODEC_BUG stays 5, no new bug pair**, cells 1224, fields 15299. **6 YAML-less pairs' raw drift fell** (nxos/aoscx-source snmp passphrase noise no longer counted); net **+1 METHODOLOGY_under / −1 EXPECTED_LOSSY** on one YAML-having pair whose `snmp: lossy` now honestly over-declares (left lossy rather than risk a parent flip, per #20). All CI-guard invariants hold vs the git-HEAD baseline.

## Verification

- Live-mesh audit (152 cells characterized) + real-codec sanity of the helper (passphrase-only → preserved; group/trap_hosts drift survives; non-snmp/non-dict no-op).
- Full `tests/unit tests/integration` local run: green. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
