### PR TITLE
docs(expectations): correct stale "canonical lacks a vrf field" reason text (reason-only)

### DIFF
--- a/tests/fixtures/cross_vendor_expectations/arista_eos__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__aruba_aoss.yaml
@@ -234,12 +234,14 @@ per_field_expectation:
       Default-VRF IPv4 static routes round-trip cleanly (both
       vendors emit CIDR; no dotted-mask conversion noise).
       Per-VRF static routes (``ip route vrf X ...``) are
-      currently parse-and-ignore at the canonical layer
-      (CanonicalStaticRoute lacks a ``vrf`` field), so the data
-      never reaches the Aruba target.  IPv6 default routes
+      harvested from the Arista source onto
+      ``CanonicalStaticRoute.vrf``, but the aruba_aoss target
+      has no VRF / routing-instance model and renders every
+      route into the global table, dropping the per-VRF
+      binding.  IPv6 default routes
       (``ipv6 route ::/0 <gw>``) are not reliably parsed on the
       Aruba side either, so cross-vendor IPv6 routes also drop.
-      Known canonical-model gap.
+      Known target-side gap (aruba_aoss has no VRF model).
     references: [static_routes]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
@@ -230,11 +230,13 @@ per_field_expectation:
     reason: >
       Default-VRF static routes round-trip cleanly (Arista's CIDR
       form converts to / from Cisco's dotted-mask form via the
-      codecs).  However, per-VRF static routes (``ip route vrf X
-      ...``) are currently parse-and-ignore on both codecs
-      (CanonicalStaticRoute lacks a ``vrf`` field).  This is a
-      known canonical-model gap that lands alongside per-VRF route
-      wire-up.
+      codecs).  Per-VRF static routes (``ip route vrf X ...``)
+      now round-trip too: both codecs harvest and render the
+      per-VRF form via ``CanonicalStaticRoute.vrf`` (Arista
+      ``ip route vrf X`` <-> Cisco ``ip route vrf X``).  The
+      ``lossy`` disposition is a conservative holdover from
+      before the v0.2.0 vrf wire-up (the mesh reads this cell as
+      preserved); a candidate for promotion to ``good``.
     references: [static_routes, vrf]
 
   # ── Tier 2 — auto-translate with review ──
@@ -471,9 +473,10 @@ per_field_expectation:
 #
 # Deferred items (not researched in depth this pass):
 #
-#   * Per-VRF static routes (``ip route vrf X ...``) — neither codec
-#     populates them today; canonical model lacks a vrf field on
-#     CanonicalStaticRoute.  Lands alongside richer VRF wire-up.
+#   * Per-VRF static routes (``ip route vrf X ...``) — now wired
+#     on both codecs via ``CanonicalStaticRoute.vrf`` (v0.2.0);
+#     round-trips cleanly.  The static_routes cell above is still
+#     conservatively declared lossy.
 #
 #   * NTP per-server options (prefer / iburst / key / source) —
 #     canonical model is host-list-only.  Lossy by design;

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__fortigate_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__fortigate_cli.yaml
@@ -253,8 +253,9 @@ per_field_expectation:
       CIDR ``ip route 10.50.0.0/16 10.0.0.2`` -> FortiOS ``set dst
       10.50.0.0 255.255.0.0 / set gateway 10.0.0.2``.  Per-VRF
       static routes (Arista ``ip route vrf X ...``) are
-      parse-and-ignore (canonical model lacks a vrf field on
-      CanonicalStaticRoute).  Outgoing-interface field requires
+      harvested onto ``CanonicalStaticRoute.vrf`` but drop on
+      render because the fortigate_cli codec has no per-route
+      VRF/VDOM binding.  Outgoing-interface field requires
       the port-rename mesh to map ``Ethernet1`` -> ``port1``.
       Metric semantics differ (Arista default 1 / per-static
       comparator vs FortiGate default 10 / AD-ordering) so the

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__mikrotik_routeros.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__mikrotik_routeros.yaml
@@ -300,9 +300,10 @@ per_field_expectation:
       RouterOS render emits ``/ipv6 route add`` with the same
       shape.  Lossy bits: (1) per-VRF Arista routes (``ip route
       vrf TENANT_A ...``) drop to the global table on render
-      because the canonical model lacks a vrf field on
-      ``CanonicalStaticRoute`` (deferred — lands alongside VRF
-      wire-up); (2) Arista route-tag / metric overrides are
+      because the mikrotik_routeros codec emits no per-route
+      ``routing-table=<vrf>`` binding (the ``CanonicalStaticRoute.vrf``
+      field is harvested from Arista but unrendered on RouterOS);
+      (2) Arista route-tag / metric overrides are
       partially modelled (metric carried, tag dropped); (3)
       blackhole / Null0 semantics not modelled canonically (Arista
       has the form; RouterOS has the ``blackhole=yes`` flag — both

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__opnsense.yaml
@@ -475,10 +475,10 @@ per_field_expectation:
       gateways).  The OPNsense codec does not currently render
       either block on cross-vendor; canonical static_routes from
       an Arista source therefore drop pending wire-up.  Per-VRF
-      static routes (Arista ``ip route vrf X ...``) are
-      unsupported on the cross-pair (canonical lacks a VRF field
-      on CanonicalStaticRoute, and OPNsense has no VRF model
-      anyway).  Arista's ``0.0.0.0/0`` form would also need
+      static routes (Arista ``ip route vrf X ...``) carry a
+      populated ``CanonicalStaticRoute.vrf`` but drop on this
+      cross-pair because OPNsense has no VRF model.  Arista's
+      ``0.0.0.0/0`` form would also need
       remapping to the OPNsense default-gateway idiom (set via
       the WAN zone interface).
     references: [opnsense-gateways, arista-routing-cg]

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__arista_eos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__arista_eos.yaml
@@ -179,10 +179,13 @@ per_field_expectation:
     reason: >
       Default-VRF static routes round-trip cleanly (Cisco's dotted-
       mask form converts to / from Arista's CIDR form via the
-      codecs).  However, per-VRF static routes (``ip route vrf X
-      ...``) are currently parse-and-ignore on the Cisco codec
-      (CanonicalStaticRoute lacks a ``vrf`` field).  This is a
-      known gap that lands alongside VRF wire-up.
+      codecs).  Per-VRF static routes (``ip route vrf X ...``)
+      now round-trip too: both codecs harvest and render the
+      per-VRF form via ``CanonicalStaticRoute.vrf`` (Cisco
+      ``ip route vrf X`` <-> Arista ``ip route vrf X``).  The
+      ``lossy`` disposition is a conservative holdover from
+      before the v0.2.0 vrf wire-up; a candidate for promotion
+      to ``good``.
     references: [static_routes, vrf]
 
   # ── Tier 2 — auto-translate with review ──
@@ -390,8 +393,9 @@ per_field_expectation:
 # Deferred items (not researched in depth this pass):
 #
 #   * Per-VRF static routes (``ip route vrf X ...``) — Cisco parses
-#     and emits them, Arista same; canonical model lacks a vrf field
-#     on CanonicalStaticRoute.  Lands alongside VRF wire-up.
+#     and emits them, Arista same, now bound to
+#     ``CanonicalStaticRoute.vrf`` (v0.2.0); round-trips cleanly.
+#     The static_routes cell above is conservatively still lossy.
 #
 #   * NTP per-server options (prefer / iburst / key / source) —
 #     canonical model is host-list-only.  Lossy by design;

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__fortigate_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__fortigate_cli.yaml
@@ -208,8 +208,9 @@ per_field_expectation:
       Default-VRF static routes round-trip cleanly via
       ``_mask_to_prefix`` / ``_prefix_to_mask`` conversions.
       Per-VRF static routes (Cisco ``ip route vrf X ...``) are
-      parse-and-ignore (canonical model lacks a vrf field on
-      CanonicalStaticRoute).  Metric semantics differ (Cisco
+      harvested onto ``CanonicalStaticRoute.vrf`` but drop on
+      render because the fortigate_cli codec has no per-route
+      VRF/VDOM binding.  Metric semantics differ (Cisco
       per-static-comparator vs FortiGate distance / AD-ordering)
       so the integer preserves but its meaning differs.
       Description (Cisco ``name <desc>``) is FortiGate-unwired.

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__juniper_junos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__juniper_junos.yaml
@@ -474,8 +474,9 @@ per_field_expectation:
       Default-VRF static routes round-trip cleanly (Cisco's
       dotted-mask form converts to/from Junos's CIDR via codec
       parsers).  Per-VRF static routes (``ip route vrf X ...``)
-      are parse-and-ignore in v1 (CanonicalStaticRoute lacks a
-      ``vrf`` field).  Cisco's "administrative distance" and
+      now round-trip via ``CanonicalStaticRoute.vrf`` (Cisco
+      ``ip route vrf X`` -> Junos ``set routing-instances X
+      routing-options static``).  Cisco's "administrative distance" and
       Junos's "preference" are vendor-specific scalars not 1:1;
       ``CanonicalStaticRoute.metric`` is the operator-visible
       metric, not preference/AD.  Junos's ``qualified-next-hop``

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__mikrotik_routeros.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__mikrotik_routeros.yaml
@@ -212,9 +212,10 @@ per_field_expectation:
       interface-as-gateway form (``ip route X Y GigabitEthernet0/0/2``)
       maps to RouterOS's ``gateway=ether2`` form.  The lossy bit
       is per-VRF: Cisco ``ip route vrf X ...`` drops to the global
-      table on render because the canonical model lacks a vrf field
-      on CanonicalStaticRoute (deferred — lands alongside VRF
-      wire-up).
+      table on render because the mikrotik_routeros codec emits no
+      per-route ``routing-table=<vrf>`` binding — the
+      ``CanonicalStaticRoute.vrf`` field is harvested from Cisco
+      but unrendered on RouterOS.
     references: [mikrotik_ip_routing]
 
   # ── Tier 2 — auto-translate with review banner ──

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
@@ -416,8 +416,9 @@ per_field_expectation:
       gateways).  The OPNsense codec does not currently parse
       OR emit either block; canonical static_routes from a Cisco
       source therefore drop on render.  Per-VRF static routes
-      (Cisco ``ip route vrf X ...``) are unsupported (canonical
-      lacks a VRF field on CanonicalStaticRoute).
+      (Cisco ``ip route vrf X ...``) carry a populated
+      ``CanonicalStaticRoute.vrf`` but drop on this cross-pair
+      because OPNsense has no VRF model.
     references: [opnsense-gateways]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/fortigate_cli__arista_eos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/fortigate_cli__arista_eos.yaml
@@ -247,9 +247,9 @@ per_field_expectation:
       preserves but its meaning shifts on the target.  Description
       / comment (FortiGate ``set comment``) parse coverage may be
       inconsistent in v1.  Per-VRF static routes (FortiGate ``set
-      vrf <id>``) are unsupported on this pair — canonical model
-      lacks a vrf field on CanonicalStaticRoute AND the FortiGate
-      codec does not currently parse ``set vrf``.  IPv6 static
+      vrf <id>``) are unsupported on this pair — the fortigate_cli
+      codec does not currently parse ``set vrf`` into
+      ``CanonicalStaticRoute.vrf``.  IPv6 static
       routes live under ``config router static6`` on FortiOS
       (separate edit-table; not currently wired through the
       canonical static_routes list).

--- a/tests/fixtures/cross_vendor_expectations/fortigate_cli__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/fortigate_cli__aruba_aoss.yaml
@@ -273,8 +273,9 @@ per_field_expectation:
       meaning differs.  Description / comment (FortiGate ``set
       comment``) is not currently parsed.  Per-VRF static routes
       (FortiGate ``set vrf <id>``) are unsupported on this pair —
-      canonical model lacks a vrf field on CanonicalStaticRoute
-      AND Aruba has no VRF concept.  Aruba's legacy
+      the fortigate_cli codec does not parse ``set vrf`` into
+      ``CanonicalStaticRoute.vrf``, AND Aruba has no VRF concept.
+      Aruba's legacy
       ``ip default-gateway`` form synthesises from a 0.0.0.0/0
       canonical record on render.
     references: [static_routes]

--- a/tests/fixtures/cross_vendor_expectations/fortigate_cli__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/fortigate_cli__cisco_iosxe_cli.yaml
@@ -217,8 +217,8 @@ per_field_expectation:
       per-static-comparator) so the integer preserves but its
       meaning differs.  Description (FortiGate ``set comment``) is
       not currently parsed.  Per-VRF static routes (FortiGate ``set
-      vrf <id>``) are unsupported — canonical model lacks a vrf
-      field on CanonicalStaticRoute.
+      vrf <id>``) are unsupported — the fortigate_cli codec does not
+      parse ``set vrf`` into ``CanonicalStaticRoute.vrf``.
     references: [static_routes]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__fortigate_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__fortigate_cli.yaml
@@ -558,8 +558,9 @@ per_field_expectation:
       semantics differ from Junos preference, so the integer
       preserves but its meaning differs.  Per-VRF static routes
       (``set routing-instances X routing-options static route
-      ...``) are parse-and-ignore in v1 (CanonicalStaticRoute
-      lacks a vrf field).  ``description`` field not rendered
+      ...``) are harvested onto ``CanonicalStaticRoute.vrf`` but
+      drop on render because the fortigate_cli codec has no
+      per-route VRF/VDOM binding.  ``description`` field not rendered
       (FortiGate has no comment surface on ``edit N`` static
       routes in v1 codec).
     references: [junos-static-routing, fortios-static-routes]

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__mikrotik_routeros.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__mikrotik_routeros.yaml
@@ -550,7 +550,9 @@ per_field_expectation:
       multiple canonical entries and expands to multiple RouterOS
       records; (3) per-VRF static routes (`routing-instances X
       routing-options static`) flatten to the global table because
-      ``CanonicalStaticRoute`` lacks a ``vrf`` field (deferred).
+      the mikrotik_routeros codec emits no per-route
+      ``routing-table=<vrf>`` binding (``CanonicalStaticRoute.vrf``
+      is harvested from Junos but unrendered on RouterOS).
     references: [junos-static-routing, mikrotik-ip-routing]
 
   # ── Tier 2 — DHCP server ──

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__opnsense.yaml
@@ -533,9 +533,10 @@ per_field_expectation:
       OPNsense codec does not currently parse OR emit either block;
       canonical static_routes from a Junos source therefore drop on
       render.  Per-VRF static routes (Junos ``set routing-instances
-      <vrf> routing-options static``) are unsupported (canonical
-      lacks a VRF field on CanonicalStaticRoute, and OPNsense has
-      no VRF anyway).  Junos's ``qualified-next-hop`` flattens to
+      <vrf> routing-options static``) carry a populated
+      ``CanonicalStaticRoute.vrf`` from the Junos source but drop
+      on this cross-pair because OPNsense has no VRF model.
+      Junos's ``qualified-next-hop`` flattens to
       multiple canonical entries.
     references: [junos-static-routing, opnsense-gateways]
 

--- a/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__arista_eos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__arista_eos.yaml
@@ -290,10 +290,11 @@ per_field_expectation:
       ``gateway=ether2`` interface form maps to Arista's
       interface-as-gateway form.  IPv6 routes round-trip via
       ``/ipv6 route`` -> ``ipv6 route ::/0 ...``.  Lossy bits: (1)
-      per-VRF routes (``routing-table=TENANT-A``) drop to default
-      VRF on render because the canonical model lacks a vrf field
-      on CanonicalStaticRoute (deferred — lands alongside VRF
-      wire-up); (2) RouterOS's ``blackhole=yes`` flag has no
+      per-VRF routes (``routing-table=TENANT-A``) drop to the
+      global table because the mikrotik_routeros codec
+      parses-and-ignores the ``routing-table=`` binding, so
+      ``CanonicalStaticRoute.vrf`` is never populated on the
+      RouterOS source; (2) RouterOS's ``blackhole=yes`` flag has no
       canonical surface — render encodes it via the ``Null0``
       next-hop on Arista side, which is semantic-equivalent but
       not byte-identical; (3) RouterOS's per-route ``distance=N``

--- a/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__aruba_aoss.yaml
@@ -215,9 +215,10 @@ per_field_expectation:
       add dst-address=X/N gateway=Y`` -> Aruba ``ip route X/N
       Y``.  Aruba accepts both CIDR and dotted-mask destinations;
       codec emits CIDR by default.  Lossy bits: (1) per-VRF
-      routes (``routing-table=TENANT-A``) drop to default VRF
-      because the canonical model lacks a vrf field on
-      CanonicalStaticRoute, AND Aruba target structurally has no
+      routes (``routing-table=TENANT-A``) drop to the global
+      table because the mikrotik_routeros codec parses-and-ignores
+      the ``routing-table=`` binding (``CanonicalStaticRoute.vrf``
+      never populated), AND the Aruba target structurally has no
       VRF concept anyway; (2) ``blackhole=yes`` flag has no
       canonical equivalent — drops on render with banner;
       (3) interface-as-gateway (``gateway=ether2``) populates

--- a/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__cisco_iosxe.yaml
+++ b/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__cisco_iosxe.yaml
@@ -382,9 +382,12 @@ per_field_expectation:
       walk <network-instances> / <protocols><protocol identifier=
       "STATIC"> on emit.  Render-side wire-up gap; the matrix
       declares /routing/static-route "supported" aspirationally.
-      Flips to lossy once wired (per-VRF routes drop to default VRF
-      because canonical CanonicalStaticRoute lacks a vrf field;
-      blackhole=yes maps to Null0 interface name on Cisco side which
+      Flips to lossy once wired (per-VRF routes drop to the global
+      table because the mikrotik_routeros codec parses-and-ignores
+      the ``routing-table=<vrf>`` binding, so
+      ``CanonicalStaticRoute.vrf`` is never populated on the
+      RouterOS source; blackhole=yes maps to Null0 interface name
+      on Cisco side which
       is semantic-equivalent but not byte-identical).
     references: [oc-network-instance, scope-summary]
 

--- a/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__cisco_iosxe_cli.yaml
@@ -212,9 +212,11 @@ per_field_expectation:
       Codec converts CIDR <-> dotted-mask transparently.
       RouterOS's ``gateway=ether2`` interface form maps to Cisco's
       interface-as-gateway form.  Lossy bits: (1) per-VRF routes
-      (``routing-table=TENANT-A``) drop to default VRF on render
-      because the canonical model lacks a vrf field on
-      CanonicalStaticRoute; (2) ``blackhole=yes`` has no canonical
+      (``routing-table=TENANT-A``) drop to the global table
+      because the mikrotik_routeros codec parses-and-ignores the
+      ``routing-table=`` binding, so ``CanonicalStaticRoute.vrf``
+      is never populated on the RouterOS source; (2)
+      ``blackhole=yes`` has no canonical
       flag — render encodes it via the ``Null0`` interface name on
       Cisco side, which is semantic-equivalent but not byte-
       identical.

--- a/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__juniper_junos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__juniper_junos.yaml
@@ -530,7 +530,9 @@ per_field_expectation:
       Junos ``preference`` are vendor-specific AD scalars not 1:1
       with canonical ``metric``; (2) per-VRF static routes
       (RouterOS ``routing-table=<name>``) flatten to global because
-      ``CanonicalStaticRoute`` lacks a ``vrf`` field (deferred);
+      the mikrotik_routeros codec parses-and-ignores the
+      ``routing-table=`` binding (``CanonicalStaticRoute.vrf`` is
+      never populated on the RouterOS source);
       (3) RouterOS ``type=blackhole`` semantics not modelled
       canonically — drops to a destination-only record.
     references: [mikrotik-ip-routing, junos-static-routing]


### PR DESCRIPTION
## Summary

Doc hygiene: `CanonicalStaticRoute` gained a `vrf` field in v0.2.0, but **23 reason/comment lines across 21 cross-vendor expectation YAMLs** still claimed the canonical model *"lacks a vrf field"* — a stale, definitively-false statement. This corrects the prose to the **actual** per-VRF-static-route mechanism, **changing no `disposition:` values**.

## Why (verify-first)

Grouped the 23 lines by what really happens to a per-VRF route, and verified each:

- **Both-wiring pairs** (`arista_eos ↔ cisco_iosxe_cli`, `cisco_iosxe_cli → juniper_junos`): a live `parse → render` probe confirmed per-VRF routes **now round-trip** via `CanonicalStaticRoute.vrf` (`ip route vrf X` and `set routing-instances X routing-options static` both survive). The `arista_eos → cisco_iosxe_cli` cell already reads **`preserved`** in the mesh (a `METHODOLOGY_under` over-declaration); prose now says so and flags it a **promotion candidate**. Disposition left `lossy` — that's a separate, user-steered promotion.
- **Target-drop pairs** (`aruba_aoss` / `opnsense` / `fortigate_cli` / `mikrotik_routeros` as target): the source harvests `vrf`, but the target renders every route into the global table (no per-VRF / routing-instance model). Loss is **target-side**, not a canonical gap. Stays `lossy`/`unsupported`.
- **Source-drop pairs** (`mikrotik_routeros` / `fortigate_cli` as source): the codec parses-and-ignores its per-VRF binding (RouterOS `routing-table=` / FortiOS `set vrf`), so `CanonicalStaticRoute.vrf` is never populated — matches the mikrotik codec's own `/routing/static-route/vrf` lossy declaration. Unchanged.

## Scope + safety

- **Reason/comment text ONLY.** Zero `disposition:` edits (flipping the non-vrf-wiring targets would mint false `CODEC_BUG`s). Confirmed with `git diff | grep -E "^[+-].*disposition:"` (empty) and a shallow-indent structural-key diff check (empty).
- Reason text is free-text the reconciler never classifies on → `latest.json` + `PHASE4_RECONCILIATION.md` are **byte-identical** (no re-baseline).
- Verified: **0** stale phrases remain; all 21 files still CRLF + parse as YAML; `test_cross_mesh_ci_guard.py` (8) + `test_run_phase4_reconciliation.py` green — **CODEC_BUG still 5, cells 1224, no classification movement**.

## Out of scope (flagged, not folded in)

Two adjacent comment lines (`cisco_iosxe_cli__arista_eos.yaml` + its mirror) say the Cisco codec *"parse-and-ignores VRF declarations entirely"* — also stale (it harvests `vrf definition` / `ip vrf` since #278), but that's the **routing_instances** surface, not static-route `vrf`, and needs its own verification pass. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
