### PR TITLE
fix(honesty): opnsense->cisco_iosxe dns_servers not_applicable -> unsupported (HEAD-review, mesh re-baselined)

### DIFF
--- a/tests/fixtures/cross_vendor_expectations/opnsense__cisco_iosxe.yaml
+++ b/tests/fixtures/cross_vendor_expectations/opnsense__cisco_iosxe.yaml
@@ -155,15 +155,18 @@ per_field_expectation:
     references: [oc-system]
 
   dns_servers:
-    disposition: not_applicable
-    note: >
-      OPNsense parse DOES harvest `<system>/<dnsserver>` into
-      canonical intent.dns_servers (opnsense parse.py:232), so the
-      source list is populated.  The drop is entirely target-side:
-      the cisco_iosxe NETCONF/OpenConfig Phase-0.5 stub render emits
-      no `<system><dns>` element, so intent.dns_servers is dropped on
-      render.  Flips to lossy once the target render side grows a
-      `/system/dns-server` wire-up.
+    disposition: unsupported
+    reason: >
+      OPNsense source populates intent.dns_servers by harvesting
+      `<system>/<dnsserver>` (opnsense parse.py:232), so the source
+      list is populated.  The drop is entirely target-side: the
+      cisco_iosxe NETCONF/OpenConfig Phase-0.5 stub render emits no
+      `<system><dns>` element, so intent.dns_servers is dropped on
+      render.  Same render-side wire-up gap as hostname / domain —
+      the target codec declares both `/dns_servers` and
+      `/system/dns-server` under `unsupported` (cisco_iosxe
+      codec.py:614/477).  Flips to supported once the stub render
+      grows a `/system/dns-server` wire-up.
     references: [oc-system]
 
   ntp_servers:

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -15,14 +15,14 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 | ALIGNED | 1678 | ok |
 | CODEC_BUG | 5 | **high** |
 | EXPECTED_LOSSY | 1224 | ok |
-| EXPECTED_UNSUPPORTED | 732 | ok |
+| EXPECTED_UNSUPPORTED | 736 | ok |
 | METHODOLOGY_ISSUE_under | 930 | low/medium |
-| METHODOLOGY_ISSUE_over | 25 | low |
+| METHODOLOGY_ISSUE_over | 21 | low |
 | STRUCTURAL_ONLY | 1179 | low |
 | TRIVIAL_EMPTY | 9526 | ok |
 | **Total field-cells classified** | **15299** | |
 
-Severity roll-up: 5 high, 107 medium, 2027 low, 13160 ok.
+Severity roll-up: 5 high, 107 medium, 2023 low, 13164 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-14T16:36:22+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260714T163621Z.json",
-  "mesh_run_started_utc": "2026-07-14T16:36:14+00:00",
+  "started_utc": "2026-07-17T00:54:16+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260717T005406Z.json",
+  "mesh_run_started_utc": "2026-07-17T00:53:53+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4137,16 +4137,16 @@
     "ALIGNED": 1678,
     "CODEC_BUG": 5,
     "EXPECTED_LOSSY": 1224,
-    "EXPECTED_UNSUPPORTED": 732,
+    "EXPECTED_UNSUPPORTED": 736,
     "METHODOLOGY_ISSUE_under": 930,
-    "METHODOLOGY_ISSUE_over": 25,
+    "METHODOLOGY_ISSUE_over": 21,
     "STRUCTURAL_ONLY": 1179,
     "TRIVIAL_EMPTY": 9526,
     "fields_total": 15299,
     "severity_high": 5,
     "severity_medium": 107,
-    "severity_low": 2027,
-    "severity_ok": 13160
+    "severity_low": 2023,
+    "severity_ok": 13164
   },
   "severity_matrix": {
     "arista_eos": {


### PR DESCRIPTION
## What

Corrects the `opnsense → cisco_iosxe` **dns_servers** cross-vendor expectation from `disposition: not_applicable` to `disposition: unsupported`, and re-baselines the phase4 reconciliation to match.

This is the **last mesh-moving deferred item** from the 2026-07-12 HEAD-review (`3def246`) — flagged suspect during Wave 5 and independently corroborated by an adversarial verifier during the D8/D9-residual reason sweep (#379).

## Why `unsupported`, not `not_applicable`

`not_applicable` means *"structurally absent on the SOURCE vendor's wire — the source never populates the field"* (`cross_vendor_expectations/README.md`). That is false here:

- **Source populates it:** OPNsense parse unconditionally harvests `<system>/<dnsserver>` into `intent.dns_servers` (`opnsense/parse.py:232`).
- **Target genuinely can't emit it:** the cisco_iosxe Phase-0.5 stub render emits no `<system><dns>` element, and the codec already declares **both** `/dns_servers` (`codec.py:614`) and `/system/dns-server` (`codec.py:477`) as `UnsupportedPath`.

Source-populated + target-dropped-and-declared-unsupported ⇒ `unsupported` — identical mechanics to the `hostname` / `domain` siblings in this same file, which are already `unsupported`. The note's closing sentence was also logically inverted ("Flips to *lossy* once render grows dns wire-up" — growing render support **preserves** the data → *supported*); fixed, and the `note:` key converted to `reason:` to match the unsupported siblings.

## Mesh impact (re-baselined)

Regenerated via `run_full_mesh.py` + `run_phase4_reconciliation.py --write-baseline`. Of the 8 `opnsense → cisco_iosxe` cells, the **4 fixtures that populate dns_servers** move from `METHODOLOGY_ISSUE_over` (the reconciler was already flagging `not_applicable` as an over-declaration) into the correctly-declared `EXPECTED_UNSUPPORTED` bucket; the 4 with no dns stay `TRIVIAL_EMPTY`.

| Bucket | Before | After | Δ |
|---|---|---|---|
| **CODEC_BUG** | **5** | **5** | **0** (same 5 cells, identity-verified) |
| EXPECTED_UNSUPPORTED | 732 | 736 | +4 |
| METHODOLOGY_ISSUE_over | 25 | 21 | −4 |
| severity_low | 2027 | 2023 | −4 |
| severity_ok | 13160 | 13164 | +4 |
| cells_total | 1224 | 1224 | 0 |

Render output is **byte-unchanged** (no codec code touched), so `CROSS_MESH_RESULTS.md` does not move — only the expectation YAML, the `latest.json` baseline, and the `PHASE4_RECONCILIATION.md` skeleton change.

## Verification

- Cross-mesh CI guard `tests/integration/test_cross_mesh_ci_guard.py` — **10/10 green** (CODEC_BUG ≤ 5 absolute-pinned, cells 1224, coverage-not-reduced, CROSS_MESH_RESULTS reproduces).
- `tests/unit/audit/` + `tests/unit/migration/test_opnsense.py` — green.
- YAML valid; no `C:\Users` literal in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
