### PR TITLE
fix(fidelity): matrix/mesh hygiene — dead supported+lossy entries, ratchet pair-set pin, honest self-pair comments, nxos feature-tunnel gate (HEAD-review Fid-F4/F5/F6/F9)

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -342,8 +342,7 @@ output.
 
 | Path | Class | Reason |
 |---|---|---|
-| `/interfaces/interface/vrrp-groups/group` | Supported (Wave B, CARP variant) | Hosts CARP-only HA groups via `<virtualip><vip><mode>carp</mode><vhid>N</vhid>…</vip></virtualip>` with `mode="carp"` discriminator on the canonical record. |
-| `/interfaces/interface/vrrp-groups/group` | Lossy (Wave B) | OPNsense `<virtualip>` hosts CARP-only HA groups in the v1 wire-up.  `CanonicalVRRPGroup` records with `mode="vrrp"` or `mode="hsrp"` are SKIPPED on render — OPNsense has no native HSRP wire protocol, and its pure-VRRP mode under `<virtualip>` is rarely deployed and not yet emitted.  Only `mode="carp"` round-trips.  Additionally, the `advskew`↔`priority` mapping (`priority = 254 - advskew`) preserves relative HA-pair ordering but not exact election timing. |
+| `/interfaces/interface/vrrp-groups/group` | Lossy (Wave B, CARP variant) | Hosts CARP-only HA groups via `<virtualip><vip><mode>carp</mode><vhid>N</vhid>…</vip></virtualip>` with a `mode="carp"` discriminator on the canonical record.  Lossy because `CanonicalVRRPGroup` records with `mode="vrrp"` or `mode="hsrp"` are SKIPPED on render — OPNsense has no native HSRP wire protocol, and its pure-VRRP mode under `<virtualip>` is rarely deployed and not yet emitted; only `mode="carp"` round-trips.  Additionally, the `advskew`↔`priority` mapping (`priority = 254 - advskew`) preserves relative HA-pair ordering but not exact election timing. |
 | `/interfaces/interface/ipv4/address/virtual-gateway-address` | Unsupported | OPNsense uses CARP for HA (distinct semantics); no anycast-gateway grammar. |
 | `/interfaces/interface/ipv6/address/virtual-gateway-address` | Unsupported | Same as IPv4 — no native anycast grammar. |
 | `/anycast-gateway-mac` | Unsupported | No chassis-wide anycast MAC concept. |

--- a/netcanon/migration/codecs/aruba_aoss/codec.py
+++ b/netcanon/migration/codecs/aruba_aoss/codec.py
@@ -114,7 +114,6 @@ class ArubaAOSSCodec(CodecBase):
             "/interfaces/interface/name",
             "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
-            "/interfaces/interface/config/type",
             "/interfaces/interface/ipv4/address/ip",
             "/interfaces/interface/ipv4/address/prefix-length",
             "/interfaces/interface/ipv6/address/ip",         # GAP-EVPN-3

--- a/netcanon/migration/codecs/cisco_iosxr/codec.py
+++ b/netcanon/migration/codecs/cisco_iosxr/codec.py
@@ -150,11 +150,11 @@ class CiscoIOSXRCodec(CodecBase):
             # Static routes — default VRF + per-VRF (`router static / vrf`)
             "/routing/static-route",
             "/routing/static-route/vrf",
-            # Phase 2 — VRF declarations.  Also declared lossy below (the
-            # route-distinguisher must be read from / rendered to the
-            # `router bgp` block) → the path classifies lossy.  Name /
-            # description / route-target import+export round-trip cleanly.
-            "/routing-instances/instance",
+            # Phase 2 — VRF.  Name / description / route-target import+export
+            # round-trip cleanly (implicit-supported).  The container
+            # `/routing-instances/instance` classifies lossy (declared below —
+            # the route-distinguisher must be read from / rendered to the
+            # `router bgp` block), so it is intentionally NOT listed supported.
             # Phase 2 — Bundle-Ether LAGs (`bundle id <N> mode <m>`)
             "/lags/lag/name",
             "/lags/lag/members",

--- a/netcanon/migration/codecs/cisco_nxos/codec.py
+++ b/netcanon/migration/codecs/cisco_nxos/codec.py
@@ -163,17 +163,19 @@ class CiscoNXOSCodec(CodecBase):
             "/local-users/user/name",
             "/local-users/user/role",
             "/local-users/user/hashed-password",
-            # VRF (name + description + Phase-3 RD / route-target)
+            # VRF (name + description + rt-exports).  route-distinguisher and
+            # rt-imports classify lossy (declared below), so they are
+            # intentionally NOT listed supported.
             "/routing-instances/instance/name",
             "/routing-instances/instance/description",
-            "/routing-instances/instance/route-distinguisher",
-            "/routing-instances/instance/rt-imports",
             "/routing-instances/instance/rt-exports",
             # Static routes (default VRF + Phase-3 per-VRF)
             "/routing/static-route",
             "/routing/static-route/vrf",
-            # VXLAN-EVPN (Phase 4) — L2 VLAN↔VNI + VTEP + L3VNI
-            "/vxlan-vnis/vni",
+            # VXLAN-EVPN (Phase 4) — L2 VLAN↔VNI + VTEP + L3VNI.  The `vni`
+            # identity classifies lossy (declared below — per-VNI sub-flags
+            # normalise to BGP-EVPN defaults), so it is intentionally NOT
+            # listed supported.
             "/vxlan-vnis/source-interface",
             "/vxlan-vnis/mcast-group",
             "/vxlan-vnis/flood-list",

--- a/netcanon/migration/codecs/cisco_nxos/render.py
+++ b/netcanon/migration/codecs/cisco_nxos/render.py
@@ -216,11 +216,21 @@ def _derive_features(tree: CanonicalIntent) -> list[str]:
     features: set[str] = set()
     if any(_is_svi(i.name) for i in tree.interfaces):
         features.add("interface-vlan")
-    # A bare ``interface Tunnel<N>`` is invalid on a real Nexus without
-    # ``feature tunnel``.  Gate on the ``Tunnel`` name prefix — NOT
-    # interface_type=="ianaift:tunnel", which also covers ``nve1`` (a VXLAN
-    # VTEP gated by ``feature nv overlay``, not ``feature tunnel``).
-    if any(i.name.lower().startswith("tunnel") for i in tree.interfaces):
+    # A tunnel interface is invalid on a real Nexus without ``feature
+    # tunnel``.  Fire on EITHER the ``Tunnel`` name prefix (a bare ``interface
+    # TunnelN`` whose canonical carries no tunnel_type) OR a GRE/IP-in-IP encap
+    # (``tunnel_type`` set on an ``ianaift:tunnel`` interface).  The second arm
+    # matches the same predicate the ``tunnel mode`` emitter uses, so a tunnel
+    # whose canonical NAME does not start with "tunnel" (e.g. MikroTik
+    # ``gre-tunnel1``) no longer emits ``tunnel mode gre ip`` without its
+    # feature gate (HEAD-review Fid-F9).  It deliberately does NOT match
+    # ``nve1`` — a VXLAN VTEP is ``interface_type=="ianaift:tunnel"`` but
+    # carries no ``tunnel_type`` and is gated by ``feature nv overlay``.
+    if any(
+        i.name.lower().startswith("tunnel")
+        or (i.tunnel_type and i.interface_type == "ianaift:tunnel")
+        for i in tree.interfaces
+    ):
         features.add("tunnel")
     if tree.lags:
         features.add("lacp")

--- a/netcanon/migration/codecs/fortigate_cli/codec.py
+++ b/netcanon/migration/codecs/fortigate_cli/codec.py
@@ -116,9 +116,7 @@ class FortiGateCLICodec(CodecBase):
             "/system/dns-server",
             "/system/ntp-server",
             "/interfaces/interface/name",
-            "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
-            "/interfaces/interface/config/type",
             "/interfaces/interface/ipv4/address/ip",
             "/interfaces/interface/ipv4/address/prefix-length",
             # Additional interface IPs via ``config secondaryip`` (promotion #3).

--- a/netcanon/migration/codecs/mikrotik_routeros/codec.py
+++ b/netcanon/migration/codecs/mikrotik_routeros/codec.py
@@ -138,7 +138,6 @@ class MikroTikRouterOSCodec(CodecBase):
             "/interfaces/interface/ipv6/address/prefix-length",  # GAP-EVPN-3
             "/interfaces/interface/tunnel-type",             # /interface gre vs eoip vs ipip discriminator
             "/vlans/vlan/id",
-            "/vlans/vlan/name",
             "/routing/static-route",
             "/routing/static-route/gateway",      # audit e5b77d7 — next-hop round-trips
             "/routing/static-route/description",  # run3 — `comment=...`

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -135,7 +135,6 @@ class OPNsenseCodec(CodecBase):
             "/system/domain",
             "/system/dns-server",
             "/interfaces/interface/name",
-            "/interfaces/interface/config/description",
             "/interfaces/interface/config/enabled",
             "/interfaces/interface/ipv4/address/ip",
             "/interfaces/interface/ipv4/address/prefix-length",
@@ -159,11 +158,11 @@ class OPNsenseCodec(CodecBase):
             "/local-users/user/hashed-password",
             "/local-users/user/role",
             # Wave B (v0.2.0) — CARP groups on /virtualip/vip.
-            # OPNsense's BSD-CARP HA primitive parses + renders
-            # round-trip through CanonicalVRRPGroup with
-            # ``mode="carp"``.  See LossyPath below for the mode-
-            # restriction caveat (non-CARP modes drop on render).
-            "/interfaces/interface/vrrp-groups/group",
+            # OPNsense's BSD-CARP HA primitive parses + renders round-trip
+            # through CanonicalVRRPGroup with ``mode="carp"``, but the path
+            # is declared lossy below (non-CARP modes drop on render — the
+            # mode-restriction caveat), so it classifies lossy and is
+            # intentionally NOT listed supported.
         ],
         lossy=[
             LossyPath(

--- a/tests/integration/test_cross_mesh_ci_guard.py
+++ b/tests/integration/test_cross_mesh_ci_guard.py
@@ -277,6 +277,23 @@ def test_no_yaml_less_pair_drift_regressed(mesh_and_recon, baseline):
 
     live = _by_pair(result["pair_drift_yaml_less"])
     base = _by_pair(baseline["pair_drift_yaml_less"])
+    # The ``<=`` ratchet below iterates the BASELINE pairs, so a pair that is
+    # YAML-less in LIVE but ABSENT from the baseline would never be checked
+    # (HEAD-review Fid-F5).  Reaching that state needs an expectation-YAML
+    # rename/swap that keeps the coverage counts equal (so
+    # test_expectation_yaml_coverage_not_reduced stays green) yet moves a pair
+    # into the unpinned yaml-less bucket.  Pin the pair SET so any such shuffle
+    # turns red and forces a conscious re-baseline.  (88 == 88 at HEAD.)
+    assert set(live) == set(base), (
+        "YAML-less cross-mesh pair SET changed vs the baseline "
+        f"(added: {sorted(set(live) - set(base))}; "
+        f"removed: {sorted(set(base) - set(live))}).\nAn expectation-YAML "
+        "rename/swap moved a (source, target) pair into (or out of) the "
+        "unpinned yaml-less bucket without tripping the coverage guard — the "
+        "moved pair's drift is no longer ratcheted.  Re-author the expectation "
+        "coverage or regenerate the baseline consciously "
+        "(tools/run_phase4_reconciliation.py --write-baseline)."
+    )
     regressed = {
         pair: (base[pair], live.get(pair, 0))
         for pair in base

--- a/tests/unit/migration/test_cisco_nxos.py
+++ b/tests/unit/migration/test_cisco_nxos.py
@@ -1493,3 +1493,44 @@ class TestSameVendorBannerEcho:
         assert "version 9.3(11) Bios:version" in codec.render(cross)
         empty = CanonicalIntent(hostname="sw1", source_vendor="cisco_nxos")
         assert "version 9.3(11) Bios:version" in codec.render(empty)
+
+
+class TestFeatureTunnelGate:
+    """``feature tunnel`` must be emitted whenever a ``tunnel mode`` encap
+    line is rendered, and must NOT be emitted for an ``nve1`` VXLAN VTEP
+    (gated by ``feature nv overlay``).  Regression for HEAD-review Fid-F9:
+    the gate keyed on the ``Tunnel`` name prefix alone, so a GRE tunnel whose
+    canonical name did not start with "tunnel" (e.g. MikroTik ``gre-tunnel1``)
+    rendered ``tunnel mode gre ip`` with no ``feature tunnel`` — unbootable."""
+
+    def _render(self, name, **kw):
+        tree = CanonicalIntent(
+            hostname="r1",
+            interfaces=[CanonicalInterface(name=name, enabled=True, **kw)],
+        )
+        return CiscoNXOSCodec().render(tree)
+
+    def test_non_tunnel_named_gre_gets_feature_tunnel(self):
+        # The Fid-F9 shape: name does not start with "tunnel" but the encap is
+        # a real GRE tunnel — both the mode line AND its feature gate emit.
+        out = self._render(
+            "gre-tunnel1", interface_type="ianaift:tunnel", tunnel_type="gre"
+        )
+        assert "  tunnel mode gre ip" in out
+        assert "feature tunnel" in out
+
+    def test_tunnel_named_without_type_still_gated(self):
+        # A bare ``interface TunnelN`` with no tunnel_type still needs the gate
+        # (name-prefix arm) — no regression from the pre-Fid-F9 behaviour.
+        out = self._render("Tunnel0", interface_type="ianaift:tunnel")
+        assert "feature tunnel" in out
+
+    def test_nve_vtep_does_not_get_feature_tunnel(self):
+        # ``nve1`` is interface_type=="ianaift:tunnel" but carries no
+        # tunnel_type; it is a VXLAN VTEP gated by ``feature nv overlay``.
+        out = self._render("nve1", interface_type="ianaift:tunnel")
+        assert "feature tunnel" not in out
+
+    def test_plain_interface_no_feature_tunnel(self):
+        out = self._render("Ethernet1/1")
+        assert "feature tunnel" not in out

--- a/tests/unit/migration/test_opnsense.py
+++ b/tests/unit/migration/test_opnsense.py
@@ -941,19 +941,20 @@ class TestCARPGroups:
     # ------------------------------------------------------------------
 
     def test_capability_matrix_vrrp_now_supported(self):
-        """Wave B promotes /interfaces/interface/vrrp-groups/group
-        from unsupported to supported.  The classify() resolution
-        still flags it as lossy (mode-restriction LossyPath wins
-        over the supported entry per the matrix's strictest-wins
-        rule)."""
+        """Wave B promotes /interfaces/interface/vrrp-groups/group out of
+        ``unsupported``.  Its effective disposition is ``lossy`` (the
+        mode-restriction LossyPath — non-CARP modes drop on render), so it is
+        declared ONLY in ``lossy`` and NOT also listed ``supported``: a path
+        may not appear in both (HEAD-review Fid-F4; classify() makes lossy win
+        over supported anyway, making a dual ``supported`` entry dead)."""
         caps = OPNsenseCodec().capabilities
         path = "/interfaces/interface/vrrp-groups/group"
         # Not in unsupported anymore.
         assert path not in [up.path for up in caps.unsupported]
-        # And IS in supported.
-        assert path in caps.supported
-        # The classify() rule returns "lossy" because the LossyPath
-        # entry has the same path and lossy beats supported.
+        # And NOT double-listed in supported (Fid-F4 — lossy is the honest,
+        # effective disposition, so the dead supported entry was removed).
+        assert path not in caps.supported
+        # classify() returns "lossy" from the LossyPath entry.
         assert caps.classify(path) == "lossy"
 
     def test_capability_matrix_lossy_explains_carp_only(self):

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -538,6 +538,24 @@ def test_no_supported_unsupported_overlap(name: str):
     assert not overlap, f"{name}: xpath(s) both supported AND unsupported: {overlap}"
 
 
+@pytest.mark.parametrize("name", _CODEC_NAMES)
+def test_no_supported_lossy_overlap(name: str):
+    """No xpath may appear in BOTH supported and lossy.  ``classify()``
+    resolves lossy > supported, so a dual-listed path is *dead weight* in
+    ``supported`` — the effective disposition is lossy, and anyone reading
+    ``caps.supported`` (contributor or tooling) is misled into believing the
+    path round-trips cleanly.  The class docstring itself calls double-listing
+    "a configuration bug".  Sibling of the supported∩unsupported guard above
+    (HEAD-review Fid-F4)."""
+    caps = get_codec(name).capabilities
+    overlap = set(caps.supported) & {lp.path for lp in caps.lossy}
+    assert not overlap, (
+        f"{name}: xpath(s) listed as BOTH supported AND lossy: {overlap}.  "
+        f"classify() makes lossy win, so the supported entry is dead — remove "
+        f"it (the lossy declaration is the honest disposition)."
+    )
+
+
 #: Top-level CanonicalIntent fields that are Tier-3 / metadata / provenance —
 #: carried through but never a translatable capability surface, so they need
 #: no honesty marker.  Everything else MUST have a marker entry.

--- a/tools/run_full_mesh.py
+++ b/tools/run_full_mesh.py
@@ -265,8 +265,14 @@ def _set_equal_lists(a: list[Any], b: list[Any]) -> bool:
 #: address SET round-trips losslessly across vendors — only the flag
 #: differs — so comparing it false-flagged CODEC_BUG (a junos 3-address
 #: loopback → IOS-XE renders 1 primary + 2 secondary; every IP survives).
-#: The mesh only ever compares cross-vendor pairs (intra-vendor self-pairs
-#: are skipped), so the flag is never the carrier of real intent here.
+#: This strip targets CROSS-vendor comparison, where the flag is a
+#: target-determined artifact, not intent.  Caveat: the mesh ALSO computes the
+#: 12 intra-vendor diagonals (they feed ``pair_drift_yaml_less`` — 12 of the 88
+#: ratcheted yaml-less pairs), and the strip applies there too, so a same-vendor
+#: round-trip that corrupted ``is_secondary`` would not surface on the mesh
+#: diagonal.  That case is covered separately by dedicated unit tests
+#: (test_is_secondary_fidelity.py pins arista + cisco_iosxe_cli same-vendor
+#: flag fidelity).
 _COSMETIC_LIST_SUBFIELDS: dict[str, dict[str, tuple[str, ...]]] = {
     "interfaces": {
         "ipv4_addresses": ("is_secondary",),
@@ -282,8 +288,11 @@ _COSMETIC_LIST_SUBFIELDS: dict[str, dict[str, tuple[str, ...]]] = {
 #: fully support v3.  Comparing the opaque hash false-flags drift on a
 #: credential the operator did not change — exactly the ``is_secondary``
 #: situation (a target-determined rendering artifact, not operator intent).
-#: The mesh only compares cross-vendor pairs, so the hash is never the carrier
-#: of real intent here.  Blanked on BOTH sides before the snmp-dict compare so
+#: This strip targets cross-vendor comparison; caveat, it also runs on the 12
+#: intra-vendor diagonals in ``pair_drift_yaml_less``, so a same-vendor
+#: passphrase corruption would not surface on the mesh diagonal — the snmpv3
+#: sub-field walk unit tests pin that per-codec.  Blanked on BOTH sides before
+#: the snmp-dict compare so
 #: a passphrase-only difference reads as preserved; any OTHER snmp drift
 #: (community / contact / location / trap_hosts / v3 group / protocols) still
 #: surfaces.  (Scoped subset of promotion #20 — the whole-``snmp``-dict flip


### PR DESCRIPTION
## Wave 6 PR-A — fidelity/matrix hygiene (HEAD-review Fid-F4/F5/F6/F9)

First PR of **Wave 6**, the final hygiene batch of the 2026-07-12 HEAD-review remediation. All four items are verifier-CONFIRMED. Baseline held: **CODEC_BUG 5, cells 1224**.

### Fid-F4 — dead `supported`∩`lossy` entries (MINOR)
`classify()` resolves lossy > supported, so a path listed in **both** is dead weight in `supported` that misleads anyone reading `caps.supported`. Removed all **10** such entries across 6 codecs (aruba_aoss `config/type`; cisco_iosxr `routing-instances/instance`; cisco_nxos RD + rt-imports + `vxlan-vnis/vni`; fortigate_cli `config/description` + `config/type`; mikrotik_routeros `vlans/vlan/name`; opnsense `config/description` + `vrrp-groups/group`). Effective disposition **unchanged** (all still classify lossy — verified) and the mesh reads only `unsupported` ⇒ **zero mesh impact**.

- New sibling guard `test_no_supported_lossy_overlap` beside the supported∩unsupported guard.
- Updated the opnsense CARP-group matrix test to assert the honest (lossy, not-in-supported) disposition.
- Collapsed the same dead "Supported" dup out of the CAPABILITIES.md OPNsense CARP row (the honest `Lossy` row already sat right below it).

### Fid-F5 — yaml-less ratchet pair-set pin (MINOR)
`test_no_yaml_less_pair_drift_regressed` iterated the **baseline** pairs only, so a pair that becomes yaml-less in LIVE (via an expectation-YAML rename that keeps coverage counts equal) went unratcheted. Added `assert set(live) == set(base)` (88 == 88 today).

### Fid-F6 — false "self-pairs are skipped" comments (MINOR)
Both cosmetic-strip rationales in `run_full_mesh.py` claimed intra-vendor self-pairs are skipped — **false**: the mesh computes all 12 diagonals and they feed `pair_drift_yaml_less` (12 of the 88 ratcheted pairs; `opnsense→opnsense` carries drift=3). Corrected both comments; noted the diagonal-fidelity coverage lives in dedicated unit tests.

### Fid-F9 — nxos `feature tunnel` gate (NIT, codec render)
`feature tunnel` gated on the `Tunnel` name prefix only, so a GRE tunnel whose canonical name did not start with "tunnel" (e.g. MikroTik `gre-tunnel1`) rendered `tunnel mode gre ip` with **no** `feature tunnel` — unbootable. Now gates on the name prefix **OR** the `tunnel_type` + `interface_type` predicate the mode emitter uses; still excludes `nve1` (VXLAN VTEP: `interface_type=="ianaift:tunnel"` but no `tunnel_type`). **Mesh-flat** — feature lines carry no field data, so reparse is identical (cross-mesh guard green; CROSS_MESH_RESULTS.md still reproduces).

### Verification
- Overlaps enumerated live; all 10 dispositions confirmed unchanged post-edit.
- F9 reproduced (mode line without feature gate) then fixed across 5 gate cases incl. the `nve1` exclusion.
- Both new guards **negative-controlled**: red against pre-fix code (stash), green after.
- Green: `tests/unit/migration`, `tests/unit/audit`, `tests/integration/test_cross_mesh_ci_guard.py` (10 tests, CODEC_BUG ≤5 absolute-pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
