### PR TITLE
fix(honesty): Fid-F7 promote 2 stale over-declared-lossy pairs to good + ratchet methodology-debt buckets

### DIFF
--- a/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__cisco_iosxe_cli.yaml
@@ -228,17 +228,19 @@ per_field_expectation:
     references: [vlans, switchport]
 
   static_routes:
-    disposition: lossy
-    reason: >
+    disposition: good
+    note: >
       Default-VRF static routes round-trip cleanly (Arista's CIDR
       form converts to / from Cisco's dotted-mask form via the
       codecs).  Per-VRF static routes (``ip route vrf X ...``)
-      now round-trip too: both codecs harvest and render the
-      per-VRF form via ``CanonicalStaticRoute.vrf`` (Arista
-      ``ip route vrf X`` <-> Cisco ``ip route vrf X``).  The
-      ``lossy`` disposition is a conservative holdover from
-      before the v0.2.0 vrf wire-up (the mesh reads this cell as
-      preserved); a candidate for promotion to ``good``.
+      round-trip through ``CanonicalStaticRoute.vrf`` (v0.2.0 wire-up
+      on both codecs); the two-token ``<iface> <gateway>`` form, admin
+      distance, and IPv6 (``ipv6 route``) all render and re-parse.
+      Every field the Arista parser populates (destination, gateway,
+      interface, metric, vrf) is emitted by the Cisco IOS-XE render;
+      interface next-hop names track the rename mesh.  (Fid-F7:
+      promoted from a conservative lossy holdover that predated the
+      v0.2.0 vrf wire-up.)
     references: [static_routes, vrf]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__opnsense.yaml
@@ -268,14 +268,18 @@ per_field_expectation:
     references: [junos-initial-config, opnsense-system]
 
   dns_servers:
-    disposition: lossy
-    reason: >
-      Junos ``set system name-server`` lines map to OPNsense
-      repeated ``<system>/<dnsserver>`` elements.  The OPNsense codec
-      parses those ``<system>/<dnsserver>`` children into the canonical
-      ``dns_servers`` list (parse.py:232) and re-emits one
-      ``<dnsserver>`` per entry on render (render.py:104), so the
-      resolver list round-trips junos→opnsense (preserved, not dropped).
+    disposition: good
+    note: >
+      Junos ``set system name-server`` lines parse to the canonical
+      ``dns_servers`` list (parse.py:1260, deduped first-seen at
+      parse.py:889).  The OPNsense codec re-emits one
+      ``<system>/<dnsserver>`` per entry on render (render.py:104) with
+      no count cap, comma-join, or normalization, and re-parses each
+      child back one-per-entry (parse.py:232).  The bare-address
+      resolver list round-trips junos→opnsense losslessly (Fid-F7:
+      promoted from a conservative lossy holdover — the mesh reads this
+      cell as preserved and no sub-canonical nuance is dropped for this
+      direction).
     references: [junos-initial-config, opnsense-system]
 
   ntp_servers:

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -12,17 +12,17 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 
 | Variance class | Count | Severity |
 |---|---:|---|
-| ALIGNED | 1678 | ok |
+| ALIGNED | 1689 | ok |
 | CODEC_BUG | 5 | **high** |
 | EXPECTED_LOSSY | 1224 | ok |
 | EXPECTED_UNSUPPORTED | 736 | ok |
-| METHODOLOGY_ISSUE_under | 930 | low/medium |
+| METHODOLOGY_ISSUE_under | 919 | low/medium |
 | METHODOLOGY_ISSUE_over | 21 | low |
 | STRUCTURAL_ONLY | 1179 | low |
 | TRIVIAL_EMPTY | 9526 | ok |
 | **Total field-cells classified** | **15299** | |
 
-Severity roll-up: 5 high, 107 medium, 2023 low, 13164 ok.
+Severity roll-up: 5 high, 107 medium, 2012 low, 13175 ok.
 
 ## Per-cell matrix — CODEC_BUG counts
 

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-17T00:54:16+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260717T005406Z.json",
-  "mesh_run_started_utc": "2026-07-17T00:53:53+00:00",
+  "started_utc": "2026-07-17T03:30:50+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260717T033049Z.json",
+  "mesh_run_started_utc": "2026-07-17T03:30:37+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4134,19 +4134,19 @@
     }
   ],
   "aggregate": {
-    "ALIGNED": 1678,
+    "ALIGNED": 1689,
     "CODEC_BUG": 5,
     "EXPECTED_LOSSY": 1224,
     "EXPECTED_UNSUPPORTED": 736,
-    "METHODOLOGY_ISSUE_under": 930,
+    "METHODOLOGY_ISSUE_under": 919,
     "METHODOLOGY_ISSUE_over": 21,
     "STRUCTURAL_ONLY": 1179,
     "TRIVIAL_EMPTY": 9526,
     "fields_total": 15299,
     "severity_high": 5,
     "severity_medium": 107,
-    "severity_low": 2023,
-    "severity_ok": 13164
+    "severity_low": 2012,
+    "severity_ok": 13175
   },
   "severity_matrix": {
     "arista_eos": {
@@ -5153,9 +5153,9 @@
         },
         "static_routes": {
           "actual": "preserved",
-          "expected": "lossy",
-          "variance": "METHODOLOGY_ISSUE_under",
-          "severity": "low"
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
         },
         "dhcp_servers": {
           "actual": "trivially_preserved",
@@ -5477,11 +5477,11 @@
         }
       },
       "summary": {
-        "ALIGNED": 7,
+        "ALIGNED": 8,
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 4,
         "EXPECTED_UNSUPPORTED": 0,
-        "METHODOLOGY_ISSUE_under": 1,
+        "METHODOLOGY_ISSUE_under": 0,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
         "TRIVIAL_EMPTY": 12,
@@ -5489,8 +5489,8 @@
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 1,
-        "severity_ok": 23
+        "severity_low": 0,
+        "severity_ok": 24
       }
     },
     {
@@ -6100,9 +6100,9 @@
         },
         "static_routes": {
           "actual": "preserved",
-          "expected": "lossy",
-          "variance": "METHODOLOGY_ISSUE_under",
-          "severity": "low"
+          "expected": "good",
+          "variance": "ALIGNED",
+          "severity": "ok"
         },
         "dhcp_servers": {
           "actual": "trivially_preserved",
@@ -6320,11 +6320,11 @@
         }
       },
       "summary": {
-        "ALIGNED": 7,
+        "ALIGNED": 8,
         "CODEC_BUG": 1,
         "EXPECTED_LOSSY": 3,
         "EXPECTED_UNSUPPORTED": 0,
-        "METHODOLOGY_ISSUE_under": 2,
+        "METHODOLOGY_ISSUE_under": 1,
         "METHODOLOGY_ISSUE_over": 0,
         "STRUCTURAL_ONLY": 0,
         "TRIVIAL_EMPTY": 12,
@@ -6332,8 +6332,8 @@
         "missing_in_phase1": 3,
         "severity_high": 1,
         "severity_medium": 0,
-        "severity_low": 2,
-        "severity_ok": 22
+        "severity_low": 1,
+        "severity_ok": 23
       }
     },
     {

--- a/tests/integration/test_cross_mesh_ci_guard.py
+++ b/tests/integration/test_cross_mesh_ci_guard.py
@@ -149,6 +149,38 @@ def test_codec_bug_count_within_baseline(mesh_and_recon, baseline):
     )
 
 
+def test_methodology_issue_buckets_within_baseline(mesh_and_recon, baseline):
+    """The honesty-debt buckets must not exceed the committed baseline (Fid-F7).
+
+    ``METHODOLOGY_ISSUE_under`` = (preserved, lossy/unsupported): the
+    expectation over-declares a loss the render doesn't actually incur on the
+    corpus.  ``METHODOLOGY_ISSUE_over`` = (drifted, not_applicable): the
+    expectation under-declares — a field the source populates and the target
+    drops is mislabelled 'structurally absent'.  Both are honesty debt that
+    should only SHRINK: a promotion sweep (Fid-F7) or a
+    ``not_applicable``→``unsupported`` fix lowers them, and ``<=`` lets that
+    pass.  A new wire-up that lands a parse/render half WITHOUT flipping the
+    source-side disposition YAML grows ``METHODOLOGY_under`` (the exact
+    unpinned drift Fid-F7 flagged — 908→922→926 across the promotion wave)
+    and turns this red, forcing the honesty flip to ship WITH the wire-up
+    rather than accrete as silent, unaudited debt.  When a bucket legitimately
+    moves, regenerate the baseline consciously
+    (``tools/run_phase4_reconciliation.py --write-baseline``)."""
+    _, result = mesh_and_recon
+    for bucket in ("METHODOLOGY_ISSUE_under", "METHODOLOGY_ISSUE_over"):
+        live = result["aggregate"][bucket]
+        base = baseline["aggregate"][bucket]
+        assert live <= base, (
+            f"{bucket} regressed: live={live} > baseline={base}.\n"
+            "The expectation-vs-reality mismatch debt grew — a wire-up likely "
+            "landed a parse/render half without flipping the source-side "
+            "disposition YAML (METHODOLOGY_under), or a not_applicable "
+            "disposition now hides a real drop (METHODOLOGY_over).  Flip the "
+            "stale disposition(s) in the same change, or re-baseline "
+            "consciously (tools/run_phase4_reconciliation.py --write-baseline)."
+        )
+
+
 # The absolute, human-audited ceiling on cross-vendor CODEC_BUG cells.
 # UNLIKE test_codec_bug_count_within_baseline (which compares against the
 # committed latest.json — a file run_phase4_reconciliation.py rewrites when


### PR DESCRIPTION
## What

Resolves HEAD-review **Fid-F7** (over-declaration debt) — promotes the genuinely-stale `lossy` expectations to `good` and pins the honesty-debt buckets so they can't grow silently.

Fid-F7 flagged ~90 `(preserved, lossy)` "promotion candidates" and noted the `METHODOLOGY_under` bucket is pinned by **no guard** (it drifted 908→922→926 across the promotion wave, unbounded either way).

## The audit (complete, defensible)

I ran a full audit of the **30 fresh-wave candidates** (`static_routes` / `ntp_servers` / `dns_servers`), one agent per cell, each **verifying the reason against the actual source-parse + target-render code** (not trusting the reason text), defaulting to KEEP, with an **adversarial refute pass on every PROMOTE**.

**Key insight — the mesh-blindness trap:** the cross-mesh comparator compares the *canonical* `list[str]`, so "preserved, zero drift" does **not** prove lossless. Most candidates are **honest** sub-canonical losses the comparator can't see: FortiOS's 3-server DNS cap, SNTP↔NTP + per-server modifiers (`prefer`/`iburst`/`key`/`priority`), junos qualified-next-hop flattening, mikrotik interface-drop-when-gateway-set, opnsense dynamic-gateway drop. So the genuinely-stale subset is **small: 2 pairs**.

## Promoted (`lossy → good`)

Both self-described stale holdovers, refute-confirmed, sibling-consistent:

| Pair | Field | Why stale |
|---|---|---|
| `juniper_junos → opnsense` | `dns_servers` | junos name-server list round-trips 1:1 to opnsense `<dnsserver>` (no cap/join/normalize); reason already said *"round-trips (preserved, not dropped)"* |
| `arista_eos → cisco_iosxe_cli` | `static_routes` | default + per-VRF (`CanonicalStaticRoute.vrf`, v0.2.0), two-token next-hop, distance, IPv6 all round-trip; reason self-flagged *"a candidate for promotion to `good`"* |

## Rejected for cross-cell coherence

The audit proposed a 3rd promotion — `fortigate_cli → arista_eos` ntp_servers — which I **dropped on the main thread**. The matrix treats fortigate-as-ntp-source as *uniformly lossy* (`fortigate → cisco_iosxe_cli` stays lossy for the same per-server-modifier reason), so promoting only `fortigate → arista` would be incoherent. The per-cell agent (and its refute) couldn't see that cross-cell; kept lossy.

## Ratchet guard (the finding's second half)

Adds `test_methodology_issue_buckets_within_baseline` — pins `METHODOLOGY_ISSUE_under`/`over <= committed baseline` with `<=` (mirrors `test_codec_bug_count_within_baseline`). A future wire-up that lands a parse/render half **without** flipping the source-side disposition YAML now turns the guard red, forcing the honesty flip to ship *with* the wire-up rather than accrete as silent debt.

## Mesh impact (re-baselined)

11 field-cells move `METHODOLOGY_under → ALIGNED` (6 junos→opnsense dns + 5 arista→cisco static). Render is **byte-unchanged** (no codec code touched), so `CROSS_MESH_RESULTS.md` does not move.

| Bucket | Before | After |
|---|---|---|
| **CODEC_BUG** | **5** | **5** (same 5 cells, identity-verified) |
| ALIGNED | 1678 | 1689 (+11) |
| METHODOLOGY_ISSUE_under | 930 | 919 (−11) |
| cells_total | 1224 | 1224 |

## Follow-up surfaced

The refute pass caught a **latent `aruba_aoss` parse bug**: static routes carrying a trailing metric/`distance` token are silently dropped whole by the end-anchored `_IP_ROUTE_RE` / `_IPV6_ROUTE_RE`. Tracked separately; `aruba_aoss → mikrotik_routeros` static_routes correctly **stays lossy** meanwhile (it becomes a promotion candidate once the metric is captured).

## Verification

- Cross-mesh CI guard — **11/11 green** (10 + the new ratchet; CODEC_BUG ≤ 5 absolute-pinned, cells 1224).
- `tests/unit/audit/` + `tests/unit/migration/` — green (no per-codec test encoded the old `lossy`).
- Both YAMLs valid; no `C:\Users` literal in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
