### PR TITLE
docs(changelog): cut the [0.6.1] release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-22
+
 ### Changed
 
 - **Unified design language adopted** (netcanon-dev/ui-design-spec tag
@@ -55,6 +57,23 @@ timestamp if your timezone matters for an audit.
   ARCHITECTURE.md/the migration plan): delete the now-inert legacy
   var blocks, var-ize the `tok-*` syntax palette, migrate `/docs` and
   `migrate.html`'s hardcoded chrome, surface `<nc-theme-picker>`.
+
+### Fixed
+
+- **Switchport-only VLANs now translate** (#389).  A Cisco IOS-XE
+  `show running-config` keeps its VLAN database in `vlan.dat`, so a VLAN
+  used only via `switchport access vlan N` (or trunk `native`) has no
+  `vlan <N>` stanza and no SVI in the text.  The five port-centric
+  parsers (`cisco_iosxe_cli`, `arista_eos`, `cisco_nxos`,
+  `juniper_junos`, `aruba_aoscx`) pruned those real access/native VLANs
+  as phantoms, so e.g. a Catalyst 9300 with VLANs 10/20/100/150 on
+  access ports translated to Arista/Junos with the VLAN database missing
+  all four — leaving ports that reference undeclared VLANs.  A new shared
+  `access_and_native_vlan_ids` transform keeps every access + native VID
+  (single, operator-declared) while still pruning a VID that appears
+  solely in a wide `trunk allowed vlan` range as possible phantom
+  inflation.  Round-trip stays stable, so the cross-vendor CODEC_BUG
+  count is unchanged (5).
 
 ## [0.6.0] - 2026-07-16
 


### PR DESCRIPTION
## What

Cuts the **v0.6.1** release section: moves the `[Unreleased]` content into `## [0.6.1] - 2026-07-22` and adds the #389 entry that was missing from the changelog.

**v0.6.1 contents** — both already merged to `main`:

- **Changed** — Unified design language adopted (netcanon-dev/ui-design-spec `v0.2.1`) — #388.
- **Fixed** — Switchport-only VLANs now translate; the five port-centric codecs no longer prune real `access`/`native` VLANs (Cisco `vlan.dat` case) — #389.

Per the release SOP, tagging `v0.6.1` on the merge of this PR fires the PyPI + Docker (GHCR + Docker Hub) + Desktop-MSI publish workflows. `[Unreleased]` is left empty for the next cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
