### PR TITLE
fix(codecs): tolerate nve tail + guard VARP primary IP + harvest nested ip6-mode (HEAD-review L1-5/L1-6/L1-7)

### DIFF
--- a/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
+++ b/netcanon/migration/codecs/cisco_iosxe_cli/parse.py
@@ -293,10 +293,14 @@ _NVE_SOURCE_IF_RE = re.compile(r"^\s+source-interface\s+(\S+)\s*$", re.IGNORECAS
 #: nve1``.  Group 2 (mcast-group) marks an L2 VNI's flood-and-learn group;
 #: group 3 (vrf) marks an L3VNI bound to a VRF (harvested onto
 #: CanonicalRoutingInstance.l3_vni).  A bare ``member vni <V>`` is an L2 VNI
-#: with head-end (BGP-EVPN) replication.
+#: with head-end (BGP-EVPN) replication.  A trailing ``ingress-replication
+#: [protocol bgp]`` marker (the explicit BGP-EVPN head-end spelling) is
+#: tolerated but not modelled — pre-fix the ``\s*$`` anchor rejected the whole
+#: line and the VLAN↔VNI binding silently vanished (HEAD-review L1-5).
 _NVE_MEMBER_VNI_RE = re.compile(
     r"^\s+member\s+vni\s+(\d+)"
-    r"(?:\s+mcast-group\s+(\d+\.\d+\.\d+\.\d+)|\s+vrf\s+(\S+))?\s*$",
+    r"(?:\s+mcast-group\s+(\d+\.\d+\.\d+\.\d+)|\s+vrf\s+(\S+))?"
+    r"(?:\s+\S.*)?$",
     re.IGNORECASE,
 )
 def _is_ipv4_literal(token: str) -> bool:

--- a/netcanon/migration/codecs/fortigate_cli/parse.py
+++ b/netcanon/migration/codecs/fortigate_cli/parse.py
@@ -379,7 +379,19 @@ def _apply_system_interface(  # noqa: C901
         # are intentionally not surfaced here.  ``static`` is the
         # FortiOS default and means "no DHCPv6"; we don't populate
         # the field.
+        # FortiOS 6.x puts ``set ip6-mode`` directly on the interface edit;
+        # 7.x nests it under a ``config ipv6`` sub-block (same as
+        # ``ip6-address`` below).  Read the direct form first, then the nested
+        # block — without the nested fallback a 7.x DHCPv6 client was silently
+        # dropped even though ``dhcp-client-v6`` is declared supported
+        # (HEAD-review L1-7, the un-hardened sibling of the #345 ip6-address
+        # nested harvest).
         ip6_mode_tokens = edit.settings.get("ip6-mode")
+        if not (ip6_mode_tokens and ip6_mode_tokens[0]):
+            for sub in edit.sub_blocks:
+                if sub.config_path == "ipv6":
+                    ip6_mode_tokens = sub.settings.get("ip6-mode")
+                    break
         if ip6_mode_tokens and ip6_mode_tokens[0]:
             mode_value = ip6_mode_tokens[0].lower().strip('"')
             if mode_value == "dhcp":
@@ -397,9 +409,8 @@ def _apply_system_interface(  # noqa: C901
         # form was absent — a real config carries the address in exactly
         # one place, so this never double-appends (promotion #2: the path
         # is declared supported, so a dropped nested address was a
-        # fail-open silent loss).  Only ``ip6-address`` is harvested from
-        # the nested block; nested ``ip6-mode`` is a separate surface left
-        # untouched here.
+        # fail-open silent loss).  Nested ``ip6-mode`` gets the identical
+        # direct-then-nested treatment above (HEAD-review L1-7).
         ip6_tokens = edit.settings.get("ip6-address")
         if not (ip6_tokens and ip6_tokens[0]):
             for sub in edit.sub_blocks:

--- a/netcanon/migration/codecs/fortigate_cli/render.py
+++ b/netcanon/migration/codecs/fortigate_cli/render.py
@@ -600,20 +600,27 @@ def render_intent(tree: Any) -> str:  # noqa: C901
                     out.append(f"        set vlanid {vid}")
                     if parent:
                         out.append(f'        set interface "{parent}"')
-            if iface.ipv4_addresses:
-                addr = iface.ipv4_addresses[0]
+            # Only rows with a real IP can render as FortiOS ``set ip`` — a
+            # VARP virtual-gateway anycast row carries ip='' +
+            # virtual_gateway_address, and emitting ``set ip  <mask>`` is
+            # invalid CLI.  The primary ``set ip`` line was previously taken
+            # from ``ipv4_addresses[0]`` UNGUARDED, so an SVI whose first (or
+            # only) address was VARP-only rendered the broken empty-IP line
+            # (HEAD-review L1-6); apply the same predicate as the secondary
+            # rows below and pick the first real address as the primary.
+            real_addrs = [
+                a for a in iface.ipv4_addresses
+                if a.ip and not a.virtual_gateway_address
+            ]
+            if real_addrs:
+                addr = real_addrs[0]
                 mask = _prefix_to_mask(addr.prefix_length)
                 out.append(f"        set ip {addr.ip} {mask}")
                 out.append("        set mode static")
                 # Additional interface IPs → FortiOS ``config secondaryip``
                 # table (whole-subnet reachability that used to vanish —
-                # promotion #3).  Skip rows with no real IP: a VARP virtual-
-                # gateway anycast row carries ip='' + virtual_gateway_address,
-                # and emitting ``set ip  <mask>`` would be invalid CLI.
-                secondaries = [
-                    a for a in iface.ipv4_addresses[1:]
-                    if a.ip and not a.virtual_gateway_address
-                ]
+                # promotion #3).
+                secondaries = real_addrs[1:]
                 if secondaries:
                     out.append("        set secondary-IP enable")
                     out.append("        config secondaryip")

--- a/tests/unit/migration/test_cisco_iosxe_cli_vxlan_nve.py
+++ b/tests/unit/migration/test_cisco_iosxe_cli_vxlan_nve.py
@@ -79,6 +79,27 @@ def test_real_fixture_round_trip_stable():
     assert len(a.interfaces) == len(b.interfaces)
 
 
+def test_nve_member_vni_tolerates_ingress_replication_tail():
+    # HEAD-review L1-5: ``member vni <V> ingress-replication`` (the explicit
+    # BGP-EVPN head-end spelling) under ``interface nve1``.  The ``$``-anchored
+    # regex previously rejected the whole line, so the VLAN<->VNI binding
+    # silently vanished (vxlan_vnis == []).  The tail is tolerated (not
+    # modelled) and the binding survives on this supported path.
+    raw = (
+        "hostname leaf1\n"
+        "vlan configuration 100\n"
+        " member evpn-instance 1 vni 10100\n"
+        "interface nve1\n"
+        " no ip address\n"
+        " source-interface Loopback0\n"
+        " host-reachability protocol bgp\n"
+        " member vni 10100 ingress-replication\n"
+    )
+    intent = _codec().parse(raw)
+    assert [(v.vlan_id, v.vni, v.mcast_group) for v in intent.vxlan_vnis] == \
+           [(100, 10100, "")]
+
+
 # ---------------------------------------------------------------------------
 # Synthetic round-trips (canonical -> render -> parse)
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/test_fortigate_cli.py
+++ b/tests/unit/migration/test_fortigate_cli.py
@@ -545,6 +545,54 @@ class TestSecondaryIp:
         assert "config secondaryip" not in rendered
         assert "set ip  " not in rendered
 
+    def test_varp_only_primary_not_emitted_as_invalid_set_ip(self):
+        """HEAD-review L1-6: a VARP anycast row at index 0 (ip='' +
+        virtual_gateway_address) must NOT render the invalid ``set ip <mask>``
+        PRIMARY line — the secondary predicate now guards the primary too, so a
+        real IP is promoted and a VARP-only SVI emits no ``set ip`` at all."""
+        # VARP-only SVI (no real IP): no ``set ip`` line, not the invalid one.
+        varp_only = CanonicalIntent(interfaces=[CanonicalInterface(
+            name="vlan10",
+            ipv4_addresses=[CanonicalIPv4Address(
+                ip="", prefix_length=24, virtual_gateway_address="10.0.10.1",
+            )],
+        )])
+        out = FortiGateCLICodec().render(varp_only)
+        assert "set ip  " not in out  # pre-fix: ``set ip  255.255.255.0``
+        # VARP row FIRST, real IP second: the real IP is promoted to primary.
+        varp_then_real = CanonicalIntent(interfaces=[CanonicalInterface(
+            name="vlan20",
+            ipv4_addresses=[
+                CanonicalIPv4Address(
+                    ip="", prefix_length=24,
+                    virtual_gateway_address="10.0.20.1",
+                ),
+                CanonicalIPv4Address(ip="10.0.20.2", prefix_length=24),
+            ],
+        )])
+        out2 = FortiGateCLICodec().render(varp_then_real)
+        assert "set ip 10.0.20.2 255.255.255.0" in out2
+        assert "set ip  " not in out2
+
+    def test_nested_config_ipv6_ip6_mode_dhcp_harvested(self):
+        """HEAD-review L1-7: FortiOS 7.x nests ``set ip6-mode`` under
+        ``config ipv6``.  The direct-then-nested fallback (the sibling of the
+        #345 ``ip6-address`` harvest) must read it — pre-fix a nested DHCPv6
+        client was silently dropped though ``dhcp-client-v6`` is supported."""
+        raw = (
+            "config system interface\n"
+            '    edit "port1"\n'
+            "        set ip 10.0.0.1 255.255.255.0\n"
+            "        config ipv6\n"
+            "            set ip6-mode dhcp\n"
+            "        end\n"
+            "    next\n"
+            "end\n"
+        )
+        intent = FortiGateCLICodec().parse(raw)
+        port1 = next(i for i in intent.interfaces if i.name == "port1")
+        assert port1.dhcp_client_v6 == "dhcp6"
+
     def test_interface_v4_secondary_supported_twins_stay_unsupported(self):
         caps = FortiGateCLICodec().capabilities
         assert caps.classify("/interfaces/interface/ipv4/address/secondary-ip") == "supported"


### PR DESCRIPTION
## Summary

Wave 2 PR-3 (final) of the 2026-07-12 HEAD-review remediation — three more silent losses on paths declared **supported**.

| Finding | Codec | Symptom at HEAD | Fix |
|---|---|---|---|
| **L1-5** | `cisco_iosxe_cli` | `member vni 10100 ingress-replication` under `interface nve1` → the `$`-anchored regex rejected the line → whole VLAN↔VNI binding vanished (`vxlan_vnis == []`) | tolerate a trailing `ingress-replication [protocol bgp]` marker |
| **L1-6** | `fortigate_cli` | VARP-only SVI (ip='' + `virtual_gateway_address`) at index 0 rendered the invalid `set ip  <mask>` (#344 guarded the *secondaries* but not the *primary*) | apply the same predicate to pick the first **real** address as primary; a VARP-only SVI emits no `set ip` |
| **L1-7** | `fortigate_cli` | FortiOS 7.x nested `config ipv6 / set ip6-mode dhcp` dropped (#345 added the nested fallback for `ip6-address` only) → nested DHCPv6 client lost | mirror the direct-then-nested read for `ip6-mode` |

## Verification

- **Verify-first**: a probe reproduced `vxlan_vnis == []`, the invalid `set ip  255.255.255.0`, and the lost `dhcp_client_v6` at HEAD, then confirmed each fixed. L1-6 preserves a real IP when it coexists with a VARP row (real IP promoted to primary); L1-7 is live on the `kevinguenay` `wan1`/`wan2` fixture interfaces.
- **Mesh-flat**: no fixture carries `member vni ... ingress-replication`. L1-6/L1-7 touch shipped-fixture paths, but the fidelity harness scores round-trip *preservation*, not CLI validity — a full regen confirms the aggregate is byte-identical (**CODEC_BUG 5, cells 1224**); cross-mesh CI guard green.
- **Behaviour-identical** on the plain forms; the iosxe + fortigate suites pass.
- **Negative-control** guard tests added for all three findings (fail pre-fix).

This closes **Wave 2** (the codec data-loss correctness cluster). Waves 4–6 of the HEAD review remain, unstarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
