### PR TITLE
fix(fidelity): key unsupported-in-target on the record identity leaf, not any sub-path (HEAD-review Fid-F2)

### DIFF
--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-14T16:21:57+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260714T162156Z.json",
-  "mesh_run_started_utc": "2026-07-14T16:21:49+00:00",
+  "started_utc": "2026-07-14T16:36:22+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260714T163621Z.json",
+  "mesh_run_started_utc": "2026-07-14T16:36:14+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4191,7 +4191,7 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 31
+      "drifted_total": 39
     },
     {
       "source_codec": "arista_eos",
@@ -4206,7 +4206,7 @@
     {
       "source_codec": "arista_eos",
       "target_codec": "vyos",
-      "drifted_total": 26
+      "drifted_total": 33
     },
     {
       "source_codec": "aruba_aoscx",
@@ -4266,7 +4266,7 @@
     {
       "source_codec": "aruba_aoscx",
       "target_codec": "vyos",
-      "drifted_total": 32
+      "drifted_total": 33
     },
     {
       "source_codec": "aruba_aoss",
@@ -4321,7 +4321,7 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 40
+      "drifted_total": 43
     },
     {
       "source_codec": "cisco_iosxe_cli",
@@ -4341,7 +4341,7 @@
     {
       "source_codec": "cisco_iosxe_cli",
       "target_codec": "vyos",
-      "drifted_total": 33
+      "drifted_total": 36
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4351,7 +4351,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 37
+      "drifted_total": 45
     },
     {
       "source_codec": "cisco_iosxr",
@@ -4401,7 +4401,7 @@
     {
       "source_codec": "cisco_iosxr",
       "target_codec": "vyos",
-      "drifted_total": 35
+      "drifted_total": 43
     },
     {
       "source_codec": "cisco_nxos",
@@ -4411,7 +4411,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 57
+      "drifted_total": 71
     },
     {
       "source_codec": "cisco_nxos",
@@ -4461,7 +4461,7 @@
     {
       "source_codec": "cisco_nxos",
       "target_codec": "vyos",
-      "drifted_total": 56
+      "drifted_total": 70
     },
     {
       "source_codec": "fortigate_cli",
@@ -4491,7 +4491,7 @@
     {
       "source_codec": "juniper_junos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 71
+      "drifted_total": 80
     },
     {
       "source_codec": "juniper_junos",
@@ -4511,7 +4511,7 @@
     {
       "source_codec": "juniper_junos",
       "target_codec": "vyos",
-      "drifted_total": 58
+      "drifted_total": 67
     },
     {
       "source_codec": "mikrotik_routeros",
@@ -4571,7 +4571,7 @@
     {
       "source_codec": "vyos",
       "target_codec": "aruba_aoscx",
-      "drifted_total": 43
+      "drifted_total": 46
     },
     {
       "source_codec": "vyos",

--- a/tests/unit/audit/test_run_full_mesh.py
+++ b/tests/unit/audit/test_run_full_mesh.py
@@ -22,6 +22,7 @@ from netcanon.migration.canonical.intent import (
     CanonicalInterface,
     CanonicalIPv4Address,
     CanonicalLAG,
+    CanonicalRoutingInstance,
     CanonicalSNMP,
     CanonicalSNMPv3User,
     CanonicalStaticRoute,
@@ -343,6 +344,68 @@ def test_unsupported_xpath_does_not_apply_to_other_fields() -> None:
         target_unsupported_xpaths=["/vxlan-vnis/vni"],
     )
     assert out["hostname"]["unsupported_in_target"] is False
+
+
+def test_sub_leaf_only_unsupported_does_not_mask_field() -> None:
+    """(Fid-F2) When only a SUB-detail is declared unsupported while the
+    record IDENTITY leaf is supported, the field is NOT
+    ``unsupported_in_target`` — the record still renders, so drift on it
+    must stay visible to the drift ratchet.  Mirrors aruba_aoscx/vyos,
+    which declare ``/vxlan-vnis/udp-port`` / ``…/l2vni-route-target``
+    unsupported while ``/vxlan-vnis/vni`` is supported.  FAILS pre-fix:
+    the old ``any(startswith('/vxlan-vnis/'))`` rule masked the whole
+    field, hiding the source-interface drop below."""
+    src = CanonicalIntent(
+        vxlan_vnis=[CanonicalVxlan(vlan_id=100, vni=10100,
+                                   source_interface="Loopback1")],
+    )
+    tgt = CanonicalIntent(  # identity (vlan_id/vni) held; source-iface dropped
+        vxlan_vnis=[CanonicalVxlan(vlan_id=100, vni=10100)],
+    )
+    out = compute_field_disposition(
+        src, tgt,
+        target_unsupported_xpaths=[
+            "/vxlan-vnis/udp-port",
+            "/vxlan-vnis/l2vni-route-target",
+        ],
+    )
+    rec = out["vxlan_vnis"]
+    assert rec["unsupported_in_target"] is False
+    assert rec["preserved"] is False  # the source-interface drift IS visible
+
+
+def test_routing_instance_sub_leaf_only_unsupported_does_not_mask_field() -> None:
+    """(Fid-F2) routing_instances counterpart: a target declaring only
+    ``/routing-instances/instance/l3-vni`` unsupported (identity
+    ``…/name`` supported) must not have the whole field masked."""
+    src = CanonicalIntent(
+        routing_instances=[CanonicalRoutingInstance(name="T1", l3_vni=5000)],
+    )
+    tgt = CanonicalIntent(  # name held; l3_vni dropped
+        routing_instances=[CanonicalRoutingInstance(name="T1")],
+    )
+    out = compute_field_disposition(
+        src, tgt,
+        target_unsupported_xpaths=["/routing-instances/instance/l3-vni"],
+    )
+    rec = out["routing_instances"]
+    assert rec["unsupported_in_target"] is False
+    assert rec["preserved"] is False
+
+
+def test_routing_instance_identity_leaf_unsupported_masks_field() -> None:
+    """(Fid-F2) positive control: a target declaring the routing-instance
+    IDENTITY unsupported (bare ``/routing-instances/instance`` — the
+    mikrotik/opnsense/aoss shape) IS ``unsupported_in_target``."""
+    src = CanonicalIntent(
+        routing_instances=[CanonicalRoutingInstance(name="T1")],
+    )
+    tgt = CanonicalIntent()
+    out = compute_field_disposition(
+        src, tgt,
+        target_unsupported_xpaths=["/routing-instances/instance"],
+    )
+    assert out["routing_instances"]["unsupported_in_target"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/codecs/cisco_iosxe/test_capability_matrix_honesty.py
+++ b/tests/unit/migration/codecs/cisco_iosxe/test_capability_matrix_honesty.py
@@ -277,27 +277,30 @@ class TestRenderCoverageHonesty:
         caps = CiscoIOSXECodec().capabilities
         unsupported_paths = {up.path for up in caps.unsupported}
 
-        # Mirrors tools/run_full_mesh.py::_FIELD_TO_XPATH_PREFIX.
-        # Fields covered by a prefix get `unsupported_in_target` from
-        # any xpath under the prefix; other fields need exact
-        # `/<field>`.
-        prefix_covered = {
-            "vxlan_vnis": "/vxlan-vnis/",
-            "evpn_type5_routes": "/evpn-type5-routes/",
-            "routing_instances": "/routing-instances/",
+        # Mirrors tools/run_full_mesh.py::_FIELD_TO_IDENTITY_XPATHS.
+        # (Fid-F2) A field gets `unsupported_in_target` only when its
+        # record IDENTITY leaf is declared unsupported (not merely a
+        # sub-detail); other fields need exact `/<field>`.
+        identity_covered = {
+            "vxlan_vnis": ("/vxlan-vnis/vni",),
+            "evpn_type5_routes": ("/evpn-type5-routes/route",),
+            "routing_instances": (
+                "/routing-instances/instance",
+                "/routing-instances/instance/name",
+            ),
         }
 
         for field in _DROPPED_TOP_LEVEL_FIELDS:
-            prefix = prefix_covered.get(field)
-            if prefix:
-                # Either prefix-match OR exact `/<field>` works.
+            identity = identity_covered.get(field)
+            if identity:
+                # Either an identity-leaf match OR exact `/<field>` works.
                 ok = (
-                    any(p.startswith(prefix) for p in unsupported_paths)
+                    any(idx in unsupported_paths for idx in identity)
                     or f"/{field}" in unsupported_paths
                 )
                 assert ok, (
-                    f"render drops intent.{field} but no /{field}-family "
-                    f"xpath (prefix {prefix!r} or exact /{field}) is "
+                    f"render drops intent.{field} but no identity xpath "
+                    f"({' / '.join(identity)} or exact /{field}) is "
                     f"declared unsupported.  Add an UnsupportedPath."
                 )
             else:

--- a/tools/run_full_mesh.py
+++ b/tools/run_full_mesh.py
@@ -161,25 +161,41 @@ _AUDITED_FIELDS: tuple[str, ...] = (
 )
 
 
-# Mapping from canonical field name → the prefix used by the codec's
-# CapabilityMatrix.unsupported xpaths.  When EVERY xpath under that
-# prefix is declared unsupported, the field is considered "unsupported
-# by design" for the target — drift on it is expected, not a defect.
+# Mapping from canonical field name → the IDENTITY xpath(s) that make a
+# record of that field exist at all.  A field is "unsupported by design"
+# for a target ONLY when the target declares that identity leaf
+# unsupported — i.e. the record itself cannot be represented, so drift on
+# it is expected, not a defect.  If merely a SUB-detail is unsupported
+# (e.g. ``/vxlan-vnis/udp-port`` while ``/vxlan-vnis/vni`` is supported),
+# the record still renders and any drift on it is a REAL loss the ratchet
+# must SEE, not mask.
 #
-# Matches the existing xpath shapes in the codec capability matrices
-# (see e.g. aruba_aoss declaring ``/vxlan-vnis/vni`` +
-# ``/vxlan-vnis/source-interface`` + ``/vxlan-vnis/udp-port``).
-_FIELD_TO_XPATH_PREFIX: dict[str, str] = {
-    "vxlan_vnis": "/vxlan-vnis/",
-    # NB: the EVPN prefix must include the ``-routes`` segment — every
-    # codec declares ``/evpn-type5-routes/route`` (the canonical
-    # vocabulary), so the old ``/evpn-type5/`` prefix matched nothing
-    # and the field fell through to the exact ``/evpn_type5_routes``
-    # field-marker fallback.  Normalised in the 2026-06 vocab pass
-    # (review #8) so the prefix actually catches the granular shape.
-    "evpn_type5_routes": "/evpn-type5-routes/",
-    "routing_instances": "/routing-instances/",
-    # Other fields don't have a stable xpath-prefix convention in the
+# (HEAD-review Fid-F2) The previous rule matched ``any(startswith(prefix))``
+# over the whole ``/<field>/`` prefix, so a single unsupported sub-leaf
+# (aruba_aoscx/vyos declare only ``/vxlan-vnis/l2vni-route-target`` +
+# ``/routing-instances/instance/{description,route-distinguisher,rt-*,
+# l3-vni}`` while their identity ``/vxlan-vnis/vni`` +
+# ``/routing-instances/instance/name`` are SUPPORTED) flagged the WHOLE
+# field unsupported-by-design and structurally blinded the drift ratchet —
+# the only mesh guard for those two YAML-less codecs — to VXLAN /
+# routing-instance regressions.  Keying on the identity leaf restores
+# visibility; codecs that genuinely cannot hold the record still declare
+# the identity leaf unsupported (aoss/iosxe/iosxr/fortigate/mikrotik/
+# opnsense) and stay flagged.
+_FIELD_TO_IDENTITY_XPATHS: dict[str, tuple[str, ...]] = {
+    "vxlan_vnis": ("/vxlan-vnis/vni",),
+    # Every codec declares the granular ``/evpn-type5-routes/route``
+    # identity (the canonical vocabulary; normalised in the 2026-06 vocab
+    # pass, review #8).
+    "evpn_type5_routes": ("/evpn-type5-routes/route",),
+    # A routing-instance's identity is the instance itself: some codecs
+    # declare the bare ``/routing-instances/instance`` unsupported, others
+    # the ``.../name`` leaf — either makes the record unrepresentable.
+    "routing_instances": (
+        "/routing-instances/instance",
+        "/routing-instances/instance/name",
+    ),
+    # Other fields don't have a stable xpath-identity convention in the
     # current matrix — leave them keyed only by direct equality below.
 }
 
@@ -385,10 +401,13 @@ def compute_field_disposition(
         # field names AND prefix-match against the documented prefix
         # convention for the schema-extension fields.
         unsupported = False
-        prefix = _FIELD_TO_XPATH_PREFIX.get(field)
-        if prefix:
+        identity_xpaths = _FIELD_TO_IDENTITY_XPATHS.get(field)
+        if identity_xpaths:
+            # (Fid-F2) Unsupported-by-design only when the record's
+            # IDENTITY leaf is declared unsupported — NOT when merely a
+            # sub-detail is (that would mask a real, visible loss).
             unsupported = any(
-                xp.startswith(prefix) for xp in unsupported_xpaths
+                idx in unsupported_xpaths for idx in identity_xpaths
             )
         # Also accept exact xpath ``/<field>`` — some codecs declare at
         # field level rather than per-leaf.


### PR DESCRIPTION
## Wave 4 PR-2 — Fid-F2: key unsupported-in-target on the record identity leaf

HEAD-review fidelity finding. Wave 4 hardens the **fidelity ratchet** the whole campaign leans on; this is the delicate one — it changes the mesh *classifier*, not a codec.

### The bug
`tools/run_full_mesh.py` decided a field was "unsupported by design" for a target with `any(xp.startswith('/<field>/'))` over the target's unsupported xpaths — while its own comment (:165) said the intent was **"when EVERY xpath under that prefix is unsupported."** A single unsupported **sub-leaf** masked the whole field.

`aruba_aoscx` and `vyos` declare only `/vxlan-vnis/l2vni-route-target` (+ routing-instance sub-leaves: `l3-vni`, `route-distinguisher`, `rt-*`) unsupported, while their **identity** leaves (`/vxlan-vnis/vni`, `/routing-instances/instance/name`) are **supported**. Those two codecs have **zero expectation-YAML**, so the drift ratchet is their only mesh guard — and it was structurally blind to VXLAN / routing-instance regressions on their flagship surface. A future render bug dropping every VNI into vyos would have kept all guards green.

### The fix
Replace the prefix-any map with `_FIELD_TO_IDENTITY_XPATHS` — a field is unsupported-by-design **only when the record's identity leaf is declared unsupported** (the record can't exist at all). A sub-detail being unsupported now leaves the field **visible** so its drift is counted.

### Verification (verify-first, read-only probe across all 12 codecs)
`unsupported_in_target` flips `True→False` **only** for `aruba_aoscx` + `vyos` on `vxlan_vnis` + `routing_instances`. Codecs that genuinely can't hold the record still declare the identity leaf unsupported (`aoss`/`iosxe`/`iosxr`/`fortigate`/`mikrotik`/`opnsense`) and stay flagged; `nxos`/`arista` were never flagged.

**Re-baseline triage**: 12 aoscx/vyos-target pairs' `pair_drift_yaml_less` rise (e.g. `arista_eos→aruba_aoscx` 31→39). Every newly-visible field-cell was inspected — all on **declared-lossy/unsupported** sub-leaves (`source_interface`, `vlan_id`, `l3_vni`, `route_distinguisher`, `instance_type`, `rt_*`) with the record **identity preserved**. No hidden codec bug surfaced. `CODEC_BUG` holds at **5** (it derives from YAML classification, not this flag); all aggregate buckets byte-identical.

- 3 negative-control audit tests (sub-leaf-only unsup does NOT mask vxlan/RI; identity-leaf unsup DOES) — fail pre-fix.
- Updated the iosxe capability-honesty mirror to the identity-leaf rule.
- `latest.json` re-baselined to the honest (higher) counts; cross-mesh guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
