### PR TITLE
feat(api): Conc-F4 — intake cap on POST /backups (429 + Retry-After)

### DIFF
--- a/netcanon/api/routes/backups.py
+++ b/netcanon/api/routes/backups.py
@@ -68,7 +68,7 @@ from pydantic import SecretStr
 # The backup engine in :mod:`netcanon.services.backup_runner` calls it
 # back through this module, so tests still patch it at this import site.
 from ...collectors.base import get_collector  # noqa: F401  (mock-point seam)
-from ...config import MAX_BACKUP_CONCURRENCY
+from ...config import MAX_BACKUP_CONCURRENCY, MAX_PENDING_BACKUP_JOBS
 from ...definitions.loader import DefinitionLoader
 from ...definitions.schema import DeviceDefinition
 from ...models.backup import BackupJob, JobStatus
@@ -164,6 +164,13 @@ def _resolve_credentials(
                 "(NETCANON_BLOCK_PRIVATE_EGRESS)."
             )
         },
+        429: {
+            "description": (
+                "The in-flight backup-job intake cap "
+                "(NETCANON_MAX_PENDING_BACKUP_JOBS) is reached; retry once "
+                "running jobs complete (carries a Retry-After header)."
+            )
+        },
     },
 )
 def create_backup(
@@ -195,6 +202,10 @@ def create_backup(
 
     Raises:
         HTTPException 422: If any device ``type_key`` is not loaded.
+        HTTPException 429: If the in-flight job intake cap
+            (``NETCANON_MAX_PENDING_BACKUP_JOBS``) is reached.
+        HTTPException 400: If a device address is blocked by the egress
+            allow-list (only when ``block_private_egress`` is enabled).
     """
     unknown = [
         d.type_key for d in request_body.devices if d.type_key not in definitions
@@ -206,6 +217,32 @@ def create_backup(
                 f"Unknown type_key(s): {unknown}. "
                 f"Loaded definitions: {sorted(definitions.keys())}"
             ),
+        )
+
+    # Intake cap (HEAD-review Conc-F4): bound the number of in-flight
+    # (pending / running) jobs so a runaway client / retry loop can't pile up
+    # an unbounded executor queue — each entry pinning decrypted credentials
+    # in memory — plus unbounded non-terminal registry entries and pending
+    # JSON files.  Checked BEFORE credential resolution / egress DNS so a flood
+    # is shed cheaply.  Queueing UNDER the cap is still never a failure
+    # (#333/#334); only the flood beyond it gets back-pressure the caller can
+    # see and act on (429 + Retry-After).
+    active = jobs.active_job_count()
+    if active >= MAX_PENDING_BACKUP_JOBS:
+        logger.warning(
+            "Backup intake cap reached (%d in-flight >= %d); rejecting POST "
+            "/backups with 429",
+            active,
+            MAX_PENDING_BACKUP_JOBS,
+        )
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"Too many backup jobs in flight ({active} pending/running, "
+                f"cap {MAX_PENDING_BACKUP_JOBS}).  Retry once running jobs "
+                "complete, or raise NETCANON_MAX_PENDING_BACKUP_JOBS."
+            ),
+            headers={"Retry-After": "30"},
         )
 
     # Resolve any omitted credentials from the linked device profile,

--- a/netcanon/config.py
+++ b/netcanon/config.py
@@ -118,6 +118,50 @@ def _resolve_max_concurrent_backup_jobs() -> int:
 MAX_CONCURRENT_BACKUP_JOBS: int = _resolve_max_concurrent_backup_jobs()
 
 
+#: Intake cap on the number of *in-flight* (pending / running) backup jobs —
+#: the ceiling for POST /api/v1/backups (HEAD-review Conc-F4).  The per-job /
+#: global limiters above bound device fan-out and concurrent whole jobs, but
+#: nothing bounded the NUMBER of jobs a client could enqueue: a runaway retry
+#: loop could pile up an unbounded executor queue (each entry pinning decrypted
+#: credentials in memory), unbounded non-terminal registry entries, and
+#: unbounded ``pending`` JSON files.  Sized generously — comfortably above the
+#: 200-schedule cap plus manual headroom, at the registry's own 1000-job
+#: memory sizing (~5 MB of BackupJob) — so legitimate bursts never trip it;
+#: only a flood is shed with a 429 + Retry-After.  Queueing UNDER the cap is
+#: still never a failure (#333/#334).  Override via
+#: ``NETCANON_MAX_PENDING_BACKUP_JOBS``.
+_DEFAULT_MAX_PENDING_BACKUP_JOBS: int = 1000
+
+
+def _resolve_max_pending_backup_jobs() -> int:
+    """Read the in-flight backup-job intake cap from the environment.
+
+    Reads ``NETCANON_MAX_PENDING_BACKUP_JOBS``, falling back to
+    :data:`_DEFAULT_MAX_PENDING_BACKUP_JOBS` when unset or unparseable; floored
+    at 1 so at least one job can always be enqueued.
+    """
+    raw = os.environ.get("NETCANON_MAX_PENDING_BACKUP_JOBS")
+    if raw is None:
+        return _DEFAULT_MAX_PENDING_BACKUP_JOBS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        warnings.warn(
+            f"NETCANON_MAX_PENDING_BACKUP_JOBS={raw!r} is not an integer; "
+            f"falling back to {_DEFAULT_MAX_PENDING_BACKUP_JOBS}",
+            stacklevel=2,
+        )
+        return _DEFAULT_MAX_PENDING_BACKUP_JOBS
+
+
+#: Resolved at import.  The POST /backups route binds this via
+#: ``from ...config import MAX_PENDING_BACKUP_JOBS`` at ITS import time, so a
+#: test overriding the cap must monkeypatch the ROUTE module's binding
+#: (``netcanon.api.routes.backups.MAX_PENDING_BACKUP_JOBS``), not this one
+#: (mirrors the MAX_CONCURRENT_BACKUP_JOBS note above).
+MAX_PENDING_BACKUP_JOBS: int = _resolve_max_pending_backup_jobs()
+
+
 #: Default ceiling on a single ``POST /api/v1/sanitize`` upload (16 MiB).
 #: Network configs are well under a megabyte even for large chassis, so 16 MiB
 #: is generous headroom while still bounding the work an unauthenticated /

--- a/netcanon/storage/job_registry.py
+++ b/netcanon/storage/job_registry.py
@@ -301,6 +301,22 @@ class BackupJobRegistry:
 
     # ── Registry-specific surface ───────────────────────────────────
 
+    def active_job_count(self) -> int:
+        """Number of memory-resident NON-terminal (pending / running) jobs.
+
+        Non-terminal jobs are eviction-protected (they never leave the cache
+        until they terminalise — see ``_TERMINAL_STATUSES``), so every
+        in-flight job is always memory-resident: this is the EXACT in-flight
+        count, not a sample.  It is the basis for the POST /backups intake cap
+        (HEAD-review Conc-F4).  Counted under the lock so it is consistent
+        against concurrent create / status-update writes."""
+        with self._lock:
+            return sum(
+                1
+                for j in self._cache.values()
+                if j.status not in _TERMINAL_STATUSES
+            )
+
     def total_disk_count(self) -> int:
         """Total number of jobs persisted to disk.
 

--- a/tests/integration/test_backups_api.py
+++ b/tests/integration/test_backups_api.py
@@ -11,7 +11,12 @@ state without an explicit ``wait_for_job`` call.
 """
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from unittest.mock import patch
+
 import pytest
+
+from netcanon.models.backup import BackupJob, JobStatus
 
 pytestmark = pytest.mark.integration
 
@@ -55,9 +60,61 @@ def _post_and_get(client, devices: list[dict] | None = None) -> dict:
     return client.get(f"/api/v1/backups/{job_id}").json()
 
 
+def _inject_jobs(client, count: int, status: JobStatus) -> None:
+    """Insert *count* jobs of *status* directly into the app's registry."""
+    for i in range(count):
+        job_id = f"conc-f4-{status.value}-{i}"
+        client.app.state.jobs[job_id] = BackupJob(
+            id=job_id,
+            status=status,
+            created_at=datetime.now(UTC),
+            total_devices=1,
+        )
+
+
 # ---------------------------------------------------------------------------
 # POST /api/v1/backups
 # ---------------------------------------------------------------------------
+
+
+class TestIntakeCap:
+    """HEAD-review Conc-F4: POST /backups sheds a runaway intake flood with a
+    429 once the in-flight (pending/running) job count hits the cap."""
+
+    def test_rejects_with_429_at_cap(self, client):
+        with patch(
+            "netcanon.api.routes.backups.MAX_PENDING_BACKUP_JOBS", 2
+        ):
+            _inject_jobs(client, 2, JobStatus.pending)
+            resp = _post_backup(client)
+        assert resp.status_code == 429
+
+    def test_429_carries_retry_after_header(self, client):
+        with patch(
+            "netcanon.api.routes.backups.MAX_PENDING_BACKUP_JOBS", 2
+        ):
+            _inject_jobs(client, 2, JobStatus.running)
+            resp = _post_backup(client)
+        assert resp.status_code == 429
+        assert "retry-after" in {k.lower() for k in resp.headers}
+
+    def test_under_cap_still_accepts(self, client):
+        # 1 in-flight, cap 3 → the new job (making 2) is under the cap.
+        with patch(
+            "netcanon.api.routes.backups.MAX_PENDING_BACKUP_JOBS", 3
+        ):
+            _inject_jobs(client, 1, JobStatus.pending)
+            resp = _post_backup(client)
+        assert resp.status_code == 202
+
+    def test_terminal_jobs_do_not_count_toward_cap(self, client):
+        # 5 COMPLETED jobs resident, cap 2 → active count is 0, POST accepted.
+        with patch(
+            "netcanon.api.routes.backups.MAX_PENDING_BACKUP_JOBS", 2
+        ):
+            _inject_jobs(client, 5, JobStatus.completed)
+            resp = _post_backup(client)
+        assert resp.status_code == 202
 
 
 class TestCreateBackup:

--- a/tests/unit/test_backup_job_executor.py
+++ b/tests/unit/test_backup_job_executor.py
@@ -252,6 +252,37 @@ def test_env_override_garbage_falls_back_to_default(monkeypatch):
         assert config._resolve_max_concurrent_backup_jobs() == 8
 
 
+# ── Conc-F4 intake cap (NETCANON_MAX_PENDING_BACKUP_JOBS) ──
+
+
+def test_default_pending_jobs_cap_is_1000():
+    from netcanon import config
+
+    assert config.MAX_PENDING_BACKUP_JOBS == 1000
+
+
+def test_pending_env_override_sets_cap(monkeypatch):
+    from netcanon import config
+
+    monkeypatch.setenv("NETCANON_MAX_PENDING_BACKUP_JOBS", "250")
+    assert config._resolve_max_pending_backup_jobs() == 250
+
+
+def test_pending_env_override_floors_at_one(monkeypatch):
+    from netcanon import config
+
+    monkeypatch.setenv("NETCANON_MAX_PENDING_BACKUP_JOBS", "0")
+    assert config._resolve_max_pending_backup_jobs() == 1
+
+
+def test_pending_env_override_garbage_falls_back_to_default(monkeypatch):
+    from netcanon import config
+
+    monkeypatch.setenv("NETCANON_MAX_PENDING_BACKUP_JOBS", "not-a-number")
+    with pytest.warns(UserWarning):
+        assert config._resolve_max_pending_backup_jobs() == 1000
+
+
 def test_submit_retries_once_after_pool_shutdown(monkeypatch):
     """Submit-vs-reset race (HEAD-review F7): if ``_job_executor()`` hands back
     a pool that was shut down between resolution and ``.submit`` (``RuntimeError:

--- a/tests/unit/test_job_registry.py
+++ b/tests/unit/test_job_registry.py
@@ -473,3 +473,39 @@ class TestEdgeCases:
         path.write_text("not valid JSON")
         with pytest.raises(KeyError):
             _ = registry[job_id]
+
+
+class TestActiveJobCount:
+    """``active_job_count`` (Conc-F4) counts only NON-terminal residents."""
+
+    def test_counts_only_non_terminal(self, store: FileJobStore):
+        reg = BackupJobRegistry(store, max_memory_jobs=100, warm_cache=False)
+        for st in (JobStatus.pending, JobStatus.running):
+            j = _make_job(status=st)
+            reg[j.id] = j
+        for st in (
+            JobStatus.completed,
+            JobStatus.partial,
+            JobStatus.failed,
+        ):
+            j = _make_job(status=st)
+            reg[j.id] = j
+        # 2 non-terminal (pending + running) out of 5 resident.
+        assert reg.active_job_count() == 2
+
+    def test_zero_when_all_terminal(self, store: FileJobStore):
+        reg = BackupJobRegistry(store, max_memory_jobs=100, warm_cache=False)
+        j = _make_job(status=JobStatus.completed)
+        reg[j.id] = j
+        assert reg.active_job_count() == 0
+
+    def test_non_terminal_survive_cap_so_count_is_exact(
+        self, store: FileJobStore,
+    ):
+        """Non-terminal jobs are eviction-protected, so even over a tiny cap
+        every in-flight job stays resident and the count is exact."""
+        reg = BackupJobRegistry(store, max_memory_jobs=2, warm_cache=False)
+        for _ in range(5):
+            j = _make_job(status=JobStatus.running)
+            reg[j.id] = j
+        assert reg.active_job_count() == 5


### PR DESCRIPTION
## What

Resolves HEAD-review **Conc-F4**: `POST /api/v1/backups` had no in-flight cap. Schedules cap at 200 and device profiles at 1000, but a runaway client / retry loop POSTing 10k jobs piled up an **unbounded executor queue** (each entry pinning decrypted `SecretStr` credentials in memory), unbounded non-terminal registry entries, and unbounded `pending` JSON files — every POST returned 202, so the back-pressure was **invisible to the caller**.

## Behaviour

POST /backups now bounds the number of in-flight (pending / running) jobs. Once the count hits `MAX_PENDING_BACKUP_JOBS` (default **1000**, override `NETCANON_MAX_PENDING_BACKUP_JOBS`), it rejects with **429 Too Many Requests + a `Retry-After` header** — the honest signal for a *transient* overload the caller can act on. The check runs **before** credential resolution and egress DNS so a flood is shed cheaply.

This consciously refines the #333/#334 *"queueing is never a failure"* contract: queueing **under** the cap is still never a failure — only the flood **beyond** it is shed. The default sits at the registry's own memory sizing and comfortably above the 200-schedule cap + manual headroom, so legitimate bursts never trip it.

*(Response contract confirmed with the maintainer: 429 + Retry-After over 409/503.)*

## Implementation

- **`config.py`** — `MAX_PENDING_BACKUP_JOBS` via the existing `_resolve_*` env-int pattern (floor 1, warn-and-fallback on garbage).
- **`BackupJobRegistry.active_job_count()`** — counts memory-resident **non-terminal** jobs under the lock. Non-terminal jobs are eviction-protected (#25), so every in-flight job is always resident — this is the **exact** count, not a sample.
- **`create_backup`** — intake check → 429; the response is declared in the route's `responses={}` map (keeps the API-C4 AST guard green) + docstring.

## Verification

- **Intake-cap integration tests**: 429 at cap, `Retry-After` present, under-cap still 202, terminal jobs don't count toward the cap.
- **Registry unit tests**: `active_job_count` counts non-terminal only; exact even over a tiny cap (eviction-protected).
- **Config resolve unit tests**: default 1000 / env override / floor-at-1 / garbage-fallback.
- API-C4 AST guard green (429 declared); full backups + robustness suites green; ruff clean.

Route + model only — no codec, no mesh (CODEC_BUG untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
