### PR TITLE
fix(codecs): mikrotik bonding render emits comment= so LAG descriptions round-trip (HEAD-review Fid-F3)

### DIFF
--- a/netcanon/migration/codecs/mikrotik_routeros/render.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/render.py
@@ -412,6 +412,14 @@ def render_intent(tree: Any) -> str:  # noqa: C901
 
     # ----- /interface bonding (Tier 2 LAGs) -----
     if tree.lags:
+        # The bond's human-readable comment is carried on the synthetic
+        # CanonicalInterface the parse path materialises (parse.py
+        # ``_parse_interface_bonding``), not on CanonicalLAG itself — look
+        # it up by name so a bond's ``comment=`` round-trips (it otherwise
+        # silently dropped on this supported path).
+        _lag_desc = {
+            i.name: i.description for i in tree.interfaces if i.description
+        }
         lines.append("/interface bonding")
         for lag in tree.lags:
             parts = ["add"]
@@ -421,6 +429,9 @@ def render_intent(tree: Any) -> str:  # noqa: C901
                 f"mode={_CANONICAL_MODE_TO_ROUTEROS_BONDING.get(lag.mode, '802.3ad')}"
             )
             parts.append(f"name={_quote_if_needed(lag.name)}")
+            desc = _lag_desc.get(lag.name)
+            if desc:
+                parts.append(f'comment="{_escape(desc)}"')
             lines.append(" ".join(parts))
         lines.append("")
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-14T04:37:07+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260714T043652Z.json",
-  "mesh_run_started_utc": "2026-07-14T04:36:45+00:00",
+  "started_utc": "2026-07-14T16:21:57+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260714T162156Z.json",
+  "mesh_run_started_utc": "2026-07-14T16:21:49+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4531,7 +4531,7 @@
     {
       "source_codec": "mikrotik_routeros",
       "target_codec": "mikrotik_routeros",
-      "drifted_total": 1
+      "drifted_total": 0
     },
     {
       "source_codec": "mikrotik_routeros",

--- a/tests/unit/migration/test_mikrotik_routeros.py
+++ b/tests/unit/migration/test_mikrotik_routeros.py
@@ -1040,6 +1040,43 @@ class TestInterfaceTypeInferenceRoundTrip:
         intent = MikroTikRouterOSCodec().parse(raw)
         assert intent.interfaces[0].interface_type == "ianaift:ieee8023adLag"
 
+    def test_bond_comment_round_trips(self):
+        """HEAD-review Fid-F3: a bond's ``comment=`` (harvested onto the
+        synthetic LAG CanonicalInterface's ``description``) must survive
+        parse -> render -> parse.  The render ``/interface bonding`` block
+        previously emitted only slaves/mode/name, silently dropping the
+        description on this *supported* path.  Fails pre-fix (comment == '')."""
+        codec = MikroTikRouterOSCodec()
+        raw = (
+            "/interface bonding\n"
+            'add comment="LACP bond to core" name=bond1 slaves=ether1,ether2 mode=802.3ad\n'
+        )
+        first = codec.parse(raw)
+        bond1 = next(i for i in first.interfaces if i.name == "bond1")
+        assert bond1.description == "LACP bond to core"
+
+        # The description survives the render round-trip.
+        second = codec.parse(codec.render(first))
+        bond1b = next(i for i in second.interfaces if i.name == "bond1")
+        assert bond1b.description == "LACP bond to core"
+        # ...and the LAG identity is otherwise unchanged.
+        assert [(l.name, l.members, l.mode) for l in first.lags] == \
+               [(l.name, l.members, l.mode) for l in second.lags]
+
+    def test_bond_without_comment_emits_no_comment_kv(self):
+        """Negative control — a bond with no description must NOT emit a
+        stray ``comment=`` token."""
+        codec = MikroTikRouterOSCodec()
+        out = codec.render(CanonicalIntent(
+            hostname="r1",
+            lags=[CanonicalLAG(name="bond1", members=["ether1", "ether2"])],
+        ))
+        bond_line = next(
+            l for l in out.splitlines()
+            if l.startswith("add") and "name=bond1" in l
+        )
+        assert "comment=" not in bond_line
+
 
 # ---------------------------------------------------------------------------
 # VRRP groups (v0.2.0 Wave B wire-up)

--- a/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
+++ b/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
@@ -98,19 +98,10 @@ _FIXTURE_EXTENSIONS = {".txt", ".cfg", ".xml", ".conf", ".rsc", ".set"}
 # diff equals this set precisely — a WIDER diff is a new regression, a NARROWER
 # one means the gap was fixed and this entry must be deleted (rot detection).
 _KNOWN_ROUNDTRIP_GAPS: dict[str, tuple[str, frozenset[str]]] = {
-    # mikrotik_routeros: bond-interface ``description`` round-trip drop
-    # — surfaced by the kitchen-sink's "LACP bond to upstream core"
-    # description on a synthetic bonding interface.  The render path
-    # emits the bond stanza without re-emitting its description, so
-    # the second parse sees an empty description.  Real-capture
-    # coverage doesn't hit this because none of the committed real
-    # RouterOS exports describe a bond with a description string.
-    # bond1 / bond2 sort to interfaces[0] / [1] (``_compare`` sorts by name).
-    "mikrotik_routeros::kitchen_sink.rsc": (
-        "bond-interface description not preserved through render — "
-        "TODO on mikrotik_routeros codec",
-        frozenset({"interfaces[0].description", "interfaces[1].description"}),
-    ),
+    # NB: mikrotik_routeros::kitchen_sink.rsc bond-``description`` gap was
+    # CLOSED in HEAD-review Fid-F3 — the render ``/interface bonding`` block
+    # now re-emits ``comment=`` so bond1/bond2 descriptions round-trip; the
+    # entry was deleted per this dict's rot-detection contract.
     # opnsense: parse now harvests <staticroutes>/<gateways> (#15) but the
     # renderer emits no <staticroutes> block (declared lossy on the
     # opnsense codec), so the single harvested route (172.16.0.0/12) is


### PR DESCRIPTION
## Wave 4 PR-1 — Fid-F3: mikrotik LAG comment round-trip

Third adversarial HEAD-review (`3def246`) fidelity-lens finding. Wave 4 protects the **fidelity ratchet** the whole remediation campaign leans on; this is its one real codec data-loss.

### The bug
`mikrotik_routeros`'s `/interface bonding` render block emitted only `slaves=`/`mode=`/`name=`. A bond's `comment=` is harvested on **parse** onto the synthetic LAG `CanonicalInterface.description` (`parse.py:637`), but the render iterates `tree.lags` (`CanonicalLAG`, which carries no description) and never consulted it — so a bond's description **silently dropped** on a *supported* path (the cardinal round-trip sin). Reproduced on the committed `tests/fixtures/synthetic/mikrotik_routeros/kitchen_sink.rsc` and on a real fixture (the mikrotik self-pair carried 1 drifted field).

### The fix
Render now builds a name→description lookup from `tree.interfaces` and emits `comment="<desc>"` when set, using the same `_escape` idiom every other interface block (bridge/loopback/vlan/tunnel) already uses.

```
add slaves=ether3,ether4 mode=802.3ad name=bond1 comment="LACP bond to upstream core"
```

### Verification
- Verify-first probe: parse→render→parse the kitchen_sink bonds — description drops to `''` pre-fix, survives post-fix.
- **Negative control**: `test_bond_comment_round_trips` fails pre-fix (asserts the description survives); `test_bond_without_comment_emits_no_comment_kv` guards against a stray `comment=` when no description is set.
- **Mesh**: mikrotik self-pair `drifted_total 1→0` (drift *reduced*); `CODEC_BUG` holds at **5**, all aggregate buckets byte-identical. `latest.json` baseline tightened to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
