### PR TITLE
fix(backup): heal stale-pending eviction window + finalize crashed jobs (F1/F3)

### DIFF
--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -144,7 +144,11 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
 
     from ...models.device import BackupRequest, DeviceCredentials, DeviceTarget
     from ...models.device_profile import DeviceProfile
-    from ...services.backup_runner import _job_executor, run_backup_job
+    from ...services.backup_runner import (
+        _job_executor,
+        finalize_crashed_job,
+        run_backup_job,
+    )
     from ...storage.device_profile_store import DEVICE_PROFILE_REGISTRY_LOCK
 
     schedules = app.state.schedules
@@ -279,27 +283,34 @@ async def _run_scheduled_backup_inner(schedule_id: str, app) -> None:
     # changes.  Args are passed positionally — ``run_in_executor`` takes no
     # kwargs, which matches ``run_backup_job``'s positional call here.
     loop = asyncio.get_running_loop()
-    await loop.run_in_executor(
-        _job_executor(),
-        run_backup_job,
-        job,
-        request,
-        app.state.definitions,
-        app.state.storage,
-        job_store,
-        max_workers,
-        # P1C3 layered-definition + probe wiring — schedule-triggered
-        # backups get the same overlay resolution + detected_facts
-        # persistence as interactive ones.
-        getattr(app.state, "definition_loader", None),
-        getattr(app.state, "device_profiles", None),
-        getattr(app.state, "device_profile_store", None),
-        # (HEAD-review F5) app's live Settings as the 10th positional arg
-        # (``run_in_executor`` takes no kwargs) so the scheduled job's
-        # collectors use the app-configured data dir / TOFU known_hosts store
-        # rather than a worker-resolved ``Settings()`` from env.
-        getattr(app.state, "settings", None),
-    )
+    try:
+        await loop.run_in_executor(
+            _job_executor(),
+            run_backup_job,
+            job,
+            request,
+            app.state.definitions,
+            app.state.storage,
+            job_store,
+            max_workers,
+            # P1C3 layered-definition + probe wiring — schedule-triggered
+            # backups get the same overlay resolution + detected_facts
+            # persistence as interactive ones.
+            getattr(app.state, "definition_loader", None),
+            getattr(app.state, "device_profiles", None),
+            getattr(app.state, "device_profile_store", None),
+            # (HEAD-review F5) app's live Settings as the 10th positional arg
+            # (``run_in_executor`` takes no kwargs) so the scheduled job's
+            # collectors use the app-configured data dir / TOFU known_hosts
+            # store rather than a worker-resolved ``Settings()`` from env.
+            getattr(app.state, "settings", None),
+        )
+    except Exception as exc:
+        # (HEAD-review F3) The runner raised before its own terminal logic;
+        # finalize the job so it can't strand non-terminal, then re-raise so
+        # the outer ``_run_scheduled_backup`` wrapper logs it.
+        finalize_crashed_job(job, job_store, exc)
+        raise
 
     # A minutes-long backup ran above; the operator may have deleted this
     # schedule in the meantime.  Re-check existence under the registry lock

--- a/netcanon/services/backup_runner.py
+++ b/netcanon/services/backup_runner.py
@@ -55,10 +55,11 @@ route-module home):
 
 from __future__ import annotations
 
+import inspect
 import logging
 import threading
 import time
-from concurrent.futures import Future, ThreadPoolExecutor, wait
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor, wait
 from datetime import UTC, datetime
 
 from ..config import (
@@ -200,6 +201,70 @@ def reset_job_executor(*, wait: bool = False, cancel_futures: bool = True) -> No
         executor.shutdown(wait=wait, cancel_futures=cancel_futures)
 
 
+_TERMINAL_JOB_STATUSES = frozenset(
+    {JobStatus.completed, JobStatus.partial, JobStatus.failed}
+)
+
+
+def finalize_crashed_job(
+    job: BackupJob,
+    job_store: FileJobStore | None,
+    exc: BaseException,
+) -> None:
+    """Force a job whose runner raised *before* its own terminal logic to a
+    terminal ``failed`` state and persist it (HEAD-review F3).
+
+    ``run_backup_job``'s body can raise before the safety net inside it
+    (``Settings()`` re-resolution, per-job pool construction under thread
+    exhaustion).  Without finalizing, the job is stranded non-terminal forever —
+    eviction-protected (#25) and, on the manual path, with no log line at all.
+    Idempotent: an already-terminal job is left untouched (only re-persisted).
+    Shared by the manual-path Future done-callback and the scheduled wrapper.
+    """
+    if job.status not in _TERMINAL_JOB_STATUSES:
+        for r in job.results:
+            if r.status not in ("success", "failed"):
+                r.status = "failed"
+                if not r.error:
+                    r.error = f"{r.host}: backup worker crashed ({exc})."
+        job.completed_at = datetime.now(UTC)
+        job.status = JobStatus.failed
+    if job_store is not None:
+        try:
+            job_store.save(job)
+        except OSError as save_exc:
+            logger.error(
+                "Failed to persist crashed job %s: %s", job.id, save_exc
+            )
+
+
+def _on_job_future_done(
+    fut: Future,
+    job: BackupJob | None,
+    job_store: FileJobStore | None,
+) -> None:
+    """Done-callback for the manual-path fire-and-forget Future.
+
+    ``concurrent.futures`` (unlike ``asyncio``) never surfaces an unretrieved
+    exception, so an escape from ``run_backup_job`` would otherwise vanish
+    silently.  Log it and force-fail the job so it can't strand non-terminal.
+    """
+    try:
+        exc = fut.exception()
+    except CancelledError:
+        return  # cancelled at shutdown (F6 territory) — nothing to finalize
+    if exc is None:
+        return  # normal completion — run_backup_job persisted its terminal state
+    logger.error(
+        "Backup job %s crashed in the worker: %s",
+        getattr(job, "id", "<unknown>"),
+        exc,
+        exc_info=exc,
+    )
+    if job is not None:
+        finalize_crashed_job(job, job_store, exc)
+
+
 def submit_backup_job(*args, **kwargs) -> Future:
     """Submit :func:`run_backup_job` to the dedicated backup-job executor.
 
@@ -218,7 +283,19 @@ def submit_backup_job(*args, **kwargs) -> Future:
     ``pending`` and callers must poll ``GET /backups/{id}`` for the terminal
     state (see AGENTS.md "Hard Rules").
     """
-    return _job_executor().submit(run_backup_job, *args, **kwargs)
+    fut = _job_executor().submit(run_backup_job, *args, **kwargs)
+    # (HEAD-review F3) Attach a done-callback that finalizes a crashed job.
+    # Recover the job + its store from the runner args by NAME (robust to
+    # positional/keyword; ``run_backup_job`` is resolved at call time so a
+    # monkeypatched stub with a different signature just yields ``None``).
+    try:
+        bound = inspect.signature(run_backup_job).bind_partial(*args, **kwargs)
+        job = bound.arguments.get("job")
+        job_store = bound.arguments.get("job_store")
+    except TypeError:
+        job = job_store = None
+    fut.add_done_callback(lambda f: _on_job_future_done(f, job, job_store))
+    return fut
 
 
 def _process_one_device_limited(*args, **kwargs) -> None:

--- a/netcanon/storage/job_registry.py
+++ b/netcanon/storage/job_registry.py
@@ -219,8 +219,18 @@ class BackupJobRegistry:
         job = self._store.load_one(job_id)
         if job is None:
             raise KeyError(job_id)
-        # Promote to cache (may evict).
-        self[job_id] = job
+        # Promote to cache (may evict) — but ONLY if the disk snapshot is
+        # TERMINAL (HEAD-review F1).  A non-terminal disk load means the job was
+        # evicted in the window between the runner's in-memory terminal flip and
+        # its terminal disk save, OR is a crash leftover (CONC-16).  Caching the
+        # stale non-terminal copy would PIN it (non-terminal jobs are
+        # eviction-protected, #25) and answer the wrong status until restart.
+        # Returning it WITHOUT promotion lets the next poll re-read disk and
+        # HEAL the instant the terminal save lands — this also covers the
+        # swallowed terminal-save ``OSError`` sibling, which has no timing
+        # window at all.
+        if job.status in _TERMINAL_STATUSES:
+            self[job_id] = job
         return job
 
     def __contains__(self, job_id: object) -> bool:

--- a/tests/unit/test_backup_job_executor.py
+++ b/tests/unit/test_backup_job_executor.py
@@ -165,6 +165,60 @@ def test_submit_backup_job_runs_run_backup_job_on_the_dedicated_pool(monkeypatch
         backup_runner.reset_job_executor()
 
 
+def test_submit_backup_job_finalizes_a_crashed_runner(monkeypatch, tmp_path, caplog):
+    """(HEAD-review F3) A ``run_backup_job`` body exception lands on the
+    fire-and-forget Future — and, unlike ``asyncio``, ``concurrent.futures``
+    never surfaces an unretrieved exception, so pre-fix it vanished with the job
+    stranded non-terminal (eviction-protected) and ZERO log lines.  The
+    done-callback must log it and force-fail + persist the job."""
+    import logging as _logging
+    import time
+    from datetime import UTC, datetime
+
+    from netcanon.models.backup import BackupJob, BackupResult, JobStatus
+    from netcanon.storage.job_store import FileJobStore
+
+    backup_runner.reset_job_executor()
+    store = FileJobStore(tmp_path / "jobs")
+    job = BackupJob(
+        id="crash-1", status=JobStatus.running, created_at=datetime.now(UTC),
+        total_devices=1,
+        results=[BackupResult(
+            host="10.0.0.1", device_type="Cisco", status="running",
+            duration_seconds=0.0,
+        )],
+    )
+    store.save(job)  # pending/running on disk before the crash
+
+    def crash_run(
+        job, request=None, definitions=None, storage=None, job_store=None,
+        *a, **k,
+    ):
+        # Same leading param names as run_backup_job so the callback's
+        # signature-bind recovers job + job_store.
+        raise RuntimeError("kaboom in the worker body")
+
+    monkeypatch.setattr(backup_runner, "run_backup_job", crash_run)
+    try:
+        with caplog.at_level(
+            _logging.ERROR, logger="netcanon.services.backup_runner"
+        ):
+            backup_runner.submit_backup_job(job, None, {}, None, store, 1)
+            deadline = time.monotonic() + 10
+            while (
+                job.status not in backup_runner._TERMINAL_JOB_STATUSES
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+    finally:
+        backup_runner.reset_job_executor()
+
+    assert job.status is JobStatus.failed  # not stranded non-terminal
+    assert store.load_one("crash-1").status is JobStatus.failed  # persisted
+    assert job.results[0].status == "failed"
+    assert "crashed in the worker" in caplog.text  # no longer silent
+
+
 # ---------------------------------------------------------------------------
 # Config resolution: default / env override / floor / garbage fallback
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_job_registry_eviction_medium.py
+++ b/tests/unit/test_job_registry_eviction_medium.py
@@ -63,3 +63,32 @@ class TestNonTerminalEvictionProtection:
         reg[c.id] = c
         assert a.id not in list(reg)  # oldest terminal evicted
         assert b.id in list(reg) and c.id in list(reg)
+
+    def test_stale_pending_disk_load_not_promoted_then_heals(self, registry):
+        # (HEAD-review F1) The runner flips a job terminal IN MEMORY before its
+        # terminal DISK save.  If an eviction lands in that window and a poll
+        # disk-loads the stale ``pending`` snapshot, PROMOTING it would pin it
+        # non-terminal forever (eviction-protected, #25) and answer the wrong
+        # status until restart.  __getitem__ must NOT cache a non-terminal disk
+        # load -> the next poll re-reads disk and HEALS once the terminal save
+        # lands.  (Also covers the swallowed terminal-save OSError sibling.)
+        reg = registry(2)
+        store = reg._store
+        a = _job(JobStatus.pending)
+        reg[a.id] = a
+        store.save(a)  # creation snapshot on disk: pending
+        filler = _job(JobStatus.completed)
+        reg[filler.id] = filler  # cache at cap: {a(pending), filler(done)}
+        a.status = JobStatus.completed  # in-memory terminal flip, NOT saved yet
+        overflow = _job(JobStatus.completed)
+        reg[overflow.id] = overflow  # over cap -> evicts A (LRU-most terminal)
+        assert a.id not in list(reg)  # A evicted in the window
+
+        # Poll while disk still says pending: returns pending but must NOT cache
+        # it (pre-fix: promoted -> pinned pending forever).
+        assert reg[a.id].status is JobStatus.pending
+        assert a.id not in list(reg), "stale pending must not be promoted (F1)"
+
+        # Terminal save lands -> the next poll re-reads disk and heals.
+        store.save(a)
+        assert reg[a.id].status is JobStatus.completed


### PR DESCRIPTION
## Summary

Wave 3, part 2: two backup-job-lifecycle robustness holes in the #333/#334 executor wave (HEAD-review **F1** + **F3**, both MAJOR).

## F1 — stale-pending eviction window now heals instead of pinning

`run_backup_job` flips `job.status` terminal **in memory** *before* its terminal **disk** save. In that ~ms window the #25 terminal-only-eviction guard sees the job as evictable while disk still holds the creation-time `pending` snapshot. If an insert evicts it and a poll disk-loads the stale `pending` copy, `__getitem__` **promoted** it into the cache → non-terminal → **eviction-protected forever** → `GET /backups/{id}` answered `pending` until restart while disk said `completed` (`wait_for_job` hangs).

**Fix:** `__getitem__` promotes a disk load **only when it's terminal**; a non-terminal load is returned **without caching**, so the next poll re-reads disk and **heals** the instant the terminal save lands. This also covers the swallowed terminal-save `OSError` sibling (which has no timing window at all).

## F3 — a crashed runner no longer strands the job silently

`create_backup` fire-and-forgets the `Future` and `submit_backup_job` attached no callback. Unlike `asyncio`, `concurrent.futures` **never surfaces an unretrieved exception**, so any escape from `run_backup_job`'s own body (`Settings()` re-resolution, per-job pool construction under thread exhaustion) vanished — job stuck `pending`/`running` forever (non-terminal → eviction-protected), disk stale, **zero log lines**.

**Fix:** a shared `finalize_crashed_job` helper (mirrors the runner's safety net) + `submit_backup_job` now attaches a done-callback that logs `fut.exception()` and force-fails + persists the job (binds the runner args by **name** to recover job + job_store, robust to a monkeypatched stub). The scheduled path's `run_in_executor` await is wrapped to call the same helper before re-raising to its logging wrapper.

## Verification (verify-first)

Deterministic read-only probe, **both reproduced pre-fix**:
- **F1**: poll#1 returns disk `pending` *uncached* → poll#2 heals to `completed` after the terminal save.
- **F3**: a raising stub leaves the job `failed` in memory **and** on disk with an ERROR log (pre-fix: silent + non-terminal).

Regression tests (both genuine negative controls):
- `test_job_registry_eviction_medium.py`: stale non-terminal disk load is not promoted, then heals from disk.
- `test_backup_job_executor.py`: a crashed runner finalizes the job to `failed` (memory + disk) and logs it.

`tests/unit` + backup/schedule/disk-fallback integration suites green; ruff clean.

Completes Wave 3 (backup-subsystem trust) alongside the [F5 settings-seam PR #360](https://github.com/netcanon/netcanon/pull/360). Deferred siblings noted in the review: F2 (eviction overshoot never shrinks), F4 (no intake cap — design call), F6 (drain-on-exit) — hygiene batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
