### PR TITLE
perf(codecs): fix quadratic parse-time list-dedup (junos trunk P1 + mgmt-plane P2)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -490,15 +490,18 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         intent.domain = m.group(1)
     for ntp_m in _NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(ntp_m.group(1))
+    seen_syslog = set(intent.syslog_servers)
     for syslog_m in _SYSLOG_LINE_RE.finditer(raw):
         # First IP-literal token on the ``logging`` line is the syslog host;
-        # non-destination sub-commands carry no IP token.  De-dup, first-seen.
+        # non-destination sub-commands carry no IP token.  De-dup, first-seen
+        # (``seen_syslog`` set-guard keeps it O(1) per line -- perf review P2).
         for token in syslog_m.group(1).split():
             try:
                 ipaddress.ip_address(token)
             except ValueError:
                 continue
-            if token not in intent.syslog_servers:
+            if token not in seen_syslog:
+                seen_syslog.add(token)
                 intent.syslog_servers.append(token)
             break
     for route_m in _IP_ROUTE_RE.finditer(raw):

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -700,17 +700,20 @@ def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
         intent.domain = m.group(1)
     for m in _TOP_NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(m.group(1))
+    seen_syslog = set(intent.syslog_servers)
     for m in _SYSLOG_LINE_RE.finditer(raw):
         # Harvest the first token on the ``logging`` line that is a valid
         # IPv4/IPv6 literal — that is the destination host.  Non-destination
         # sub-commands (buffer sizes, severities, message ids) carry no IP
-        # token, so they contribute nothing.  De-dup, first-seen order.
+        # token, so they contribute nothing.  De-dup, first-seen order
+        # (``seen_syslog`` set-guard keeps it O(1) per line -- perf review P2).
         for token in m.group(1).split():
             try:
                 ipaddress.ip_address(token)
             except ValueError:
                 continue
-            if token not in intent.syslog_servers:
+            if token not in seen_syslog:
+                seen_syslog.add(token)
                 intent.syslog_servers.append(token)
             break
 

--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -346,15 +346,18 @@ def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
         # ``maxpoll`` / ``prefer`` tails and the ``source`` / ``update-
         # calendar`` sibling lines (no ``server`` keyword).
         intent.ntp_servers.extend(_NTP_SERVER_LINE_RE.findall(block.group(1)))
+    seen_syslog = set(intent.syslog_servers)
     for m in _SYSLOG_LINE_RE.finditer(raw):
         # First IP-literal token on a ``logging`` line is the syslog host;
-        # non-destination sub-commands carry no IP token.  De-dup, first-seen.
+        # non-destination sub-commands carry no IP token.  De-dup, first-seen
+        # (``seen_syslog`` set-guard keeps it O(1) per line -- perf review P2).
         for token in m.group(1).split():
             try:
                 ipaddress.ip_address(token)
             except ValueError:
                 continue
-            if token not in intent.syslog_servers:
+            if token not in seen_syslog:
+                seen_syslog.add(token)
                 intent.syslog_servers.append(token)
             break
 

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -525,15 +525,18 @@ def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
             intent.dns_servers.append(token)
     for m in _NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(m.group(1))
+    seen_syslog = set(intent.syslog_servers)
     for m in _SYSLOG_LINE_RE.finditer(raw):
         # First IP-literal token on the ``logging`` line is the syslog host;
-        # non-destination sub-commands carry no IP token.  De-dup, first-seen.
+        # non-destination sub-commands carry no IP token.  De-dup, first-seen
+        # (``seen_syslog`` set-guard keeps it O(1) per line -- perf review P2).
         for token in m.group(1).split():
             try:
                 ipaddress.ip_address(token)
             except ValueError:
                 continue
-            if token not in intent.syslog_servers:
+            if token not in seen_syslog:
+                seen_syslog.add(token)
                 intent.syslog_servers.append(token)
             break
 

--- a/netcanon/migration/codecs/juniper_junos/parse.py
+++ b/netcanon/migration/codecs/juniper_junos/parse.py
@@ -611,11 +611,18 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
                 continue
             # (#8) Each member may be a name, a numeric VID, or a numeric
             # range (``100-110``) — resolve/expand all three.
+            # Set-guard the dedup (perf review P1): a ``members 1-4094`` token
+            # expands to 4094 VIDs, each previously deduped by ``not in`` over
+            # a list that grows to 4094 -> ~16.7M compares/line (O(range x
+            # list)).  A ``seen`` set makes it O(1) per VID; order preserved
+            # (VID-ascending within a range, first-seen across ranges).
+            seen_vids = set(iface.trunk_allowed_vlans)
             for vname in names_list:
                 for vid in _resolve_vlan_member_to_vids(
                     vname, vid_by_vlan_name
                 ):
-                    if vid not in iface.trunk_allowed_vlans:
+                    if vid not in seen_vids:
+                        seen_vids.add(vid)
                         iface.trunk_allowed_vlans.append(vid)
 
     # 3. Attach IRB SVI L3 addresses to the matching CanonicalVlan
@@ -876,6 +883,12 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         len(applied_groups),
         len(raw),
     )
+    # De-dup the additive management-plane server lists once, first-seen order
+    # preserved -- the per-line appends above are O(1); a per-line ``not in``
+    # scan would be O(N^2) in the count of distinct servers (perf review P2).
+    intent.dns_servers = list(dict.fromkeys(intent.dns_servers))
+    intent.ntp_servers = list(dict.fromkeys(intent.ntp_servers))
+    intent.syslog_servers = list(dict.fromkeys(intent.syslog_servers))
     return intent
 
 
@@ -1241,9 +1254,10 @@ def _apply_system(
         intent.domain = tokens[1]
         return
     if tokens[0] == "name-server" and len(tokens) >= 2:
-        # ``set system name-server <ip>`` — additive list.
-        if tokens[1] not in intent.dns_servers:
-            intent.dns_servers.append(tokens[1])
+        # ``set system name-server <ip>`` — additive; deduped once at the end
+        # of parse_intent (O(1) append here vs an O(N^2) per-line ``not in``
+        # scan — perf review P2).
+        intent.dns_servers.append(tokens[1])
         return
     if (
         tokens[0] == "ntp"
@@ -1251,20 +1265,18 @@ def _apply_system(
         and tokens[1] == "server"
     ):
         # ``set system ntp server <ip> [prefer]`` — additive; ignore
-        # trailing ``prefer`` / ``key`` / ``version`` options.
-        server = tokens[2]
-        if server not in intent.ntp_servers:
-            intent.ntp_servers.append(server)
+        # trailing ``prefer`` / ``key`` / ``version`` options.  Deduped once
+        # at the end of parse_intent (perf review P2).
+        intent.ntp_servers.append(tokens[2])
         return
     if (
         tokens[0] == "syslog"
         and len(tokens) >= 3
         and tokens[1] == "host"
     ):
-        # ``set system syslog host <ip> [any ...]`` — additive list.
-        host = tokens[2]
-        if host not in intent.syslog_servers:
-            intent.syslog_servers.append(host)
+        # ``set system syslog host <ip> [any ...]`` — additive; deduped once
+        # at the end of parse_intent (perf review P2).
+        intent.syslog_servers.append(tokens[2])
         return
     if tokens[0] == "login" and len(tokens) >= 3 and tokens[1] == "user":
         # ``set system login user <name> class <class>``

--- a/netcanon/migration/codecs/vyos/parse.py
+++ b/netcanon/migration/codecs/vyos/parse.py
@@ -476,6 +476,9 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             return sc
         return None  # deeper nesting we don't model in v1
 
+    # ``system name-server`` dedup (perf review P2): a ``seen`` set keeps the
+    # per-line membership test O(1) instead of an O(N^2) growing-list scan.
+    seen_dns_servers = set(intent.dns_servers)
     for raw_line in raw.splitlines():
         line = raw_line.strip()
         if (
@@ -622,7 +625,8 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
                 ipaddress.ip_address(value)
             except ValueError:
                 continue
-            if value not in intent.dns_servers:
+            if value not in seen_dns_servers:
+                seen_dns_servers.add(value)
                 intent.dns_servers.append(value)
             continue
 

--- a/tests/unit/migration/test_parse_quadratic_scan_perf.py
+++ b/tests/unit/migration/test_parse_quadratic_scan_perf.py
@@ -207,3 +207,94 @@ class TestDiffAutojunkLinear:
         compute_diff(_rec(), left, _rec(), right)
         elapsed = time.perf_counter() - start
         assert elapsed < 3.0, f"compute_diff is quadratic on repeated lines ({elapsed:.2f}s)"
+
+
+# ── HEAD-review P1: junos trunk ``members`` range x growing-list dedup ──
+# The #8 numeric-range spelling (in-range since the last review) made the junos
+# trunk dedup O(range x list): ``members 1-4094`` expands to 4094 VIDs, each
+# previously ``not in``-tested over a list that grows to 4094 (~16.7M compares
+# per line).  Set-guarded, mirroring #11.  Un-hardened sibling of that fix.
+
+_JUNOS_TRUNK_BASE = (
+    "set interfaces xe-0/0/0 unit 0 family ethernet-switching interface-mode trunk\n"
+)
+_JUNOS_TRUNK_FULL_RANGE = (
+    "set interfaces xe-0/0/0 unit 0 family ethernet-switching vlan members 1-4094\n"
+)
+
+
+class TestJunosTrunkMembersLinear:
+    def test_repeated_full_range_dedup_unchanged(self) -> None:
+        # A second full-range line must not duplicate: set-guarded dedup keeps
+        # first-seen (VID-ascending) order -> the union is exactly 1..4094.
+        intent = JunosCodec().parse(
+            _JUNOS_TRUNK_BASE + _JUNOS_TRUNK_FULL_RANGE * 2
+        )
+        trunk = next(
+            i.trunk_allowed_vlans for i in intent.interfaces if i.trunk_allowed_vlans
+        )
+        assert trunk == list(range(1, 4095))
+
+    def test_repeated_full_range_is_linear(self) -> None:
+        # Pre-fix (O(range x list)): 32 full-range lines ~1.1 s.  Post-fix
+        # (set-guard): ~5 ms.  The ~265x separation makes an absolute ceiling a
+        # clean, machine-tolerant negative control.
+        cfg = _JUNOS_TRUNK_BASE + _JUNOS_TRUNK_FULL_RANGE * 32
+        start = time.perf_counter()
+        intent = JunosCodec().parse(cfg)
+        elapsed = time.perf_counter() - start
+        trunk = next(
+            i.trunk_allowed_vlans for i in intent.interfaces if i.trunk_allowed_vlans
+        )
+        assert len(trunk) == 4094
+        assert elapsed < 0.5, f"junos trunk range dedup is quadratic ({elapsed:.2f}s)"
+
+
+# ── HEAD-review P2: mgmt-plane server-list dedup via list membership ────
+# The #347/#352-#354 DNS/NTP/syslog wire-ups deduped additive server lists with
+# ``token not in intent.<list>`` -> O(N**2) in the count of DISTINCT servers.
+# Fixed with a per-list ``set`` seen-guard (finditer sites) or append-then-
+# dedup-once-at-parse-end (junos per-stanza).  Both preserve first-seen order.
+
+
+class TestMgmtPlaneServerDedupLinear:
+    def test_arista_syslog_dedup_first_seen_unchanged(self) -> None:
+        cfg = (
+            "hostname r\nlogging host 10.0.0.1\nlogging host 10.0.0.2\n"
+            "logging host 10.0.0.1\n"
+        )
+        assert AristaEOSCodec().parse(cfg).syslog_servers == ["10.0.0.1", "10.0.0.2"]
+
+    def test_junos_server_lists_dedup_at_end_unchanged(self) -> None:
+        # Append-then-dedup-once: duplicates removed, first-seen order kept.
+        cfg = (
+            "set system name-server 10.0.0.1\nset system name-server 10.0.0.1\n"
+            "set system name-server 10.0.0.2\n"
+            "set system ntp server 10.1.0.1\nset system ntp server 10.1.0.1\n"
+            "set system syslog host 10.2.0.1\nset system syslog host 10.2.0.1\n"
+        )
+        intent = JunosCodec().parse(cfg)
+        assert intent.dns_servers == ["10.0.0.1", "10.0.0.2"]
+        assert intent.ntp_servers == ["10.1.0.1"]
+        assert intent.syslog_servers == ["10.2.0.1"]
+
+    def test_arista_syslog_dedup_is_linear(self) -> None:
+        # Pre-fix O(N**2) in distinct servers; post-fix set-guarded linear.
+        # 4x the server count -> ~4x time when linear, ~16x when quadratic;
+        # assert well under the quadratic line (machine-independent ratio).
+        def parse_n(n: int) -> None:
+            lines = ["hostname r"]
+            lines += [f"logging host 10.{i // 256 % 256}.{i % 256}.1" for i in range(n)]
+            AristaEOSCodec().parse("\n".join(lines) + "\n")
+
+        def best(n: int) -> float:
+            times = []
+            for _ in range(3):
+                start = time.perf_counter()
+                parse_n(n)
+                times.append(time.perf_counter() - start)
+            return min(times)
+
+        best(4000)  # warm up import/JIT caches
+        ratio = best(16000) / best(4000)
+        assert ratio < 8.0, f"arista syslog dedup scales quadratically (4x count -> {ratio:.1f}x time)"


### PR DESCRIPTION
## Summary

Fix **P1** (MAJOR) + **P2** (MINOR) from the 2026-07-12 HEAD review — two parse-time quadratic scans on the same unauthenticated `POST /plan` door SEC-1 rides, both **un-hardened siblings** of the #11 / #30–#33 set-dedup pass.

### P1 (MAJOR) — junos trunk `vlan members` range × growing-list dedup

The #8 numeric-range spelling (in-range since the last review) made the junos trunk dedup **O(range × list)**: `members 1-4094` expands to 4094 VIDs, each deduped by `if vid not in iface.trunk_allowed_vlans` over a list that grows to 4094 → **~16.7M comparisons per line**. A single 60-byte token drives it; the 10 MB `raw_text` cap is ~76 min of one pinned worker.

Fixed with a `seen` set, mirroring `merge_trunk_allowed` (#11). **Measured: 32 full-range lines (2.5 KB) 1088 ms → 4.1 ms (~265×)**; `trunk_allowed` byte-identical (`1..4094`).

### P2 (MINOR) — mgmt-plane DNS/NTP/syslog server lists (#347/#352–#354)

Six sites deduped an additive server list with `token not in intent.<list>` → **O(N²)** in the count of *distinct* servers:
- syslog `finditer` loops: `arista_eos:501`, `cisco_iosxe_cli:713`, `cisco_nxos:536`, `cisco_iosxr:357`
- junos per-stanza: `juniper_junos:1245/1256/1266` (dns/ntp/syslog)
- `vyos:625` (dns)

Fixed with a per-list `set` seen-guard on the loop sites, and append-then-dedup-once (`dict.fromkeys`) at the end of the junos `parse_intent`. **Measured: arista syslog N=8000 202 ms → 53 ms, now linear**; every parsed list byte-identical (first-seen order, dupes removed). Gentler constant (real configs carry <10 servers) but adversarially reachable — closed on parity with P1.

## Verification (verify-first)

- **Timing:** P1 32-line repro **1088 ms → 4.1 ms**; P2 arista syslog O(n²) → linear. Both measured before/after through the real codec `parse()`.
- **Behaviour-identical:** `trunk_allowed=1..4094`; syslog/dns/ntp dedup lists first-seen-identical; vyos brace-form dedup `['10.0.0.1','10.0.0.9']`.
- **Mesh-flat:** cross-mesh CI guard green — **CODEC_BUG stays 5, cells 1224** (no fixture carries the pathological shape).
- `tests/unit` green; ruff clean.
- **Guard:** two new classes in `test_parse_quadratic_scan_perf.py` — P1 an absolute ceiling (265× separation), P2 a machine-independent 4×-count ratio — each with behaviour-identity assertions and verified as negative controls (FAIL pre-fix, pass wide post-fix).

Second half of Wave 1 (the [SEC-1 ReDoS PR #358](https://github.com/netcanon/netcanon/pull/358) was the first). Same "parse-time CPU amplification via `/plan`" theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
