### PR TITLE
fix(codecs): preserve two-token `<dest> <iface> <gateway>` static route (HEAD-review L1-8/L1-1/L1-9)

### DIFF
--- a/netcanon/migration/codecs/arista_eos/parse.py
+++ b/netcanon/migration/codecs/arista_eos/parse.py
@@ -99,18 +99,28 @@ _IP_ROUTE_RE = re.compile(
     # The optional ``vrf <name>`` infix (group 1) lands on
     # ``CanonicalStaticRoute.vrf`` and round-trips through render
     # (mirrors the cisco_iosxe_cli graduation, PR #24).
-    # A trailing integer (group 5) is the administrative distance
-    # (``ip route <prefix> <next-hop> <distance>``, 1-255) — lands on
-    # ``CanonicalStaticRoute.metric``; the optional group keeps distance-
-    # less routes byte-identical.
-    r"^ip route\s+(?:vrf\s+(\S+)\s+)?(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)(?:\s+(\d+))?",
+    # Next-hop group 4 is an IP literal (gateway) OR an egress interface.  The
+    # two-token ``ip route <prefix> <iface> <gateway>`` form adds an optional
+    # dotted-quad gateway (group 5) after the interface; without it EOS's
+    # ``ip route <agg> Null0 10.1.1.1`` lost the gateway (its leading octet was
+    # mis-harvested as the admin distance — HEAD-review L1-1).  A trailing
+    # integer (group 6) is the administrative distance (1-255) → ``metric``.
+    # The ``(?=\s|$)`` boundary stops the distance group from biting a partial
+    # digit run off a following token; every optional group keeps the plain
+    # ``ip route <prefix> <next-hop>`` form byte-identical.
+    r"^ip route\s+(?:vrf\s+(\S+)\s+)?(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)"
+    r"(?:\s+(\d+\.\d+\.\d+\.\d+))?(?:\s+(\d+))?(?=\s|$)",
     re.MULTILINE,
 )
 _IPV6_ROUTE_RE = re.compile(
     # ``ipv6 route 2001:db8::/48 2001:db8::1`` — v6 uses the ``ipv6 route``
     # keyword with the prefix form (does not overlap ``^ip route``).
-    # The optional ``vrf <name>`` infix mirrors the v4 form above.
-    r"^ipv6 route\s+(?:vrf\s+(\S+)\s+)?([0-9A-Fa-f:]+/\d+)\s+(\S+)(?:\s+(\d+))?",
+    # The optional ``vrf <name>`` infix mirrors the v4 form above.  Group 4 is
+    # the optional two-token gateway (``ipv6 route <prefix> <iface> <v6-gw>``);
+    # it must contain a colon so a bare admin-distance integer (group 5) is not
+    # mistaken for a gateway.  ``(?=\s|$)`` boundary as in the v4 form.
+    r"^ipv6 route\s+(?:vrf\s+(\S+)\s+)?([0-9A-Fa-f:]+/\d+)\s+(\S+)"
+    r"(?:\s+([0-9A-Fa-f]*:[0-9A-Fa-f:]*))?(?:\s+(\d+))?(?=\s|$)",
     re.MULTILINE,
 )
 _SNMP_COMMUNITY_RE = re.compile(
@@ -505,7 +515,7 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
                 intent.syslog_servers.append(token)
             break
     for route_m in _IP_ROUTE_RE.finditer(raw):
-        vrf, ip, prefix, next_hop, distance = route_m.groups()
+        vrf, ip, prefix, next_hop, gw2, distance = route_m.groups()
         # A next hop is either an IP literal (gateway) or an interface name
         # (``Null0``, ``Ethernet1`` — an interface/connected route, ubiquitous
         # as a BGP aggregate anchor ``ip route <agg> Null0``).  Route it to the
@@ -513,11 +523,17 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
         # the identical cisco_iosxe_cli branch).
         gateway = ""
         interface = ""
-        try:
-            ipaddress.IPv4Address(next_hop)
-            gateway = next_hop
-        except ipaddress.AddressValueError:
+        if gw2:
+            # Two-token ``<iface> <gateway>``: next_hop is the egress
+            # interface, gw2 the forwarding address (HEAD-review L1-1).
             interface = next_hop
+            gateway = gw2
+        else:
+            try:
+                ipaddress.IPv4Address(next_hop)
+                gateway = next_hop
+            except ipaddress.AddressValueError:
+                interface = next_hop
         # The optional ``vrf <name>`` infix lands on ``route.vrf`` — NOT a
         # routing-instance.  Harvesting a per-VRF route must never conjure a
         # phantom ``CanonicalRoutingInstance`` (that surface comes only from
@@ -531,15 +547,20 @@ def parse_intent(raw: str) -> CanonicalIntent:  # noqa: C901
             vrf=vrf or "",
         ))
     for route_m in _IPV6_ROUTE_RE.finditer(raw):
-        vrf, dest, next_hop, distance = route_m.groups()
+        vrf, dest, next_hop, gw2, distance = route_m.groups()
         # Same gateway-or-interface split as the v4 branch.
         gateway = ""
         interface = ""
-        try:
-            ipaddress.IPv6Address(next_hop)
-            gateway = next_hop
-        except ipaddress.AddressValueError:
+        if gw2:
+            # Two-token ``<iface> <v6-gateway>`` (HEAD-review L1-1).
             interface = next_hop
+            gateway = gw2
+        else:
+            try:
+                ipaddress.IPv6Address(next_hop)
+                gateway = next_hop
+            except ipaddress.AddressValueError:
+                interface = next_hop
         intent.static_routes.append(CanonicalStaticRoute(
             destination=dest,
             gateway=gateway,

--- a/netcanon/migration/codecs/arista_eos/render.py
+++ b/netcanon/migration/codecs/arista_eos/render.py
@@ -945,6 +945,13 @@ def render_intent(tree: Any) -> str:  # noqa: C901
             target = route.gateway or route.interface
             if not target:
                 continue
+            # Two-token next-hop ``<iface> <gateway>`` (egress interface plus
+            # an explicit forwarding address): emit BOTH, interface first, per
+            # the ``ip route <prefix> <iface> <gateway>`` grammar — else a
+            # route carrying both fields drops the interface (HEAD-review
+            # L1-1 render half).
+            if route.interface and route.gateway:
+                target = f"{route.interface} {route.gateway}"
             # Per-VRF routes carry the ``vrf <name>`` qualifier between the
             # ``ip route`` / ``ipv6 route`` keyword and the destination.
             # Without this, a donor-carried ``route.vrf`` (e.g. a cisco

--- a/netcanon/migration/codecs/aruba_aoscx/parse.py
+++ b/netcanon/migration/codecs/aruba_aoscx/parse.py
@@ -264,13 +264,20 @@ _VLAN_DESC_RE = re.compile(r"^\s+description\s+(.+)", re.IGNORECASE)
 #: ``ip route <dest>/<prefix> <gw> [<dist>]`` — top-level (default VRF)
 #: static route.  AOS-CX uses CIDR destinations.
 _STATIC_ROUTE_RE = re.compile(
-    r"^ip\s+route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)(?:\s+(\d+))?",
+    # Optional group 4 = two-token gateway (``ip route <dest> <iface> <gw>``);
+    # group 5 = admin distance.  ``(?=\s|$)`` boundary stops the distance group
+    # from biting a partial digit run off the gateway (HEAD-review L1-9).
+    r"^ip\s+route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)"
+    r"(?:\s+(\d+\.\d+\.\d+\.\d+))?(?:\s+(\d+))?(?=\s|$)",
     re.IGNORECASE,
 )
 #: ``ipv6 route <prefix>/<len> <nh> [<dist>]`` — the IPv6 form uses the
 #: ``ipv6 route`` keyword (does not overlap ``^ip route``).
 _STATIC_ROUTE_V6_RE = re.compile(
-    r"^ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)(?:\s+(\d+))?",
+    # Optional group 3 = two-token IPv6 gateway (must contain a colon so a bare
+    # distance integer in group 4 is not mistaken for it).
+    r"^ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)"
+    r"(?:\s+([0-9A-Fa-f]*:[0-9A-Fa-f:]*))?(?:\s+(\d+))?(?=\s|$)",
     re.IGNORECASE,
 )
 
@@ -884,15 +891,20 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
     for line in raw.splitlines():
         m6 = _STATIC_ROUTE_V6_RE.match(line)
         if m6:
-            dest, gw_or_iface, metric_str = m6.groups()
+            dest, gw_or_iface, gw2, metric_str = m6.groups()
             metric = int(metric_str) if metric_str else 0
             gateway = ""
             iface = ""
-            try:
-                ipaddress.IPv6Address(gw_or_iface)
-                gateway = gw_or_iface
-            except ipaddress.AddressValueError:
+            if gw2:
+                # Two-token ``<iface> <v6-gateway>`` (HEAD-review L1-9).
                 iface = gw_or_iface
+                gateway = gw2
+            else:
+                try:
+                    ipaddress.IPv6Address(gw_or_iface)
+                    gateway = gw_or_iface
+                except ipaddress.AddressValueError:
+                    iface = gw_or_iface
             routes.append(CanonicalStaticRoute(
                 destination=dest,  # already <prefix>/<len>
                 gateway=gateway,
@@ -903,15 +915,21 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
         m = _STATIC_ROUTE_RE.match(line)
         if not m:
             continue
-        dest_ip, prefix, gw_or_iface, metric_str = m.groups()
+        dest_ip, prefix, gw_or_iface, gw2, metric_str = m.groups()
         metric = int(metric_str) if metric_str else 0
         gateway = ""
         iface = ""
-        try:
-            ipaddress.IPv4Address(gw_or_iface)
-            gateway = gw_or_iface
-        except ipaddress.AddressValueError:
+        if gw2:
+            # Two-token ``<iface> <gateway>``: gw_or_iface is the egress
+            # interface, gw2 the forwarding address (HEAD-review L1-9).
             iface = gw_or_iface
+            gateway = gw2
+        else:
+            try:
+                ipaddress.IPv4Address(gw_or_iface)
+                gateway = gw_or_iface
+            except ipaddress.AddressValueError:
+                iface = gw_or_iface
         routes.append(CanonicalStaticRoute(
             destination=f"{dest_ip}/{prefix}",
             gateway=gateway,

--- a/netcanon/migration/codecs/aruba_aoscx/render.py
+++ b/netcanon/migration/codecs/aruba_aoscx/render.py
@@ -240,6 +240,11 @@ def _render_static_route(route) -> str:
     destination uses ``ipv6 route`` (``ip route <v6>`` is invalid CLI).
     """
     nexthop = route.gateway or route.interface
+    # Two-token next-hop ``<iface> <gateway>``: emit BOTH, interface first, per
+    # the ``ip route <dest> <iface> <gateway>`` grammar — else a route carrying
+    # both fields drops the interface (HEAD-review L1-9 render half).
+    if route.interface and route.gateway:
+        nexthop = f"{route.interface} {route.gateway}"
     keyword = "ipv6 route" if ":" in (route.destination or "") else "ip route"
     out = f"{keyword} {route.destination} {nexthop}".rstrip()
     if route.metric:

--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -299,6 +299,28 @@ _NVE_MEMBER_VNI_RE = re.compile(
     r"(?:\s+mcast-group\s+(\d+\.\d+\.\d+\.\d+)|\s+vrf\s+(\S+))?\s*$",
     re.IGNORECASE,
 )
+def _is_ipv4_literal(token: str) -> bool:
+    """True if ``token`` parses as a bare IPv4 address (a static-route
+    next-hop gateway).  Disambiguates the two-token ``ip route <dest> <mask>
+    <iface> <gateway>`` form — a trailing dotted-quad after an egress
+    interface is the gateway, not an admin distance."""
+    try:
+        ipaddress.IPv4Address(token)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
+def _is_ipv6_literal(token: str) -> bool:
+    """True if ``token`` parses as a bare IPv6 address (the ``ipv6 route``
+    two-token next-hop gateway)."""
+    try:
+        ipaddress.IPv6Address(token)
+        return True
+    except ipaddress.AddressValueError:
+        return False
+
+
 _STATIC_ROUTE_RE = re.compile(
     r"^ip\s+route\s+(?:vrf\s+(\S+)\s+)?"
     r"(\d+\.\d+\.\d+\.\d+)\s+(\d+\.\d+\.\d+\.\d+)\s+(\S+)"
@@ -1532,6 +1554,13 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
                     t += 2
                 elif tok in ("tag", "track") and t + 1 < len(tail):
                     t += 2  # keyword + its value — not modelled
+                elif gateway == "" and _is_ipv6_literal(tail[t]):
+                    # Two-token next-hop ``<iface> <gateway>``: group(3) was
+                    # the egress interface, so this trailing IPv6 literal is
+                    # the gateway.  Pre-fix it hit the ``else`` arm and the
+                    # next-hop was silently discarded (HEAD-review L1-8).
+                    gateway = tail[t]
+                    t += 1
                 elif tail[t].isdigit() and metric == 0:
                     metric = int(tail[t])
                     t += 1
@@ -1582,6 +1611,13 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
                     t += 2
                 elif tok in ("tag", "track") and t + 1 < len(tail):
                     t += 2  # keyword + its value — not modelled
+                elif gateway == "" and _is_ipv4_literal(tail[t]):
+                    # Two-token next-hop ``<iface> <gateway>``: group(4) was
+                    # the egress interface, so this trailing dotted-quad is the
+                    # gateway.  Pre-fix it hit the ``else`` arm and the next-hop
+                    # was silently discarded (HEAD-review L1-8).
+                    gateway = tail[t]
+                    t += 1
                 elif tail[t].isdigit() and metric == 0:
                     metric = int(tail[t])
                     t += 1

--- a/netcanon/migration/codecs/cisco_iosxe_cli/render.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/render.py
@@ -590,6 +590,13 @@ def render_intent(tree: Any) -> str:  # noqa: C901
         target = route.gateway or route.interface
         if not target:
             continue
+        # Two-token next-hop ``<iface> <gateway>`` (directly-attached egress
+        # with an explicit forwarding address): emit BOTH, interface first, to
+        # match the ``ip route <dest> <mask> <iface> <gateway>`` grammar.
+        # Without this a route carrying both fields drops the interface — the
+        # render half of the two-token round-trip (HEAD-review L1-8).
+        if route.interface and route.gateway:
+            target = f"{route.interface} {route.gateway}"
         # ``name <NAME>`` route label (run3): IOS-XE route names are a
         # single whitespace-free token, so emit it only when the
         # description has no spaces — a multi-word description (e.g. a

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -302,13 +302,20 @@ _VRF_AF_RE = re.compile(r"^\s+address-family\s+\S+", re.IGNORECASE)
 #: (the ``vrf context`` header created it), so the harvest can never
 #: conjure a phantom routing-instance (see the per-VRF harvest memory).
 _VRF_IP_ROUTE_RE = re.compile(
-    r"^\s+ip\s+route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)(?:\s+(\d+))?",
+    # Optional group 4 = two-token gateway (``ip route <dest> <iface> <gw>``);
+    # group 5 = admin distance.  ``(?=\s|$)`` boundary keeps the distance group
+    # from biting a partial digit run (HEAD-review L1-9).
+    r"^\s+ip\s+route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)"
+    r"(?:\s+(\d+\.\d+\.\d+\.\d+))?(?:\s+(\d+))?(?=\s|$)",
     re.IGNORECASE,
 )
 #: ``  ipv6 route <prefix>/<len> <nh> [<pref>]`` nested in a ``vrf context``
 #: block (does not overlap the v4 form; ``ipv6`` != ``ip``).
 _VRF_IPV6_ROUTE_RE = re.compile(
-    r"^\s+ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)(?:\s+(\d+))?",
+    # Optional group 3 = two-token IPv6 gateway (must contain a colon so a
+    # bare distance integer in group 4 is not mistaken for it).
+    r"^\s+ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)"
+    r"(?:\s+([0-9A-Fa-f]*:[0-9A-Fa-f:]*))?(?:\s+(\d+))?(?=\s|$)",
     re.IGNORECASE,
 )
 # ── VXLAN-EVPN (Phase 4) ──
@@ -357,13 +364,17 @@ _VLAN_NAME_RE = re.compile(r"^\s+name\s+(.+)", re.IGNORECASE)
 #: static route.  Per-VRF routes (indented inside ``vrf context``) do
 #: NOT match this top-level anchor and are deferred to Phase 3.
 _STATIC_ROUTE_RE = re.compile(
-    r"^ip\s+route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)(?:\s+(\d+))?",
+    # Optional group 4 = two-token gateway (``ip route <dest> <iface> <gw>``);
+    # group 5 = admin distance.  ``(?=\s|$)`` boundary as in the per-VRF form.
+    r"^ip\s+route\s+(\d+\.\d+\.\d+\.\d+)/(\d+)\s+(\S+)"
+    r"(?:\s+(\d+\.\d+\.\d+\.\d+))?(?:\s+(\d+))?(?=\s|$)",
     re.IGNORECASE,
 )
 #: ``ipv6 route <prefix>/<len> <nh> [<pref>]`` — top-level (default VRF)
 #: IPv6 static route (does not overlap the v4 anchor above).
 _STATIC_ROUTE_V6_RE = re.compile(
-    r"^ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)(?:\s+(\d+))?",
+    r"^ipv6\s+route\s+([0-9A-Fa-f:]+/\d+)\s+(\S+)"
+    r"(?:\s+([0-9A-Fa-f]*:[0-9A-Fa-f:]*))?(?:\s+(\d+))?(?=\s|$)",
     re.IGNORECASE,
 )
 _SVI_NAME_RE = re.compile(r"^Vlan(\d+)$", re.IGNORECASE)
@@ -608,16 +619,16 @@ def _parse_routing_instances(
         route6_m = _VRF_IPV6_ROUTE_RE.match(line)
         if route6_m:
             per_vrf_routes.append(_make_static_route_v6(
-                route6_m.group(1), route6_m.group(2), route6_m.group(3),
-                vrf=current.name,
+                route6_m.group(1), route6_m.group(2), route6_m.group(4),
+                vrf=current.name, second_hop=route6_m.group(3),
             ))
             return
         route_m = _VRF_IP_ROUTE_RE.match(line)
         if route_m:
             per_vrf_routes.append(_make_static_route(
                 route_m.group(1), route_m.group(2),
-                route_m.group(3), route_m.group(4),
-                vrf=current.name,
+                route_m.group(3), route_m.group(5),
+                vrf=current.name, second_hop=route_m.group(4),
             ))
             return
         vnim = _VRF_VNI_RE.match(line)
@@ -1136,6 +1147,7 @@ def _make_static_route(
     gw_or_iface: str,
     metric_str: str | None,
     vrf: str = "",
+    second_hop: str | None = None,
 ) -> CanonicalStaticRoute:
     """Build a :class:`CanonicalStaticRoute` from matched NX-OS tokens.
 
@@ -1143,17 +1155,24 @@ def _make_static_route(
     and the per-VRF harvest inside ``vrf context`` blocks
     (:func:`_parse_routing_instances`).  A next-hop that parses as an
     IPv4 address becomes ``gateway``; otherwise it's an egress
-    ``interface`` (directly-attached next-hop).  The trailing integer
-    (if any) is the route preference / administrative distance → ``metric``.
+    ``interface`` (directly-attached next-hop).  In the two-token
+    ``ip route <dest> <iface> <gateway>`` form ``second_hop`` carries the
+    trailing dotted-quad gateway and ``gw_or_iface`` is the egress interface
+    (HEAD-review L1-9).  The trailing integer (if any) is the route
+    preference / administrative distance → ``metric``.
     """
     metric = int(metric_str) if metric_str else 0
     gateway = ""
     iface = ""
-    try:
-        ipaddress.IPv4Address(gw_or_iface)
-        gateway = gw_or_iface
-    except ipaddress.AddressValueError:
+    if second_hop:
         iface = gw_or_iface
+        gateway = second_hop
+    else:
+        try:
+            ipaddress.IPv4Address(gw_or_iface)
+            gateway = gw_or_iface
+        except ipaddress.AddressValueError:
+            iface = gw_or_iface
     return CanonicalStaticRoute(
         destination=f"{dest_ip}/{prefix}",
         gateway=gateway,
@@ -1168,19 +1187,27 @@ def _make_static_route_v6(
     gw_or_iface: str,
     metric_str: str | None,
     vrf: str = "",
+    second_hop: str | None = None,
 ) -> CanonicalStaticRoute:
     """Build a :class:`CanonicalStaticRoute` from matched ``ipv6 route``
     tokens.  ``dest`` is already ``<prefix>/<len>`` form; a next-hop that
     parses as an IPv6 address becomes ``gateway``, otherwise an egress
-    ``interface`` (directly-attached next-hop)."""
+    ``interface`` (directly-attached next-hop).  In the two-token
+    ``ipv6 route <dest> <iface> <gateway>`` form ``second_hop`` carries the
+    trailing IPv6 gateway and ``gw_or_iface`` is the egress interface
+    (HEAD-review L1-9)."""
     metric = int(metric_str) if metric_str else 0
     gateway = ""
     iface = ""
-    try:
-        ipaddress.IPv6Address(gw_or_iface)
-        gateway = gw_or_iface
-    except ipaddress.AddressValueError:
+    if second_hop:
         iface = gw_or_iface
+        gateway = second_hop
+    else:
+        try:
+            ipaddress.IPv6Address(gw_or_iface)
+            gateway = gw_or_iface
+        except ipaddress.AddressValueError:
+            iface = gw_or_iface
     return CanonicalStaticRoute(
         destination=dest,
         gateway=gateway,
@@ -1208,14 +1235,16 @@ def _parse_static_routes(raw: str) -> list[CanonicalStaticRoute]:
         m6 = _STATIC_ROUTE_V6_RE.match(line)
         if m6:
             routes.append(_make_static_route_v6(
-                m6.group(1), m6.group(2), m6.group(3),
+                m6.group(1), m6.group(2), m6.group(4),
+                second_hop=m6.group(3),
             ))
             continue
         m = _STATIC_ROUTE_RE.match(line)
         if not m:
             continue
         routes.append(_make_static_route(
-            m.group(1), m.group(2), m.group(3), m.group(4),
+            m.group(1), m.group(2), m.group(3), m.group(5),
+            second_hop=m.group(4),
         ))
     return routes
 

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -249,6 +249,11 @@ def _render_static_route(route) -> str:
     ``ipv6 route`` (``ip route <v6>`` is invalid and rejected on commit).
     """
     nexthop = route.gateway or route.interface
+    # Two-token next-hop ``<iface> <gateway>``: emit BOTH, interface first, per
+    # the ``ip route <dest> <iface> <gateway>`` grammar — else a route carrying
+    # both fields drops the interface (HEAD-review L1-9 render half).
+    if route.interface and route.gateway:
+        nexthop = f"{route.interface} {route.gateway}"
     keyword = "ipv6 route" if ":" in (route.destination or "") else "ip route"
     out = f"{keyword} {route.destination} {nexthop}".rstrip()
     if route.metric:

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -14,15 +14,15 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 |---|---:|---|
 | ALIGNED | 1678 | ok |
 | CODEC_BUG | 5 | **high** |
-| EXPECTED_LOSSY | 1228 | ok |
+| EXPECTED_LOSSY | 1224 | ok |
 | EXPECTED_UNSUPPORTED | 732 | ok |
-| METHODOLOGY_ISSUE_under | 926 | low/medium |
+| METHODOLOGY_ISSUE_under | 930 | low/medium |
 | METHODOLOGY_ISSUE_over | 25 | low |
 | STRUCTURAL_ONLY | 1179 | low |
 | TRIVIAL_EMPTY | 9526 | ok |
 | **Total field-cells classified** | **15299** | |
 
-Severity roll-up: 5 high, 107 medium, 2023 low, 13164 ok.
+Severity roll-up: 5 high, 107 medium, 2027 low, 13160 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-12T22:04:44+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260712T215945Z.json",
-  "mesh_run_started_utc": "2026-07-12T21:59:32+00:00",
+  "started_utc": "2026-07-14T04:37:07+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260714T043652Z.json",
+  "mesh_run_started_utc": "2026-07-14T04:36:45+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4136,17 +4136,17 @@
   "aggregate": {
     "ALIGNED": 1678,
     "CODEC_BUG": 5,
-    "EXPECTED_LOSSY": 1228,
+    "EXPECTED_LOSSY": 1224,
     "EXPECTED_UNSUPPORTED": 732,
-    "METHODOLOGY_ISSUE_under": 926,
+    "METHODOLOGY_ISSUE_under": 930,
     "METHODOLOGY_ISSUE_over": 25,
     "STRUCTURAL_ONLY": 1179,
     "TRIVIAL_EMPTY": 9526,
     "fields_total": 15299,
     "severity_high": 5,
     "severity_medium": 107,
-    "severity_low": 2023,
-    "severity_ok": 13164
+    "severity_low": 2027,
+    "severity_ok": 13160
   },
   "severity_matrix": {
     "arista_eos": {
@@ -4346,7 +4346,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "arista_eos",
-      "drifted_total": 28
+      "drifted_total": 26
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4366,7 +4366,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "cisco_iosxe_cli",
-      "drifted_total": 25
+      "drifted_total": 23
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4376,7 +4376,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "cisco_nxos",
-      "drifted_total": 27
+      "drifted_total": 25
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4466,7 +4466,7 @@
     {
       "source_codec": "fortigate_cli",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 29
+      "drifted_total": 28
     },
     {
       "source_codec": "fortigate_cli",
@@ -4476,7 +4476,7 @@
     {
       "source_codec": "fortigate_cli",
       "target_codec": "cisco_nxos",
-      "drifted_total": 22
+      "drifted_total": 21
     },
     {
       "source_codec": "fortigate_cli",

--- a/tests/unit/migration/test_arista_eos.py
+++ b/tests/unit/migration/test_arista_eos.py
@@ -134,6 +134,28 @@ class TestParseScalars:
         assert [(r.destination, r.interface) for r in reparsed.static_routes] == \
                [(r.destination, r.interface) for r in intent.static_routes]
 
+    def test_two_token_next_hop_iface_and_gateway_round_trip(self):
+        """HEAD-review L1-1: ``ip route <prefix> <iface> <gateway>`` — the
+        two-token next-hop.  Pre-fix the distance group bit the gateway's
+        leading octet (``metric=10``, v6 ``metric=2001``) and the gateway was
+        lost; render emitted ``ip route ... Ethernet1 10``.  Both fields must
+        survive the round-trip."""
+        raw = (
+            "ip route 10.99.0.0/16 Ethernet1 10.1.1.1\n"
+            "ipv6 route 2001:db8::/48 Ethernet1 2001:db8::1\n"
+        )
+        codec = AristaEOSCodec()
+        intent = codec.parse(raw)
+        by_dest = {r.destination: r for r in intent.static_routes}
+        assert (by_dest["10.99.0.0/16"].interface,
+                by_dest["10.99.0.0/16"].gateway,
+                by_dest["10.99.0.0/16"].metric) == ("Ethernet1", "10.1.1.1", 0)
+        assert (by_dest["2001:db8::/48"].interface,
+                by_dest["2001:db8::/48"].gateway) == ("Ethernet1", "2001:db8::1")
+        rendered = codec.render(intent)
+        assert "ip route 10.99.0.0/16 Ethernet1 10.1.1.1" in rendered
+        assert "ipv6 route 2001:db8::/48 Ethernet1 2001:db8::1" in rendered
+
     def test_static_route_interface_classified_supported(self):
         assert AristaEOSCodec().capabilities.classify(
             "/routing/static-route/interface") == "supported"

--- a/tests/unit/migration/test_aruba_aoscx.py
+++ b/tests/unit/migration/test_aruba_aoscx.py
@@ -223,6 +223,27 @@ def test_ipv6_static_route_render_and_round_trip(codec: ArubaAOSCXCodec) -> None
     )
 
 
+def test_two_token_next_hop_iface_and_gateway_round_trip(
+    codec: ArubaAOSCXCodec,
+) -> None:
+    # HEAD-review L1-9: ``ip route <dest> <iface> <gateway>`` two-token form.
+    # Pre-fix the distance group bit the gateway's leading octet (``metric=10``)
+    # and the gateway was lost; render dropped it.  Both must round-trip.
+    raw = (
+        "ip route 10.99.0.0/16 1/1/1 10.1.1.1\n"
+        "ipv6 route 2001:db8::/48 1/1/1 2001:db8::1\n"
+    )
+    by_dest = {r.destination: r for r in codec.parse(raw).static_routes}
+    assert (by_dest["10.99.0.0/16"].interface,
+            by_dest["10.99.0.0/16"].gateway,
+            by_dest["10.99.0.0/16"].metric) == ("1/1/1", "10.1.1.1", 0)
+    assert (by_dest["2001:db8::/48"].interface,
+            by_dest["2001:db8::/48"].gateway) == ("1/1/1", "2001:db8::1")
+    out = codec.render(codec.parse(raw))
+    assert "ip route 10.99.0.0/16 1/1/1 10.1.1.1" in out
+    assert "ipv6 route 2001:db8::/48 1/1/1 2001:db8::1" in out
+
+
 # ---------------------------------------------------------------------------
 # Multi-token interface names + stanza interception
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/test_cisco_iosxe_cli.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli.py
@@ -496,6 +496,38 @@ class TestRender:
         # on switches with no routing).
         assert "ip route 0.0.0.0 0.0.0.0 10.0.0.1" in out
 
+    def test_two_token_next_hop_iface_and_gateway_round_trip(self):
+        # HEAD-review L1-8: ``ip route <dest> <mask> <iface> <gateway>`` — a
+        # directly-attached-egress route with an explicit forwarding address
+        # (2 shipped fixtures carry it).  Pre-fix the tail-walk ``else`` arm
+        # discarded the trailing gateway and render emitted a broken
+        # single-token route.  Both fields must survive parse → render → parse.
+        codec = CiscoIOSXECLICodec()
+        intent = codec.parse(
+            "ip route 0.0.0.0 0.0.0.0 GigabitEthernet1 10.10.20.254\n"
+        )
+        route = intent.static_routes[0]
+        assert route.interface == "GigabitEthernet1"
+        assert route.gateway == "10.10.20.254"  # pre-fix: "" (silently lost)
+        out = codec.render(intent)
+        assert "ip route 0.0.0.0 0.0.0.0 GigabitEthernet1 10.10.20.254" in out
+        reparsed = codec.parse(out).static_routes[0]
+        assert (reparsed.interface, reparsed.gateway) == (
+            "GigabitEthernet1", "10.10.20.254",
+        )
+
+    def test_two_token_ipv6_next_hop_iface_and_gateway_round_trip(self):
+        # The ``ipv6 route`` sibling of the L1-8 two-token form.
+        codec = CiscoIOSXECLICodec()
+        intent = codec.parse(
+            "ipv6 route 2001:db8::/48 GigabitEthernet1 2001:db8::1\n"
+        )
+        route = intent.static_routes[0]
+        assert route.interface == "GigabitEthernet1"
+        assert route.gateway == "2001:db8::1"  # pre-fix: "" (silently lost)
+        out = codec.render(intent)
+        assert "ipv6 route 2001:db8::/48 GigabitEthernet1 2001:db8::1" in out
+
     def test_per_vrf_ip_route_parse_sets_vrf(self):
         # v0.2.0 — ``ip route vrf <NAME> <dest> <mask> <gw>`` populates
         # CanonicalStaticRoute.vrf (previously parse-and-ignored).

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -261,6 +261,34 @@ class TestParse:
         # Exactly one instance — no phantom duplicate from the route harvest.
         assert [r.name for r in intent.routing_instances] == ["TENANT"]
 
+    def test_two_token_next_hop_iface_and_gateway_round_trip(self, codec):
+        # HEAD-review L1-9: ``ip route <dest> <iface> <gateway>`` two-token
+        # form — top-level AND nested per-VRF, v4 AND v6.  Pre-fix the distance
+        # group bit the gateway's leading octet (``metric=10``) and the gateway
+        # was lost; render emitted ``ip route ... Ethernet1/1 10``.
+        raw = (
+            "!Command: show running-config\n"
+            "hostname R1\n"
+            "vrf context TENANT\n"
+            "  ip route 10.50.0.0/16 Ethernet1/2 172.16.0.2\n"
+            "  ipv6 route 2001:db8:a::/48 Ethernet1/2 2001:db8:a::2\n"
+            "ip route 10.99.0.0/16 Ethernet1/1 10.1.1.1\n"
+            "ipv6 route 2001:db8::/48 Ethernet1/1 2001:db8::1\n"
+        )
+        by_dest = {r.destination: r for r in codec.parse(raw).static_routes}
+        assert (by_dest["10.99.0.0/16"].interface,
+                by_dest["10.99.0.0/16"].gateway,
+                by_dest["10.99.0.0/16"].metric) == ("Ethernet1/1", "10.1.1.1", 0)
+        assert (by_dest["2001:db8::/48"].interface,
+                by_dest["2001:db8::/48"].gateway) == ("Ethernet1/1", "2001:db8::1")
+        assert (by_dest["10.50.0.0/16"].interface,
+                by_dest["10.50.0.0/16"].gateway,
+                by_dest["10.50.0.0/16"].vrf) == (
+                    "Ethernet1/2", "172.16.0.2", "TENANT")
+        out = codec.render(codec.parse(raw))
+        assert "ip route 10.99.0.0/16 Ethernet1/1 10.1.1.1" in out
+        assert "ipv6 route 2001:db8::/48 Ethernet1/1 2001:db8::1" in out
+
     def test_render_ipv6_static_route_uses_ipv6_keyword(self, codec):
         # NX-OS keys the AF off the keyword: an IPv6 destination must render
         # ``ipv6 route`` (``ip route <v6>`` is invalid CLI).  Covers both the


### PR DESCRIPTION
## Summary

Wave 2 PR-1 of the 2026-07-12 HEAD-review remediation — the **static-route two-token family** (L1-8 / L1-1 / L1-9). The freshly-wired static-route parsers greedily consumed the trailing next-hop token, so the two-token `ip route <dest> <iface> <gateway>` form (a directly-attached-egress route with an explicit forwarding address) lost its gateway across four codecs.

| Finding | Codec | Symptom at HEAD |
|---|---|---|
| **L1-8** | `cisco_iosxe_cli` | tail-walk `else` arm discarded the gateway → `ip route 0.0.0.0 0.0.0.0 GigabitEthernet1 10.10.20.254` renders the broken `... GigabitEthernet1`. **Live on 2 shipped fixtures.** |
| **L1-1** | `arista_eos` | distance group `(?:\s+(\d+))?` bit the gateway's leading octet → `metric=10` (v6 `metric=2001`), gateway lost |
| **L1-9** | `cisco_nxos` + `aruba_aoscx` | same shape — top-level + nested per-VRF, v4 + v6 |

## Fix — parse + render PAIRED per codec

The render side emitted only `route.gateway or route.interface`, so a parse-only fix would have converted "lost gateway" into "dropped interface". Both halves land together:

- **parse** — iosxe recognises a trailing dotted-quad / IPv6 literal as the gateway in its tail-walk; arista/nxos/aoscx add an optional second next-hop group + a `(?=\s|$)` boundary on the distance group (v4 dotted-quad; v6 colon-required so a bare distance can't masquerade as a gateway). Covers top-level and nested per-VRF, v4 and v6.
- **render** — emit `<dest> <iface> <gateway>` when both fields are set.

## Verification

- **Verify-first**: a probe reproduced the lost gateway / bogus metric at HEAD across all four codecs, then confirmed correct + byte-identical output on every single-token / distance / name control after the fix.
- **Behaviour-identical**: full per-codec unit suites + the whole `tests/unit/migration` package pass.
- **Mesh regenerated** (`run_full_mesh` → `run_phase4_reconciliation`): **CODEC_BUG stays 5, cells 1224**. The 2 iosxe fixtures now preserve the gateway, moving 4 field-cells `EXPECTED_LOSSY → METHODOLOGY_ISSUE_under` (drift *reduced*; no new high-severity finding). Cross-mesh CI guard green.
- **Negative-control** round-trip guard tests added for all four codecs (fail pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
