### PR TITLE
feat(ui): adopt unified design language (ui-design-spec v0.2.1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@
 # handling (CHANGELOG.md is intentionally CRLF).
 requirements.lock text eol=lf
 /tools/gen_requirements_lock.sh text eol=lf
+# Vendored unified-UI files are byte-pinned to a spec-repo tag by sha256
+# (see netcanon/templates/_vendor/README.md).  Any EOL rewrite breaks the
+# pin, so exempt them from text normalization entirely.
+/netcanon/templates/_vendor/* -text

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -703,13 +703,16 @@ the source of truth):
   follow the renamed record.  Collisions merge on first-wins
   (auth/priv keys are NEVER combined across users).
 * **theme-toggle.js** — global light/dark mode toggle wired to
-  the `nav-theme-toggle` button.  Flips `<html data-theme>`
-  between `light`/`dark`, persists to
-  `localStorage["netcanon.theme.v1"]`, updates `aria-label` +
-  `aria-pressed` to reflect the next-action.  The inline boot
-  script in `base.html`'s `<head>` (NOT this partial) sets the
-  initial theme synchronously before CSS parses — required for
-  FOUC prevention.
+  the `nav-theme-toggle` button.  Calls `NcTheme.set(null, mode)`
+  (from the vendored `_vendor/theme-picker.js`), which flips
+  `<html data-nc-mode>` between `light`/`dark` and persists to
+  `localStorage["nc-mode"]`; also mirrors the value one-way into
+  the legacy `localStorage["netcanon.theme.v1"]` key so the
+  self-contained `/docs` theme copy follows.  Updates `aria-label`
+  + `aria-pressed` to reflect the next-action.  The vendored
+  theme-picker include in `base.html`'s `<head>` (NOT this
+  partial) applies the persisted theme synchronously before CSS
+  parses — required for FOUC prevention.
 
 **Why include-splice rather than ES-modules?** The templates embed
 inline `<script>` blocks that share lexical scope with the rest of the
@@ -725,43 +728,55 @@ element in every template — including content generated inside
 partials — carries a `data-testid` attribute.  The full inventory
 lives in [`tests/testid_reference.md`](tests/testid_reference.md).
 
-**Theming (dark mode).**  The app supports light + dark modes via
-CSS custom properties toggled on `<html data-theme>`.  One source
-of truth: the `:root` block in `base.html` defines light-mode
-tokens; the `[data-theme="dark"]` selector overrides the same
-names with dark-mode values.  All themed CSS declarations use
-`var(--token)` — never raw hex.  Tokens are curated for the
-80/20 high-visibility surfaces (page / surface / text / border /
-badges / buttons / nav); incremental migration of edge-case
-declarations is tolerated.
+**Theming (unified design language).**  The app's palette + mode
+ship from the vendored netcanon-dev/ui-design-spec deliverable
+(pinned tag + checksums in `netcanon/templates/_vendor/README.md`).
+Three layers, all Jinja-inlined by `base.html`:
 
-Three rules keep the pattern robust:
+1. `_vendor/netcanon-ui.css` — the unified `--nc-*` tokens: ten
+   palettes selected by `<html data-nc-theme>` (netcanon defaults
+   to `indigo`), light/dark forced by `<html data-nc-mode>`, and
+   an absent `data-nc-mode` = follow the OS via
+   `prefers-color-scheme`.
+2. `_vendor/compat-netcanon.css` — the compat shim: remaps the
+   legacy `--page-bg`/`--surface`/… var names onto `--nc-*` under
+   `:root[data-nc-theme]`, which outranks the legacy `:root` and
+   `[data-theme="dark"]` blocks still present (inert) in
+   `base.html`.  Every themed declaration keeps using
+   `var(--token)` — never raw hex — and re-themes through the
+   shim without a rewrite.
+3. `_vendor/theme-picker.js` — the `NcTheme` runtime.  Its boot
+   applies persisted `localStorage["nc-theme"]`/`["nc-mode"]`
+   prefs to `<html>` synchronously in `<head>` before CSS parses
+   (FOUC prevention — do NOT move it to an external
+   `<script src=>`; it must block).  A tiny inline snippet just
+   before it migrates a pre-unification
+   `localStorage["netcanon.theme.v1"]` value into `nc-mode` once.
 
-1. **Inline boot script, blocking, in `<head>`.**  The tiny IIFE
-   in `base.html`'s `<head>` reads `localStorage["netcanon.theme.v1"]`
-   (user override) then falls back to `prefers-color-scheme` and
-   sets the `data-theme` attribute on `documentElement`
-   *synchronously* before any CSS parses.  This prevents FOUC
-   (flash of unstyled content) on reload.  Do NOT move the boot
-   script to an external `<script src=>`; it must block.
-2. **JS-driven theme apply, not `@media (prefers-color-scheme)`.**
-   One `[data-theme]` selector is the sole theme gate; the media
-   query is read ONCE by the boot script, not by CSS.  This
-   lets localStorage cleanly override the system preference
-   without duplicated rule blocks or cascade-order headaches.
+Rules that keep the pattern robust:
+
+1. **Never edit `_vendor/` files by hand** — they are byte-pinned
+   to a spec-repo tag by sha256 (`_vendor/README.md`); re-vendor
+   at a newer tag to change them.
+2. **New CSS uses `var(--token)`** — legacy names still resolve
+   through the shim; new code may reference `--nc-*` directly.
 3. **Theme-aware toast/alert colour pairs via CSS class, never
    inline style.**  `showToast()` assigns a CSS class
    (`.toast-info` / `.toast-error` / `.toast-success`) instead
    of writing `element.style.background = '#...'` — the class
    resolves to `var(--badge-*-bg)` / `var(--badge-*-fg)` so
    dark mode inherits the semantic pair automatically.
+4. **The `<pre>` code wells stay fixed-dark in both modes** — the
+   `tok-*` syntax-highlight palette is hardcoded for a dark well;
+   var-izing it is a follow-up (see the shim's header comment).
 
 The global toggle is a single icon button
 (`data-testid="nav-theme-toggle"`) right-aligned on the nav; sun
-glyph in dark mode, moon glyph in light mode, swap via CSS
-attribute-selectors so JS never mutates the button content.  See
-`_partials/theme-toggle.js` for the toggle function +
-`aria-label` updater.
+glyph in dark mode, moon glyph in light mode, swap via CSS keyed
+on `data-nc-mode` (plus a `prefers-color-scheme` fallback pair
+for the no-attribute "auto" state) so JS never mutates the button
+content.  See `_partials/theme-toggle.js` for the toggle function
++ `aria-label` updater.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,36 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Changed
+
+- **Unified design language adopted** (netcanon-dev/ui-design-spec tag
+  `v0.2.1`, commit `1c4af329`).  Why: netcanon's hand-rolled two-theme
+  var set drifts from the org look with every tweak; vendoring the
+  spec's drop-in deliverable makes the palette/mode a runtime user
+  setting shared across netcanon-dev projects while leaving every
+  template's `var(--…)` reference untouched.  Three files are
+  byte-pinned (sha256) under `netcanon/templates/_vendor/` and
+  Jinja-inlined by `base.html` exactly like the `_partials`:
+  `netcanon-ui.css` (the `--nc-*` tokens — ten palettes ×
+  light/dark/auto via `data-nc-theme`/`data-nc-mode`),
+  `theme-picker.js` (the `NcTheme` runtime; owns persistence in
+  `localStorage["nc-mode"]`/`["nc-theme"]`), and
+  `compat-netcanon.css` (remaps the legacy `--page-bg`/`--surface`/…
+  vars onto `--nc-*`).  Default palette: `indigo`; light + dark +
+  follow-the-OS all remain available.  The nav sun/moon toggle now
+  drives `NcTheme.set(null, mode)` (`<html data-nc-mode>`) instead of
+  the old plain `data-theme` attribute; a one-time boot snippet
+  migrates a previously persisted `localStorage["netcanon.theme.v1"]`
+  into `nc-mode`, and the toggle still mirrors its choice one-way
+  into the legacy key so the self-contained `/docs` theme copy stays
+  in step.  Visible changes: the nav is now the unified surface-toned
+  app bar (no longer fixed navy), accents/badges/focus rings take
+  unified values, and the `<pre>` code wells deliberately keep the
+  fixed VS Code Dark+ palette in both modes.  Follow-ups (tracked in
+  ARCHITECTURE.md/the migration plan): delete the now-inert legacy
+  var blocks, var-ize the `tok-*` syntax palette, migrate `/docs` and
+  `migrate.html`'s hardcoded chrome, surface `<nc-theme-picker>`.
+
 ## [0.6.0] - 2026-07-16
 
 Two threads land together here: the **codec promotion wave** (#344–#356) that

--- a/netcanon/templates/_partials/theme-toggle.js
+++ b/netcanon/templates/_partials/theme-toggle.js
@@ -1,26 +1,43 @@
 /* ── Theme toggle ── */
-/* Flips the document `data-theme` attribute between "light" and
-   "dark", persists the choice to
-   localStorage["netcanon.theme.v1"], and updates the toggle's
-   aria-label so screen readers announce the correct next-action.
-   The icon glyph itself swaps via CSS attribute-selector rules —
-   no DOM mutation of the button contents.
+/* Flips the unified UI mode between "light" and "dark" via
+   NcTheme.set(null, mode) — NcTheme is defined by the vendored
+   _vendor/theme-picker.js include in base.html's <head>.  NcTheme
+   owns persistence (localStorage["nc-mode"]) and the
+   <html data-nc-mode> attribute; the icon glyph swaps via CSS
+   keyed on that attribute (absent attribute = follow the OS —
+   see base.html).
 
-   The initial theme was ALREADY set by the inline boot script in
-   <head> (see base.html).  That boot script runs before CSS
-   applies, preventing FOUC.  This function only handles
-   user-initiated toggles thereafter. */
+   The initial theme/mode was ALREADY applied by NcTheme.boot()
+   inside the vendored include.  It runs synchronously in <head>
+   before CSS applies, preventing FOUC.  This function only
+   handles user-initiated toggles thereafter.
+
+   The legacy localStorage["netcanon.theme.v1"] key is still
+   WRITTEN (one-way mirror) so the self-contained /docs page —
+   which keeps its own pre-unification theme copy — follows the
+   mode chosen here.  This page no longer READS the legacy key
+   (a one-time snippet in <head> migrated it into "nc-mode"). */
+
+/* Effective mode: the forced <html data-nc-mode> when present,
+   otherwise the OS preference — mirrors how the vendored CSS
+   resolves the "auto" state. */
+function _effectiveMode() {
+  var forced = document.documentElement.getAttribute('data-nc-mode');
+  if (forced === 'dark' || forced === 'light') return forced;
+  return (window.matchMedia &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches)
+    ? 'dark' : 'light';
+}
+
 function toggleTheme() {
-  var html = document.documentElement;
-  var current = html.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
-  var next = current === 'dark' ? 'light' : 'dark';
-  html.setAttribute('data-theme', next);
+  var next = _effectiveMode() === 'dark' ? 'light' : 'dark';
+  NcTheme.set(null, next);
   try {
     localStorage.setItem('netcanon.theme.v1', next);
   } catch (_) {
     /* Sandboxed iframes / privacy-mode browsers may deny
-       localStorage; the toggle still works for the session, it
-       just won't persist across reloads. */
+       localStorage; NcTheme.set already applied the mode for this
+       session, the mirror just won't reach the /docs page. */
   }
   _updateThemeToggleAriaLabel(next);
 }
@@ -42,10 +59,9 @@ function _updateThemeToggleAriaLabel(activeTheme) {
   );
 }
 
-/* Initialise aria-label on DOMContentLoaded.  The boot script
-   set `data-theme` before the DOM existed, so we re-read it here
-   and seed the button's aria state to match. */
+/* Initialise aria-label on DOMContentLoaded.  NcTheme.boot() set
+   the mode attributes before the DOM existed, so we resolve the
+   effective mode here and seed the button's aria state to match. */
 document.addEventListener('DOMContentLoaded', function() {
-  var current = document.documentElement.getAttribute('data-theme');
-  _updateThemeToggleAriaLabel(current === 'dark' ? 'dark' : 'light');
+  _updateThemeToggleAriaLabel(_effectiveMode());
 });

--- a/netcanon/templates/_vendor/README.md
+++ b/netcanon/templates/_vendor/README.md
@@ -1,0 +1,29 @@
+# _vendor/ — pinned drop-in from netcanon-dev/ui-design-spec
+
+Vendored, byte-pinned copies of the unified UI deliverable.  **Never edit these
+files by hand** — they are generated in the spec repo and pinned here by sha256;
+to change anything, bump the pin to a newer spec tag and re-copy.
+
+| File | Source (in spec repo) | sha256 |
+|---|---|---|
+| `netcanon-ui.css` | `dist/netcanon-ui.css` | `0cc326194373fa6ba8d19a281e0946043a6c056a1dbe9b6ec9bbd0940fe40e68` |
+| `theme-picker.js` | `dist/theme-picker.js` | `eb49114e4e921abb749490400d3085af93d86042f0f135031214c8bfe4bc69a8` |
+| `compat-netcanon.css` | `dist/compat/netcanon.css` | `25e9bd3876a1263ca088a61eff427a4c347ff7aee829767b68761f018463c362` |
+
+**Pinned tag:** `v0.2.1` (peels to commit `1c4af32911e0ddc370a4a3049112adb4e35e8f7f`
+via `git rev-parse 'v0.2.1^{commit}'`) of netcanon-dev/ui-design-spec.
+
+These files are Jinja-`{% include %}`d inline by `templates/base.html` (same
+mechanism as `_partials/*.js` — netcanon serves no static files).  They contain
+no Jinja delimiters, so the include splices them verbatim.  A `.gitattributes`
+rule (`/netcanon/templates/_vendor/* -text`) exempts them from EOL conversion so
+the checksums above stay true on every checkout.
+
+To re-vendor at a newer tag:
+
+    git -C <spec-repo> show <tag>:dist/netcanon-ui.css     > netcanon-ui.css
+    git -C <spec-repo> show <tag>:dist/theme-picker.js     > theme-picker.js
+    git -C <spec-repo> show <tag>:dist/compat/netcanon.css > compat-netcanon.css
+
+then update this README's tag + sha256 table (and the CHANGELOG) in the same
+commit.  See `dist/README.md` in the spec repo for the integration model.

--- a/netcanon/templates/_vendor/compat-netcanon.css
+++ b/netcanon/templates/_vendor/compat-netcanon.css
@@ -1,0 +1,70 @@
+/* compat/netcanon.css — remaps netcanon's ~40 base.html vars onto the unified nc-* tokens.
+   Include AFTER netcanon-ui.css. `:root[data-nc-theme]` outranks netcanon's `:root` AND its
+   `[data-theme="dark|light"]` overrides, so both of its hand-rolled themes are superseded.
+   Notes:
+   - netcanon's own theming writes data-theme="dark|light" on <html>; the unified system uses
+     the NAMESPACED data-nc-theme / data-nc-mode, so nothing collides. Its old toggle now flips
+     dead vars — rewire it to NcTheme.set(null, "light"|"dark"|"auto") or replace it with
+     <nc-theme-picker>, and remove its boot script when convenient.
+   - The navy inverse nav becomes a unified surface-toned app bar in both modes (this is the
+     shared silhouette; delete netcanon's own dark-mode nav overrides when convenient).
+   - The eight Bootstrap badge bg/fg pairs collapse into feedback-tint rules.
+   - The <pre> code wells stay the fixed VS Code Dark+ palette in BOTH modes: netcanon's
+     syntax-highlight .tok-* colors (#569cd6, #ce9178, …) are hardcoded for a dark well and
+     would be illegible on a light background. Migrate the tok-* palette to vars before
+     making the wells mode-aware.
+   Source var inventory: netcanon/templates/base.html (baselines/netcanon.md). */
+:root[data-nc-theme] {
+  --page-bg: var(--nc-bg);
+  --surface: var(--nc-surface);
+  --surface-alt: var(--nc-surface);
+  --surface-elev: var(--nc-surface-2);
+  --surface-hover: var(--nc-surface-2);
+  --text-primary: var(--nc-text);
+  --text-muted: var(--nc-text-muted);
+  --text-faint: var(--nc-text-faint);
+  --border: var(--nc-border);
+  --border-strong: var(--nc-border-strong);
+
+  --nav-bg: var(--nc-surface);
+  --nav-fg: var(--nc-text-muted);
+  --nav-fg-hover: var(--nc-text);
+  --nav-accent: var(--nc-accent);
+  --nav-accent-hov: var(--nc-accent);
+
+  --accent: var(--nc-accent);
+  --focus-ring: var(--nc-focus);
+
+  --btn-primary-bg: var(--nc-accent-emphasis);
+  --btn-primary-fg: var(--nc-on-accent);
+  --btn-primary-bg-hover: var(--nc-accent-hover);
+  --btn-secondary-bg: var(--nc-surface-2);
+  --btn-secondary-fg: var(--nc-text);
+  --btn-secondary-bg-hover: var(--nc-border);
+  --btn-danger-bg: var(--nc-danger-emphasis);
+  --btn-danger-bg-hover: color-mix(in srgb, var(--nc-danger-emphasis) 85%, #000);
+  /* missed by the original baseline capture (2026-07-12 re-audit): white is AA on both
+     unified danger fills (5.36:1 light / 4.61:1 dark) */
+  --btn-danger-fg: #ffffff;
+
+  --badge-pending-bg: rgba(var(--nc-muted-rgb), .15);
+  --badge-pending-fg: var(--nc-text-muted);
+  --badge-failed-bg: rgba(var(--nc-danger-rgb), .15);
+  --badge-failed-fg: var(--nc-danger);
+  --badge-running-bg: rgba(var(--nc-warn-rgb), .15);
+  --badge-running-fg: var(--nc-warn);
+  --badge-completed-bg: rgba(var(--nc-ok-rgb), .15);
+  --badge-completed-fg: var(--nc-ok);
+  --badge-partial-bg: rgba(var(--nc-warn-rgb), .22);
+  --badge-partial-fg: var(--nc-warn);
+  --alert-info-bg: rgba(var(--nc-accent-rgb), .12);
+  --alert-info-fg: var(--nc-accent);
+
+  /* fixed dark well (netcanon's original values) — see header note on the tok-* palette */
+  --pre-bg: #1e1e1e;
+  --pre-fg: #d4d4d4;
+
+  --shadow-card: var(--nc-shadow-sm);
+  --shadow-lift: var(--nc-shadow-md);
+  --shadow-modal: var(--nc-shadow-lg);
+}

--- a/netcanon/templates/_vendor/netcanon-ui.css
+++ b/netcanon/templates/_vendor/netcanon-ui.css
@@ -1,0 +1,674 @@
+/* netcanon-ui.css — GENERATED from tokens/ by tools/build_css.py. DO NOT EDIT BY HAND.
+   Source of truth: netcanon-dev/ui-design-spec tokens/*.json (pin a tagged version).
+   Usage: <html data-nc-theme="ocean" data-nc-mode="dark|light">  (omit data-nc-mode for auto).
+   Attributes are nc-namespaced so existing apps' own data-theme usage cannot collide. */
+
+:root {
+  --nc-font: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --nc-mono: ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
+  --nc-fs-xs: 11px;
+  --nc-fs-sm: 12px;
+  --nc-fs-base: 14px;
+  --nc-fs-md: 15px;
+  --nc-fs-lg: 18px;
+  --nc-fs-xl: 22px;
+  --nc-fs-2xl: 28px;
+  --nc-fw-regular: 400;
+  --nc-fw-medium: 500;
+  --nc-fw-semibold: 600;
+  --nc-fw-bold: 700;
+  --nc-lh-tight: 1.2;
+  --nc-lh-base: 1.5;
+  --nc-lh-relaxed: 1.7;
+  --nc-space-0: 0px;
+  --nc-space-1: 2px;
+  --nc-space-2: 4px;
+  --nc-space-3: 8px;
+  --nc-space-4: 12px;
+  --nc-space-5: 16px;
+  --nc-space-6: 20px;
+  --nc-space-7: 24px;
+  --nc-space-8: 32px;
+  --nc-space-9: 40px;
+  --nc-space-10: 48px;
+  --nc-space-11: 64px;
+  --nc-r-xs: 3px;
+  --nc-r-sm: 4px;
+  --nc-r-md: 6px;
+  --nc-r-lg: 8px;
+  --nc-r-xl: 12px;
+  --nc-r-full: 9999px;
+  --nc-dur-fast: 120ms;
+  --nc-dur-base: 200ms;
+  --nc-dur-slow: 320ms;
+  --nc-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --nc-ease-decelerate: cubic-bezier(0, 0, 0, 1);
+  --nc-ease-accelerate: cubic-bezier(0.3, 0, 1, 1);
+  --nc-gradient: linear-gradient(135deg, var(--nc-grad-a), var(--nc-grad-b));
+  --nc-focus: var(--nc-accent);
+  --nc-bg: #ffffff;
+  --nc-surface: #f6f8fa;
+  --nc-surface-2: #ebeff3;
+  --nc-bg-inverse: #0d1117;
+  --nc-scrim: rgba(15,23,42,.35);
+  --nc-text: #1f2328;
+  --nc-text-muted: #656d76;
+  --nc-text-faint: #6e6e6e;
+  --nc-text-inverse: #ffffff;
+  --nc-border: #d0d7de;
+  --nc-border-strong: #afb8c1;
+  --nc-ok: #1a7f37;
+  --nc-warn: #9a6700;
+  --nc-danger: #cf222e;
+  --nc-ok-emphasis: #1a7f37;
+  --nc-warn-emphasis: #9a6700;
+  --nc-danger-emphasis: #cf222e;
+  --nc-ok-rgb: 26,127,55;
+  --nc-warn-rgb: 154,103,0;
+  --nc-danger-rgb: 207,34,46;
+  --nc-muted-rgb: 101,109,118;
+  --nc-shadow-sm: 0 1px 3px rgba(0,0,0,.1);
+  --nc-shadow-md: 0 4px 18px rgba(15,23,42,.08);
+  --nc-shadow-lg: 0 20px 50px rgba(15,23,42,.18);
+  --nc-accent: #0969da;
+  --nc-accent-emphasis: #0969da;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #0860ca;
+  --nc-accent-rgb: 9,105,218;
+  --nc-grad-a: #0969da;
+  --nc-grad-b: #1b7c83;
+  --nc-grad-a-rgb: 9,105,218;
+  --nc-grad-b-rgb: 27,124,131;
+}
+
+[data-nc-mode="dark"] {
+  --nc-bg: #0d1117;
+  --nc-surface: #161b22;
+  --nc-surface-2: #1c2330;
+  --nc-bg-inverse: #e6edf3;
+  --nc-scrim: rgba(0,0,0,.6);
+  --nc-text: #e6edf3;
+  --nc-text-muted: #8b949e;
+  --nc-text-faint: #7d8590;
+  --nc-text-inverse: #0d1117;
+  --nc-border: #30363d;
+  --nc-border-strong: #444c56;
+  --nc-ok: #3fb950;
+  --nc-warn: #d29922;
+  --nc-danger: #f85149;
+  --nc-ok-emphasis: #238636;
+  --nc-warn-emphasis: #9e6a03;
+  --nc-danger-emphasis: #da3633;
+  --nc-ok-rgb: 63,185,80;
+  --nc-warn-rgb: 210,153,34;
+  --nc-danger-rgb: 248,81,73;
+  --nc-muted-rgb: 139,148,158;
+  --nc-shadow-sm: 0 1px 3px rgba(0,0,0,.4);
+  --nc-shadow-md: 0 4px 20px rgba(0,0,0,.3);
+  --nc-shadow-lg: 0 20px 60px rgba(0,0,0,.5);
+  --nc-accent: #4493f8;
+  --nc-accent-emphasis: #1f6feb;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #1a5fd0;
+  --nc-accent-rgb: 68,147,248;
+  --nc-grad-a: #1f6feb;
+  --nc-grad-b: #39c5cf;
+  --nc-grad-a-rgb: 31,111,235;
+  --nc-grad-b-rgb: 57,197,207;
+}
+
+[data-nc-theme="ocean"] {
+  --nc-accent: #0969da;
+  --nc-accent-emphasis: #0969da;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #0860ca;
+  --nc-accent-rgb: 9,105,218;
+  --nc-grad-a: #0969da;
+  --nc-grad-b: #1b7c83;
+  --nc-grad-a-rgb: 9,105,218;
+  --nc-grad-b-rgb: 27,124,131;
+}
+[data-nc-mode="dark"][data-nc-theme="ocean"] {
+  --nc-accent: #4493f8;
+  --nc-accent-emphasis: #1f6feb;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #1a5fd0;
+  --nc-accent-rgb: 68,147,248;
+  --nc-grad-a: #1f6feb;
+  --nc-grad-b: #39c5cf;
+  --nc-grad-a-rgb: 31,111,235;
+  --nc-grad-b-rgb: 57,197,207;
+}
+
+[data-nc-theme="indigo"] {
+  --nc-accent: #4f46e5;
+  --nc-accent-emphasis: #4f46e5;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #4338ca;
+  --nc-accent-rgb: 79,70,229;
+  --nc-grad-a: #4f46e5;
+  --nc-grad-b: #7c3aed;
+  --nc-grad-a-rgb: 79,70,229;
+  --nc-grad-b-rgb: 124,58,237;
+}
+[data-nc-mode="dark"][data-nc-theme="indigo"] {
+  --nc-accent: #818cf8;
+  --nc-accent-emphasis: #4f46e5;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #4338ca;
+  --nc-accent-rgb: 129,140,248;
+  --nc-grad-a: #6366f1;
+  --nc-grad-b: #a78bfa;
+  --nc-grad-a-rgb: 99,102,241;
+  --nc-grad-b-rgb: 167,139,250;
+}
+
+[data-nc-theme="lagoon"] {
+  --nc-accent: #1b7c83;
+  --nc-accent-emphasis: #1b7c83;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #136c72;
+  --nc-accent-rgb: 27,124,131;
+  --nc-grad-a: #1b7c83;
+  --nc-grad-b: #0969da;
+  --nc-grad-a-rgb: 27,124,131;
+  --nc-grad-b-rgb: 9,105,218;
+}
+[data-nc-mode="dark"][data-nc-theme="lagoon"] {
+  --nc-accent: #39c5cf;
+  --nc-accent-emphasis: #1b7c83;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #14646a;
+  --nc-accent-rgb: 57,197,207;
+  --nc-grad-a: #39c5cf;
+  --nc-grad-b: #2f81f7;
+  --nc-grad-a-rgb: 57,197,207;
+  --nc-grad-b-rgb: 47,129,247;
+}
+
+[data-nc-theme="verdant"] {
+  --nc-accent: #047857;
+  --nc-accent-emphasis: #047857;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #065f46;
+  --nc-accent-rgb: 4,120,87;
+  --nc-grad-a: #047857;
+  --nc-grad-b: #0369a1;
+  --nc-grad-a-rgb: 4,120,87;
+  --nc-grad-b-rgb: 3,105,161;
+}
+[data-nc-mode="dark"][data-nc-theme="verdant"] {
+  --nc-accent: #00e5a0;
+  --nc-accent-emphasis: #00e5a0;
+  --nc-on-accent: #06121f;
+  --nc-accent-hover: #2df0b2;
+  --nc-accent-rgb: 0,229,160;
+  --nc-grad-a: #00e5a0;
+  --nc-grad-b: #0ea5e9;
+  --nc-grad-a-rgb: 0,229,160;
+  --nc-grad-b-rgb: 14,165,233;
+}
+
+[data-nc-theme="violet"] {
+  --nc-accent: #8250df;
+  --nc-accent-emphasis: #8250df;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #6639ba;
+  --nc-accent-rgb: 130,80,223;
+  --nc-grad-a: #8250df;
+  --nc-grad-b: #bf3989;
+  --nc-grad-a-rgb: 130,80,223;
+  --nc-grad-b-rgb: 191,57,137;
+}
+[data-nc-mode="dark"][data-nc-theme="violet"] {
+  --nc-accent: #a371f7;
+  --nc-accent-emphasis: #8957e5;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #7645d3;
+  --nc-accent-rgb: 163,113,247;
+  --nc-grad-a: #a371f7;
+  --nc-grad-b: #f778ba;
+  --nc-grad-a-rgb: 163,113,247;
+  --nc-grad-b-rgb: 247,120,186;
+}
+
+[data-nc-theme="rose"] {
+  --nc-accent: #bf3989;
+  --nc-accent-emphasis: #bf3989;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #99286e;
+  --nc-accent-rgb: 191,57,137;
+  --nc-grad-a: #bf3989;
+  --nc-grad-b: #8250df;
+  --nc-grad-a-rgb: 191,57,137;
+  --nc-grad-b-rgb: 130,80,223;
+}
+[data-nc-mode="dark"][data-nc-theme="rose"] {
+  --nc-accent: #f778ba;
+  --nc-accent-emphasis: #bf3989;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #a63180;
+  --nc-accent-rgb: 247,120,186;
+  --nc-grad-a: #f778ba;
+  --nc-grad-b: #a371f7;
+  --nc-grad-a-rgb: 247,120,186;
+  --nc-grad-b-rgb: 163,113,247;
+}
+
+[data-nc-theme="ember"] {
+  --nc-accent: #bc4c00;
+  --nc-accent-emphasis: #bc4c00;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #9b3d00;
+  --nc-accent-rgb: 188,76,0;
+  --nc-grad-a: #bc4c00;
+  --nc-grad-b: #bf3989;
+  --nc-grad-a-rgb: 188,76,0;
+  --nc-grad-b-rgb: 191,57,137;
+}
+[data-nc-mode="dark"][data-nc-theme="ember"] {
+  --nc-accent: #f0883e;
+  --nc-accent-emphasis: #bc4c00;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #a04100;
+  --nc-accent-rgb: 240,136,62;
+  --nc-grad-a: #f0883e;
+  --nc-grad-b: #f778ba;
+  --nc-grad-a-rgb: 240,136,62;
+  --nc-grad-b-rgb: 247,120,186;
+}
+
+[data-nc-theme="gold"] {
+  --nc-accent: #9a6700;
+  --nc-accent-emphasis: #9a6700;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #7d5300;
+  --nc-accent-rgb: 154,103,0;
+  --nc-grad-a: #9a6700;
+  --nc-grad-b: #bc4c00;
+  --nc-grad-a-rgb: 154,103,0;
+  --nc-grad-b-rgb: 188,76,0;
+}
+[data-nc-mode="dark"][data-nc-theme="gold"] {
+  --nc-accent: #e3b341;
+  --nc-accent-emphasis: #e3b341;
+  --nc-on-accent: #231b00;
+  --nc-accent-hover: #eac55f;
+  --nc-accent-rgb: 227,179,65;
+  --nc-grad-a: #e3b341;
+  --nc-grad-b: #f0883e;
+  --nc-grad-a-rgb: 227,179,65;
+  --nc-grad-b-rgb: 240,136,62;
+}
+
+[data-nc-theme="graphite"] {
+  --nc-accent: #57606a;
+  --nc-accent-emphasis: #57606a;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #424a53;
+  --nc-accent-rgb: 87,96,106;
+  --nc-grad-a: #57606a;
+  --nc-grad-b: #768390;
+  --nc-grad-a-rgb: 87,96,106;
+  --nc-grad-b-rgb: 118,131,144;
+}
+[data-nc-mode="dark"][data-nc-theme="graphite"] {
+  --nc-accent: #9ea7b3;
+  --nc-accent-emphasis: #5d6773;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #4d545e;
+  --nc-accent-rgb: 158,167,179;
+  --nc-grad-a: #768390;
+  --nc-grad-b: #9ea7b3;
+  --nc-grad-a-rgb: 118,131,144;
+  --nc-grad-b-rgb: 158,167,179;
+}
+
+[data-nc-theme="aurora"] {
+  --nc-accent: #6741d9;
+  --nc-accent-emphasis: #6741d9;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #5330b0;
+  --nc-accent-rgb: 103,65,217;
+  --nc-grad-a: #6741d9;
+  --nc-grad-b: #047857;
+  --nc-grad-a-rgb: 103,65,217;
+  --nc-grad-b-rgb: 4,120,87;
+}
+[data-nc-mode="dark"][data-nc-theme="aurora"] {
+  --nc-accent: #a78bfa;
+  --nc-accent-emphasis: #7452e0;
+  --nc-on-accent: #ffffff;
+  --nc-accent-hover: #6039cc;
+  --nc-accent-rgb: 167,139,250;
+  --nc-grad-a: #7c5cf0;
+  --nc-grad-b: #00e5a0;
+  --nc-grad-a-rgb: 124,92,240;
+  --nc-grad-b-rgb: 0,229,160;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-nc-mode="light"]) {
+    --nc-bg: #0d1117;
+    --nc-surface: #161b22;
+    --nc-surface-2: #1c2330;
+    --nc-bg-inverse: #e6edf3;
+    --nc-scrim: rgba(0,0,0,.6);
+    --nc-text: #e6edf3;
+    --nc-text-muted: #8b949e;
+    --nc-text-faint: #7d8590;
+    --nc-text-inverse: #0d1117;
+    --nc-border: #30363d;
+    --nc-border-strong: #444c56;
+    --nc-ok: #3fb950;
+    --nc-warn: #d29922;
+    --nc-danger: #f85149;
+    --nc-ok-emphasis: #238636;
+    --nc-warn-emphasis: #9e6a03;
+    --nc-danger-emphasis: #da3633;
+    --nc-ok-rgb: 63,185,80;
+    --nc-warn-rgb: 210,153,34;
+    --nc-danger-rgb: 248,81,73;
+    --nc-muted-rgb: 139,148,158;
+    --nc-shadow-sm: 0 1px 3px rgba(0,0,0,.4);
+    --nc-shadow-md: 0 4px 20px rgba(0,0,0,.3);
+    --nc-shadow-lg: 0 20px 60px rgba(0,0,0,.5);
+    --nc-accent: #4493f8;
+    --nc-accent-emphasis: #1f6feb;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #1a5fd0;
+    --nc-accent-rgb: 68,147,248;
+    --nc-grad-a: #1f6feb;
+    --nc-grad-b: #39c5cf;
+    --nc-grad-a-rgb: 31,111,235;
+    --nc-grad-b-rgb: 57,197,207;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="ocean"] {
+    --nc-accent: #4493f8;
+    --nc-accent-emphasis: #1f6feb;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #1a5fd0;
+    --nc-accent-rgb: 68,147,248;
+    --nc-grad-a: #1f6feb;
+    --nc-grad-b: #39c5cf;
+    --nc-grad-a-rgb: 31,111,235;
+    --nc-grad-b-rgb: 57,197,207;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="indigo"] {
+    --nc-accent: #818cf8;
+    --nc-accent-emphasis: #4f46e5;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #4338ca;
+    --nc-accent-rgb: 129,140,248;
+    --nc-grad-a: #6366f1;
+    --nc-grad-b: #a78bfa;
+    --nc-grad-a-rgb: 99,102,241;
+    --nc-grad-b-rgb: 167,139,250;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="lagoon"] {
+    --nc-accent: #39c5cf;
+    --nc-accent-emphasis: #1b7c83;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #14646a;
+    --nc-accent-rgb: 57,197,207;
+    --nc-grad-a: #39c5cf;
+    --nc-grad-b: #2f81f7;
+    --nc-grad-a-rgb: 57,197,207;
+    --nc-grad-b-rgb: 47,129,247;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="verdant"] {
+    --nc-accent: #00e5a0;
+    --nc-accent-emphasis: #00e5a0;
+    --nc-on-accent: #06121f;
+    --nc-accent-hover: #2df0b2;
+    --nc-accent-rgb: 0,229,160;
+    --nc-grad-a: #00e5a0;
+    --nc-grad-b: #0ea5e9;
+    --nc-grad-a-rgb: 0,229,160;
+    --nc-grad-b-rgb: 14,165,233;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="violet"] {
+    --nc-accent: #a371f7;
+    --nc-accent-emphasis: #8957e5;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #7645d3;
+    --nc-accent-rgb: 163,113,247;
+    --nc-grad-a: #a371f7;
+    --nc-grad-b: #f778ba;
+    --nc-grad-a-rgb: 163,113,247;
+    --nc-grad-b-rgb: 247,120,186;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="rose"] {
+    --nc-accent: #f778ba;
+    --nc-accent-emphasis: #bf3989;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #a63180;
+    --nc-accent-rgb: 247,120,186;
+    --nc-grad-a: #f778ba;
+    --nc-grad-b: #a371f7;
+    --nc-grad-a-rgb: 247,120,186;
+    --nc-grad-b-rgb: 163,113,247;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="ember"] {
+    --nc-accent: #f0883e;
+    --nc-accent-emphasis: #bc4c00;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #a04100;
+    --nc-accent-rgb: 240,136,62;
+    --nc-grad-a: #f0883e;
+    --nc-grad-b: #f778ba;
+    --nc-grad-a-rgb: 240,136,62;
+    --nc-grad-b-rgb: 247,120,186;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="gold"] {
+    --nc-accent: #e3b341;
+    --nc-accent-emphasis: #e3b341;
+    --nc-on-accent: #231b00;
+    --nc-accent-hover: #eac55f;
+    --nc-accent-rgb: 227,179,65;
+    --nc-grad-a: #e3b341;
+    --nc-grad-b: #f0883e;
+    --nc-grad-a-rgb: 227,179,65;
+    --nc-grad-b-rgb: 240,136,62;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="graphite"] {
+    --nc-accent: #9ea7b3;
+    --nc-accent-emphasis: #5d6773;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #4d545e;
+    --nc-accent-rgb: 158,167,179;
+    --nc-grad-a: #768390;
+    --nc-grad-b: #9ea7b3;
+    --nc-grad-a-rgb: 118,131,144;
+    --nc-grad-b-rgb: 158,167,179;
+  }
+  :root:not([data-nc-mode="light"])[data-nc-theme="aurora"] {
+    --nc-accent: #a78bfa;
+    --nc-accent-emphasis: #7452e0;
+    --nc-on-accent: #ffffff;
+    --nc-accent-hover: #6039cc;
+    --nc-accent-rgb: 167,139,250;
+    --nc-grad-a: #7c5cf0;
+    --nc-grad-b: #00e5a0;
+    --nc-grad-a-rgb: 124,92,240;
+    --nc-grad-b-rgb: 0,229,160;
+  }
+}
+
+/* ---- skeleton: the shared netcanon-dev body plan ------------------------------------
+   Opt-in .nc-* classes so nothing collides with a project's existing CSS. The layout
+   language is distilled from the baselines: app bar + brand, ~1140px content column,
+   auto-fill card grid, 1px-border depth, uppercase micro-headers, mono for values. */
+
+/* base element defaults — deliberately minimal, safe over existing app CSS */
+html { -webkit-text-size-adjust: 100%; }
+body {
+  margin: 0;
+  font: var(--nc-fw-regular) var(--nc-fs-base)/var(--nc-lh-base) var(--nc-font);
+  background: var(--nc-bg);
+  color: var(--nc-text);
+  transition: background-color var(--nc-dur-base) var(--nc-ease-standard),
+              color var(--nc-dur-base) var(--nc-ease-standard);
+}
+a { color: var(--nc-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+::selection { background: rgba(var(--nc-accent-rgb), .30); }
+:focus-visible { outline: 2px solid var(--nc-focus); outline-offset: 2px; border-radius: 2px; }
+code, kbd, pre, samp { font-family: var(--nc-mono); }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition-duration: .01ms !important; animation-duration: .01ms !important; }
+}
+/* set by theme-picker.js for ~80ms around a theme/mode swap: the swap must be atomic,
+   never a crossfade (fills and on-colors would fade out of step and turn illegible) */
+[data-nc-switching], [data-nc-switching] *,
+[data-nc-switching] *::before, [data-nc-switching] *::after { transition: none !important; }
+
+/* layout */
+.nc-container { max-width: 1140px; margin: 0 auto; padding: 0 var(--nc-space-7); }
+.nc-main { padding: var(--nc-space-7) 0 var(--nc-space-9); }
+
+/* app bar — the shared silhouette; the 2px gradient strip is the family signature */
+.nc-header {
+  position: relative;
+  display: flex; align-items: center; gap: var(--nc-space-5);
+  padding: var(--nc-space-4) var(--nc-space-7);
+  background: var(--nc-surface);
+  border-bottom: 1px solid var(--nc-border);
+}
+.nc-header::before {
+  content: ""; position: absolute; inset: 0 0 auto 0; height: 2px;
+  background: var(--nc-gradient);
+}
+.nc-brand {
+  display: flex; align-items: center; gap: var(--nc-space-3);
+  font-weight: var(--nc-fw-semibold); font-size: var(--nc-fs-lg); color: var(--nc-text);
+}
+.nc-brand-dot {
+  width: 14px; height: 14px; border-radius: var(--nc-r-sm);
+  background: var(--nc-gradient); flex: none;
+}
+.nc-nav { display: flex; gap: var(--nc-space-5); margin-left: auto; align-items: center; }
+.nc-nav a {
+  color: var(--nc-text-muted); font-weight: var(--nc-fw-medium); font-size: var(--nc-fs-sm);
+  padding: var(--nc-space-2) 0; border-bottom: 2px solid transparent;
+}
+.nc-nav a:hover { color: var(--nc-text); text-decoration: none; }
+.nc-nav a.active { color: var(--nc-text); border-image: var(--nc-gradient) 1; border-bottom: 2px solid; }
+
+/* cards */
+.nc-grid {
+  display: grid; gap: var(--nc-space-4);
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+.nc-card {
+  background: var(--nc-surface);
+  border: 1px solid var(--nc-border);
+  border-radius: var(--nc-r-lg);
+  padding: var(--nc-space-5);
+}
+.nc-card h3 { margin: 0 0 var(--nc-space-3); font-size: var(--nc-fs-md); font-weight: var(--nc-fw-semibold); }
+.nc-card .nc-meta { color: var(--nc-text-muted); font-size: var(--nc-fs-sm); }
+.nc-stat { font: var(--nc-fw-bold) var(--nc-fs-2xl)/var(--nc-lh-tight) var(--nc-mono); }
+
+/* buttons — min-height spacing.10 (48px) clears the 44px touch-target floor the button
+   spec mandates; border-box so the height is identical on <button> and <a>/<div> */
+.nc-btn {
+  box-sizing: border-box;
+  display: inline-flex; align-items: center; justify-content: center; gap: var(--nc-space-3);
+  padding: var(--nc-space-3) var(--nc-space-5);
+  min-height: var(--nc-space-10);
+  font: var(--nc-fw-medium) var(--nc-fs-base)/1 var(--nc-font);
+  border-radius: var(--nc-r-md);
+  border: 1px solid var(--nc-border-strong);
+  background: var(--nc-surface-2); color: var(--nc-text);
+  cursor: pointer;
+  transition: background-color var(--nc-dur-fast) var(--nc-ease-standard),
+              border-color var(--nc-dur-fast) var(--nc-ease-standard);
+}
+.nc-btn:hover { background: var(--nc-surface); }
+.nc-btn.primary {
+  background: var(--nc-accent-emphasis); color: var(--nc-on-accent);
+  border-color: transparent;
+}
+.nc-btn.primary:hover { background: var(--nc-accent-hover); }
+.nc-btn.ghost { background: transparent; border-color: transparent; color: var(--nc-accent); }
+.nc-btn.ghost:hover { background: rgba(var(--nc-accent-rgb), .12); }
+.nc-btn.danger { background: var(--nc-danger-emphasis); color: #ffffff; border-color: transparent; }
+.nc-btn[disabled] { opacity: .55; cursor: not-allowed; }
+
+/* forms */
+.nc-field { display: flex; flex-direction: column; gap: var(--nc-space-2); margin-bottom: var(--nc-space-4); }
+.nc-label {
+  font-size: var(--nc-fs-sm); font-weight: var(--nc-fw-semibold);
+  color: var(--nc-text-muted); text-transform: uppercase; letter-spacing: .04em;
+}
+.nc-input, .nc-select, .nc-textarea {
+  font: var(--nc-fw-regular) var(--nc-fs-base)/var(--nc-lh-base) var(--nc-font);
+  color: var(--nc-text);
+  background: var(--nc-surface-2);
+  border: 1px solid var(--nc-border-strong);
+  border-radius: var(--nc-r-md);
+  padding: var(--nc-space-3) var(--nc-space-4);
+}
+.nc-input:focus, .nc-select:focus, .nc-textarea:focus {
+  outline: none; border-color: var(--nc-focus);
+  box-shadow: 0 0 0 3px rgba(var(--nc-accent-rgb), .25);
+}
+
+/* tables — the shared infra-console look */
+.nc-table { width: 100%; border-collapse: collapse; font-size: var(--nc-fs-base); }
+.nc-table th {
+  text-align: left; padding: var(--nc-space-3) var(--nc-space-4);
+  font-size: var(--nc-fs-xs); font-weight: var(--nc-fw-semibold);
+  color: var(--nc-text-muted); text-transform: uppercase; letter-spacing: .05em;
+  border-bottom: 1px solid var(--nc-border-strong);
+  background: var(--nc-surface-2);
+}
+.nc-table td { padding: var(--nc-space-3) var(--nc-space-4); border-bottom: 1px solid var(--nc-border); }
+.nc-table tbody tr:hover { background: var(--nc-surface-2); }
+.nc-table .nc-mono { font-family: var(--nc-mono); font-size: var(--nc-fs-sm); }
+
+/* badges & alerts — feedback hues are theme-invariant so state never changes meaning */
+.nc-badge {
+  display: inline-block; padding: 2px var(--nc-space-3);
+  border-radius: var(--nc-r-full);
+  font-size: var(--nc-fs-sm); font-weight: var(--nc-fw-semibold); line-height: 1.6;
+}
+.nc-badge.ok     { color: var(--nc-ok);     background: rgba(var(--nc-ok-rgb), .15); }
+.nc-badge.warn   { color: var(--nc-warn);   background: rgba(var(--nc-warn-rgb), .15); }
+.nc-badge.danger { color: var(--nc-danger); background: rgba(var(--nc-danger-rgb), .15); }
+.nc-badge.accent { color: var(--nc-accent); background: rgba(var(--nc-accent-rgb), .15); }
+.nc-badge.neutral{ color: var(--nc-text-muted); background: rgba(var(--nc-muted-rgb), .15); }
+.nc-alert {
+  padding: var(--nc-space-4) var(--nc-space-5);
+  border: 1px solid; border-radius: var(--nc-r-md);
+  font-size: var(--nc-fs-base); margin-bottom: var(--nc-space-4);
+}
+.nc-alert.ok     { color: var(--nc-ok);     border-color: rgba(var(--nc-ok-rgb), .4);     background: rgba(var(--nc-ok-rgb), .08); }
+.nc-alert.warn   { color: var(--nc-warn);   border-color: rgba(var(--nc-warn-rgb), .4);   background: rgba(var(--nc-warn-rgb), .08); }
+.nc-alert.danger { color: var(--nc-danger); border-color: rgba(var(--nc-danger-rgb), .4); background: rgba(var(--nc-danger-rgb), .08); }
+.nc-alert.info   { color: var(--nc-accent); border-color: rgba(var(--nc-accent-rgb), .4); background: rgba(var(--nc-accent-rgb), .08); }
+
+/* misc chrome */
+.nc-kbd {
+  font: var(--nc-fw-semibold) var(--nc-fs-sm)/1.4 var(--nc-mono);
+  background: var(--nc-surface-2); border: 1px solid var(--nc-border-strong);
+  border-bottom-width: 2px; border-radius: var(--nc-r-xs); padding: 1px var(--nc-space-2);
+}
+.nc-pre {
+  font: var(--nc-fw-regular) var(--nc-fs-sm)/var(--nc-lh-base) var(--nc-mono);
+  background: var(--nc-surface-2); color: var(--nc-text);
+  border: 1px solid var(--nc-border); border-radius: var(--nc-r-md);
+  padding: var(--nc-space-4) var(--nc-space-5); overflow-x: auto;
+}
+.nc-divider { border: 0; border-top: 1px solid var(--nc-border); margin: var(--nc-space-6) 0; }
+.nc-progress {
+  height: 6px; border-radius: var(--nc-r-full);
+  background: var(--nc-surface-2); overflow: hidden;
+}
+.nc-progress > span { display: block; height: 100%; background: var(--nc-gradient); border-radius: inherit; }
+.nc-gradient-text {
+  background: var(--nc-gradient);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent; color: transparent;
+}

--- a/netcanon/templates/_vendor/theme-picker.js
+++ b/netcanon/templates/_vendor/theme-picker.js
@@ -1,0 +1,213 @@
+/* theme-picker.js — GENERATED from tokens/themes.json by tools/build_css.py. DO NOT EDIT dist/ BY HAND.
+ *
+ * The netcanon-dev theme GUI setting. Zero dependencies, light DOM.
+ *
+ * Usage (the closing script tag is spelled <\/script> below so this comment cannot
+ * terminate an inline <script> block if this file is ever pasted into a page):
+ *   <script src="theme-picker.js"><\/script>         <!-- early in <head>: applies saved prefs, no FOUC -->
+ *   <nc-theme-picker></nc-theme-picker>              <!-- the control, wherever you want it -->
+ *   <nc-theme-picker compact></nc-theme-picker>      <!-- swatches only, no labels -->
+ *
+ * State lives on <html> as data-nc-theme / data-nc-mode (nc-namespaced: apps like netcanon and
+ * Settlement Hunter already use a plain data-theme attribute for their own light/dark switching,
+ * so ours must not collide). Persists in localStorage ("nc-theme", "nc-mode"). Omitted
+ * data-nc-mode = follow the OS. Emits "nc-theme-change" on document when the user picks anything.
+ */
+(function () {
+  "use strict";
+
+  var THEMES = [{"id":"ocean","label":"Ocean","swatch":{"light":["#0969da","#1b7c83"],"dark":["#1f6feb","#39c5cf"]}},{"id":"indigo","label":"Indigo","swatch":{"light":["#4f46e5","#7c3aed"],"dark":["#6366f1","#a78bfa"]}},{"id":"lagoon","label":"Lagoon","swatch":{"light":["#1b7c83","#0969da"],"dark":["#39c5cf","#2f81f7"]}},{"id":"verdant","label":"Verdant","swatch":{"light":["#047857","#0369a1"],"dark":["#00e5a0","#0ea5e9"]}},{"id":"violet","label":"Violet","swatch":{"light":["#8250df","#bf3989"],"dark":["#a371f7","#f778ba"]}},{"id":"rose","label":"Rose","swatch":{"light":["#bf3989","#8250df"],"dark":["#f778ba","#a371f7"]}},{"id":"ember","label":"Ember","swatch":{"light":["#bc4c00","#bf3989"],"dark":["#f0883e","#f778ba"]}},{"id":"gold","label":"Gold","swatch":{"light":["#9a6700","#bc4c00"],"dark":["#e3b341","#f0883e"]}},{"id":"graphite","label":"Graphite","swatch":{"light":["#57606a","#768390"],"dark":["#768390","#9ea7b3"]}},{"id":"aurora","label":"Aurora","swatch":{"light":["#6741d9","#047857"],"dark":["#7c5cf0","#00e5a0"]}}];
+  var MODES = [
+    { id: "light", label: "Light" },
+    { id: "auto", label: "Auto" },
+    { id: "dark", label: "Dark" }
+  ];
+
+  var NcTheme = {
+    themes: THEMES,
+    get: function () {
+      return {
+        theme: document.documentElement.getAttribute("data-nc-theme") || "ocean",
+        mode: document.documentElement.getAttribute("data-nc-mode") || "auto"
+      };
+    },
+    set: function (theme, mode) {
+      var root = document.documentElement;
+      // Swap atomically: suppress transitions so fills and on-colors can't crossfade out of
+      // step (e.g. a blue fill fading under an already-swapped dark label = illegible flash).
+      root.setAttribute("data-nc-switching", "");
+      clearTimeout(NcTheme._switchTimer);
+      NcTheme._switchTimer = setTimeout(function () {
+        root.removeAttribute("data-nc-switching");
+      }, 80);
+      if (theme) {
+        root.setAttribute("data-nc-theme", theme);
+        try { localStorage.setItem("nc-theme", theme); } catch (e) { /* storage may be unavailable */ }
+      }
+      if (mode) {
+        if (mode === "auto") root.removeAttribute("data-nc-mode");
+        else root.setAttribute("data-nc-mode", mode);
+        try { localStorage.setItem("nc-mode", mode); } catch (e) { /* storage may be unavailable */ }
+      }
+      document.dispatchEvent(new CustomEvent("nc-theme-change", { detail: NcTheme.get() }));
+    },
+    boot: function () {
+      var theme, mode;
+      try {
+        theme = localStorage.getItem("nc-theme");
+        mode = localStorage.getItem("nc-mode");
+      } catch (e) { /* storage may be unavailable */ }
+      var root = document.documentElement;
+      if (theme && THEMES.some(function (t) { return t.id === theme; })) root.setAttribute("data-nc-theme", theme);
+      else if (!root.hasAttribute("data-nc-theme")) root.setAttribute("data-nc-theme", "ocean");
+      if (mode === "light" || mode === "dark") root.setAttribute("data-nc-mode", mode);
+      // A persisted "auto" must UNDO a markup-hardcoded data-nc-mode, or the user's Auto
+      // choice is silently dropped on reload. Stored-null leaves the markup default alone.
+      else if (mode === "auto") root.removeAttribute("data-nc-mode");
+    }
+  };
+  window.NcTheme = NcTheme;
+  NcTheme.boot();
+
+  var CSS =
+    ".nc-theme-picker{display:inline-flex;flex-direction:column;gap:8px;font-family:var(--nc-font,system-ui,sans-serif)}" +
+    ".ncp-swatches{display:flex;flex-wrap:wrap;gap:6px}" +
+    ".ncp-swatch{width:26px;height:26px;border-radius:50%;border:2px solid transparent;padding:0;cursor:pointer;" +
+      "background-origin:border-box;box-shadow:inset 0 0 0 2px var(--nc-bg,#fff)}" +
+    ".ncp-swatch[aria-checked=true]{border-color:var(--nc-text,#111)}" +
+    ".ncp-swatch:focus-visible{outline:2px solid var(--nc-focus,#0969da);outline-offset:2px}" +
+    ".ncp-modes{display:inline-flex;border:1px solid var(--nc-border-strong,#888);border-radius:6px;overflow:hidden;width:max-content}" +
+    ".ncp-mode{font:500 12px/1 var(--nc-font,system-ui,sans-serif);color:var(--nc-text-muted,#666);" +
+      "background:transparent;border:0;padding:6px 10px;cursor:pointer}" +
+    ".ncp-mode[aria-checked=true]{background:var(--nc-accent-emphasis,#0969da);color:var(--nc-on-accent,#fff)}" +
+    ".ncp-mode:focus-visible{outline:2px solid var(--nc-focus,#0969da);outline-offset:-2px}";
+
+  function injectCss() {
+    if (document.getElementById("nc-theme-picker-css")) return;
+    var s = document.createElement("style");
+    s.id = "nc-theme-picker-css";
+    s.textContent = CSS;
+    document.head.appendChild(s);
+  }
+
+  function swatchGradient(t) {
+    var mode = document.documentElement.getAttribute("data-nc-mode");
+    if (!mode) mode = matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    var g = t.swatch[mode] || t.swatch.dark;
+    return "linear-gradient(135deg," + g[0] + "," + g[1] + ")";
+  }
+
+  // APG radio-group keyboard model: arrows move AND select (wrapping); the checked
+  // option is the only tab stop (roving tabindex).
+  function wireArrowKeys(group, buttons, onPick) {
+    group.addEventListener("keydown", function (e) {
+      var delta = (e.key === "ArrowRight" || e.key === "ArrowDown") ? 1
+                : (e.key === "ArrowLeft" || e.key === "ArrowUp") ? -1 : 0;
+      if (!delta) return;
+      var i = buttons.indexOf(document.activeElement);
+      if (i === -1) return;
+      e.preventDefault();
+      var next = buttons[(i + delta + buttons.length) % buttons.length];
+      onPick(next);          // set() dispatches nc-theme-change -> update() runs synchronously
+      next.focus();          // in-place update keeps the node alive, so focus survives
+    });
+  }
+
+  var NcThemePicker = /** @type {any} */ (function () {
+    function P() { return Reflect.construct(HTMLElement, [], P); }
+    P.prototype = Object.create(HTMLElement.prototype);
+
+    P.prototype.connectedCallback = function () {
+      injectCss();
+      this.classList.add("nc-theme-picker");
+      this.build();
+      this.update();
+      var self = this;
+      this._onChange = function () { self.update(); };
+      document.addEventListener("nc-theme-change", this._onChange);
+      // in auto mode the swatch gradients depend on the OS scheme — re-sync on flips
+      this._mq = matchMedia("(prefers-color-scheme: dark)");
+      this._onScheme = function () { self.update(); };
+      if (this._mq.addEventListener) this._mq.addEventListener("change", this._onScheme);
+      else if (this._mq.addListener) this._mq.addListener(this._onScheme);
+    };
+
+    P.prototype.disconnectedCallback = function () {
+      document.removeEventListener("nc-theme-change", this._onChange);
+      if (this._mq) {
+        if (this._mq.removeEventListener) this._mq.removeEventListener("change", this._onScheme);
+        else if (this._mq.removeListener) this._mq.removeListener(this._onScheme);
+      }
+    };
+
+    // Build the DOM once; update() mutates in place so keyboard focus is never destroyed.
+    P.prototype.build = function () {
+      this.textContent = "";
+      var compact = this.hasAttribute("compact");
+
+      var sw = document.createElement("div");
+      sw.className = "ncp-swatches";
+      sw.setAttribute("role", "radiogroup");
+      sw.setAttribute("aria-label", "Color theme");
+      this._swatchBtns = THEMES.map(function (t) {
+        var b = document.createElement("button");
+        b.type = "button";
+        b.className = "ncp-swatch";
+        b.setAttribute("role", "radio");
+        b.setAttribute("aria-label", t.label);
+        b.title = t.label;
+        b._nc = t;
+        b.addEventListener("click", function () { NcTheme.set(t.id, null); });
+        sw.appendChild(b);
+        return b;
+      });
+      wireArrowKeys(sw, this._swatchBtns, function (btn) { NcTheme.set(btn._nc.id, null); });
+      this.appendChild(sw);
+
+      this._modeBtns = [];
+      if (!compact) {
+        var md = document.createElement("div");
+        md.className = "ncp-modes";
+        md.setAttribute("role", "radiogroup");
+        md.setAttribute("aria-label", "Color mode");
+        this._modeBtns = MODES.map(function (m) {
+          var b = document.createElement("button");
+          b.type = "button";
+          b.className = "ncp-mode";
+          b.setAttribute("role", "radio");
+          b.textContent = m.label;
+          b._nc = m;
+          b.addEventListener("click", function () { NcTheme.set(null, m.id); });
+          md.appendChild(b);
+          return b;
+        });
+        wireArrowKeys(md, this._modeBtns, function (btn) { NcTheme.set(null, btn._nc.id); });
+        this.appendChild(md);
+      }
+    };
+
+    P.prototype.update = function () {
+      var state = NcTheme.get();
+      function rove(buttons, checkedIdx) {
+        buttons.forEach(function (b, i) {
+          b.setAttribute("aria-checked", String(i === checkedIdx));
+          b.tabIndex = (i === (checkedIdx === -1 ? 0 : checkedIdx)) ? 0 : -1;
+        });
+      }
+      var themeIdx = THEMES.findIndex(function (t) { return t.id === state.theme; });
+      this._swatchBtns.forEach(function (b) {
+        b.style.background = swatchGradient(b._nc) + " border-box";
+      });
+      rove(this._swatchBtns, themeIdx);
+      if (this._modeBtns.length) {
+        rove(this._modeBtns, MODES.findIndex(function (m) { return m.id === state.mode; }));
+      }
+    };
+
+    return P;
+  })();
+
+  if (!customElements.get("nc-theme-picker")) {
+    customElements.define("nc-theme-picker", NcThemePicker);
+  }
+})();

--- a/netcanon/templates/base.html
+++ b/netcanon/templates/base.html
@@ -1,34 +1,40 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en" data-nc-theme="indigo">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Netcanon{% endblock %}</title>
-  <!-- Theme boot: runs BEFORE the <style> block parses so the
-       document paints in the correct theme without a flash of
-       light content (FOUC).  Reads localStorage first (user
-       override), then falls back to `prefers-color-scheme` for
-       first-visit users.  Mutates `document.documentElement`
-       synchronously before any CSS applies. -->
+  <!-- Unified theme boot: runs BEFORE the <style> blocks parse so
+       the document paints in the correct palette + mode without a
+       flash of wrong theme (FOUC).  Two stages:
+       1. One-time migration — a previously persisted
+          localStorage["netcanon.theme.v1"] ("light"|"dark", written
+          by the pre-unification toggle) is copied into the unified
+          "nc-mode" key, only while "nc-mode" is still unset so the
+          user's newer choice always wins.  The legacy key is left
+          in place: the self-contained /docs page still reads it.
+       2. The vendored theme-picker.js (netcanon-dev/ui-design-spec
+          v0.2.1 — see _vendor/README.md) then runs NcTheme.boot():
+          applies saved "nc-theme"/"nc-mode" prefs to <html>
+          synchronously before any CSS applies.  No stored mode =
+          data-nc-mode absent = follow the OS. -->
   <script>
     (function() {
       try {
-        var stored = localStorage.getItem('netcanon.theme.v1');
-        var theme;
-        if (stored === 'dark' || stored === 'light') {
-          theme = stored;
-        } else if (window.matchMedia &&
-                   window.matchMedia('(prefers-color-scheme: dark)').matches) {
-          theme = 'dark';
-        } else {
-          theme = 'light';
+        if (localStorage.getItem('nc-mode') === null) {
+          var legacy = localStorage.getItem('netcanon.theme.v1');
+          if (legacy === 'dark' || legacy === 'light') {
+            localStorage.setItem('nc-mode', legacy);
+          }
         }
-        document.documentElement.setAttribute('data-theme', theme);
       } catch (_) {
         /* localStorage access can fail in sandboxed iframes; fall
-           through to the default (light) already on the root. */
+           through to the vendored boot's defaults. */
       }
     })();
+  </script>
+  <script>
+  {% include "_vendor/theme-picker.js" %}
   </script>
   <style>
     /* ── Theme tokens ──
@@ -238,17 +244,28 @@
       border-color: rgba(255,255,255,.18);
       outline: none;
     }
-    /* Icon swap: light theme shows moon (click to go dark);
-       dark theme shows sun (click to go light).  Using CSS
+    /* Icon swap: light mode shows moon (click to go dark);
+       dark mode shows sun (click to go light).  Using CSS
        attribute-state + content swap means no DOM mutation on
        toggle — the button's aria-label is updated by JS for
-       screen-reader accuracy but the glyph flips via CSS alone. */
+       screen-reader accuracy but the glyph flips via CSS alone.
+       Mode source is the unified <html data-nc-mode> attribute
+       (vendored theme-picker.js).  Absent attribute = "auto":
+       the html:not([data-nc-mode]) pair below resolves the glyph
+       from the OS scheme, mirroring how the vendored CSS resolves
+       auto mode.  The :not() rules and the forced-mode rules are
+       mutually exclusive by attribute presence. */
     #nav-theme-toggle .moon,
     #nav-theme-toggle .sun {
       display: none;
     }
-    [data-theme="light"] #nav-theme-toggle .moon { display: inline; }
-    [data-theme="dark"]  #nav-theme-toggle .sun  { display: inline; }
+    [data-nc-mode="light"] #nav-theme-toggle .moon { display: inline; }
+    [data-nc-mode="dark"]  #nav-theme-toggle .sun  { display: inline; }
+    html:not([data-nc-mode]) #nav-theme-toggle .moon { display: inline; }
+    @media (prefers-color-scheme: dark) {
+      html:not([data-nc-mode]) #nav-theme-toggle .moon { display: none; }
+      html:not([data-nc-mode]) #nav-theme-toggle .sun  { display: inline; }
+    }
 
     main { max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }
     h1 { margin-bottom: 1.25rem; font-size: 1.5rem; }
@@ -372,6 +389,21 @@
       border:2px solid var(--focus-ring); border-radius:4px;
       text-decoration:none; font-weight:600;
     }
+  </style>
+  <!-- Unified design language (vendored from netcanon-dev/ui-design-spec
+       v0.2.1 — see _vendor/README.md; never edit the included files).
+       Order is load-bearing: netcanon-ui.css defines the --nc-* tokens
+       (+ .nc-* skeleton for future pages); compat-netcanon.css then
+       remaps the legacy --page-bg/--surface/... vars above onto them.
+       Both sit AFTER the inline <style> block so the shim also wins
+       source-order ties against the legacy :root definitions (its
+       :root[data-nc-theme] selector already outranks them on
+       specificity). -->
+  <style>
+  {% include "_vendor/netcanon-ui.css" %}
+  </style>
+  <style>
+  {% include "_vendor/compat-netcanon.css" %}
   </style>
 </head>
 <body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,13 @@ include = ["netcanon*", "netcanon_desktop*"]
 netcanon = [
     "templates/*.html",
     "templates/_partials/*.js",
+    # Vendored unified-UI deliverable (netcanon-dev/ui-design-spec
+    # v0.2.1; see templates/_vendor/README.md).  Jinja-inlined by
+    # base.html exactly like the _partials above, so the same
+    # wheel-packaging trap applies: a missing glob here 500s every
+    # HTML page on a `pip install netcanon` install.
+    "templates/_vendor/*.css",
+    "templates/_vendor/*.js",
     # Device-definition library (per-vendor `*.yaml` + Tier-3
     # `target_profiles/`).  These MUST ship in the wheel: the app loads
     # them at startup via DefinitionLoader, and the default

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -50,25 +50,31 @@ class TestNavigation:
 
 
 class TestThemeToggle:
-    """Global dark-mode toggle on the top nav (``data-testid``
-    ``nav-theme-toggle``).  Covers:
+    """Global light/dark toggle on the top nav (``data-testid``
+    ``nav-theme-toggle``), rewired to the unified theme runtime
+    (vendored ``_vendor/theme-picker.js``).  Covers:
 
     * Button is always visible on the nav across pages.
-    * Click flips `<html data-theme>` between ``light``/``dark``.
-    * Choice persists to ``localStorage["netcanon.theme.v1"]``.
-    * Reload re-applies the persisted theme (no flash of wrong
-      theme — the inline boot script in ``<head>`` runs before
-      CSS parses).
+    * Click flips ``<html data-nc-mode>`` between ``light``/``dark``
+      via ``NcTheme.set(null, mode)``.
+    * Choice persists to ``localStorage["nc-mode"]`` and is mirrored
+      one-way into the legacy ``netcanon.theme.v1`` key (the
+      self-contained /docs page still reads it).
+    * A pre-unification ``netcanon.theme.v1`` value migrates into
+      ``nc-mode`` exactly once at boot.
+    * Reload re-applies the persisted mode (no flash of wrong mode —
+      ``NcTheme.boot()`` runs inline in ``<head>`` before CSS
+      parses).
     * ``aria-label`` + ``aria-pressed`` reflect the next-action
       (not the current state) for screen-reader clarity.
     """
 
-    def _theme_attr(self, page: Page) -> str:
-        return page.locator("html").get_attribute("data-theme") or ""
+    def _mode_attr(self, page: Page) -> str:
+        return page.locator("html").get_attribute("data-nc-mode") or ""
 
-    def _stored_theme(self, page: Page) -> str:
+    def _stored_mode(self, page: Page) -> str:
         return page.evaluate(
-            "() => localStorage.getItem('netcanon.theme.v1') || ''"
+            "() => localStorage.getItem('nc-mode') || ''"
         )
 
     def test_toggle_button_visible_on_dashboard(
@@ -91,27 +97,43 @@ class TestThemeToggle:
         page.goto("/")
         # Reset local state so the test is deterministic regardless
         # of OS prefers-color-scheme.
-        page.evaluate(
-            "() => { localStorage.setItem('netcanon.theme.v1', 'light'); "
-            "document.documentElement.setAttribute('data-theme', 'light'); }"
-        )
-        assert self._theme_attr(page) == "light"
+        page.evaluate("() => NcTheme.set(null, 'light')")
+        assert self._mode_attr(page) == "light"
         page.get_by_test_id("nav-theme-toggle").click()
-        assert self._theme_attr(page) == "dark"
-        assert self._stored_theme(page) == "dark"
+        assert self._mode_attr(page) == "dark"
+        assert self._stored_mode(page) == "dark"
+        # One-way mirror keeps the self-contained /docs page in step.
+        assert page.evaluate(
+            "() => localStorage.getItem('netcanon.theme.v1')"
+        ) == "dark"
         page.get_by_test_id("nav-theme-toggle").click()
-        assert self._theme_attr(page) == "light"
-        assert self._stored_theme(page) == "light"
+        assert self._mode_attr(page) == "light"
+        assert self._stored_mode(page) == "light"
 
     def test_choice_persists_across_reload(
         self, page: Page, base_url: str,
     ):
         page.goto("/")
         page.evaluate(
-            "() => localStorage.setItem('netcanon.theme.v1', 'dark')"
+            "() => localStorage.setItem('nc-mode', 'dark')"
         )
         page.reload()
-        assert self._theme_attr(page) == "dark"
+        assert self._mode_attr(page) == "dark"
+
+    def test_legacy_key_migrates_once(
+        self, page: Page, base_url: str,
+    ):
+        """A pre-unification user's persisted netcanon.theme.v1 value
+        is copied into nc-mode at boot — only while nc-mode is unset,
+        so the user's newer unified choice always wins."""
+        page.goto("/")
+        page.evaluate(
+            "() => { localStorage.clear(); "
+            "localStorage.setItem('netcanon.theme.v1', 'dark'); }"
+        )
+        page.reload()
+        assert self._mode_attr(page) == "dark"
+        assert self._stored_mode(page) == "dark"
 
     def test_aria_label_reflects_next_action(
         self, page: Page, base_url: str,
@@ -121,8 +143,7 @@ class TestThemeToggle:
         accessibility guidance."""
         page.goto("/")
         page.evaluate(
-            "() => { localStorage.setItem('netcanon.theme.v1', 'light'); "
-            "document.documentElement.setAttribute('data-theme', 'light'); "
+            "() => { NcTheme.set(null, 'light'); "
             "_updateThemeToggleAriaLabel('light'); }"
         )
         btn = page.get_by_test_id("nav-theme-toggle")
@@ -137,25 +158,24 @@ class TestThemeToggle:
     ):
         """End-to-end visual check: clicking the toggle actually
         changes the page's rendered background colour via the
-        CSS variable chain.  Guards against regressions where the
-        data-theme attribute flips but the var(--page-bg)
-        reference doesn't resolve."""
+        CSS variable chain (nc tokens -> compat shim -> legacy var
+        names).  Guards against regressions where data-nc-mode flips
+        but var(--page-bg) doesn't resolve through the shim."""
         page.goto("/")
         # Force light for deterministic baseline.
-        page.evaluate(
-            "() => { localStorage.setItem('netcanon.theme.v1', 'light'); "
-            "document.documentElement.setAttribute('data-theme', 'light'); }"
-        )
+        page.evaluate("() => NcTheme.set(null, 'light')")
         light_bg = page.evaluate(
             "() => getComputedStyle(document.body).backgroundColor"
         )
         page.get_by_test_id("nav-theme-toggle").click()
-        # ``body`` animates ``background-color`` over a ~.15s CSS transition,
-        # so reading the computed value *immediately* after the click returns
-        # the pre-/mid-transition (still-light) colour — a flaky read.  Poll
-        # until the rendered background has actually moved off the light token
-        # before asserting; if it genuinely never changes this times out and
-        # the failure points at a real var(--page-bg) regression, not timing.
+        # ``body`` animates ``background-color`` over a ~.15s CSS transition
+        # (suppressed for ~80ms by the runtime's data-nc-switching guard),
+        # so reading the computed value *immediately* after the click can
+        # return the pre-/mid-transition (still-light) colour — a flaky
+        # read.  Poll until the rendered background has actually moved off
+        # the light token before asserting; if it genuinely never changes
+        # this times out and the failure points at a real var(--page-bg)
+        # regression, not timing.
         page.wait_for_function(
             "light => getComputedStyle(document.body).backgroundColor !== light",
             arg=light_bg,

--- a/tests/integration/test_ui_routes.py
+++ b/tests/integration/test_ui_routes.py
@@ -215,13 +215,15 @@ class TestJobScheduleFields:
 
 
 class TestThemeToggleRendered:
-    """Dark-mode wiring is in base.html, so EVERY page that extends
-    it should carry:
+    """Theme wiring is in base.html, so EVERY page that extends it
+    should carry:
 
-    * ``<html data-theme="light">`` default on the root element
-      (boot script overrides on the client before CSS paints).
-    * Inline boot script reading ``localStorage`` + prefers-color-
-      scheme.
+    * ``<html data-nc-theme="indigo">`` on the root element, with NO
+      hardcoded ``data-nc-mode`` (light + dark + follow-the-OS all
+      stay reachable; the vendored boot applies saved prefs on the
+      client before CSS paints).
+    * The inlined unified runtime (``NcTheme``) + the one-time
+      ``netcanon.theme.v1`` -> ``nc-mode`` migration snippet.
     * The ``nav-theme-toggle`` button with sun + moon glyphs.
     * The theme-toggle partial inclusion.
 
@@ -231,24 +233,26 @@ class TestThemeToggleRendered:
 
     _PAGES = ["/", "/jobs", "/schedules", "/configs", "/definitions"]
 
-    def test_html_has_data_theme_attribute(self, client: TestClient) -> None:
+    def test_html_has_data_nc_theme_attribute(self, client: TestClient) -> None:
         for path in self._PAGES:
             resp = client.get(path)
             assert resp.status_code == 200, path
-            assert 'data-theme="light"' in resp.text, (
-                f"{path} missing default data-theme on <html>"
+            # Full-tag assertion: pins the indigo default AND the
+            # absence of a hardcoded data-nc-mode / legacy data-theme.
+            assert '<html lang="en" data-nc-theme="indigo">' in resp.text, (
+                f"{path} missing/altered unified theme root attributes"
             )
 
     def test_boot_script_present(self, client: TestClient) -> None:
-        """FOUC-prevention: the boot script MUST be inline in <head>
-        (not an external <script src>) so it runs synchronously
-        before CSS parses."""
+        """FOUC-prevention: the theme runtime MUST be inline in <head>
+        (not an external <script src>) so NcTheme.boot() runs
+        synchronously before CSS parses."""
         resp = client.get("/")
-        assert "netcanon.theme.v1" in resp.text
+        assert "NcTheme.boot();" in resp.text
         assert "prefers-color-scheme" in resp.text
-        # Boot script references documentElement (not body/DOM) —
-        # required so the attribute is set before the body renders.
-        assert "document.documentElement.setAttribute" in resp.text
+        # One-time legacy-key migration snippet precedes the runtime.
+        assert "netcanon.theme.v1" in resp.text
+        assert "localStorage.setItem('nc-mode', legacy)" in resp.text
 
     def test_nav_theme_toggle_button_present(
         self, client: TestClient,
@@ -263,8 +267,9 @@ class TestThemeToggleRendered:
         self, client: TestClient,
     ) -> None:
         """The glyph swap happens via CSS, not DOM mutation — both
-        spans are in the markup, one hidden by the data-theme
-        selector rules."""
+        spans are in the markup, one hidden by the data-nc-mode
+        selector rules (plus a prefers-color-scheme pair for the
+        no-attribute "auto" state)."""
         resp = client.get("/")
         # Sun (U+2600) + moon (U+263D) — HTML entities, mixed case
         # tolerated (the template uses lowercase hex).
@@ -279,13 +284,20 @@ class TestThemeToggleRendered:
         assert "_updateThemeToggleAriaLabel" in resp.text
 
     def test_css_variables_declared(self, client: TestClient) -> None:
-        """Dark-mode CSS tokens must be present (regression guard
-        against someone accidentally removing the :root or
-        [data-theme=\"dark\"] block)."""
+        """Both CSS layers must be present: the vendored unified
+        tokens + compat shim (regression guard against someone
+        removing the _vendor includes), and the legacy :root /
+        [data-theme=\"dark\"] blocks the shim remaps (dead but
+        deliberately kept until the deletion follow-up)."""
         resp = client.get("/")
+        # Unified layer (vendored).
+        assert "--nc-bg:" in resp.text
+        assert '[data-nc-theme="indigo"]' in resp.text
+        assert ":root[data-nc-theme]" in resp.text
+        assert "--page-bg: var(--nc-bg);" in resp.text
+        # Legacy layer (inert; shim outranks it).
         assert "--page-bg:" in resp.text
         assert '[data-theme="dark"]' in resp.text
-        # Spot-check a few tokens; no need to enumerate all.
         assert "--surface:" in resp.text
         assert "--text-primary:" in resp.text
         assert "--nav-bg:" in resp.text

--- a/tests/testid_reference.md
+++ b/tests/testid_reference.md
@@ -18,7 +18,7 @@ CSS class names or element structure — so UI refactoring does not break tests.
 | `nav-definitions`  | `<a>`   | Link to `/definitions`; active on Definitions page |
 | `nav-api-docs`     | `<a>`   | Link to `/docs` |
 | `kbd-cheatsheet-open-btn` | `<button>` | Right-rail `?` nav button; opens the keyboard-shortcut cheatsheet modal.  Sits immediately before `nav-theme-toggle` |
-| `nav-theme-toggle` | `<button>` | Right-aligned sun/moon toggle; flips `<html data-theme>` between `light`/`dark`, persists to `localStorage["netcanon.theme.v1"]`.  `aria-label` and `aria-pressed` live-update to reflect the ACTION (next-state), not the current state |
+| `nav-theme-toggle` | `<button>` | Right-aligned sun/moon toggle; calls `NcTheme.set(null, mode)` (vendored `_vendor/theme-picker.js`) to flip `<html data-nc-mode>` between `light`/`dark`, persisted to `localStorage["nc-mode"]` and mirrored one-way into the legacy `localStorage["netcanon.theme.v1"]` for the self-contained `/docs` page.  `aria-label` and `aria-pressed` live-update to reflect the ACTION (next-state), not the current state |
 | `toast`            | `<div>` | Fixed-position toast notification; hidden by default |
 
 ### Keyboard shortcut cheatsheet modal (`base.html`)


### PR DESCRIPTION
## Why

netcanon's theming was a hand-rolled two-theme var set in `base.html` (a `:root` light block, a `[data-theme="dark"]` override, an inline no-FOUC boot script, and a sun/moon toggle flipping `data-theme`). It drifts from the org look with every tweak and can't share a palette across netcanon-dev projects.

This adopts the org-wide unified design language (**netcanon-dev/ui-design-spec `v0.2.1`**, commit `1c4af329`) **without rewriting any page CSS**.

## What

Vendor three **byte-pinned (sha256)** files under `netcanon/templates/_vendor/` and Jinja-`{% include %}` them inline — the same mechanism as the existing `_partials/*.js` (netcanon serves no static files):

| File | Role |
|---|---|
| `netcanon-ui.css` | the `--nc-*` tokens — ten palettes × light/dark/auto via `data-nc-theme` / `data-nc-mode` |
| `theme-picker.js` | the `NcTheme` runtime — owns `nc-mode`/`nc-theme` persistence + a synchronous no-FOUC boot |
| `compat-netcanon.css` | remaps the legacy `--page-bg`/`--surface`/… vars onto `--nc-*` under `:root[data-nc-theme]`, which outranks the legacy (now inert) `:root` blocks |

Every template's `var(--…)` reference re-themes with no edit. Default palette **indigo**; light + dark + a new **follow-the-OS** auto state all remain reachable. The nav sun/moon toggle now drives `NcTheme.set(null, mode)`; a one-time boot snippet migrates a persisted `netcanon.theme.v1` into `nc-mode`, and the toggle still mirrors its choice one-way into the legacy key so the self-contained `/docs` theme copy stays in step. The `<pre>` code wells keep the fixed VS Code Dark+ palette in both modes by design.

The vendored bytes are pinned by sha256 (`_vendor/README.md`), exempted from EOL rewrites (`.gitattributes`), and packaged into wheels (`pyproject.toml`). Server-side + e2e theme tests, the testid reference, `ARCHITECTURE.md`, and the `CHANGELOG` are updated to match.

## Verification

- Vendored sha256 matches the pins (working tree **and** staged blob).
- `ruff` clean; `test_ui_routes.py` (incl. rewritten theme class) 36/36; `/docs` swagger tests stay green; wheel smoke packages all three vendored files; all 8 UI routes render 200 with the runtime inlined.
- Live browser smoke: indigo default; light = white body + surface-toned nav; dark = `#0d1117`/`#161b22`; code wells fixed `#1e1e1e` both modes; toggle flips `data-nc-mode` + persists + mirrors + updates aria; the one-time `netcanon.theme.v1 → nc-mode` migration fires at boot.

## Rollback

Single logical commit → `git revert <sha>` restores the pre-adoption state byte-for-byte; user-side residue is only additive `localStorage` keys the restored code ignores.

## Follow-ups (deliberately out of scope)

Delete the inert legacy var blocks · var-ize the `tok-*` syntax palette · migrate `/docs` and `migrate.html`'s hardcoded chrome off their pre-unification copies · surface a `<nc-theme-picker>` palette control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
