### PR TITLE
fix(security): harden five ReDoS siblings of #337 (polynomial parse-time DoS via /plan)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -213,6 +213,10 @@ _VRF_RD_RE = re.compile(r"^\s+rd\s+(\S+)\s*$")
 # ``\S`` are disjoint classes so there is exactly one split; the ``.strip()``
 # on the captured group still trims any trailing whitespace ``.*`` absorbed.
 _VRF_DESC_RE = re.compile(r"^\s+description\s+(\S.*)$")
+#: ``vrrp <gid> description <text>`` (operator-supplied).  Module-level so the
+#: ReDoS-hardening guard can pin it; ``(\S.*)`` not ``(.+?)\s*$`` for the same
+#: reason as ``_VRF_DESC_RE`` above (the consumer ``.strip()``s the capture).
+_VRRP_DESCRIPTION_RE = re.compile(r"^vrrp\s+(\d+)\s+description\s+(\S.*)$")
 _VRF_RT_RE = re.compile(
     r"^\s+route-target\s+(import|export|both)\s+(?:evpn\s+)?(\S+)\s*$"
 )
@@ -1406,10 +1410,9 @@ def _apply_iface_subcommand(  # noqa: C901
             g = _vrrp_group_for(iface, int(m.group(2)), mode="vrrp")
             g.preempt = not bool(m.group(1))
             return
-        # ``vrrp <gid> description <text>`` (operator-supplied).
-        m = re.match(
-            r'^vrrp\s+(\d+)\s+description\s+(.+?)\s*$', line,
-        )
+        # ``vrrp <gid> description <text>`` (operator-supplied); pattern is
+        # ``_VRRP_DESCRIPTION_RE`` (module-level, ReDoS-hardened + guard-pinned).
+        m = _VRRP_DESCRIPTION_RE.match(line)
         if m:
             g = _vrrp_group_for(iface, int(m.group(1)), mode="vrrp")
             text = m.group(2).strip()

--- a/netcanon/migration/codecs/aruba_aoss/parse.py
+++ b/netcanon/migration/codecs/aruba_aoss/parse.py
@@ -315,8 +315,13 @@ _VRRP_PRIORITY_RE = re.compile(
 #   authentication mode plaintext-password "X"
 # Captured verbatim; stored as ``"plain:X"`` per the
 # :class:`CanonicalVRRPGroup.authentication` opaque-token convention.
+# ``(\S.*)`` NOT ``"?([^"\n]+?)"?\s*$``: the lazy body + trailing ``\s*$``
+# backtrack O(n^2) on a space-padded line (the #337 ReDoS shape).  The value
+# is now captured verbatim (incl. any surrounding quotes) and the consumer
+# ``.strip().strip('"')``s it — behaviour-identical to the old inline quote/
+# whitespace trimming, but linear.
 _VRRP_AUTH_PLAINTEXT_RE = re.compile(
-    r'^authentication\s+mode\s+plaintext-password\s+"?([^"\n]+?)"?\s*$',
+    r'^authentication\s+mode\s+plaintext-password\s+(\S.*)$',
     re.IGNORECASE,
 )
 
@@ -770,7 +775,8 @@ def _parse_vrrp_group_stanza(
 
         auth = _VRRP_AUTH_PLAINTEXT_RE.match(stripped)
         if auth:
-            group.authentication = f"plain:{auth.group(1)}"
+            secret = auth.group(1).strip().strip('"')
+            group.authentication = f"plain:{secret}"
             i += 1
             continue
 

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -152,8 +152,11 @@ _VRRP_PREEMPT_RE = re.compile(
     r"^\s+(?P<no>no\s+)?vrrp\s+(?P<group>\d+)\s+preempt\b.*$",
     re.IGNORECASE,
 )
+# ``(?P<text>\S.*)`` NOT ``(?P<text>.+?)\s*$``: the lazy body overlapping the
+# trailing ``\s*$`` backtracks O(n^2) on a space-padded line (the #337 ReDoS
+# shape); the consumer ``.strip()``s so the trailing trim is redundant here.
 _VRRP_DESCRIPTION_RE = re.compile(
-    r"^\s+vrrp\s+(?P<group>\d+)\s+description\s+(?P<text>.+?)\s*$",
+    r"^\s+vrrp\s+(?P<group>\d+)\s+description\s+(?P<text>\S.*)$",
     re.IGNORECASE,
 )
 _VRRP_AUTH_MD5_RE = re.compile(

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -148,8 +148,13 @@ class _EditBlock:
         self.sub_blocks: list[_ConfigBlock] = []
 
 
-_CONFIG_HEADER_RE = re.compile(r"^config\s+(.+?)\s*$", re.IGNORECASE)
-_EDIT_HEADER_RE = re.compile(r"^edit\s+(.+?)\s*$", re.IGNORECASE)
+#: ``(\S.*)`` (greedy-to-EOL, anchored on a non-space) NOT ``(.+?)\s*$``:
+#: a lazy body whose class overlaps the trailing ``\s*$`` backtracks O(n^2)
+#: on ``config <x><run of spaces><non-space>`` (the #337 ReDoS shape).  The
+#: consumers ``.strip()`` the capture, so dropping the trailing trim from the
+#: pattern is behaviour-identical.
+_CONFIG_HEADER_RE = re.compile(r"^config\s+(\S.*)$", re.IGNORECASE)
+_EDIT_HEADER_RE = re.compile(r"^edit\s+(\S.*)$", re.IGNORECASE)
 _SET_RE = re.compile(r"^set\s+(\S+)\s*(.*)$", re.IGNORECASE)
 _COMMENT_RE = re.compile(r"^\s*#")
 #: FortiOS release from the ``#config-version`` header, e.g.

--- a/tests/unit/migration/test_redos_hardening.py
+++ b/tests/unit/migration/test_redos_hardening.py
@@ -29,15 +29,26 @@ from netcanon.migration.codecs.arista_eos.parse import (
 from netcanon.migration.codecs.arista_eos.parse import (
     _VRF_DESC_RE as _ARISTA_VRF_DESC_RE,
 )
+from netcanon.migration.codecs.arista_eos.parse import (
+    _VRRP_DESCRIPTION_RE as _ARISTA_VRRP_DESCRIPTION_RE,
+)
 from netcanon.migration.codecs.aruba_aoscx.parse import _VLAN_TRUNK_ALLOWED_RE
+from netcanon.migration.codecs.aruba_aoss.parse import _VRRP_AUTH_PLAINTEXT_RE
 from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
     _STATIC_ROUTE_RE,
 )
 from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
     _VRF_DESCRIPTION_RE as _IOSXE_VRF_DESCRIPTION_RE,
 )
+from netcanon.migration.codecs.cisco_iosxe_cli.parse import (
+    _VRRP_DESCRIPTION_RE as _IOSXE_VRRP_DESCRIPTION_RE,
+)
 from netcanon.migration.codecs.cisco_nxos.parse import (
     _VRF_DESCRIPTION_RE as _NXOS_VRF_DESCRIPTION_RE,
+)
+from netcanon.migration.codecs.fortigate_cli.parse import (
+    _CONFIG_HEADER_RE,
+    _EDIT_HEADER_RE,
 )
 
 pytestmark = pytest.mark.unit
@@ -90,6 +101,35 @@ def test_static_route_still_captures_and_keeps_trailing_tokens():
     assert (bare.group(5) or "").split() == []
 
 
+# --- #337-follow-up siblings: the same lazy ``(.+?)\s*$`` shape survived in
+#     five more parse.py patterns (fortigate config/edit headers, arista + iosxe
+#     inline VRRP descriptions, aoss plaintext-password) -- all now ``(\S.*)$``.
+
+
+def test_config_edit_headers_still_capture():
+    # fortigate section/edit headers -- consumer .strip().strip('"').strip("'").
+    assert _CONFIG_HEADER_RE.match("config system global  ").group(1).strip() == "system global"
+    assert _EDIT_HEADER_RE.match('edit "port1"').group(1).strip().strip('"') == "port1"
+
+
+def test_vrrp_description_still_captures():
+    # arista has no leading indent (``^vrrp``); iosxe requires it (``^\s+vrrp``).
+    assert _ARISTA_VRRP_DESCRIPTION_RE.match("vrrp 5 description core gw  ").group(2).strip() == "core gw"
+    assert _IOSXE_VRRP_DESCRIPTION_RE.match(" vrrp 5 description core gw  ").group("text").strip() == "core gw"
+
+
+def test_vrrp_plaintext_auth_still_captures():
+    # aoss captures the value verbatim (incl. any surrounding quotes); the
+    # consumer ``.strip().strip('"')``s it -- quoted / bare / trailing-space
+    # all normalise to the same token.
+    for line, want in [
+        ('authentication mode plaintext-password "secret"', "secret"),
+        ("authentication mode plaintext-password secret", "secret"),
+        ("authentication mode plaintext-password secret   ", "secret"),
+    ]:
+        assert _VRRP_AUTH_PLAINTEXT_RE.match(line).group(1).strip().strip('"') == want
+
+
 # ---------------------------------------------------------------------------
 # ReDoS gone: CodeQL's own attack strings complete in linear time.
 # ---------------------------------------------------------------------------
@@ -107,9 +147,16 @@ def test_static_route_still_captures_and_keeps_trailing_tokens():
         # STARTS with a non-space so the greedy ``\s+`` can't absorb the run;
         # the trailing ``!`` defeats ``\s*$`` and forces the O(n^2) rescan.
         (_ARISTA_VRF_DESC_RE, "   description a" + " " * _REPS + "!"),    # #151
+        # #337-follow-up siblings (same value-then-padding-then-non-space shape).
+        (_CONFIG_HEADER_RE, "config a" + " " * _REPS + "!"),
+        (_EDIT_HEADER_RE, "edit a" + " " * _REPS + "!"),
+        (_ARISTA_VRRP_DESCRIPTION_RE, "vrrp 1 description a" + " " * _REPS + "!"),
+        (_IOSXE_VRRP_DESCRIPTION_RE, " vrrp 1 description a" + " " * _REPS + "!"),
+        (_VRRP_AUTH_PLAINTEXT_RE, "authentication mode plaintext-password a" + " " * _REPS + "!"),
     ],
     ids=["dns-server", "vlan-trunk", "nxos-desc", "iosxe-desc", "static-route",
-         "arista-desc"],
+         "arista-desc", "fg-config-header", "fg-edit-header", "arista-vrrp-desc",
+         "iosxe-vrrp-desc", "aoss-plaintext-auth"],
 )
 def test_attack_string_is_linear_time(rx, attack):
     _m, elapsed = _timed_match(rx, attack)


### PR DESCRIPTION
## Summary

Fix **SEC-1** from the 2026-07-12 HEAD review: five un-hardened **ReDoS siblings** of the #337 fix. The polynomial `\s+…(<lazy>)\s*$` shape that #337 / CodeQL #124–#128 / #151 eliminated survived in five more `parse.py` patterns the guard test didn't cover.

| Site | Old (vulnerable) | New (hardened) |
|---|---|---|
| `fortigate_cli` `_CONFIG_HEADER_RE` / `_EDIT_HEADER_RE` | `(.+?)\s*$` | `(\S.*)$` |
| `arista_eos` inline `vrrp … description` | `(.+?)\s*$` | `(\S.*)$` (promoted to module-level `_VRRP_DESCRIPTION_RE` so the guard can pin it) |
| `cisco_iosxe_cli` `_VRRP_DESCRIPTION_RE` | `(?P<text>.+?)\s*$` | `(?P<text>\S.*)$` |
| `aruba_aoss` `_VRRP_AUTH_PLAINTEXT_RE` | `"?([^"\n]+?)"?\s*$` | `(\S.*)$` + consumer `.strip().strip('"')` |

## Why it matters

All five are reachable through the **unauthenticated `POST /plan`** door (`raw_text`, `max_length=10_000_000`, no per-line guard — a single line can be the whole 10 MB body). Measured O(n²): a ~500 KB line pins one anyio worker ~10 min, a full 10 MB line ~65 h; ~40 such requests freeze every synchronous route.

Default posture is fail-closed loopback (desktop / zero-config) + the Docker image refuses an unauthenticated non-loopback bind, so the *unauthenticated-remote* worst case is deployment-gated (reverse-proxy / authenticated-multi-tenant / consciously-insecure bind) — but an operator can self-freeze by pasting an attacker-supplied "translate my config" file.

## Fix

Anchor each value group on `\S` — the same disjoint-class fix #337 applied (`\s+` and `\S` can split a run exactly one way → no backtracking). **Behaviour-identical**: every consumer already `.strip()`s the captured value; the one exception (`aruba_aoss`, which stored the capture verbatim) now `.strip().strip('"')`s at the call site, so quoted / bare / trailing-space inputs all still normalise to the same token.

## Verification (verify-first)

- **Timing:** measured **O(n²) → flat** on all five — a 200k-char attack line drops from seconds-to-minutes to microseconds (`< 1s` budget in the guard).
- **Behaviour-identical:** captured values byte-identical pre/post on realistic input (`fortigate` `R1`/`port1`; arista/iosxe VRRP descriptions; aoss `plain:secret` for quoted/bare/trailing-space).
- **Mesh-flat:** cross-mesh CI guard green — **CODEC_BUG stays 5, cells 1224** (no fixture carries the attack shape).
- `tests/unit` + full migration suite green; ruff clean.
- **Guard extended:** `test_redos_hardening.py` now pins all five (behaviour-preserved captures + linear-time attack strings), mirroring what #337 did for `_VRF_DESC_RE`.

Part of Wave 1 of the HEAD-review remediation. The sibling perf finding (P1 junos `members 1-4094` quadratic dedup) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
