### PR TITLE
docs(honesty): correct the last stale static-route reason (cisco_iosxe_cli->opnsense) missed by the D7-D9 sweep (HEAD-review finder-17 §b)

### DIFF
--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
@@ -413,12 +413,15 @@ per_field_expectation:
       OPNsense splits static-route declaration into two blocks:
       ``<gateways>/<gateway_item>`` (named gateways) and
       ``<staticroutes>/<route>`` (routes referencing named
-      gateways).  The OPNsense codec does not currently parse
-      OR emit either block; canonical static_routes from a Cisco
-      source therefore drop on render.  Per-VRF static routes
-      (Cisco ``ip route vrf X ...``) carry a populated
-      ``CanonicalStaticRoute.vrf`` but drop on this cross-pair
-      because OPNsense has no VRF model.
+      gateways).  The OPNsense codec now PARSES both blocks
+      (``parse.py`` ``_parse_static_routes`` harvests the
+      ``<gateway_item>`` default route + ``<staticroutes>/<route>``
+      entries, resolving named gateways to their IP; promotion #15),
+      but the config.xml renderer still emits neither block, so
+      canonical static_routes from a Cisco source drop on render.
+      Per-VRF static routes (Cisco ``ip route vrf X ...``) carry a
+      populated ``CanonicalStaticRoute.vrf`` but drop on this
+      cross-pair because OPNsense has no VRF model.
     references: [opnsense-gateways]
 
   # ── Tier 2 — auto-translate with review ──


### PR DESCRIPTION
## D8/D9-residual reason sweep — finder-17 §(b) tail

The HEAD-review docs-truth finder (§b) listed ~10 expectation-YAML `reason:` blocks as stale — but that report predates the **D7-D9 sweep (#372)**. A verify-first pass over all 10 (each file independently source-verified against HEAD parse/render/codec, then adversarially re-verified by a second agent) found:

- **9 of 10 already accurate at HEAD** — corrected by #372; no change warranted. Editing them would have introduced churn or false claims. (Verified with per-file source citations.)
- **1 genuine correction** — `cisco_iosxe_cli__opnsense.yaml` static_routes: "The OPNsense codec does not currently parse OR emit either block" — the **parse half is false** post-#350/promotion-#15 (`opnsense/parse.py _parse_static_routes` harvests `<gateway_item>` + `<staticroutes>/<route>`). Rewritten to match reality (parses both blocks; renderer still emits neither → Cisco-source routes drop on render), mirroring the codec's own LossyPath wording and the sibling `mikrotik_routeros__opnsense.yaml`.

**Reason text only — disposition byte-untouched** (still `lossy`). Mesh-flat: phase4 reads `disposition:` not `reason:`; cross-mesh guard green, **CODEC_BUG 5 / cells 1224**, coverage unchanged; YAML valid.

### Corroborated-but-deferred
The adversarial verifier independently confirmed `opnsense__cisco_iosxe.yaml` dns_servers has `disposition: not_applicable` while OPNsense parse **does** populate dns_servers (source-populated + target-dropped ⇒ `unsupported`, matching the hostname/domain siblings in that same file). That flip **moves the mesh** (needs a phase4 regen + re-baseline), so it stays the separately-tracked mesh-mover — not part of this reason-only sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
