### PR TITLE
fix(security): SEC-3 — egress allow-list unwraps all IPv6 transition formats (NAT64/6to4/IPv4-compat)

### DIFF
--- a/netcanon/ip_transition.py
+++ b/netcanon/ip_transition.py
@@ -1,0 +1,61 @@
+"""IPv6 transition-format IPv4 extraction — shared primitive (SEC-3 / #42).
+
+Several IPv6 formats smuggle a routable IPv4 in their low bits: 6to4
+(``2002::/16``), IPv4-mapped (``::ffff:a.b.c.d``), Teredo (``2001:0::/32``),
+NAT64 (``64:ff9b::/96`` + the RFC 8215 local-use prefix), and the deprecated
+IPv4-compatible ``::a.b.c.d``.  A check that only inspects the v6 layer misses
+the embedded IPv4 entirely — NAT64 and 6to4 even classify as reserved/private
+at the v6 layer, so ``is_loopback`` / ``is_private`` on the IPv6 object never
+fire on the address that actually gets routed.
+
+Two callers need the same extraction with opposite polarity, so it lives here:
+
+* the sanitizer (:func:`netcanon.tools.sanitize._embedded_public_ipv4`) keeps
+  the embedded IPv4 iff it is *public* (a leak to redact), and
+* the egress allow-list (:func:`netcanon.services.egress._is_blocked_ip`)
+  blocks the target iff the embedded IPv4 is loopback / link-local /
+  unspecified — the metadata-endpoint SSRF surface (``64:ff9b::169.254.169.254``
+  reaches ``169.254.169.254``).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+# NAT64 carries the IPv4 in its low 32 bits but — unlike 6to4 / IPv4-mapped /
+# Teredo — has no ``ipaddress`` accessor, so we recognise the prefixes and
+# slice the bits ourselves.  Both the well-known prefix (RFC 6052) and the
+# RFC 8215 local-use prefix are in play.
+NAT64_NETWORKS = (
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+)
+
+
+def embedded_ipv4s(
+    addr: ipaddress.IPv6Address,
+) -> list[ipaddress.IPv4Address]:
+    """Every IPv4 embedded in an IPv6 *transition* literal, in precedence order.
+
+    Recognises 6to4, IPv4-mapped, Teredo (server + client), NAT64 (both
+    prefixes), and — only when none of the above match — the deprecated
+    IPv4-compatible ``::a.b.c.d`` form.  Returns an empty list for a native
+    IPv6 address (and never yields ``::`` / ``::1``, whose low word is <= 1).
+    """
+    candidates: list[ipaddress.IPv4Address] = []
+    if addr.sixtofour is not None:
+        candidates.append(addr.sixtofour)
+    if addr.ipv4_mapped is not None:
+        candidates.append(addr.ipv4_mapped)
+    if addr.teredo is not None:
+        # (server, client): both are clear-text routable IPv4s.
+        candidates.extend(addr.teredo)
+    if any(addr in net for net in NAT64_NETWORKS):
+        candidates.append(ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF))
+    if not candidates:
+        # IPv4-compatible (deprecated): ``::a.b.c.d`` — all high bits zero
+        # with a non-trivial low word (exclude ``::`` and ``::1``).
+        low = int(addr) & 0xFFFFFFFF
+        if (int(addr) >> 32) == 0 and low > 1:
+            candidates.append(ipaddress.IPv4Address(low))
+    return candidates

--- a/netcanon/services/egress.py
+++ b/netcanon/services/egress.py
@@ -28,6 +28,8 @@ import ipaddress
 import logging
 import socket
 
+from ..ip_transition import embedded_ipv4s
+
 logger = logging.getLogger(__name__)
 
 
@@ -45,17 +47,23 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     connect to the unspecified address routes to loopback, so without this
     check the allow-list could be bypassed to reach a loopback service.
 
-    IPv4-mapped IPv6 literals (``::ffff:127.0.0.1``) parse as IPv6 and would
-    otherwise sidestep the IPv4 loopback/link-local checks, so the embedded
-    IPv4 address is unwrapped and re-checked.
+    IPv6 *transition* literals (IPv4-mapped ``::ffff:127.0.0.1``, 6to4
+    ``2002:7f00:1::``, NAT64 ``64:ff9b::a9fe:a9fe``, Teredo, and the
+    deprecated IPv4-compatible ``::a.b.c.d``) parse as IPv6 and classify as
+    ``reserved`` / ``private`` at the v6 layer, so they would otherwise
+    sidestep the IPv4 loopback/link-local checks and reach the metadata
+    endpoint (``64:ff9b::169.254.169.254`` routes to ``169.254.169.254``).
+    Every embedded IPv4 is unwrapped and re-checked — the same
+    transition-format extraction the sanitizer uses (SEC-3 / #42).
     """
     if ip.is_loopback or ip.is_link_local or ip.is_unspecified:
         return True
-    mapped = getattr(ip, "ipv4_mapped", None)
-    return bool(
-        mapped is not None
-        and (mapped.is_loopback or mapped.is_link_local or mapped.is_unspecified)
-    )
+    if isinstance(ip, ipaddress.IPv6Address):
+        return any(
+            v4.is_loopback or v4.is_link_local or v4.is_unspecified
+            for v4 in embedded_ipv4s(ip)
+        )
+    return False
 
 
 def assert_egress_allowed(host: str) -> None:

--- a/netcanon/tools/sanitize.py
+++ b/netcanon/tools/sanitize.py
@@ -133,6 +133,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from ..ip_transition import embedded_ipv4s
 from ..migration.canonical.intent import CanonicalIntent
 from ..migration.codecs.base import ParseError
 from ..migration.codecs.registry import get_codec
@@ -987,16 +988,6 @@ def sanitize_intent(  # noqa: C901
 # Substitution-table — counter-per-session for cross-reference stability
 # ---------------------------------------------------------------------------
 
-# NAT64 carries the IPv4 in its low 32 bits but — unlike 6to4 / IPv4-mapped /
-# Teredo — has no ``ipaddress`` accessor, so we recognise the prefixes and
-# slice the bits ourselves.  Both the well-known prefix (RFC 6052) and the
-# RFC 8215 local-use prefix are in play.
-_NAT64_NETWORKS = (
-    ipaddress.ip_network("64:ff9b::/96"),
-    ipaddress.ip_network("64:ff9b:1::/48"),
-)
-
-
 def _ipv4_is_public(addr: ipaddress.IPv4Address) -> bool:
     """True iff *addr* is a globally-routable IPv4 the sanitizer must
     redact — the exact inverse of :meth:`_SubstitutionTable.redact_ipv4`'s
@@ -1030,24 +1021,11 @@ def _embedded_public_ipv4(
     preserve branch emitted them verbatim — leaking the embedded public
     IPv4 (audit 276eaeb T0-4).  Returns ``None`` when no transition IPv4
     is present, or the embedded IPv4 is itself private / docs / reserved
-    (nothing to leak — e.g. ``2002:c0a8:0101::`` embeds 192.168.1.1)."""
-    candidates: list[ipaddress.IPv4Address] = []
-    if addr.sixtofour is not None:
-        candidates.append(addr.sixtofour)
-    if addr.ipv4_mapped is not None:
-        candidates.append(addr.ipv4_mapped)
-    if addr.teredo is not None:
-        # (server, client): both are clear-text routable IPv4s.
-        candidates.extend(addr.teredo)
-    if any(addr in net for net in _NAT64_NETWORKS):
-        candidates.append(ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF))
-    if not candidates:
-        # IPv4-compatible (deprecated): ``::a.b.c.d`` — all high bits zero
-        # with a non-trivial low word (exclude ``::`` and ``::1``).
-        low = int(addr) & 0xFFFFFFFF
-        if (int(addr) >> 32) == 0 and low > 1:
-            candidates.append(ipaddress.IPv4Address(low))
-    for v4 in candidates:
+    (nothing to leak — e.g. ``2002:c0a8:0101::`` embeds 192.168.1.1).
+
+    The transition-format extraction is shared with the egress allow-list
+    via :func:`netcanon.ip_transition.embedded_ipv4s` (SEC-3 / #42)."""
+    for v4 in embedded_ipv4s(addr):
         if _ipv4_is_public(v4):
             return v4
     return None

--- a/tests/unit/test_egress.py
+++ b/tests/unit/test_egress.py
@@ -40,6 +40,26 @@ def test_loopback_and_link_local_are_blocked(host: str) -> None:
 @pytest.mark.parametrize(
     "host",
     [
+        "64:ff9b::a9fe:a9fe",     # NAT64 (RFC 6052) -> 169.254.169.254 metadata
+        "64:ff9b:1::a9fe:a9fe",   # NAT64 local-use (RFC 8215) -> metadata
+        "2002:7f00:0001::",       # 6to4 -> 127.0.0.1 loopback
+        "2002:a9fe:a9fe::",       # 6to4 -> 169.254.169.254 metadata
+        "::127.0.0.1",            # deprecated IPv4-compatible -> loopback
+    ],
+)
+def test_ipv6_transition_formats_to_blocked_ipv4_are_blocked(host: str) -> None:
+    """SEC-3 / #42: NAT64, 6to4 and the deprecated IPv4-compatible literals
+    smuggle an IPv4 in their low bits and classify as reserved/private at the
+    v6 layer, so a v6-only check let them reach loopback / the metadata
+    endpoint.  The embedded IPv4 is now unwrapped and re-checked (the same
+    transition-format extraction the sanitizer uses)."""
+    with pytest.raises(EgressBlocked):
+        assert_egress_allowed(host)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
         "8.8.8.8",
         "1.1.1.1",
         "192.168.1.1",   # RFC-1918 — real managed devices live here
@@ -47,6 +67,8 @@ def test_loopback_and_link_local_are_blocked(host: str) -> None:
         "172.16.0.1",
         "100.64.0.1",    # CGNAT
         "2001:db8::1",
+        "2002:0808:0808::",   # 6to4 embedding PUBLIC 8.8.8.8 — allowed
+        "64:ff9b::0808:0808",  # NAT64 embedding PUBLIC 8.8.8.8 — allowed
     ],
 )
 def test_public_and_private_ranges_are_allowed(host: str) -> None:

--- a/tests/unit/test_ip_transition.py
+++ b/tests/unit/test_ip_transition.py
@@ -1,0 +1,45 @@
+"""Unit tests for the shared IPv6 transition-format IPv4 extractor (SEC-3 / #42).
+
+``embedded_ipv4s`` is the primitive behind both the sanitizer's public-IPv4
+leak guard and the egress allow-list's embedded-loopback guard, so it is
+pinned directly here in addition to the two consumers' behavioural tests.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+import pytest
+
+from netcanon.ip_transition import embedded_ipv4s
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected"),
+    [
+        ("::ffff:127.0.0.1", ["127.0.0.1"]),        # IPv4-mapped
+        ("2002:7f00:0001::", ["127.0.0.1"]),        # 6to4 -> 127.0.0.1
+        ("2002:0808:0808::", ["8.8.8.8"]),          # 6to4 -> 8.8.8.8
+        ("64:ff9b::a9fe:a9fe", ["169.254.169.254"]),   # NAT64 well-known
+        ("64:ff9b:1::a9fe:a9fe", ["169.254.169.254"]),  # NAT64 local-use
+        ("::127.0.0.1", ["127.0.0.1"]),             # deprecated IPv4-compatible
+    ],
+)
+def test_extracts_embedded_ipv4(literal: str, expected: list[str]) -> None:
+    addr = ipaddress.IPv6Address(literal)
+    assert [str(v) for v in embedded_ipv4s(addr)] == expected
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "2606:4700::1111",  # native public IPv6 — nothing embedded
+        "2001:db8::1",      # documentation range
+        "::",               # unspecified — low word 0, excluded
+        "::1",              # loopback — low word 1, excluded
+    ],
+)
+def test_native_ipv6_yields_nothing(literal: str) -> None:
+    assert embedded_ipv4s(ipaddress.IPv6Address(literal)) == []


### PR DESCRIPTION
## What

Resolves HEAD-review **SEC-3** (prior `#42`): the egress allow-list's `_is_blocked_ip` unwrapped only IPv4-mapped IPv6, so a transition literal embedding a **loopback / link-local** IPv4 in its low bits slipped through — most importantly the cloud-metadata endpoint via NAT64.

## The bypass (verify-first, reproduced at HEAD)

`64:ff9b::169.254.169.254` (NAT64) routes to `169.254.169.254` but classifies as `reserved` at the v6 layer, so `is_link_local` never fired:

| Literal | Embeds | HEAD | Fixed |
|---|---|---|---|
| `64:ff9b::a9fe:a9fe` (NAT64 RFC 6052) | 169.254.169.254 | ✅ allowed (bypass) | 🛑 blocked |
| `64:ff9b:1::a9fe:a9fe` (NAT64 RFC 8215) | 169.254.169.254 | ✅ allowed | 🛑 blocked |
| `2002:7f00:0001::` (6to4) | 127.0.0.1 | ✅ allowed | 🛑 blocked |
| `2002:a9fe:a9fe::` (6to4) | 169.254.169.254 | ✅ allowed | 🛑 blocked |
| `::127.0.0.1` (IPv4-compatible) | 127.0.0.1 | ✅ allowed | 🛑 blocked |
| `::ffff:127.0.0.1` (IPv4-mapped) | 127.0.0.1 | 🛑 blocked | 🛑 blocked |

**Severity:** this is prior `#42`, consciously deferred — reachable only with `NETCANON_BLOCK_PRIVATE_EGRESS=true` **and** the transition prefix actually routed. Defence-in-depth hardening of an opt-in guard, not a default-path exploit; not a regression at HEAD.

## Fix

As `#42` noted, the sanitizer already handled every transition format in `_embedded_public_ipv4`. I extracted its candidate-gatherer into a shared `netcanon/ip_transition.py::embedded_ipv4s(addr)` and used it on both sides with opposite polarity:

- **sanitizer** keeps the embedded IPv4 iff it's *public* (a leak to redact),
- **egress** blocks iff the embedded IPv4 is *loopback / link-local / unspecified*.

`_is_blocked_ip` now unwraps 6to4, IPv4-mapped, Teredo, NAT64 (both prefixes) and IPv4-compatible. **No over-blocking:** public embeds (`2002:0808:0808::` → 8.8.8.8) and native public IPv6 stay allowed; RFC-1918 / CGNAT remain allowed by policy.

## Verification

- 6 must-block + 6 must-allow probes correct post-fix (verify-first: all 4 transition classes reproduced the bypass before).
- Sanitizer refactor is **behaviour-preserving** — 140 sanitize + egress tests unchanged & green.
- New tests: `test_egress.py` transition-block + public-transition-allow cases; `tests/unit/test_ip_transition.py` pins `embedded_ipv4s` directly. ruff clean.

Code + test only — no codec, no mesh (CODEC_BUG untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
