### PR TITLE
docs(api): API-C4 — declare full non-2xx OpenAPI response surface + AST guard

### DIFF
--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -157,6 +157,14 @@ def _resolve_credentials(
     status_code=202,
     response_model=BackupJob,
     summary="Create a backup job",
+    responses={
+        400: {
+            "description": (
+                "A device address is blocked by the egress allow-list "
+                "(NETCANON_BLOCK_PRIVATE_EGRESS)."
+            )
+        },
+    },
 )
 def create_backup(
     request_body: BackupRequest,

--- a/netcanon/api/routes/configs.py
+++ b/netcanon/api/routes/configs.py
@@ -47,6 +47,12 @@ router = APIRouter(prefix="/configs", tags=["configs"])
 # Extensions permitted for the open-in-editor feature.
 _OPEN_ALLOWED_EXTENSIONS = frozenset({".cfg", ".conf", ".txt", ".xml", ".log"})
 
+#: Shared OpenAPI error declaration (API-C4) so the generated schema and
+#: clients see the 404 surface, not just the auto ``[2xx, 422]``.
+_CONFIG_404: dict[int | str, dict] = {
+    404: {"description": "The named config file does not exist."}
+}
+
 
 @router.get(
     "/",
@@ -66,6 +72,7 @@ def list_configs(
     "/{filename}",
     response_class=PlainTextResponse,
     summary="Retrieve the text of a stored configuration",
+    responses=_CONFIG_404,
 )
 def get_config(
     filename: str,
@@ -95,6 +102,7 @@ def get_config(
     "/{filename}",
     status_code=204,
     summary="Delete a stored configuration file",
+    responses=_CONFIG_404,
 )
 def delete_config(
     filename: str,
@@ -122,6 +130,21 @@ def delete_config(
     "/{filename}/open",
     status_code=204,
     summary="Open a stored configuration in the OS default text editor",
+    responses={
+        400: {
+            "description": (
+                "The file's extension is not on the open-in-editor allow-list."
+            )
+        },
+        403: {"description": "Open-in-editor is disabled on this server."},
+        **_CONFIG_404,
+        500: {"description": "The OS refused to open the file."},
+        501: {
+            "description": (
+                "This platform has no OS default-editor helper available."
+            )
+        },
+    },
 )
 def open_config(
     filename: str,
@@ -138,6 +161,7 @@ def open_config(
         filename: Bare filename as returned by the list endpoint.
 
     Raises:
+        HTTPException 400: If the file's extension is not on the allow-list.
         HTTPException 403: If ``open_in_editor`` is disabled in settings.
         HTTPException 404: If the file does not exist.
         HTTPException 501: If the platform does not support ``os.startfile``.

--- a/netcanon/api/routes/definitions.py
+++ b/netcanon/api/routes/definitions.py
@@ -39,6 +39,9 @@ def list_definitions(
     "/{type_key}",
     response_model=DeviceDefinition,
     summary="Get a single device definition by type_key",
+    responses={
+        404: {"description": "No definition with this `type_key` is loaded."}
+    },
 )
 def get_definition(
     type_key: str,

--- a/netcanon/api/routes/device_profiles.py
+++ b/netcanon/api/routes/device_profiles.py
@@ -34,6 +34,25 @@ from ..deps import (
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/devices", tags=["device-profiles"])
 
+#: Shared OpenAPI error declarations (API-C4) so the generated schema and
+#: clients see the full non-2xx surface, not just the auto ``[2xx, 422]``.
+#: Mirrors the ``_JOB_STATUS_RESPONSES`` template in migration.py.
+_PROFILE_404: dict[int | str, dict] = {
+    404: {"description": "No device profile with this id exists."}
+}
+_CAPACITY_409: dict[int | str, dict] = {
+    409: {"description": "The device-profile capacity limit (1000) is reached."}
+}
+_PERSIST_500: dict[int | str, dict] = {
+    500: {
+        "description": (
+            "Persisting the change to disk failed (OSError); the in-memory "
+            "registry was rolled back so the listed state stays consistent "
+            "with disk (review #47b)."
+        )
+    }
+}
+
 #: DeviceProfile fields whose annotation admits ``None`` — the only fields a
 #: PUT may explicitly clear (``enable_password``, ``notes``, ``os_version``,
 #: ``model``; plus the API-read-only ``detected_facts``).  Derived from the
@@ -86,6 +105,7 @@ def list_device_profiles(
     "/{profile_id}",
     response_model=DeviceProfilePublic,
     summary="Get a device profile by ID",
+    responses=_PROFILE_404,
 )
 def get_device_profile(
     profile_id: str,
@@ -111,6 +131,7 @@ def get_device_profile(
     status_code=201,
     response_model=DeviceProfilePublic,
     summary="Create a device profile",
+    responses={**_CAPACITY_409, **_PERSIST_500},
 )
 def create_device_profile(
     body: DeviceProfileCreate,
@@ -165,6 +186,7 @@ def create_device_profile(
     "/{profile_id}",
     response_model=DeviceProfilePublic,
     summary="Update a device profile",
+    responses={**_PROFILE_404, **_PERSIST_500},
 )
 def update_device_profile(
     profile_id: str,
@@ -241,6 +263,7 @@ def update_device_profile(
     "/{profile_id}",
     status_code=204,
     summary="Delete a device profile",
+    responses={**_PROFILE_404, **_PERSIST_500},
 )
 def delete_device_profile(
     profile_id: str,

--- a/netcanon/api/routes/schedules.py
+++ b/netcanon/api/routes/schedules.py
@@ -34,6 +34,25 @@ from ..deps import get_schedule_store, get_scheduler, get_schedules
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/schedules", tags=["schedules"])
 
+#: Shared OpenAPI error declarations (API-C4) so the generated schema and
+#: clients see the full non-2xx surface, not just the auto ``[2xx, 422]``.
+#: Mirrors the ``_JOB_STATUS_RESPONSES`` template in migration.py.
+_SCHEDULE_404: dict[int | str, dict] = {
+    404: {"description": "No schedule with this id exists."}
+}
+_CAPACITY_409: dict[int | str, dict] = {
+    409: {"description": "The schedule capacity limit (200) is reached."}
+}
+_PERSIST_500: dict[int | str, dict] = {
+    500: {
+        "description": (
+            "Persisting the schedule to disk failed (OSError); the in-memory "
+            "registry and the APScheduler job were rolled back so the listed "
+            "state stays consistent with disk (C3, the #47b sibling)."
+        )
+    }
+}
+
 
 # ---------------------------------------------------------------------------
 # Scheduler helpers (also called from main.py lifespan)
@@ -357,6 +376,7 @@ def list_schedules(
     status_code=201,
     response_model=BackupSchedulePublic,
     summary="Create a backup schedule",
+    responses={**_CAPACITY_409, **_PERSIST_500},
 )
 def create_schedule(
     body: ScheduleCreate,
@@ -415,6 +435,7 @@ def create_schedule(
     "/{schedule_id}",
     status_code=204,
     summary="Delete a backup schedule",
+    responses={**_SCHEDULE_404, **_PERSIST_500},
 )
 def delete_schedule(
     schedule_id: str,
@@ -458,6 +479,7 @@ def delete_schedule(
     "/{schedule_id}/toggle",
     response_model=BackupSchedulePublic,
     summary="Enable or disable a schedule",
+    responses={**_SCHEDULE_404, **_PERSIST_500},
 )
 def toggle_schedule(
     schedule_id: str,

--- a/tests/integration/test_openapi_response_declarations.py
+++ b/tests/integration/test_openapi_response_declarations.py
@@ -1,0 +1,90 @@
+"""Guard: every error status a route hand-raises is declared in OpenAPI (API-C4).
+
+FastAPI auto-declares only the success code(s) plus ``422`` (when a route has
+params).  Any ``raise HTTPException(status_code=N)`` a handler makes for a
+``400``/``403``/``404``/``409``/``500``/``501`` is invisible to ``/docs`` and
+generated clients unless the route decorator lists it in ``responses={}`` —
+exactly the drift prior-#51 / HEAD-review API-C4 flagged across the CRUD
+routers.
+
+This pins the contract *structurally* rather than with a hand-maintained table:
+it AST-parses each route's handler, collects every inline ``HTTPException``
+status code, and asserts it appears in the generated schema's declared
+responses.  A new handler that raises an undeclared code turns this red, so the
+``responses={}`` map must be updated in the same change.  (Codes raised only in
+a shared helper the handler *calls* are out of scope — declare those by hand.)
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import textwrap
+
+import pytest
+from starlette.routing import Route
+
+from netcanon.main import create_app
+
+pytestmark = pytest.mark.integration
+
+# Success codes FastAPI declares from status_code=/response_model; a handler
+# that also raises one of these (it doesn't, but be defensive) isn't an error
+# gap.  422 is auto-declared for any route with params, so a hand-raised 422
+# (e.g. an unknown type_key) is always already present.
+_AUTO_CODES = frozenset({200, 201, 202, 204, 301, 302, 304, 307, 308, 422})
+
+
+def _raised_status_codes(fn) -> set[int]:
+    """Return every integer status code the function's source hand-raises via
+    ``HTTPException(status_code=...)`` — literal ``404`` or ``status.HTTP_404_*``."""
+    try:
+        src = textwrap.dedent(inspect.getsource(fn))
+    except (OSError, TypeError):
+        return set()
+    tree = ast.parse(src)
+    codes: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        if name != "HTTPException":
+            continue
+        for kw in node.keywords:
+            if kw.arg != "status_code":
+                continue
+            val = kw.value
+            if isinstance(val, ast.Constant) and isinstance(val.value, int):
+                codes.add(val.value)
+            elif isinstance(val, ast.Attribute):  # status.HTTP_404_NOT_FOUND
+                m = re.search(r"HTTP_(\d{3})", val.attr)
+                if m:
+                    codes.add(int(m.group(1)))
+    return codes
+
+
+def test_every_raised_status_is_declared_in_openapi():
+    app = create_app()
+    schema = app.openapi()
+    gaps: list[str] = []
+    for route in app.routes:
+        if not isinstance(route, Route):
+            continue
+        for method in sorted(route.methods or set()):
+            if method not in ("GET", "POST", "PUT", "DELETE", "PATCH"):
+                continue
+            op = schema["paths"].get(route.path, {}).get(method.lower(), {})
+            declared = {
+                int(c) for c in op.get("responses", {}) if str(c).isdigit()
+            }
+            raised = _raised_status_codes(route.endpoint)
+            missing = {c for c in raised if c not in declared and c not in _AUTO_CODES}
+            if missing:
+                gaps.append(
+                    f"{method} {route.path}: raises {sorted(missing)} but OpenAPI "
+                    f"declares {sorted(declared)} — add them to the route's "
+                    f"responses={{}} map (mirror _JOB_STATUS_RESPONSES)."
+                )
+    assert not gaps, "Undeclared error responses:\n" + "\n".join(gaps)


### PR DESCRIPTION
## What

Resolves HEAD-review **API-C4** (prior `#51`-broad): the CRUD routers declared only `[2xx, 422]` in OpenAPI while their handlers actually return `400`/`403`/`404`/`409`/`500`/`501`, so `/docs` and generated clients modelled only half the error space.

## Approach (verify-first)

Wave-6 PR-B already fixed `GET /backups/{id}` (404) and the bad-UUID 422 doc, so I generated the **live** schema (not the review-HEAD dump) and diffed declared-vs-actually-raised per route. Then I AST-swept **every** route to enumerate the real inline-raise surface. **12 routes** were under-declared; each now carries a `responses={}` map mirroring the `_JOB_STATUS_RESPONSES` template, with shared per-router constants for the recurring `404` / capacity-`409` / persist-`500`.

| Route | Added |
|---|---|
| `POST /backups/` | `400` (egress block) |
| `GET /configs/{filename}` | `404` |
| `DELETE /configs/{filename}` | `404` |
| `POST /configs/{filename}/open` | `400, 403, 404, 500, 501` (+docstring 400) |
| `GET /devices/{profile_id}` | `404` |
| `POST /devices/` | `409, 500` |
| `PUT /devices/{profile_id}` | `404, 500` |
| `DELETE /devices/{profile_id}` | `404, 500` |
| `POST /schedules/` | `409, 500` |
| `DELETE /schedules/{schedule_id}` | `404, 500` |
| `POST /schedules/{schedule_id}/toggle` | `404, 500` |
| `GET /definitions/{type_key}` | `404` |

**Verify-first catch:** the `409`s are **capacity** limits ("Maximum … limit reached"), not "already exists"; the `500`s are OSError persist/delete-**with-rollback** (`#47b`/C3). Descriptions reflect the real mechanism. Also fixed the `open_config` docstring, which omitted its own `400` (extension allow-list).

## Durable guard (self-maintaining)

`tests/integration/test_openapi_response_declarations.py` AST-parses each route handler, collects every inline `HTTPException(status_code=N)`, and asserts it's declared in the generated schema. A future handler that raises an undeclared code turns it red — so the `responses={}` map must be updated in the same change. The full-route AST sweep is **clean** at HEAD; the guard is negative-control-verified (stripping a declaration flags it).

## Scope

Route/model only — **no codec, no mesh** (CODEC_BUG untouched, no re-baseline). API-touching suites (migration-api, swagger-docs, sec01-auth, desktop server, api-robustness-wave6) + the new guard all green; ruff clean.

**Not included** (a distinct sub-nit — response *body*, not error codes): `POST /definitions/reload` still returns a bare dict with no `response_model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
