### PR TITLE
ci(release): close release-footguns + pin/guard hygiene (HEAD-review Pkg-P2/P3/P4/P6/P7/P8/P9/P10/P11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,13 @@ jobs:
           set -euo pipefail
           sdist="$(ls "${GITHUB_WORKSPACE}"/dist/*.tar.gz)"
           echo "Inspecting sdist: ${sdist}"
-          leaked="$(tar tzf "${sdist}" | grep -E '/tests/' || true)"
+          # Capture the listing UNGUARDED first (P8): the `|| true` below is
+          # needed for grep's exit-1-on-no-match, but on `tar … | grep … || true`
+          # it ALSO swallows a `tar` failure (corrupt / unreadable sdist) under
+          # `set -euo pipefail`, vacuous-passing the licensing gate.  Splitting
+          # the steps makes a tar failure fail the step.
+          listing="$(tar tzf "${sdist}")"
+          leaked="$(grep -E '/tests/' <<<"${listing}" || true)"
           if [ -n "${leaked}" ]; then
             echo "FAIL: the source distribution ships test-suite files that must be excluded"
             echo "(blind audit f92e97a, T0-5 — see MANIFEST.in 'prune tests'):"

--- a/.github/workflows/desktop-msi-publish.yml
+++ b/.github/workflows/desktop-msi-publish.yml
@@ -133,7 +133,22 @@ jobs:
             echo "::error::Ref '${TAG_RAW}' is not a tag — refusing to build/publish an MSI from a non-tag ref."
             exit 1
           fi
-          echo "OK: '${tag}' is a tag."
+          # Guard against `actions/checkout` resolving an ambiguous short ref
+          # as a BRANCH tip that merely shares a name with the tag (P4b):
+          # require the checked-out HEAD to BE the tag's own commit, else the
+          # MSI and the tag point at different commits (the residual crack in
+          # the exact hole #55 closed).
+          head_sha="$(git rev-parse HEAD)"
+          tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          if [ "${head_sha}" != "${tag_sha}" ]; then
+            echo "::error::Checked-out HEAD ${head_sha} is not tag '${tag}' commit ${tag_sha} — refusing (an ambiguous ref resolved to a branch tip)."
+            exit 1
+          fi
+          # Normalize the tag ONCE so the release-attach step's tag_name can't
+          # be a full ref (P4a): a raw `refs/tags/vX.Y.Z` dispatch input made
+          # softprops create a junk `refs/tags/refs/tags/vX.Y.Z` tag at HEAD.
+          echo "RELEASE_TAG=${tag}" >> "$GITHUB_ENV"
+          echo "OK: '${tag}' is a tag at the checked-out commit ${head_sha}."
 
       # Refuse to build/attach an MSI for a tag that isn't on main (see
       # pypi-publish.yml for rationale).  Covers both tag-push and the
@@ -292,16 +307,20 @@ jobs:
         # softprops/action-gh-release creates the release page if it
         # doesn't yet exist (handy for tags pushed before this workflow
         # existed) and otherwise appends the MSI to the existing one.
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          # Normalized tag (never a full ref) from the "Refuse a non-tag ref"
+          # step so softprops can't mint a junk `refs/tags/refs/tags/…` tag (P4a).
+          tag_name: ${{ env.RELEASE_TAG }}
           files: dist/*.msi
           fail_on_unmatched_files: true
           # When the release page is auto-created here (e.g. backfill
           # via workflow_dispatch on a tag with no release page yet),
           # populate it with the auto-generated PR / commit changelog.
           generate_release_notes: true
-          # Mark pre-release tags (e.g. v0.1.0-rc7) as "Pre-release" so
-          # the GitHub Releases page sorts them correctly and the
-          # "latest release" link skips over them.
-          prerelease: ${{ contains(inputs.tag || github.ref_name, '-rc') || contains(inputs.tag || github.ref_name, '-alpha') || contains(inputs.tag || github.ref_name, '-beta') }}
+          # Mark ANY pre-release tag (a `-` suffix — rc / alpha / beta / pre /
+          # dev) as "Pre-release" so the "Latest release" badge + /releases/
+          # latest skip over it.  Unified with the Docker `:latest` predicate
+          # (any `-`); the old `-rc|-alpha|-beta`-only form let a `v0.6.0-pre1`
+          # / `-dev1` tag take the "Latest release" slot (P3).
+          prerelease: ${{ contains(env.RELEASE_TAG, '-') }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,16 @@ on:
       - 'v*.*.*'
       - 'v*.*.*-*'    # rc / alpha / beta pre-release tags
   workflow_dispatch:
+    inputs:
+      move_latest:
+        description: >-
+          Move the :latest tag onto this build.  IGNORED on a tag-push run (a
+          stable push always moves :latest).  Only consulted on a manual
+          re-dispatch, where it defaults to false so re-running an OLDER stable
+          tag's publish cannot repoint :latest backwards onto old bytes (P2).
+        type: boolean
+        default: false
+        required: false
 
 # Least-privilege default: at the workflow level only the pytest `test`
 # gate's checkout runs, so read is all it needs.  The registry-push,
@@ -95,6 +105,17 @@ jobs:
         run: |
           if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
             echo "::error::Refusing to publish from '${GITHUB_REF}' — the image publish must run from a version tag (refs/tags/v*), not a branch. A branch run would move :latest onto a .devN build."
+            exit 1
+          fi
+          # Reject a stable-looking but non-semver tag (P10): a PEP 440 spelling
+          # slip like `v0.6.0rc1` (no dash) or a 4-part `v0.6.0.1` matches the
+          # `v*.*.*` trigger, but `type=semver` emits nothing so
+          # `steps.meta.outputs.version` falls back to the raw `latest` and the
+          # SETUPTOOLS_SCM_PRETEND_VERSION=latest build-arg fails PEP 440 parsing
+          # deep in the builder with a confusing "invalid version 'latest'".
+          # Name the real problem here instead.
+          if [[ ! "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Tag '${GITHUB_REF#refs/tags/}' is not a valid semver release tag (expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-PRERELEASE — e.g. v0.6.0 or v0.6.0-rc1). A PEP 440 spelling like v0.6.0rc1 (no dash) or a 4-part v0.6.0.1 fails version derivation deep in the build; respell the tag."
             exit 1
           fi
           echo "OK: publishing from tag '${GITHUB_REF}'."
@@ -254,7 +275,14 @@ jobs:
             # pushes publish their versioned image without touching
             # `:latest`, while a stable tag updates the documented quickstart
             # tag.  `{{major}}.{{minor}}` above is already prerelease-aware.
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            #
+            # AND require a push trigger OR an explicit move_latest input (P2):
+            # a `workflow_dispatch` rebuild of an OLDER stable tag (a legitimate
+            # "refresh a corrupted artifact" use) otherwise passes every guard
+            # and repoints `:latest` BACKWARD onto the old release's bytes.  On
+            # a tag push `:latest` moves for a stable tag as before; on a manual
+            # re-dispatch it moves only when the maintainer sets move_latest=true.
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') && (github.event_name != 'workflow_dispatch' || inputs.move_latest) }}
 
       - name: Build and push
         id: build
@@ -350,7 +378,7 @@ jobs:
           done
 
       - name: Generate SBOM (SPDX JSON) via syft
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: spdx-json

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,7 +9,10 @@ on:
 
 permissions:
   contents: read
-  actions: read    # read the CI run conclusion for the "require CI success" gate
+  # `actions: read` (for the CI-success + PII-guard run-conclusion polls) is
+  # scoped to the `build` job below — NOT here at the workflow level — so the
+  # `test` gate job doesn't carry a scope it never uses (PKG-4 symmetry with
+  # docker-publish.yml / desktop-msi-publish.yml) (P11).
 
 # Serialise release runs for a given ref so a re-pushed tag (or a
 # workflow_dispatch racing the tag push) can't double-publish.  Never
@@ -68,6 +71,9 @@ jobs:
     name: Build sdist + wheel
     needs: [test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read    # read the CI + pii-guard run conclusions for the gate polls
 
     steps:
       # Refuse to publish from anything but a version tag.  A bare

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@
 # ===========================================================================
 # Stage 1 — wheel builder
 # ===========================================================================
-# Base image pinned by digest (the multi-arch index for 3.14.5-slim-bookworm)
+# Base image pinned by digest (the multi-arch index for 3.14.6-slim-bookworm)
 # so the build is reproducible and not silently re-tagged upstream.  Dependabot's
 # docker ecosystem bumps both the tag and this digest together.
 FROM python:3.14.6-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9 AS builder
 
 # build-essential lets cryptography / paramiko / pyyaml fall back to source
-# if the wheel index lacks a Python 3.13 / linux/amd64 prebuilt.  The runtime
+# if the wheel index lacks a Python 3.14 / linux/amd64 prebuilt.  The runtime
 # stage doesn't carry these.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -19,6 +19,7 @@ replace.  These guards assert:
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -114,6 +115,18 @@ def test_every_release_tag_has_changelog_entry() -> None:
     unavailable; the CI test job fetches full history + tags."""
     tags = _git_stable_tags()
     if not tags:
+        # In CI the test job checks out with fetch-depth: 0 (full history +
+        # tags), so a tag-less checkout THERE means that fetch regressed and
+        # the release guard is silently disarmed — setuptools_scm would then
+        # guess a `.devN` version and nothing else goes red.  Fail loudly in CI
+        # rather than skip (P7); the skip stays for legitimate tarball / shallow
+        # local checkouts.
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            pytest.fail(
+                "no git tags visible in CI — the test checkout lost its "
+                "full-history+tags fetch (fetch-depth: 0). The tag↔CHANGELOG "
+                "release guard is silently disarmed; restore the deep fetch."
+            )
         pytest.skip("no git tags available (shallow / tarball checkout) — tag↔changelog check skipped")
     headers = {".".join(map(str, v)) for v in _versions(_ANY_VERSION)}
     missing = sorted(t for t in tags if t not in headers)

--- a/tests/unit/test_requirements_lock.py
+++ b/tests/unit/test_requirements_lock.py
@@ -29,6 +29,11 @@ pytestmark = pytest.mark.unit
 _ROOT = Path(__file__).resolve().parents[2]
 _PYPROJECT = _ROOT / "pyproject.toml"
 _LOCK = _ROOT / "requirements.lock"
+_DOCKERFILE = _ROOT / "Dockerfile"
+_LOCK_SCRIPT = _ROOT / "tools" / "gen_requirements_lock.sh"
+
+#: ``python:<tag>@sha256:<64-hex>`` — the base-image digest pin.
+_BASE_DIGEST_RE = re.compile(r"python:[^@\s\"']+@sha256:([0-9a-f]{64})")
 
 #: A pinned line: ``name==version \`` (extras stripped by --strip-extras).
 _PIN_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==(\S+?)\s*\\?\s*$")
@@ -85,4 +90,25 @@ def test_lock_targets_the_runtime_python() -> None:
     assert "with Python 3.14" in header, (
         "requirements.lock header does not show 'with Python 3.14' -- it must be regenerated "
         "inside the digest-pinned 3.14 base image (tools/gen_requirements_lock.sh), not on another Python"
+    )
+
+
+def test_lock_script_base_digest_matches_dockerfile() -> None:
+    """``tools/gen_requirements_lock.sh``'s ``BASE=`` image digest must equal
+    the ``FROM`` digest in the Dockerfile (P9c).  The script comment requires
+    keeping them "in lock-step" BY HAND; a Dependabot base bump that touches the
+    Dockerfile but not the script would regenerate the lock inside the OLD image
+    (wrong-platform wheels), surfacing only as a ``--require-hashes`` failure at
+    the next image build.  This guards the manual invariant the same greppable
+    way test_requirements_lock does for the lock itself."""
+    df = _BASE_DIGEST_RE.search(_DOCKERFILE.read_text(encoding="utf-8"))
+    sh = _BASE_DIGEST_RE.search(_LOCK_SCRIPT.read_text(encoding="utf-8"))
+    assert df is not None, "no `python:...@sha256:` FROM digest found in Dockerfile"
+    assert sh is not None, "no `BASE=python:...@sha256:` digest found in gen_requirements_lock.sh"
+    assert df.group(1) == sh.group(1), (
+        "base-image digest drift: Dockerfile FROM pins sha256:"
+        f"{df.group(1)} but tools/gen_requirements_lock.sh BASE= pins sha256:"
+        f"{sh.group(1)}.  A Dependabot base bump updated one but not the other; "
+        "sync gen_requirements_lock.sh's BASE= to the Dockerfile and regenerate "
+        "the lock inside the new image."
     )


### PR DESCRIPTION
## Wave 6 PR-E — release-footguns + packaging hygiene (HEAD-review P2/P3/P4/P6/P7/P8/P9/P10/P11)

Fifth PR of **Wave 6** (Pkg-**P1** shipped in Wave 5 #370). Packaging / CI / release-engineering. **No codec touch — CODEC_BUG stays 5 / cells 1224.**

> ⚠️ The publish-workflow changes run **only on a tag**, so PR CI does not exercise them — they are verified-at-next-release (like #339). Every edit was YAML-validated and the Actions expressions kept conservative & pattern-matched to existing usage.

### Release-footguns (config-only)
- **P2** — `:latest` keyed only on "not a pre-release" → a `workflow_dispatch` rebuild of an **older stable tag** repointed `:latest` **backward**. Added a `move_latest` boolean dispatch input (default false) + AND-gated `:latest` on `(push OR move_latest)`. (Boolean input over `git tag|sort -V` per the review's over-eng guardrail.)
- **P10** — a non-semver stable-looking tag (`v0.6.0rc1`, `v0.6.0.1`) failed PEP 440 deep in the builder with a confusing error → added a **semver-shape regex assert** in the refuse-non-tag step that names the real problem.
- **P3** — MSI Release prerelease predicate matched only `-rc|-alpha|-beta` → a `v0.6.0-pre1`/`-dev1` took the "Latest release" slot. **Unified** with the Docker any-`-` predicate.
- **P4** — MSI attach used the raw dispatch input (a full ref minted a junk `refs/tags/refs/tags/…` tag) and the guard only checked tag *existence*. **Normalize** the tag once into `RELEASE_TAG` + use it at `tag_name`; add a **HEAD==tag-commit** assertion (closes the ambiguous-branch crack in #55).

### Pin / guard hygiene
- **P6** — the two floating `# v0` / `# v3` SHA-pin comments (missed by #338) now name the exact release (sbom-action **v0.24.0**, gh-release **v3.0.1**, resolved live).
- **P7** — the tag↔CHANGELOG guard `pytest.skip`'d on a tag-less checkout → **`pytest.fail` in CI** (fetch-depth regressed = silently disarmed), skip retained for local tarballs.
- **P8** — the T0-5 sdist licensing gate's `tar … | grep … || true` swallowed a `tar` failure (vacuous pass) → split into unguarded `tar` capture + guarded grep.
- **P9** — Dockerfile comments said "3.14.5" / "Python 3.13" (base is 3.14.6); corrected + added a **unit guard** asserting the base-image digest in `gen_requirements_lock.sh` == the Dockerfile `FROM` digest.

### Deferred (flagged, NOT done)
**P5** — hash-lock the PyPI `pip install build twine` + PEP 517 build env. Needs a generated `requirements-build.lock` + a real release-path pip resolution I can't verify locally without risking the release; its own follow-up PR (matches the already-deferred MSI `[desktop-build]` sibling).

### Verification
All 4 modified workflows YAML-parse; the two SHAs resolved live to v0.24.0 / v3.0.1; `test_changelog` + `test_requirements_lock` (incl. the new digest guard) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
