### PR TITLE
test(guards): un-skip vacuous canaries, pin wait_for_job, fail-not-skip on missing Certainty header (HEAD-review Tests-T8/T9/T10)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import textwrap
 import time
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import pytest
 from fastapi.testclient import TestClient
@@ -168,7 +169,12 @@ class AutoWaitTestClient(TestClient):
         # Only a successful create against the backups *collection* endpoint
         # spawns a job to wait on (not GET /{id}, not a 422/400 rejection,
         # not a POST to some other resource).
-        if resp.status_code == 202 and url.rstrip("/").endswith("/api/v1/backups"):
+        # Match on the URL PATH only (T9): a POST carrying a query string
+        # (`/api/v1/backups?x=1`) or a full URL would otherwise fail the
+        # endswith and silently skip the wait, leaving tests reading a frozen
+        # `pending` snapshot.  No current caller does either, but the path-parse
+        # makes the trigger robust to one.
+        if resp.status_code == 202 and urlsplit(url).path.rstrip("/").endswith("/api/v1/backups"):
             try:
                 job_id = resp.json().get("id")
             except Exception:  # non-JSON / unexpected body — nothing to wait on

--- a/tests/unit/migration/test_codec_header_certainty.py
+++ b/tests/unit/migration/test_codec_header_certainty.py
@@ -8,9 +8,11 @@ claimed ``best_effort`` while ``codec.py`` declared ``certified``.  This
 test mechanically enforces header↔code agreement for every codec that
 declares a ``Certainty:`` line, so the contradiction can't recur.
 
-Codecs whose header omits a ``Certainty:`` line are skipped (header
-uniformity across all codecs is a separate, lower-priority item) — the
-guard checks consistency *where the claim is made*, not presence.
+Every real codec declares a ``Certainty:`` line; only the internal ``mock``
+test codec omits one and is skipped.  A real codec with no header now FAILS
+(HEAD-review T10) so a codec can't dodge the guard by deleting its header line
+instead of updating it — the guard checks consistency where the claim is made
+AND that every real codec makes the claim.
 """
 
 from __future__ import annotations
@@ -39,7 +41,17 @@ def test_header_certainty_matches_classvar(name):
 
     m = _CERTAINTY_RE.search(doc)
     if m is None:
-        pytest.skip(f"{name}: package header declares no 'Certainty:' line")
+        # Only the internal `mock` test codec omits a Certainty header; every
+        # real codec declares one (verified at HEAD).  Fail — not skip — for a
+        # real codec so a codec can't dodge this header↔code guard by DELETING
+        # its header line instead of updating it when demoted (T10).
+        if name == "mock":
+            pytest.skip(f"{name}: internal test codec declares no 'Certainty:' line")
+        pytest.fail(
+            f"{name}: package header ({pkg_name}) declares no 'Certainty:' line "
+            "— every real codec must declare one (a demoted codec must UPDATE "
+            "its header, not delete the line)."
+        )
 
     header_value = m.group(1)
     assert header_value == codec.certainty, (

--- a/tests/unit/migration/test_real_captures.py
+++ b/tests/unit/migration/test_real_captures.py
@@ -669,8 +669,15 @@ def test_every_mapped_fixture_dir_yields_at_least_one_capture() -> None:
     failing the build.  Assert every mapped vendor directory that exists
     on disk contributes at least one discovered fixture.
     """
-    if not REAL_FIXTURES_ROOT.is_dir():
-        pytest.skip(f"{REAL_FIXTURES_ROOT} does not exist")
+    # The fixture root is a committed directory — its ABSENCE is the exact
+    # failure this canary exists to catch (relocated/renamed root → discovery
+    # returns [] → the parametrized suites skip to green).  Skipping here too
+    # would let that failure pass silently, so assert instead of skip (T8).
+    assert REAL_FIXTURES_ROOT.is_dir(), (
+        f"{REAL_FIXTURES_ROOT} is missing — the real-capture corpus root "
+        "vanished, so ~300 parametrized tests silently skipped to green. "
+        "Restore the fixture root / fix _DIR_TO_CODEC_NAME."
+    )
     covered = {codec_key for codec_key, _ in _FIXTURE_PARAMS}
     expected = {
         vendor_dir

--- a/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
+++ b/tests/unit/migration/test_synthetic_kitchen_sink_round_trips.py
@@ -408,8 +408,15 @@ def test_corpus_covers_every_round_trippable_codec() -> None:
     internal ``mock`` test codec is the sole exemption (it ships no
     synthetic fixture).
     """
-    if not SYNTHETIC_FIXTURES_ROOT.is_dir():
-        pytest.skip(f"{SYNTHETIC_FIXTURES_ROOT} does not exist")
+    # The fixture root is a committed directory — its ABSENCE is the exact
+    # failure this canary exists to catch (relocated/renamed root → discovery
+    # returns [] → the parametrized suites skip to green).  Skipping here too
+    # would let that failure pass silently, so assert instead of skip (T8).
+    assert SYNTHETIC_FIXTURES_ROOT.is_dir(), (
+        f"{SYNTHETIC_FIXTURES_ROOT} is missing — the synthetic kitchen-sink "
+        "corpus root vanished, so the parametrized round-trip suites silently "
+        "skipped to green. Restore the fixture root."
+    )
     expected = {n for n in list_codecs() if n != "mock"}
     covered = {codec_name for codec_name, _ in _FIXTURE_PARAMS}
     missing = expected - covered

--- a/tests/unit/test_wait_for_job.py
+++ b/tests/unit/test_wait_for_job.py
@@ -1,0 +1,69 @@
+"""Direct unit test for the ``wait_for_job`` test helper (HEAD-review T9).
+
+``wait_for_job`` (and the ``AutoWaitTestClient`` that calls it) is load-bearing
+for every backups-tier test since #27 moved dispatch off FastAPI
+``BackgroundTasks`` — yet its correctness was only ever inferred from downstream
+side-effect asserts.  Pin it directly: it must poll until terminal and return
+that body, and it must raise ``AssertionError`` (not hang) on a job that never
+terminalises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import wait_for_job
+
+pytestmark = pytest.mark.unit
+
+
+class _Resp:
+    def __init__(self, status_code: int, body: dict | None = None) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self) -> dict:
+        return self._body
+
+
+class _StubClient:
+    """A ``.get(url)`` stub that returns a scripted sequence of responses,
+    repeating the last one once the script is exhausted."""
+
+    def __init__(self, responses: list[_Resp]) -> None:
+        self._responses = responses
+        self.calls = 0
+
+    def get(self, _url: str) -> _Resp:
+        resp = self._responses[min(self.calls, len(self._responses) - 1)]
+        self.calls += 1
+        return resp
+
+
+def test_returns_terminal_body_after_polling():
+    client = _StubClient([
+        _Resp(200, {"status": "pending"}),
+        _Resp(200, {"status": "running"}),
+        _Resp(200, {"status": "completed", "id": "abc"}),
+    ])
+    body = wait_for_job(client, "abc", timeout=1.0, poll=0.0)
+    assert body["status"] == "completed"
+    assert client.calls == 3  # polled until terminal, then returned
+
+
+def test_raises_on_never_terminal_job():
+    client = _StubClient([_Resp(200, {"status": "pending"})])  # never terminalises
+    with pytest.raises(AssertionError, match="did not reach a terminal state"):
+        wait_for_job(client, "stuck", timeout=0.05, poll=0.0)
+
+
+def test_404_before_terminal_is_tolerated_then_heals():
+    # A brief 404 (e.g. the corrupt-file / eviction window) must not crash the
+    # poll — it keeps trying until the terminal 200 lands.
+    client = _StubClient([
+        _Resp(404),
+        _Resp(200, {"status": "running"}),
+        _Resp(200, {"status": "failed", "id": "z"}),
+    ])
+    body = wait_for_job(client, "z", timeout=1.0, poll=0.0)
+    assert body["status"] == "failed"


### PR DESCRIPTION
## Wave 6 PR-F — test-guard hygiene (HEAD-review Tests-T8/T9/T10)

**The final PR of Wave 6** — closing the 2026-07-12 HEAD-review. Test/CI guard hygiene only; no product code. **CODEC_BUG stays 5 / cells 1224.**

| # | Fix |
|---|-----|
| **T8** | The two vacuous-skip **canaries** (which exist to catch "fixture root relocated → discovery returns [] → parametrized suites skip to green") themselves began with `if not <ROOT>.is_dir(): pytest.skip(...)` — so on that exact failure the canary ALSO skipped. The roots are committed dirs; both now **`assert <ROOT>.is_dir()`**. |
| **T9** | (1) The `AutoWaitTestClient` auto-wait trigger matched `url…endswith("/api/v1/backups")`, so a query-string/full-URL POST silently skipped the wait → tests read a frozen `pending` snapshot. Now matches **`urlsplit(url).path`**. (2) `wait_for_job` had **zero direct test** → added `tests/unit/test_wait_for_job.py` (polls-to-terminal, raises-on-never-terminal, tolerates a transient 404). |
| **T10** | The codec-header↔code Certainty guard **skipped** a codec with no header (delete-the-line-to-dodge hole). Only the internal `mock` codec omits one (all 12 real codecs declare it — verified); now skip **only `mock`** and **`pytest.fail`** for a real codec. Born green. |

### Not shipped — Tests-T7 superseded (verify-first)
Adding an interface-description case to `test_silent_loss_list_subfields._CASES` was left out **deliberately**: the drop it targeted (mikrotik bond descriptions) was fixed in Wave 4 (Fid-F3 emits `comment=`), and fortigate/opnsense declare the path lossy (Wave 6 Fid-F4). Probed all 12 codecs → **none** keeps the interface name while dropping the description undeclared, so the module's own `test_some_codec_demonstrates_each_case` guard-the-guard test would reject the case as **vacuous** (red). Mikrotik's regression is already covered by the Wave-4 dedicated bond-comment tests. (Tests-T5/T4 shipped in PR-A; Tests-T1 in Wave 4.)

### Verification
Probed: only `mock` lacks a Certainty header; no codec demonstrates the T7 drop. `wait_for_job` tested directly; ruff clean; backups integration suite green after the conftest change.

---

🎉 **This completes the HEAD-review (`3def246`) remediation** — Waves 1–6 all shipped. Deferred-with-cause items flagged separately: Conc-F4 (intake cap), Pkg-P5 (build-toolchain lock), the D8/D9-residual stale reason-YAMLs, and the `opnsense__cisco_iosxe` dns `not_applicable` mesh-look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
