### PR TITLE
docs(honesty): correct 5 stale management-plane microcopy claims (HEAD-review D14/D16/D17/D18/D19)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -926,7 +926,10 @@ What's queued:
 - Per-pane overrides for **NTP servers**, **DNS servers**,
   **syslog servers**, **SNMP trap-hosts**, and **RADIUS** — all
   list-oriented cross-vendor-stable management-plane surfaces with
-  per-codec parse+render already in place.  Following the same
+  per-codec parse+render already in place **on the codecs that wire
+  them** (e.g. syslog on 5 of 12; RADIUS and trap-hosts are declared
+  unsupported on some, such as vyos RADIUS and aoscx trap-hosts).
+  Following the same
   three-step recipe (orchestrator → pipeline → pane) as ports /
   VLANs / local_users / SNMP-community / SNMPv3-users.  See
   [`translator-plans.txt`](translator-plans.txt) for viability

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -98,9 +98,11 @@ names the canonical surface, not a blanket guarantee.
   promotions #1/#11), cisco_nxos (`logging server <ip>`, #4) and
   cisco_iosxr (bare `logging <ip>`, #13).  These are
   Tier-1 by data shape but NOT yet a cross-vendor guarantee — the §A
-  per-codec panels are authoritative, and an unwired field is dropped
-  on parse (with a banner where the codec declares it unsupported,
-  silently otherwise).
+  per-codec panels are authoritative.  An unwired field is dropped on
+  parse and surfaces the cross-vendor banner where the codec declares it
+  unsupported; for `syslog_servers` and `timezone` every codec declares
+  the path (`syslog_servers` 5 supported + 7 unsupported, `timezone`
+  unsupported on all 12), so those drops are always bannered, never silent.
 * `interfaces[].vrrp_groups` (v0.2.0 Wave B — classic FHRP
   redundancy, mode discriminator `vrrp` / `hsrp` / `carp`) — wired
   across the bidirectional codecs.  See

--- a/netcanon/migration/canonical/README.md
+++ b/netcanon/migration/canonical/README.md
@@ -189,9 +189,11 @@ and the codec's `CapabilityMatrix` declarations:
 
 * **Tier 1 — auto-translatable.**  Every vendor models the concept;
   cross-vendor semantics are stable.  Core fields — `hostname`,
-  `domain`, `interfaces`, `vlans`, `static_routes` — are wired on every
-  bidirectional codec, and a codec that fails to wire one of these is a
-  bug, not a gap.  `dns_servers` / `ntp_servers` are wired on most
+  `domain`, `interfaces`, `vlans`, `static_routes` — are wired on
+  nearly every bidirectional codec; the few declared exceptions (e.g.
+  VyOS exposes no VLAN-database surface, OPNsense renders no static
+  routes) live in the per-codec matrices as gaps, not bugs.
+  `dns_servers` / `ntp_servers` are wired on most
   codecs; `timezone` and `syslog_servers` are wired on only a subset
   (`timezone` on none as of this release; `syslog_servers` on
   `juniper_junos`, `cisco_iosxe_cli`, `arista_eos` — `logging host

--- a/netcanon/migration/canonical/intent.py
+++ b/netcanon/migration/canonical/intent.py
@@ -857,10 +857,10 @@ class CanonicalIntent(BaseModel):
             ``juniper_junos`` (``set system syslog host <ip>``),
             ``cisco_iosxe_cli`` and ``arista_eos`` (``logging host <ip>``,
             promotions #1/#11), ``cisco_nxos`` (``logging server <ip>``,
-            #4) and ``cisco_iosxr`` (bare ``logging <ip>``, #13).  Other
-            codecs still drop it — the ones
-            that declare it ``unsupported`` surface the cross-vendor
-            banner; the rest fall through to an implicit drop.  Not yet a
+            #4) and ``cisco_iosxr`` (bare ``logging <ip>``, #13).  The other
+            seven codecs all declare it ``unsupported`` and surface the
+            cross-vendor banner on a source-side value (there is no
+            implicit-drop "rest" — every codec declares this path).  Not yet a
             universal round-trip guarantee — see docs/CAPABILITIES.md.
         interfaces: Tier 1 — per-interface configuration records.
         vlans: Tier 1 — VLAN definitions with port membership.

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -2092,12 +2092,11 @@
           '<div style="flex:1">'
           + '<strong>\u26A0 Target codec doesn\'t render '
           + escapeHtml(label) + '.</strong> '
-          + escapeHtml(vendorLabel) + ' parses + renders interfaces '
-          + 'and VLANs but ' + escapeHtml(label) + ' are currently '
-          + 'kept as an opaque Tier-3 pass-through, not translated.  Rename overrides '
-          + 'will apply to the canonical tree but won\'t appear in '
-          + 'the rendered output until the codec wires full '
-          + 'round-trip support for this category.'
+          + escapeHtml(vendorLabel) + ' renders only a limited surface; '
+          + escapeHtml(label) + ' do not appear in the rendered output '
+          + '(they are dropped on render, not preserved).  Rename overrides '
+          + 'will apply to the canonical tree but won\'t be emitted until '
+          + 'the codec wires full round-trip support for this category.'
           + '</div>';
       } else {
         el.style.display = 'none';

--- a/tests/fixtures/real/phase4_findings_residuals.md
+++ b/tests/fixtures/real/phase4_findings_residuals.md
@@ -7,6 +7,11 @@ an anycast-**unsupported** target as `EXPECTED_UNSUPPORTED` rather than
 `CODEC_BUG` — the 424-cell / 45-real-fixture mesh leaves **5 residual
 `CODEC_BUG` cells**.
 
+> **Cell/fixture counts are as-of this 2026-06-13 triage.**  The mesh has since
+> grown (1224 cells at HEAD); the live totals + the current residual cell list
+> are in [`PHASE4_RECONCILIATION.md`](PHASE4_RECONCILIATION.md).  The 5-cell
+> triage below still matches HEAD's 5 `CODEC_BUG` cells.
+
 All 5 were triaged and are **benign methodology / modelling artifacts — not
 codec defects.**  Documented here (per the Phase 4b convention) so the count
 in `PHASE4_RECONCILIATION.md` reads as *explained* rather than as open


### PR DESCRIPTION
## Wave 6 PR-D — docs-truth microcopy NITs (HEAD-review D14/D16/D17/D18/D19)

Fourth PR of **Wave 6**. Doc/microcopy only — no code behaviour, **no mesh impact (CODEC_BUG stays 5 / cells 1224)**. Every claim was verified against the live matrix before editing.

| # | Fix |
|---|-----|
| **D14** | `migrate.html` rename banner claimed "parses + renders interfaces and VLANs but <cat> kept as an opaque Tier-3 pass-through" — false for the cisco_iosxe NETCONF stub (renders interfaces only) and "pass-through" implies preservation while snmpv3 is *dropped* on render. Reworded to "renders a limited surface; <cat> is dropped on render, not preserved". |
| **D16** | The syslog docstring (`intent.py`) + `CAPABILITIES.md` said non-declaring codecs "fall through to an implicit drop" / drop it "silently otherwise" — an **empty set**: all 12 declare `/system/syslog-server` (5 supported + 7 unsupported) and `timezone` is unsupported on all 12, so drops are always bannered. Dropped the empty-set clause in both. |
| **D17** | `canonical/README.md` claimed the core Tier-1 fields are "wired on every bidirectional codec … a codec that fails is a bug, not a gap" — VyOS (no VLAN-db) and OPNsense (no static-route render) are **declared gaps**. Softened to "nearly every; declared exceptions in the matrices as gaps, not bugs". |
| **D18** | `ARCHITECTURE.md` roadmap claimed NTP/DNS/syslog/trap/RADIUS all have "per-codec parse+render already in place" — syslog is 5/12; vyos RADIUS + aoscx trap-hosts unsupported. Added "on the codecs that wire them" + the concrete exceptions. |
| **D19** | `phase4_findings_residuals.md` cited a "424-cell / 45-real-fixture mesh" (1224 at HEAD). Added an as-of-2026-06-13 note pointing at `PHASE4_RECONCILIATION.md` for live totals; the 5-cell list still matches HEAD. |

### Verification
- Live probes: `/system/syslog-server` declared on all 12; `/system/timezone` unsupported on all 12; vyos `/radius-servers/server/key` + aoscx `/snmp/trap-host` unsupported.
- No test references the old strings; `test_tier1_wiring_honesty` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
