### PR TITLE
fix(api): harden the un-hardened error/persistence siblings — 500→4xx + rollback (HEAD-review C1/C2/C3/C5/C6/C7)

### DIFF
--- a/netcanon/api/_errors.py
+++ b/netcanon/api/_errors.py
@@ -42,9 +42,10 @@ catch; ``ConnectionRefusedError`` before generic ``OSError`` since
 the former is an ``OSError`` subclass).
 
 Design rationale: a helper function — not a FastAPI exception handler
-— because the failing code runs inside a ``BackgroundTasks`` worker
-thread (see :func:`netcanon.services.backup_runner.run_backup_job` via
-:class:`ThreadPoolExecutor`), not in an HTTP request lifecycle.
+— because the failing code runs inside a dedicated backup-executor
+worker thread (see :func:`netcanon.services.backup_runner.run_backup_job`,
+dispatched via the ``submit_backup_job`` :class:`ThreadPoolExecutor`, #27),
+not in an HTTP request lifecycle.
 FastAPI's ``@app.exception_handler`` only fires on the request stack;
 it cannot intercept exceptions inside a background worker that writes
 to ``BackupResult.error``.  A function call from the broad-except is

--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -316,6 +316,20 @@ def list_jobs(
     "/{job_id}",
     response_model=BackupJob,
     summary="Get a backup job by ID",
+    responses={
+        404: {
+            "description": (
+                "No job with this id exists (or its on-disk snapshot is "
+                "corrupt/empty)."
+            )
+        },
+        422: {
+            "description": (
+                "`job_id` is not a well-formed UUID — rejected by the path "
+                "pattern guard (SEC-3) before the lookup (C5)."
+            )
+        },
+    },
 )
 def get_job(
     job_id: str = Path(
@@ -338,8 +352,18 @@ def get_job(
         job_id: UUID returned by ``POST /api/v1/backups``.
 
     Raises:
-        HTTPException 404: If no job with *job_id* exists.
+        HTTPException 404: If no job with *job_id* exists, OR its on-disk
+            snapshot is corrupt/empty (a power-loss / hand-edit artifact).
+        HTTPException 422: If *job_id* is not a well-formed UUID — the path
+            ``pattern`` guard rejects it before this handler runs (SEC-3).
     """
-    if job_id not in jobs:
+    # Use ``.get()`` rather than ``in`` + ``[]``: ``__contains__`` answers via a
+    # cheap ``path.exists()`` (no JSON parse) while ``__getitem__`` raises
+    # ``KeyError`` when ``load_one`` yields ``None`` for a corrupt file — so the
+    # two disagreed for a truncated/zero-byte ``jobs/{uuid}.json`` and the read
+    # 500'd after passing the membership guard (C2).  ``.get()`` lazy-loads and
+    # returns ``None`` on both "missing" and "corrupt", so both map to 404.
+    job = jobs.get(job_id)
+    if job is None:
         raise HTTPException(status_code=404, detail=f"Job not found: {job_id!r}")
-    return jobs[job_id]
+    return job

--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -283,6 +283,20 @@ def delete_device_profile(
                 profile_id[:8],
                 referencing,
             )
+        profile = device_profiles[profile_id]
         del device_profiles[profile_id]
-        device_profile_store.delete(profile_id)
+        try:
+            device_profile_store.delete(profile_id)
+        except OSError as exc:
+            # The unlink can fail (a Windows AV / indexer file lock raises
+            # PermissionError).  Without a rollback the profile is gone from
+            # memory but survives on disk and RESURRECTS at next startup via
+            # load_all — mirror #47b's create/update rollback on the delete
+            # half (C3): re-insert and 500 so memory + disk stay in step.
+            device_profiles[profile_id] = profile
+            logger.error("Failed to delete device profile from disk: %s", exc)
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to delete device profile from disk.",
+            ) from exc
     logger.info("Deleted device profile %s", profile_id[:8])

--- a/netcanon/api/routes/sanitize.py
+++ b/netcanon/api/routes/sanitize.py
@@ -124,6 +124,25 @@ async def post_sanitize(
             status_code=422,
             detail=f"Failed to render sanitized {source_vendor!r}: {e}",
         ) from e
+    except Exception as e:  # un-hardened-sibling net (C1)
+        # Any OTHER crash from the parse→redact→render pipeline (a raw
+        # IndexError / AttributeError codec bug — the crash-on-input class this
+        # project has repeatedly found) must be a clean 4xx, not an uncaught
+        # 500.  This is the sibling of run_plan's broad-except
+        # (services/migration_pipeline.py) and /detect's per-probe net — the
+        # same untrusted config text reaches a codec here.  Keep the full
+        # traceback server-side; hand the caller only the exception type.
+        logger.exception(
+            "sanitize pipeline crashed on %r input", source_vendor
+        )
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Sanitize pipeline failed unexpectedly "
+                f"({type(e).__name__}) on {source_vendor!r} input — please "
+                "report this with the config snippet that triggered it."
+            ),
+        ) from e
 
     if dry_run:
         return JSONResponse({

--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -377,15 +377,30 @@ def create_schedule(
             )
         schedule = BackupSchedule(**body.model_dump())
         schedules[schedule.id] = schedule
-        schedule_store.save(schedule)
-
-        register_schedule_job(scheduler, schedule, request.app)
-
-        # Capture the first calculated next_run_at
-        ap_job = scheduler.get_job(schedule.id)
-        if ap_job and ap_job.next_run_time:
-            schedule.next_run_at = ap_job.next_run_time
+        try:
             schedule_store.save(schedule)
+
+            register_schedule_job(scheduler, schedule, request.app)
+
+            # Capture the first calculated next_run_at
+            ap_job = scheduler.get_job(schedule.id)
+            if ap_job and ap_job.next_run_time:
+                schedule.next_run_at = ap_job.next_run_time
+                schedule_store.save(schedule)
+        except OSError as exc:
+            # Sole persistence — roll back the in-memory insert (and any
+            # APScheduler job registered before the failing save) so a
+            # disk-full / permission error can't leave a schedule that is
+            # listed by GET, never fires, and vanishes on restart (C3, the
+            # #47b create-half sibling).
+            schedules.pop(schedule.id, None)
+            if scheduler.get_job(schedule.id):
+                scheduler.remove_job(schedule.id)
+            logger.error("Failed to persist new schedule: %s", exc)
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to persist schedule to disk.",
+            ) from exc
 
     logger.info(
         "Created schedule '%s' (every %d min, id=%s)",
@@ -417,8 +432,23 @@ def delete_schedule(
             raise HTTPException(
                 status_code=404, detail=f"Schedule not found: {schedule_id!r}"
             )
+        schedule = schedules[schedule_id]
         del schedules[schedule_id]
-        schedule_store.delete(schedule_id)
+        try:
+            schedule_store.delete(schedule_id)
+        except OSError as exc:
+            # unlink can fail (a Windows AV / indexer file lock raises
+            # PermissionError).  Without a rollback the schedule is gone from
+            # memory but its JSON survives and RESURRECTS at next startup via
+            # load_all — re-insert and 500 (C3, the #47b delete-half sibling).
+            # The APScheduler job is still registered (we roll back BEFORE
+            # removing it below), so nothing is orphaned.
+            schedules[schedule_id] = schedule
+            logger.error("Failed to delete schedule from disk: %s", exc)
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to delete schedule from disk.",
+            ) from exc
         if scheduler.get_job(schedule_id):
             scheduler.remove_job(schedule_id)
     logger.info("Deleted schedule %s", schedule_id)
@@ -445,6 +475,8 @@ def toggle_schedule(
                 status_code=404, detail=f"Schedule not found: {schedule_id!r}"
             )
         schedule = schedules[schedule_id]
+        was_enabled = schedule.enabled
+        prev_next_run = schedule.next_run_at
         schedule.enabled = not schedule.enabled
 
         if schedule.enabled:
@@ -457,7 +489,25 @@ def toggle_schedule(
                 scheduler.remove_job(schedule_id)
             schedule.next_run_at = None
 
-        schedule_store.save(schedule)
+        try:
+            schedule_store.save(schedule)
+        except OSError as exc:
+            # Roll BOTH the in-memory flag AND the APScheduler job set back to
+            # the pre-toggle state so a failed persist can't leave memory +
+            # scheduler ahead of disk (a restart would silently revert to the
+            # old enabled value) (C3, the #47b toggle sibling).  Reconcile the
+            # job set to match was_enabled rather than reversing the action.
+            schedule.enabled = was_enabled
+            schedule.next_run_at = prev_next_run
+            if was_enabled:
+                register_schedule_job(scheduler, schedule, request.app)
+            elif scheduler.get_job(schedule_id):
+                scheduler.remove_job(schedule_id)
+            logger.error("Failed to persist schedule toggle: %s", exc)
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to persist schedule to disk.",
+            ) from exc
     logger.info(
         "Schedule '%s' %s", schedule.name, "enabled" if schedule.enabled else "disabled"
     )

--- a/netcanon/models/backup.py
+++ b/netcanon/models/backup.py
@@ -89,8 +89,11 @@ class BackupResult(BaseModel):
 class BackupJob(BaseModel):
     """An in-progress or completed backup job.
 
-    Jobs are created synchronously by the ``POST /api/v1/backups`` endpoint
-    and run to completion in a FastAPI ``BackgroundTask``.
+    Jobs are created by the ``POST /api/v1/backups`` endpoint, which returns
+    ``202`` immediately with ``status='pending'`` and submits the work to a
+    dedicated bounded ``ThreadPoolExecutor`` (``submit_backup_job``, #27) — NOT
+    a FastAPI ``BackgroundTask``.  Poll ``GET /api/v1/backups/{id}`` for the
+    live state.
 
     Attributes:
         id: UUID4 string, generated at job creation.

--- a/netcanon/models/device_profile.py
+++ b/netcanon/models/device_profile.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .validators import validate_host as _validate_host
 
@@ -158,6 +158,12 @@ class DeviceProfileUpdate(BaseModel):
             (reverts to family-base lookup).
         model: New model pin; pass ``None`` to clear.
     """
+
+    # PATCH semantics: "only what you sent is applied".  Reject unknown fields
+    # so a typo'd field name (``"nots"`` for ``"notes"``) 422s with the bad loc
+    # instead of silently no-op'ing with 200 — the whole contract is that the
+    # caller can trust an accepted key was applied (C7).
+    model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
     type_key: str | None = None

--- a/tests/integration/test_api_robustness_wave6.py
+++ b/tests/integration/test_api_robustness_wave6.py
@@ -1,0 +1,189 @@
+"""HEAD-review Wave 6 PR-B — API robustness negative-controls (C1/C2/C3/C5/C7).
+
+Each test reproduces a bug the fix converts to a clean 4xx (+ rollback):
+
+* C1 — ``/sanitize`` 500'd on any non-Parse/RenderError codec crash; now 422.
+* C2 — ``GET /backups/{id}`` 500'd on a corrupt on-disk job JSON; now 404.
+* C3 — schedule/profile create/toggle/delete left memory ahead of (or behind)
+  disk on an ``OSError``; now a clean 500 + rollback so a restart can't
+  resurrect / lose the object.
+* C5 — ``GET /backups/{malformed-uuid}`` is 422 (path pattern guard), declared.
+* C7 — ``PUT /devices/{id}`` with an unknown field is 422, not a silent 200.
+
+The ``client`` fixture runs with ``raise_server_exceptions=True``, so the
+pre-fix code (which let a raw exception escape to an unhandled 500) would ERROR
+here rather than return a status — these are genuine negative-controls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _profile_body(**overrides) -> dict:
+    body = {
+        "name": "Robustness Cisco",
+        "type_key": "Cisco",
+        "host": "10.0.0.9",
+        "username": "admin",
+        "password": "hunter2",
+    }
+    body.update(overrides)
+    return body
+
+
+def _schedule_body(**overrides) -> dict:
+    body = {
+        "name": "Robustness Schedule",
+        "interval_minutes": 1440,
+        "target_type_keys": ["Cisco"],
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# C1 — /sanitize broad-except net
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeBroadExcept:
+    def test_unexpected_codec_crash_is_422_not_500(self, client, monkeypatch):
+        """A non-Parse/RenderError crash in the sanitize pipeline (the
+        crash-on-input class — a raw ``IndexError`` on a malformed line) must
+        become a clean 422, not an uncaught 500 (C1)."""
+
+        def _boom(*_a, **_k):
+            raise IndexError("simulated codec crash on a malformed line")
+
+        monkeypatch.setattr(
+            "netcanon.api.routes.sanitize.sanitize_text", _boom
+        )
+        resp = client.post(
+            "/api/v1/sanitize",
+            data={"source_vendor": "aruba_aoss"},
+            files={"config": ("c.cfg", "hostname x\n", "text/plain")},
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "unexpectedly" in detail.lower()
+        assert "IndexError" in detail  # the exception type is surfaced
+
+
+# ---------------------------------------------------------------------------
+# C2 — corrupt on-disk job JSON
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptJobFile:
+    _BOGUS_ID = "11111111-2222-4333-8444-555555555555"
+
+    def _write(self, client, content: str) -> None:
+        jobs_dir = client.app.state.jobs._store._dir
+        jobs_dir.mkdir(parents=True, exist_ok=True)
+        (jobs_dir / f"{self._BOGUS_ID}.json").write_text(
+            content, encoding="utf-8"
+        )
+
+    def test_truncated_json_is_404_not_500(self, client):
+        self._write(client, "{not valid json")
+        resp = client.get(f"/api/v1/backups/{self._BOGUS_ID}")
+        assert resp.status_code == 404
+
+    def test_zero_byte_file_is_404_not_500(self, client):
+        self._write(client, "")
+        resp = client.get(f"/api/v1/backups/{self._BOGUS_ID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# C3 — persistence rollback on OSError
+# ---------------------------------------------------------------------------
+
+
+def _make_raiser():
+    def _raise(*_a, **_k):
+        raise OSError("simulated disk failure (disk-full / AV file lock)")
+
+    return _raise
+
+
+class TestSchedulePersistenceRollback:
+    def test_create_rolls_back_on_save_oserror(self, client, monkeypatch):
+        monkeypatch.setattr(
+            client.app.state.schedule_store, "save", _make_raiser()
+        )
+        resp = client.post("/api/v1/schedules/", json=_schedule_body())
+        assert resp.status_code == 500
+        # The failed insert must NOT survive in memory (else it is listed,
+        # never fires, and vanishes on restart).
+        assert client.app.state.schedules == {}
+        assert client.get("/api/v1/schedules/").json() == []
+
+    def test_delete_rolls_back_on_delete_oserror(self, client, monkeypatch):
+        created = client.post(
+            "/api/v1/schedules/", json=_schedule_body()
+        ).json()
+        sid = created["id"]
+        monkeypatch.setattr(
+            client.app.state.schedule_store, "delete", _make_raiser()
+        )
+        resp = client.delete(f"/api/v1/schedules/{sid}")
+        assert resp.status_code == 500
+        # The schedule must survive in memory (else it resurrects on restart
+        # from the JSON that was never removed).
+        assert sid in client.app.state.schedules
+
+    def test_toggle_rolls_back_flag_on_save_oserror(self, client, monkeypatch):
+        created = client.post(
+            "/api/v1/schedules/", json=_schedule_body()
+        ).json()
+        sid = created["id"]
+        before = client.app.state.schedules[sid].enabled
+        monkeypatch.setattr(
+            client.app.state.schedule_store, "save", _make_raiser()
+        )
+        resp = client.post(f"/api/v1/schedules/{sid}/toggle")
+        assert resp.status_code == 500
+        # The enabled flag must be rolled back to its pre-toggle value.
+        assert client.app.state.schedules[sid].enabled == before
+
+
+class TestProfileDeleteRollback:
+    def test_delete_rolls_back_on_delete_oserror(self, client, monkeypatch):
+        created = client.post(
+            "/api/v1/devices/", json=_profile_body()
+        ).json()
+        pid = created["id"]
+        monkeypatch.setattr(
+            client.app.state.device_profile_store, "delete", _make_raiser()
+        )
+        resp = client.delete(f"/api/v1/devices/{pid}")
+        assert resp.status_code == 500
+        # The profile must survive in memory (else it resurrects on restart).
+        assert pid in client.app.state.device_profiles
+
+
+# ---------------------------------------------------------------------------
+# C5 / C7 — contract honesty
+# ---------------------------------------------------------------------------
+
+
+class TestContractHonesty:
+    def test_get_backup_malformed_uuid_is_422(self, client):
+        """C5: the SEC-3 UUID path pattern rejects a non-UUID id with 422
+        before the handler runs — now declared in the route ``responses``."""
+        resp = client.get("/api/v1/backups/not-a-uuid")
+        assert resp.status_code == 422
+
+    def test_update_profile_unknown_field_is_422(self, client):
+        """C7: a typo'd field in a partial PUT must 422 (extra='forbid'), not
+        silently no-op with 200 on a PATCH-semantics endpoint."""
+        created = client.post(
+            "/api/v1/devices/", json=_profile_body()
+        ).json()
+        pid = created["id"]
+        resp = client.put(f"/api/v1/devices/{pid}", json={"nots": "typo"})
+        assert resp.status_code == 422


### PR DESCRIPTION
## Wave 6 PR-B — API robustness (HEAD-review C1/C2/C3/C5/C6/C7)

Second PR of **Wave 6**. All instances of the standing *hardened-path/un-hardened-sibling* theme. Route/model layer only — **no codec touch, CODEC_BUG stays 5 / cells 1224**.

| # | Sev | Fix |
|---|-----|-----|
| **C1** | MINOR | `/sanitize` caught only Parse/RenderError → any other pipeline crash (a raw `IndexError` — the crash-on-input class) 500'd while `/plan` degrades gracefully. Added a broad-except → **422** surfacing the exception type, traceback kept server-side. |
| **C2** | MINOR | `GET /backups/{id}` used `in` (cheap `path.exists()`) + `[]` (`KeyError` on a corrupt file) → a truncated/zero-byte `jobs/{uuid}.json` passed the 404 guard then **500'd**. Switched to `jobs.get(id)` → corrupt & missing both → **404**. |
| **C3** | MINOR | Replicated review-#47b rollback-on-`OSError` across the 4 un-hardened persistence siblings: schedule **create** (insert + APScheduler job), schedule **toggle** (flag + job set reconciled to pre-toggle), and **both deletes** (schedule + device profile — `del` before an unguarded `unlink`, so a Windows AV `PermissionError` deleted from memory while the JSON survived and **resurrected on restart**). Now clean **500 + rollback**. |
| **C5** | NIT | Documented that `GET /backups/{malformed-uuid}` → **422** (SEC-3 path pattern) in the docstring + route `responses` (was advertising only 404). |
| **C6** | NIT | Two stale present-tense `BackgroundTask` docstrings (`models/backup.py`, `api/_errors.py`) corrected to the #27 dedicated-executor reality. |
| **C7** | NIT | `DeviceProfileUpdate` tolerated unknown fields → a typo'd field in a partial PUT silently no-op'd with 200. `extra="forbid"` → **422** with the bad loc. |

**C4 (the OpenAPI `responses={}` CRUD sweep) stays deferred** per its #51-broad status.

### Verification
- All six probe-reproduced.
- New negative-control suite `tests/integration/test_api_robustness_wave6.py` (9 tests) is **red against pre-fix source** (8 fail — C1, C2×2, C3×4, C7; C5 is a contract-lock that holds either way) and **green after**.
- Green: the full backups / schedules / device-profiles / sanitize integration suites + affected model unit suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
