### PR TITLE
docs: sync operator docs to the live matrix after the #340-#351 promotion wave (HEAD-review D1-D6/D10-D13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,13 @@ across vendors.  Full per-codec matrix is in
 
 * **Tier 1 — auto-translatable.**  hostname, interfaces (name /
   description / enabled state / IPv4 + IPv6 addresses / per-interface
-  VRF binding), VLANs, static routes.  Every shipped codec parses +
-  renders these fully (the experimental `cisco_iosxe` NETCONF stub
-  excepted — it renders interfaces only).  DNS / NTP servers translate
+  VRF binding), VLANs, static routes.  Nearly every shipped codec
+  parses + renders these — the per-codec §A tables in
+  [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md) are authoritative for
+  the exceptions (OPNsense renders no static routes, VyOS has no
+  top-level VLAN database, per-interface VRF binding is wired on 6 of
+  the 12 codecs, and the experimental `cisco_iosxe` NETCONF stub
+  renders interfaces only).  DNS / NTP servers translate
   on most codecs; `syslog` servers translate on `juniper_junos`,
   `cisco_iosxe_cli`, `arista_eos` (`logging host <ip>` /
   `set system syslog host <ip>`), `cisco_nxos` (`logging server <ip>`)

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -125,14 +125,17 @@ lossy where vendors disagree on representation.
   a plaintext fallback
 * `radius_servers`
 * `dhcp_servers` (per-pool — network, gateway, range, options)
-* `vxlan_vnis`, `evpn_type5_routes` (ship-before-wire — schema
-  shipped ahead of wire-up; declared `unsupported` on each codec
-  until the per-vendor wiring lands)
+* `vxlan_vnis`, `evpn_type5_routes` (shipped schema-first; `vxlan_vnis`
+  is now wired `supported` on `arista_eos`, `cisco_nxos`,
+  `aruba_aoscx`, `vyos`, `cisco_iosxe_cli` — the per-codec §A tables
+  are authoritative; `evpn_type5_routes` stays lossy-by-default on
+  every codec)
 * `routing_instances` + per-interface `vrf` (cross-vendor VRF
-  primitive — same ship-before-wire pattern)
+  primitive — schema-first, now wired on multiple codecs; see the
+  per-codec §A tables)
 * `static_routes[].vrf` (v0.2.0 Wave A — per-VRF route
-  discriminator; wired as `lossy` on Junos, `unsupported`
-  elsewhere pending dispatch-side widening)
+  discriminator; wired `supported` on `juniper_junos`, `arista_eos`,
+  `cisco_iosxe_cli`, `cisco_nxos`, `cisco_iosxr`)
 * `interfaces[].ipv4_addresses[].virtual_gateway_address` /
   `virtual_gateway_mac` / `is_secondary` and the matching IPv6
   fields (v0.2.0 Wave C — anycast-gateway companion to the primary
@@ -209,11 +212,12 @@ in `netcanon/migration/codecs/<vendor>/codec.py`.
 | `/anycast-gateway-mac` | Supported (Wave C) | Top-level `fabric forwarding anycast-gateway-mac <MAC>` round-trips between Cisco dotted-triplet wire form (`0001.c73a.0000`) and canonical colon-hex. |
 | `/interfaces/interface/vrrp-groups/group/address-family` | Lossy (Wave B) | IOS-XE 17.12+ modern multi-line `vrrp <VRID> address-family ipv4` nested block is detected (so lossiness is visible) but not deep-populated; render always emits the classic single-line form (accepted by every IOS-XE 15.x+).  A config that uses ONLY the modern AF form round-trips as an empty group shell — the lossiness is intentional and operator-visible. |
 | `/interfaces/interface/ipv6/address/virtual-gateway-address` | Unsupported | IPv6 SD-Access anycast parses-and-ignores in v1.  Corpus has zero fixtures exercising it; wire-up deferred until demand arrives.  IPv4 SD-Access anycast IS supported (row above). |
-| `/routing/static-route/vrf` | Supported (v0.2.0) | Per-VRF static routes: `ip route vrf <NAME> <dest> <mask> <gw>` round-trips through parse + render onto `CanonicalStaticRoute.vrf`.  Trailing route-leak / administrative-distance / `name` tokens (e.g. the `global` next-hop-leak keyword) are not modelled and parse-and-ignore. |
+| `/routing/static-route/vrf` | Supported (v0.2.0) | Per-VRF static routes: `ip route vrf <NAME> <dest> <mask> <gw>` round-trips through parse + render onto `CanonicalStaticRoute.vrf`.  Administrative-distance is harvested onto `metric` (and re-emitted) and a trailing `name <X>` onto `description`; only the `global` route-leak / `tag` / `track` tokens are not modelled and parse-and-ignore. |
 | `/interfaces/interface/config/type` | Lossy | CLI parser infers IANA type from name prefix (GigabitEthernet → ethernetCsmacd, Loopback → softwareLoopback) but cannot detect all IANA types. |
 | `/evpn-type5-routes/route` | Lossy | Per-prefix EVPN Type-5 records are a VRF property; no codec populates them today (lossy-by-default extension point). |
 | `/interfaces/interface/subinterfaces/subinterface/ipv6` | Unsupported | Phase 0.5 scope — IPv4 only. |
-| `/vxlan-vnis/{vni,source-interface,udp-port}` | Unsupported | IOS-XE VXLAN (`interface nve1 / member vni …`) parse-and-ignore in v1; wire-up deferred until Catalyst-to-Arista migration demand arrives. |
+| `/vxlan-vnis/{vni,source-interface,mcast-group}` | Supported (#351) | IOS-XE VXLAN-EVPN L2 VNI: `interface nve1` VTEP + `member vni <V>` + `vlan configuration` VLAN↔VNI binding round-trips through parse + render; `/routing-instances/instance/l3-vni` is supported too. |
+| `/vxlan-vnis/{udp-port,flood-list}` | Lossy | The nve1 render keeps the VNI identity but normalizes the UDP port and drops head-end static ingress-replication flood peers (no IOS-XE grammar in v1). |
 | `/routing-instances/instance` | Lossy | VRF declarations parse and render bidirectionally (`parse._parse_routing_instances` → `vrf definition` emit loop; cross-vendor confirmed via Wave 10β-B / commit `40de39c`).  Lossy because `address-family ipv6` / EVPN `l2vpn evpn` sub-stanzas inside `vrf definition` are parse-and-ignore in v1.  (Per-VRF static-route membership now round-trips via the supported `/routing/static-route/vrf` surface above.) |
 | `/access-list/{extended,standard,ipv6}` | Unsupported | Tier 3 — auto-translating ACL semantics across vendors risks shipping subtly-permissive rules. |
 | `/firewall` | Unsupported | Zone-based firewall (zone-pair / policy-map type inspect) is Tier 3. |
@@ -262,7 +266,7 @@ output.
 | `/anycast-gateway-mac` | Supported (Wave C) | Chassis-wide `ip virtual-router mac-address <MAC>` round-trips to `CanonicalIntent.anycast_gateway_mac`. |
 | `/interfaces/interface/ipv4/address/virtual-gateway-mac` | Lossy (Wave C) | EOS only supports one chassis-wide virtual-router MAC; per-IP MAC overrides (Junos `virtual-gateway-v4-mac`) drop on render — cross-vendor sources carrying per-IP MACs surface a review banner so the operator can either consolidate to a single system-wide MAC or pick a vendor target that preserves per-IP overrides. |
 | `/interfaces/interface/ipv6/address/virtual-gateway-mac` | Lossy (Wave C) | Mirror of the IPv4 case — EOS shares one system-wide MAC across IPv4 and IPv6 anycast. |
-| `/routing/static-route/vrf` | Unsupported | Per-VRF static-route binding parses-and-ignores in v1; schema exists on `CanonicalStaticRoute.vrf`. |
+| `/routing/static-route/vrf` | Supported (#340) | Per-VRF static routes (`ip route vrf <NAME> …`) round-trip onto `CanonicalStaticRoute.vrf`; interface-nexthop (`… <iface>`, e.g. `Null0`) is supported too (#342). |
 | `/interfaces/interface/config/type` | Lossy | EOS interface names don't encode speed; parser defaults `Ethernet<N>` to a `gig` speed-hint and target codecs that care about speed (e.g. Cisco's GigabitEthernet vs TenGigabitEthernet distinction) may emit less-specific prefixes. |
 | `/evpn-type5-routes/route` | Lossy | Per-prefix records are a lossy-by-default extension point — no codec populates them today (would require route-map / policy-statement parsing). |
 | `/routing/bgp` | Unsupported | BGP neighbour tables / redistribution / address-families parse-and-ignore in v1. |

--- a/docs/vendors/arista_eos.md
+++ b/docs/vendors/arista_eos.md
@@ -130,7 +130,8 @@ Canonical mapping:
 - See per-codec `CapabilityMatrix.lossy` declarations.  Most fields
   parse + render cleanly within the documented surface; lossy paths
   surface only when translating to vendors with sub-field drift
-  (e.g. Arista → Cisco IOS-XE per-VRF static-route discriminator).
+  (e.g. per-IP virtual-MAC overrides collapsing onto EOS's single
+  chassis-wide virtual-router MAC).
 
 ## What we don't do
 

--- a/docs/vendors/opnsense.md
+++ b/docs/vendors/opnsense.md
@@ -27,7 +27,6 @@ Netcanon translates the shared-network-function subset.
   IPv6 (`<ipaddrv6>`); track-interface forms
 - VLANs — `<vlans><vlan>` block (tagged form with parent interface
   binding)
-- Static routes (`<staticroutes>`)
 - DHCP server pools — `<dhcpd>` with per-zone configuration
 
 [Tier 2](../CAPABILITIES.md#tier-2--translatable-with-caveats):
@@ -135,6 +134,12 @@ XML element mapping:
 - See per-codec `CapabilityMatrix.lossy` declarations in the codec
   source.  Most fields parse + render cleanly within the
   documented surface.
+- **Static routes are source-side only.**  The parser harvests
+  `<staticroutes>` + `<gateways>` into `CanonicalStaticRoute` (since
+  #350), so OPNsense-*as-source* routes translate outward — but the
+  `config.xml` renderer emits **no** `<staticroutes>`/`<route>` block,
+  so an X→OPNsense migration drops every static route on render.  The
+  loss is declared (`opnsense/codec.py` LossyPath), not silent.
 
 ## What we don't do
 

--- a/docs/vendors/vyos.md
+++ b/docs/vendors/vyos.md
@@ -52,11 +52,11 @@ translatable with caveats:
   VNI, source, multicast group / flood list, UDP port)
 
 > **Management-plane caveat.**  When VyOS is the **target**, the codec
-> renders no `system domain-name` / `system name-server` / `system
-> syslog` / DHCP-server / `radius-server` / `time-zone` config — those
-> surfaces are declared `unsupported` (the live validation report
-> flags the loss rather than reporting `severity: ok`).  **NTP is the
-> exception** — it IS translated.  See
+> renders no `system syslog` / DHCP-server / `radius-server` /
+> `time-zone` config — those surfaces are declared `unsupported` (the
+> live validation report flags the loss rather than reporting
+> `severity: ok`).  **NTP, `system domain-name`, and `system
+> name-server` (DNS) ARE translated** (#347).  See
 > [What we don't do](#what-we-dont-do).
 
 ## Lossy paths
@@ -101,9 +101,9 @@ visible, not silent):
 - **L2 switchport** — VyOS has no access/trunk model (L2 via
   `bridge` / `vif`); switchport mode / access-VLAN / trunk
   allowed-list / native VLAN / voice-VLAN all drop on render
-- **Management plane** — `domain`, `timezone`, DNS / syslog servers,
-  DHCP server pools, RADIUS servers (host + secret).  *(NTP IS
-  supported.)*
+- **Management plane** — `timezone`, syslog servers, DHCP server
+  pools, RADIUS servers (host + secret).  *(NTP, `domain`, and DNS
+  name-servers ARE supported — #347.)*
 - **Top-level VLAN database** — VyOS has none; 802.1Q VLANs are `vif`
   sub-interfaces (which ARE supported)
 - **Per-VRF static routes** — the `vrf name <X>` instances + the

--- a/tests/fixtures/real/RESULTS.md
+++ b/tests/fixtures/real/RESULTS.md
@@ -348,7 +348,7 @@ one real-deployment capture (the highest-signal class of fixture).
 
 **Codec:** `netcanon.migration.codecs.mikrotik_routeros.MikroTikRouterOSCodec`
 **Direction:** `bidirectional`
-**Certainty:** `best_effort` *(unchanged)*
+**Certainty:** `certified`
 
 ### Coverage matrix
 


### PR DESCRIPTION
## Wave 5 PR-2 — operator docs-truth sync (D1–D6 + co-located D10–D13)

The docs-truth cluster. Eleven capability-flipping PRs (`#340–#351`) touched **zero** operator docs (root cause D15), leaving CAPABILITIES.md rows pointing the **wrong direction** and two vendor pages contradicting their own codecs. Doc-only; **every claim re-verified against the live matrix / parse+render source before editing** — `classify()` optimistically defaults undeclared paths to `supported`, so explicit-declaration grep was used for the "is it actually wired" checks (that caught D6c precisely: 6 of 12 codecs, not 12).

### Wrong-direction rows (under-claims — hide shipped work)
- **D1** CAPABILITIES iosxe_cli VXLAN row `Unsupported` → split into the supported trio (`vni`/`source-interface`/`mcast-group`, #351) + the two lossy sub-paths (`udp-port`/`flood-list`); `l3-vni` supported.
- **D2** arista `/routing/static-route/vrf` `Unsupported` → `Supported` (#340; interface-nexthop #342).
- **D3** Tier-2 `static_routes[].vrf` bullet "lossy on Junos, unsupported elsewhere" → supported on 5 codecs; was self-contradicting the same file's §A rows.
- **D4** vyos.md: domain + DNS removed from the unsupported caveat + "what we don't do" (wired #347); syslog/timezone/DHCP/RADIUS stay unsupported (verified).

### Over-claims (the cardinal-sin direction)
- **D5** opnsense.md: static routes moved out of "translates well" into a source-side-only Lossy note (parser harvests `<staticroutes>` since #350 but the renderer emits none → X→OPNsense drops them). The single worst operator-facing sentence at HEAD.
- **D6** README Tier-1: the blanket "every shipped codec parses + renders these fully" now names the real exceptions (OPNsense no static-route render, VyOS no VLAN database, per-interface VRF a 6-of-12 surface).

### Co-located NITs folded in (same files — avoid a second touch)
D10 iosxe_cli static-route reason (distance→`metric` + name→`description` **are** harvested; only `global`/`tag`/`track` parse-and-ignore) · D11 arista.md stale lossy example (swapped to the still-live per-IP virtual-MAC collapse) · D12 ship-before-wire tense (`vxlan_vnis` now wired on 5) · D13 RESULTS.md mikrotik certainty (`best_effort`→`certified`, matching codec.py:100).

### Verification
No codec change — `CODEC_BUG` stays 5. Tier-1 wiring-honesty + registry-capability-honesty guards green. No test asserts on the edited doc text.

Deferred (optional, for the main thread): the #319-style roster guard that would trip the next promotion if it re-stales these rows (D15's structural-prevention idea).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
