### PR TITLE
fix(codecs): stop mgmt-plane parsers swallowing keyword tails (HEAD-review L1-2/L1-3/L1-4)

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxr/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxr/parse.py
@@ -118,8 +118,12 @@ _NAMESERVER_RE = re.compile(
 _NTP_BLOCK_RE = re.compile(
     r"^ntp[ \t]*\r?\n((?:[ \t]+.*\r?\n)+)", re.IGNORECASE | re.MULTILINE,
 )
+#: The optional ``vrf <name>`` infix precedes the address on IOS-XR
+#: (``server vrf MGMT 10.11.23.7``); without it the ``vrf`` keyword was
+#: captured as the server and the real IP lost (HEAD-review L1-3; the
+#: arista_eos ``_NTP_SERVER_RE`` twin already carries this infix).
 _NTP_SERVER_LINE_RE = re.compile(
-    r"^[ \t]+server\s+(\S+)", re.IGNORECASE | re.MULTILINE,
+    r"^[ \t]+server\s+(?:vrf\s+\S+\s+)?(\S+)", re.IGNORECASE | re.MULTILINE,
 )
 #: Syslog destinations — XR spells them bare ``logging <ip>``, but ``logging``
 #: also fronts non-destination sub-commands (``logging console debugging``,
@@ -714,7 +718,27 @@ def _parse_static_leaf(
     gateway = ""
     iface = ""
     metric = 0
-    for tok in m.group(2).split():
+    tokens = m.group(2).split()
+    t = 0
+    while t < len(tokens):
+        tok = tokens[t]
+        low = tok.lower()
+        # Trailing route attributes carry no canonical home (``description`` is
+        # declared lossy; ``tag`` / ``track`` are dropped).  Consume the keyword
+        # AND its value so it never leaks into gateway / interface / metric.
+        # Pre-fix ``tag 100`` mis-filed 100 as the admin distance, and
+        # ``description CORP`` / ``bfd fast-detect`` mis-filed the keyword as
+        # the egress interface — re-rendering invalid CLI (HEAD-review L1-4).
+        if low in ("tag", "track") and t + 1 < len(tokens):
+            t += 2
+            continue
+        if low in ("description", "bfd"):
+            # Free-text ``description`` / multi-token ``bfd fast-detect ...``
+            # run to end of line — consume the remainder.
+            break
+        if low == "permanent":
+            t += 1
+            continue
         try:
             ipaddress.ip_address(tok)  # IPv4 or IPv6 next-hop
             gateway = tok
@@ -728,6 +752,7 @@ def _parse_static_leaf(
                 metric = int(tok)
             elif not iface:
                 iface = tok
+        t += 1
     return CanonicalStaticRoute(
         destination=dest, gateway=gateway, interface=iface,
         metric=metric, vrf=vrf,

--- a/netcanon/migration/codecs/cisco_nxos/parse.py
+++ b/netcanon/migration/codecs/cisco_nxos/parse.py
@@ -531,8 +531,15 @@ def _parse_globals(raw: str, intent: CanonicalIntent) -> None:
     if m:
         intent.domain = m.group(1)
     for m in _NAME_SERVER_RE.finditer(raw):
-        # ``ip name-server 1.1.1.1 8.8.8.8`` is two resolvers on one line.
+        # ``ip name-server 1.1.1.1 8.8.8.8`` is two resolvers on one line; a
+        # trailing ``use-vrf <name>`` modifier must NOT be harvested as a
+        # resolver.  IP-guard each token (mirrors the syslog loop below) so
+        # ``use-vrf`` / ``management`` are skipped (HEAD-review L1-2).
         for token in m.group(1).split():
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                continue
             intent.dns_servers.append(token)
     for m in _NTP_SERVER_RE.finditer(raw):
         intent.ntp_servers.append(m.group(1))

--- a/tests/unit/migration/test_cisco_iosxr.py
+++ b/tests/unit/migration/test_cisco_iosxr.py
@@ -210,6 +210,35 @@ class TestParse:
         assert by_dest["10.99.0.0/16"].vrf == "CUSTOMER-A"
         assert by_dest["10.99.0.0/16"].gateway == "203.0.113.2"
 
+    def test_static_route_keyword_tails_not_misfiled(self, codec):
+        # HEAD-review L1-4: trailing ``tag`` / ``description`` / ``bfd`` route
+        # attributes must be consumed, not mis-filed into metric / interface
+        # (which re-rendered invalid CLI like ``<dest> description <gw>``).
+        raw = (
+            "router static\n"
+            " address-family ipv4 unicast\n"
+            "  10.0.0.0/8 GigabitEthernet0/0/0/2 11.1.1.2 tag 100\n"
+            "  0.0.0.0/0 1.2.3.4 description CORP-UPLINK\n"
+            "  192.0.2.0/24 5.6.7.8 bfd fast-detect\n"
+            "  172.16.0.0/12 9.9.9.9 200\n"
+        )
+        by_dest = {r.destination: r for r in codec.parse(raw).static_routes}
+        # ``tag 100`` must NOT become the admin distance.
+        assert by_dest["10.0.0.0/8"].gateway == "11.1.1.2"
+        assert by_dest["10.0.0.0/8"].interface == "GigabitEthernet0/0/0/2"
+        assert by_dest["10.0.0.0/8"].metric == 0
+        # ``description`` / ``bfd`` must NOT become the egress interface.
+        assert by_dest["0.0.0.0/0"].gateway == "1.2.3.4"
+        assert by_dest["0.0.0.0/0"].interface == ""
+        assert by_dest["192.0.2.0/24"].gateway == "5.6.7.8"
+        assert by_dest["192.0.2.0/24"].interface == ""
+        # A bare trailing integer IS still the admin distance (control).
+        assert by_dest["172.16.0.0/12"].metric == 200
+        # Render is valid CLI — the keyword never leaks back onto the line.
+        out = codec.render(codec.parse(raw))
+        assert "0.0.0.0/0 1.2.3.4" in out
+        assert "description" not in out and "bfd" not in out
+
     def test_parse_ipv6_static_routes_under_ipv6_af(self, codec):
         # Capstone: routes under ``address-family ipv6 unicast`` (default +
         # per-VRF) now parse — gateway, interface-only, and per-VRF forms.

--- a/tests/unit/migration/test_cisco_iosxr_mgmt_plane.py
+++ b/tests/unit/migration/test_cisco_iosxr_mgmt_plane.py
@@ -36,6 +36,15 @@ class TestXrNtpBlockHarvest:
         )
         assert intent.ntp_servers == ["10.0.0.1"]
 
+    def test_ntp_server_vrf_infix_keeps_the_address(self) -> None:
+        # HEAD-review L1-3: ``server vrf MGMT <ip>`` — the vrf infix precedes
+        # the address on IOS-XR; pre-fix ``vrf`` was captured as the server and
+        # the real IP lost (ntp_servers == ["vrf"]).
+        intent = get_codec("cisco_iosxr").parse(
+            "ntp\n server vrf MGMT 10.11.23.7\n"
+        )
+        assert intent.ntp_servers == ["10.11.23.7"]
+
 
 class TestXrSyslogHarvest:
     def test_ignores_non_destination_logging(self) -> None:

--- a/tests/unit/migration/test_cisco_nxos_mgmt_plane.py
+++ b/tests/unit/migration/test_cisco_nxos_mgmt_plane.py
@@ -61,6 +61,15 @@ class TestNxosManagementPlaneHarvest:
         assert intent.dns_servers == ["8.8.8.8", "1.1.1.1"]
         assert codec.parse(codec.render(intent)).dns_servers == ["8.8.8.8", "1.1.1.1"]
 
+    def test_name_server_use_vrf_tail_not_harvested(self) -> None:
+        # HEAD-review L1-2: ``ip name-server <ip> use-vrf <name>`` — the
+        # trailing ``use-vrf management`` modifier must NOT be minted as fake
+        # resolvers (pre-fix: dns_servers == ["10.0.80.10", "use-vrf",
+        # "management"]).  IP-guard drops the non-address tokens.
+        codec = get_codec("cisco_nxos")
+        intent = codec.parse("ip name-server 10.0.80.10 use-vrf management\n")
+        assert intent.dns_servers == ["10.0.80.10"]
+
     def test_no_mgmt_config_renders_nothing(self) -> None:
         codec = get_codec("cisco_nxos")
         intent = codec.parse("hostname bare\n")


### PR DESCRIPTION
## Summary

Wave 2 PR-2 of the 2026-07-12 HEAD-review remediation — the **mgmt-plane keyword-tails** (L1-2 / L1-3 / L1-4). Three freshly-wired parsers greedily consumed a trailing keyword token, either minting junk or shadowing the real value.

| Finding | Codec | Symptom at HEAD | Fix |
|---|---|---|---|
| **L1-2** | `cisco_nxos` | `ip name-server 10.0.80.10 use-vrf management` → `dns_servers = ['10.0.80.10', 'use-vrf', 'management']` | IP-guard each token (mirrors the sibling syslog loop) |
| **L1-3** | `cisco_iosxr` | `server vrf MGMT 10.11.23.7` → `ntp_servers = ['vrf']`, real IP lost | add the `(?:vrf\s+\S+\s+)?` infix the `arista_eos` twin already has |
| **L1-4** | `cisco_iosxr` | `router static` tails: `tag 100` → `metric=100`; `description CORP` / `bfd fast-detect` → `interface='description'`/`'bfd'`, re-rendering invalid CLI `<dest> description <gw>` | keyword-aware walk: consume `tag`/`track` + value, `description`/`bfd` to EOL, skip `permanent` |

`description` is already declared lossy on IOS-XR, so consume-and-ignore is the correct disposition; the render only emits `<dest> <iface> <gateway> <distance>`.

## Verification

- **Verify-first**: a probe reproduced the fake DNS servers / lost NTP IP / mis-filed static-route tails at HEAD, then confirmed correct output + byte-identical plain-form controls after the fix.
- **Mesh-flat**: no fixture carries `name-server ... use-vrf`, `ntp server vrf`, or a static-route `tag`/`description`/`bfd`/`permanent` tail (verified by grep). The cross-mesh CI guard stays green (**CODEC_BUG 5, cells 1224**) — no data-file changes.
- **Behaviour-identical** on the plain forms; the nxos + iosxr unit suites (incl. both mgmt-plane suites) pass.
- **Negative-control** guard tests added for all three findings (fail pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
