### PR TITLE
fix(backup): pass app settings into backup jobs so desktop TOFU host-keys persist (F5)

### DIFF
--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -276,6 +276,13 @@ def create_backup(
         definition_loader,
         device_profiles,
         device_profile_store,
+        # (HEAD-review F5) Pass the app's live Settings so the job's collectors
+        # use the app-configured data dir (and thus the TOFU known_hosts store)
+        # instead of the worker re-resolving ``Settings()`` from env.  On the
+        # desktop the app builds Settings programmatically with no env bridge,
+        # so the fallback resolved ``configs_dir=Path("configs")`` -> a
+        # CWD-relative known_hosts that silently broke changed-key detection.
+        settings=request.app.state.settings,
     )
     logger.info(
         "Created backup job %s for %d device(s) (max_workers=%d)",

--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -294,6 +294,11 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
         getattr(app.state, "definition_loader", None),
         getattr(app.state, "device_profiles", None),
         getattr(app.state, "device_profile_store", None),
+        # (HEAD-review F5) app's live Settings as the 10th positional arg
+        # (``run_in_executor`` takes no kwargs) so the scheduled job's
+        # collectors use the app-configured data dir / TOFU known_hosts store
+        # rather than a worker-resolved ``Settings()`` from env.
+        getattr(app.state, "settings", None),
     )
 
     # A minutes-long backup ran above; the operator may have deleted this

--- a/tests/integration/test_load_and_memory.py
+++ b/tests/integration/test_load_and_memory.py
@@ -423,3 +423,36 @@ class TestMemoryBound:
                 )
         finally:
             tracemalloc.stop()
+
+
+# ---------------------------------------------------------------------------
+# HEAD-review F5 — the settings snapshot must reach the job
+# ---------------------------------------------------------------------------
+
+
+def test_create_backup_passes_app_settings_to_the_job(test_app):
+    """``POST /backups`` must hand the app's live ``Settings`` to the job so its
+    collectors use the app-configured data dir (the TOFU ``known_hosts`` store),
+    not a worker-resolved ``Settings()`` from env.  Both dispatch call sites left
+    the ``settings`` param ``None`` pre-fix -> on the desktop (Settings built
+    programmatically, no env bridge) the worker fell back to
+    ``configs_dir=Path("configs")`` -> a CWD-relative ``known_hosts`` that
+    silently broke changed-key (MITM) detection."""
+    captured: dict = {}
+
+    def _spy(*args, **kwargs):
+        # Stub the dispatch seam: capture what create_backup forwarded; the job
+        # never runs (plain client, so no auto-wait poll to hang).
+        captured["kwargs"] = kwargs
+
+    with (
+        patch("netcanon.api.routes.backups.submit_backup_job", _spy),
+        _PlainTestClient(test_app) as c,
+    ):
+        resp = c.post(
+            "/api/v1/backups",
+            json={"devices": [_device_payload(host="10.0.0.1")]},
+        )
+    assert resp.status_code == 202, resp.text
+    # create_backup forwards it by keyword; identity, not just equality.
+    assert captured["kwargs"].get("settings") is test_app.state.settings

--- a/tests/integration/test_schedules_api.py
+++ b/tests/integration/test_schedules_api.py
@@ -374,3 +374,30 @@ class TestScheduledJobCreationPersist:
         # #26: on disk from the creation-time persist even though the stubbed
         # runner wrote nothing.  Pre-fix the scheduled path never saved -> None.
         assert app.state.job_store.load_one(job.id) is not None
+
+    async def test_scheduled_backup_passes_app_settings(
+        self, client, monkeypatch,
+    ):
+        """(HEAD-review F5) the scheduled path must pass ``app.state.settings``
+        as the final positional arg (``run_in_executor`` takes no kwargs) so the
+        job's collectors use the app data dir / TOFU ``known_hosts`` store rather
+        than a worker-resolved ``Settings()`` from env — the sibling of the
+        manual POST call site that was also left ``None``."""
+        from netcanon.api.routes.schedules import _run_scheduled_backup_inner
+        from netcanon.services import backup_runner
+
+        app = client.app
+        self._cisco_profile(app)
+        sid = _create_schedule(client)["id"]
+
+        captured: list = []
+
+        def _capture(job, *a, **k):
+            captured.append(a)
+
+        monkeypatch.setattr(backup_runner, "run_backup_job", _capture)
+        await _run_scheduled_backup_inner(sid, app)
+
+        assert captured, "runner never dispatched (no resolvable target?)"
+        # ``settings`` is the last positional arg after ``job``.
+        assert captured[0][-1] is app.state.settings


### PR DESCRIPTION
## Summary

Fix **Conc-F5** from the 2026-07-12 HEAD review (Wave 3): the #333/#334 job-level `settings` snapshot seam was **dead in production** — neither dispatch call site passed it, so every backup job re-resolved `Settings()` from env and `app.state.settings` never reached the collectors.

## Why it matters (desktop TOFU silently broke)

Harmless on web/CLI (env-resolved both sides). But the **desktop** builds its `Settings` **programmatically** (`netcanon_desktop/settings.py`, no `NETCANON_*` env bridge). The worker's fallback `Settings()` resolved `configs_dir=Path("configs")` → `effective_data_dir=Path(".")` → the TOFU `known_hosts` store landed at **`<process CWD>/known_hosts`** instead of the app's data dir.

On the frozen desktop app the CWD is the install dir; if that's unwritable (Program Files, non-elevated — the common case), `persist_paramiko_host_keys` logs-and-swallows the `OSError` → **no host-key pin ever persists**: every backup re-TOFUs unverified and a **changed key (MITM) is never detected** — silently reverting the v0.4.5 default hardening on that platform. The un-hardened sibling of a hardened path, one line from correct at each site.

## Fix

Both dispatch call sites now pass the app's live `Settings`:
- `api/routes/backups.py` `create_backup` → `submit_backup_job(…, settings=request.app.state.settings)` (`submit_backup_job` forwards `**kwargs` verbatim).
- `api/routes/schedules.py` scheduled path → `getattr(app.state, "settings", None)` as the final positional arg (`run_in_executor` takes no kwargs).

`run_backup_job` already resolves `settings or Settings()`, so passing the app's object routes the job's collectors (and thus the TOFU store) at the app-configured data dir.

## Verification

- **Two regression tests, both genuine negative controls** (fail pre-fix, where `settings` was `None`):
  - `test_load_and_memory.py`: `POST /backups` forwards `settings is app.state.settings` (spy on the dispatch seam, plain client).
  - `test_schedules_api.py`: the scheduled path passes `app.state.settings` as the last positional arg.
- No behaviour change on env-resolved deployments; backup + schedule + executor integration suites green; ruff clean.

First of Wave 3 (backup-subsystem trust). The job-lifecycle robustness pair (F1 stale-pending eviction window + F3 swallowed-exception on the fire-and-forget Future) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
