### PR TITLE
fix(backup): reclaim LRU overshoot, retry submit-vs-reset race, error-before-status, honest drain-on-exit docs (HEAD-review Conc-F2/F6/F7/F8/F9)

### DIFF
--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -109,9 +109,12 @@ def _resolve_max_concurrent_backup_jobs() -> int:
         return _DEFAULT_MAX_CONCURRENT_BACKUP_JOBS
 
 
-#: Resolved at import; the backup executor in
-#: :mod:`netcanon.services.backup_runner` reads
-#: ``config.MAX_CONCURRENT_BACKUP_JOBS`` when it lazily builds its pool.
+#: Resolved at import.  ``netcanon.services.backup_runner`` binds this value
+#: via ``from ..config import MAX_CONCURRENT_BACKUP_JOBS`` at ITS import time
+#: and reads that module-level binding when it lazily builds its pool — so a
+#: test must monkeypatch ``backup_runner.MAX_CONCURRENT_BACKUP_JOBS`` (not
+#: ``config.MAX_CONCURRENT_BACKUP_JOBS``, which the runner never re-reads) for
+#: a new size to take effect (HEAD-review F9).
 MAX_CONCURRENT_BACKUP_JOBS: int = _resolve_max_concurrent_backup_jobs()
 
 

--- a/netcanon/main.py
+++ b/netcanon/main.py
@@ -271,11 +271,22 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         scheduler.shutdown(wait=False)
         logger.info("Scheduler stopped")
         # Release the dedicated backup-job executor's threads (#27).  Let
-        # already-queued runs drain (cancel_futures=False) but don't block
-        # server shutdown behind an in-flight backup (wait=False).  Dropping
-        # the module-level singleton also lets a subsequent create_app() in
-        # the same process — every test builds a fresh app — rebuild a live
-        # executor instead of reusing a shut-down one.
+        # already-queued runs drain (cancel_futures=False) and return from the
+        # lifespan without waiting on an in-flight backup (wait=False).
+        # Dropping the module-level singleton also lets a subsequent
+        # create_app() in the same process — every test builds a fresh app —
+        # rebuild a live executor instead of reusing a shut-down one.
+        #
+        # Honest caveat (HEAD-review F6): this call returns fast, but PROCESS
+        # exit still blocks on the executor's atexit join (concurrent.futures'
+        # _python_exit joins every worker at interpreter teardown), and with
+        # cancel_futures=False those workers drain the ENTIRE queued backlog
+        # first — so a Ctrl-C / desktop Quit with a large queued backlog
+        # lingers until it has all run.  Drain-on-exit is deliberate (a queued
+        # backup shouldn't be silently dropped); flipping to
+        # cancel_futures=True would need the deferred startup stuck-pending
+        # reconciliation (CONC-16) as its companion so cancelled-queued jobs
+        # don't read `pending` forever.
         from .services.backup_runner import reset_job_executor
         reset_job_executor(wait=False, cancel_futures=False)
 

--- a/netcanon/services/backup_runner.py
+++ b/netcanon/services/backup_runner.py
@@ -187,11 +187,16 @@ def reset_job_executor(*, wait: bool = False, cancel_futures: bool = True) -> No
 
     Args:
         wait: Passed to ``ThreadPoolExecutor.shutdown``.  Defaults to
-            ``False`` so neither server shutdown nor a test teardown blocks
-            behind an in-flight (possibly minutes-long) backup.
+            ``False`` so the ``shutdown`` *call* returns without blocking
+            behind an in-flight (possibly minutes-long) backup.  Note this
+            does NOT make PROCESS exit non-blocking: concurrent.futures'
+            atexit join still waits on every worker at interpreter teardown
+            (HEAD-review F6).
         cancel_futures: Passed to ``shutdown``.  Defaults to ``True`` so
             queued-but-not-started jobs are dropped on reset; the lifespan
-            passes ``cancel_futures=False`` to let already-queued runs drain.
+            passes ``cancel_futures=False`` to let already-queued runs drain
+            (so the atexit join above then blocks on the whole backlog until
+            it has run).
     """
     global _JOB_EXECUTOR
     with _JOB_EXECUTOR_LOCK:
@@ -224,9 +229,13 @@ def finalize_crashed_job(
     if job.status not in _TERMINAL_JOB_STATUSES:
         for r in job.results:
             if r.status not in ("success", "failed"):
-                r.status = "failed"
+                # Error BEFORE status (HEAD-review F8) — see run_backup_job's
+                # safety net: a concurrent GET keys on the terminal status, so
+                # the error text must land first or a poll can serialize a
+                # failed device with `error: null`.
                 if not r.error:
                     r.error = f"{r.host}: backup worker crashed ({exc})."
+                r.status = "failed"
         job.completed_at = datetime.now(UTC)
         job.status = JobStatus.failed
     if job_store is not None:
@@ -283,7 +292,16 @@ def submit_backup_job(*args, **kwargs) -> Future:
     ``pending`` and callers must poll ``GET /backups/{id}`` for the terminal
     state (see AGENTS.md "Hard Rules").
     """
-    fut = _job_executor().submit(run_backup_job, *args, **kwargs)
+    try:
+        fut = _job_executor().submit(run_backup_job, *args, **kwargs)
+    except RuntimeError:
+        # Submit-vs-reset race (HEAD-review F7): reset_job_executor cleared the
+        # singleton and shut the old pool down between our _job_executor() read
+        # and the .submit, so we hit "cannot schedule new futures after
+        # shutdown".  reset_ guarantees the next _job_executor() rebuilds a
+        # fresh pool — retry once.  If it still fails the process is genuinely
+        # tearing down; let it propagate as shutdown noise.
+        fut = _job_executor().submit(run_backup_job, *args, **kwargs)
     # (HEAD-review F3) Attach a done-callback that finalizes a crashed job.
     # Recover the job + its store from the runner args by NAME (robust to
     # positional/keyword; ``run_backup_job`` is resolved at call time so a
@@ -703,12 +721,16 @@ def run_backup_job(
     # audit 81d9740 T0-2).
     for r in job.results:
         if r.status not in ("success", "failed"):
-            r.status = "failed"
+            # Error BEFORE status (HEAD-review F8): a concurrent GET keys on the
+            # terminal status, so writing `failed` before its `error` text lets
+            # a poll serialize a failed device with `error: null`.  This matches
+            # the error-then-status order of every other terminal write path.
             if not r.error:
                 r.error = (
                     f"{r.host}: backup did not run to completion "
                     "(the worker did not reach a terminal state)."
                 )
+            r.status = "failed"
 
     job.completed_at = datetime.now(UTC)
     success = sum(1 for r in job.results if r.status == "success")

--- a/netcanon/storage/job_registry.py
+++ b/netcanon/storage/job_registry.py
@@ -167,15 +167,22 @@ class BackupJobRegistry:
                 self._cache[job_id] = job
                 return
             self._cache[job_id] = job
-            if len(self._cache) > self._max:
-                # (#25) Evict the LRU-most TERMINAL job — NOT the oldest
-                # unconditionally.  Evicting a still-running/pending job and
-                # then serving a poll from disk promotes its stale pending
-                # snapshot to MRU, masking the live job's terminal state
-                # forever.  If every resident job is non-terminal, allow a
-                # temporary cap overshoot rather than evict a live job (the
-                # overshoot self-corrects as jobs terminalise).  Find the id
-                # first, then delete, to avoid mutating during iteration.
+            # (#25) Evict LRU-most TERMINAL jobs — NOT the oldest
+            # unconditionally.  Evicting a still-running/pending job and then
+            # serving a poll from disk promotes its stale pending snapshot to
+            # MRU, masking the live job's terminal state forever.  If every
+            # resident job is non-terminal, allow a temporary cap overshoot
+            # rather than evict a live job (the #25 escape).
+            #
+            # Loop rather than evict at most one per insert: once an overshoot
+            # has built up (while all residents were non-terminal) and those
+            # jobs later terminalise, a single-eviction-per-insert only holds
+            # the size steady (evict one, add one = net zero) and the cache
+            # stabilises at the peak forever.  The while-loop reclaims the
+            # overshoot down to cap the moment terminal candidates appear
+            # (HEAD-review F2).  Find the id first, then delete, to avoid
+            # mutating during iteration.
+            while len(self._cache) > self._max:
                 evict_id = next(
                     (
                         jid
@@ -184,21 +191,20 @@ class BackupJobRegistry:
                     ),
                     None,
                 )
-                if evict_id is not None:
-                    del self._cache[evict_id]
-                    logger.debug(
-                        "BackupJobRegistry evicted terminal %s (cache over "
-                        "cap %d)",
-                        evict_id,
-                        self._max,
-                    )
-                else:
+                if evict_id is None:
                     logger.debug(
                         "BackupJobRegistry over cap %d but all %d resident "
                         "job(s) are non-terminal; allowing temporary overshoot",
                         self._max,
                         len(self._cache),
                     )
+                    break
+                del self._cache[evict_id]
+                logger.debug(
+                    "BackupJobRegistry evicted terminal %s (cache over cap %d)",
+                    evict_id,
+                    self._max,
+                )
 
     def __getitem__(self, job_id: str) -> BackupJob:
         """Return the job with this ID.

--- a/tests/unit/test_backup_job_executor.py
+++ b/tests/unit/test_backup_job_executor.py
@@ -250,3 +250,25 @@ def test_env_override_garbage_falls_back_to_default(monkeypatch):
     monkeypatch.setenv("NETCANON_MAX_CONCURRENT_BACKUP_JOBS", "not-a-number")
     with pytest.warns(UserWarning):
         assert config._resolve_max_concurrent_backup_jobs() == 8
+
+
+def test_submit_retries_once_after_pool_shutdown(monkeypatch):
+    """Submit-vs-reset race (HEAD-review F7): if ``_job_executor()`` hands back
+    a pool that was shut down between resolution and ``.submit`` (``RuntimeError:
+    cannot schedule new futures after shutdown``), ``submit_backup_job`` retries
+    once via a fresh ``_job_executor()`` rather than 500ing the POST.  Pre-fix
+    the RuntimeError escaped uncaught."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    dead = ThreadPoolExecutor(max_workers=1)
+    dead.shutdown()  # first _job_executor() hands this back → .submit raises
+    live = ThreadPoolExecutor(max_workers=1)
+    seq = iter([dead, live])
+    monkeypatch.setattr(backup_runner, "_job_executor", lambda: next(seq))
+    # Stub the runner so the submit doesn't actually collect a backup.
+    monkeypatch.setattr(backup_runner, "run_backup_job", lambda *a, **k: "ok")
+    try:
+        fut = backup_runner.submit_backup_job()
+        assert fut.result(timeout=5) == "ok"
+    finally:
+        live.shutdown()

--- a/tests/unit/test_job_registry.py
+++ b/tests/unit/test_job_registry.py
@@ -151,6 +151,29 @@ class TestBoundedMemory:
         assert len(registry) == 1
         assert registry[j.id].status is JobStatus.completed
 
+    def test_overshoot_reclaims_to_cap_after_terminalise(
+        self, store: FileJobStore,
+    ):
+        """HEAD-review F2: an overshoot built while every resident was
+        non-terminal (the #25 escape) must be reclaimed down to cap once those
+        jobs terminalise.  A single-eviction-per-insert only holds the size
+        steady (evict one, add one = net zero) so the cache would stabilise at
+        the peak forever; the while-loop eviction reclaims it."""
+        reg = BackupJobRegistry(store, max_memory_jobs=2, warm_cache=False)
+        # Overshoot to 5 while all resident jobs are non-terminal — allowed.
+        running = [_make_job(status=JobStatus.running) for _ in range(5)]
+        for j in running:
+            reg[j.id] = j
+        assert len(reg) == 5  # overshoot tolerated (no live job evicted)
+        # They terminalise in place (the cache holds the same objects).
+        for j in running:
+            j.status = JobStatus.completed
+        # Further terminal inserts must reclaim the overshoot back to cap.
+        for _ in range(5):
+            j = _make_job(status=JobStatus.completed)
+            reg[j.id] = j
+        assert len(reg) == 2  # pre-fix: stuck at 5
+
 
 # ---------------------------------------------------------------------------
 # LRU ordering — accessed jobs move to MRU


### PR DESCRIPTION
## Wave 6 PR-C — concurrency hygiene (HEAD-review Conc-F2/F6/F7/F8/F9)

Third PR of **Wave 6**. Backup-subsystem concurrency — the **Conc-F1/F3/F5 siblings already shipped in Wave 3** (#360/#361). No codec touch — **CODEC_BUG stays 5 / cells 1224**.

| # | Sev | Fix |
|---|-----|-----|
| **F2** | MINOR | LRU cache evicted at most **one** terminal entry per insert while the insert added one → an overshoot (built while all residents were non-terminal, the #25 escape) stabilised at its peak forever (the comment even claimed it self-corrects). Changed to a `while len(cache) > max` loop → the overshoot is **reclaimed to cap** once terminal candidates appear. |
| **F7** | NIT | `submit_backup_job` had no guard on `_job_executor().submit(...)`, so a POST racing shutdown could `RuntimeError: cannot schedule new futures after shutdown` → 500. Catch + **retry once** via a fresh `_job_executor()` (the reset guarantees a rebuild). |
| **F8** | NIT | The terminal safety net wrote `status="failed"` **before** `error`, so a concurrent GET could serialize a failed device with `error: null`. Swapped **both** the `run_backup_job` safety net and the Wave-3 `finalize_crashed_job` sibling to set error first. |
| **F6** | MINOR | Lifespan-shutdown comments claimed shutdown doesn't block on in-flight backups; in fact the `concurrent.futures` atexit join waits on every worker and, with `cancel_futures=False`, drains the **entire queued backlog** first. Documented the drain-on-exit honestly (kept deliberately — flipping to `cancel_futures=True` needs the deferred CONC-16 startup reconciliation, out of scope). |
| **F9** | NIT | `config.py` claimed the executor reads `config.MAX_CONCURRENT_BACKUP_JOBS`; it reads backup_runner's `from ..config import …` binding. Corrected the comment (tests patch `backup_runner.MAX_CONCURRENT_BACKUP_JOBS`). |

### ⚠️ Design call flagged, NOT implemented
**Conc-F4** — no intake cap on `POST /backups` (unbounded executor queue pinning decrypted credentials + non-terminal registry entries). #333/#334 framed queueing as "never a failure", so this is a deliberate design decision. Flagging for a call; left untouched.

### Verification
- **F2 + F7** probe-reproduced and unit-tested with negative controls: both **red against pre-fix source** (F2 `5 != 2`; F7 uncaught `RuntimeError`), **green after**.
- **F8** is a transient-ordering fix (identical end-state — not end-state-testable).
- Green: full job-registry / executor / global-concurrency / backups suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
