### PR TITLE
docs(demo-plan): vendor the ephemeral-demo build plan into docs/demo-plan/

### DIFF
--- a/docs/demo-plan/00-overview.md
+++ b/docs/demo-plan/00-overview.md
@@ -1,0 +1,104 @@
+# 00 — Overview
+
+## Purpose
+
+Give any visitor a zero-install way to paste a network config and watch
+netcanon translate + audit it, with **architectural confidence — isolation and
+destruction at the container boundary, with every claim mapped to a verifiable
+control**. The demo is a trust artifact as much as a product artifact: its
+architecture *is* the marketing claim.
+
+## Goals
+
+1. **Instanced execution.** Each browser session gets its own netcanon
+   container. No cross-session data visibility is possible even in the presence
+   of an application-level bug, because isolation is at the container boundary.
+2. **Provable ephemerality.** Instance lifetime is capped by a **15-min hard TTL**
+   (`HARD_TTL=900 s`, ≤ ~20 min from creation even if the warden crashes) that
+   nothing the browser does can extend, and is reclaimed sooner in the common
+   cases: on browser close, and after **10 min** with no allowlisted proxied POST
+   (translate, detect, or sanitize) (`IDLE_TTL=600 s`, tightened under load). All
+   instance state lives on
+   tmpfs (RAM). Teardown = memory freed = data gone. Nothing to delete because
+   nothing was written.
+3. **Zero retention.** No request bodies, no pasted configs, no translated
+   output, no per-user identifiers in any log or store that survives the
+   session. Host logs carry operational metadata only (see [04](04-container-hardening.md#logging)).
+4. **Auditable.** Every claim in the whitepaper ([06](06-privacy-whitepaper.md))
+   maps to a config line in the public repo and a verification procedure in
+   [08](08-testing-verification.md).
+5. **Cheap and boring.** Single small VPS, Docker, Caddy. Budget headline:
+   **~$7.40/mo demo-attributable (the domain is shared with the main site)**
+   ([07](07-budget.md)).
+
+## Invariants
+
+These override everything else in this plan.
+
+- **I1 — No persistent writes from demo instances.** Demo containers run with
+  read-only root filesystem, tmpfs for all writable paths, and **zero volumes**.
+  The image declares `VOLUME ["/app/configs", "/app/data"]` (Dockerfile:113), so
+  **both** must be tmpfs-backed — a missed one becomes a persistent anonymous
+  host-disk volume that falsifies "zero volumes" — and instances are destroyed
+  with `remove(v=True, force=True)` so no anonymous volume can survive (see
+  [04](04-container-hardening.md#container-spec-per-instance)).
+- **I2 — No demo payload ever reaches disk.** Not in proxy logs, not in warden
+  logs, not in netcanon logs, not in swap (swap disabled or encrypted-ephemeral).
+- **I3 — Hard TTL.** The warden destroys any instance **≤ 15 min after
+  assignment** (`HARD_TTL=900 s`, in-RAM reaper, `deadline = assignment_time +
+  HARD_TTL`) regardless of heartbeats or activity. Nothing the browser does can
+  extend a session past it; the separate idle reclaim (`IDLE_TTL=600 s`) and
+  heartbeat timeout only ever *shorten* life. The in-memory session dict alone
+  would orphan live instances on a warden crash/restart, so the hard TTL is
+  enforced across **two independent enforcement domains (the warden and host
+  systemd), three mechanisms**: (1) the warden's in-RAM reaper at `deadline =
+  assignment_time + HARD_TTL`; (2) the warden's **startup label-sweep**, which
+  force-removes every `demo.*`-labeled container it did not itself just create
+  (every instance is labeled at creation — `demo.created_at`, `demo.instance` —
+  the immutable labels the sweep keys on; the token does not exist at create); and
+  (3) an **independent host `systemd` timer** (swept every 60 s) that force-removes
+  any `demo.*`-labeled container older than `HARD_TTL + POOL_MAX_AGE = 1200 s`.
+  Because the reaper recycles any unassigned pool instance older than
+  `POOL_MAX_AGE − reaper_period` (~290 s), no instance is ever *assigned* more than
+  `POOL_MAX_AGE` (300 s) after creation, so a live session's creation-age deadline
+  is ≤ 1200 s and the backstop — which removes only containers *older than* 1200 s
+  — never fires before the in-RAM 900 s assignment-relative deadline (see
+  [04](04-container-hardening.md#host-level-complements)).
+- **I4 — Instances are not publicly routable.** Only the warden/proxy can reach
+  them, on an internal Docker network with inter-container isolation.
+- **I5 — Egress-locked instances.** Demo containers have no outbound internet
+  access. (Translation is local computation; egress is pure risk.)
+- **I6 — The deployment is reproducible from the public repo.** Anyone can
+  diff the running system's compose file hash against the published one.
+- **I7 — Resource-capped.** Per-instance CPU/RAM/pids limits and a global
+  instance cap; when full, visitors get a friendly "demo at capacity" state,
+  never a degraded-isolation fallback.
+
+## Success criteria
+
+- Visitor lands → instance ready in **< 3 s** (warm pool) → pastes config →
+  sees translation + Tier-3/audit banners → closes tab → instance destroyed.
+  The `pagehide` `sendBeacon` makes teardown near-immediate; absent a beacon,
+  the session is reclaimed **≤ 2 min for a closed foreground tab, ≤ ~4 min for a
+  throttled background tab** — 30 s heartbeat + a visibility-aware stale threshold
+  (75 s visible, 180 s hidden) + ~10 s reaper — *not* 60 s, which the heartbeat
+  math cannot deliver. An open-but-idle tab (heartbeating, but no
+  translate/detect/sanitize activity) is reclaimed at the 10-min idle TTL (sooner
+  under heavy load); at the 15-min hard TTL, every instance is destroyed
+  unconditionally.
+- Every whitepaper claim passes its [08](08-testing-verification.md) procedure
+  on the live host.
+- `docker diff` on a live demo instance shows changes only under tmpfs mounts.
+- A full teardown leaves `docker ps -a`, `docker volume ls`, and the host
+  filesystem with **zero** artifacts attributable to the session.
+
+## Glossary
+
+- **Warden** — the small session-manager service (FastAPI, ~300 lines) that
+  owns the Docker socket, spawns/destroys instances, and proxies traffic to
+  them. Spec: [03](03-warden-spec.md).
+- **Instance** — one hardened netcanon container bound to one browser session.
+- **Warm pool** — N pre-created, never-yet-assigned instances kept ready so
+  session start is instant. An instance is assigned exactly once.
+- **Session token** — random 128-bit URL-safe token minted by the warden;
+  the only linkage between a browser and its instance; held in memory only.

--- a/docs/demo-plan/01-architecture.md
+++ b/docs/demo-plan/01-architecture.md
@@ -1,0 +1,151 @@
+# 01 — Architecture
+
+## Framework decision
+
+**Chosen: single VPS + Docker Engine + a purpose-built "warden" session manager
++ Caddy.** Evaluated against alternatives:
+
+| Option | Verdict | Why |
+|---|---|---|
+| **Docker + custom warden (chosen)** | ✅ | Full control over lifecycle/teardown proofs; one cheap host; no platform trust required — the whitepaper only has to trust *our* config, all of it public. |
+| Fly.io Machines | Viable alt | Per-session VMs, per-second billing, auto-stop — genuinely good fit. Rejected as primary because retention proofs then depend on platform attestations you can't independently audit, and cost is less predictable under abuse. Documented as the fallback if the VPS pattern ever needs geographic scale. |
+| Kubernetes (k3s) | ❌ | Operationally heavy for one node; adds attack/complexity surface with zero benefit at this scale. |
+| Shared single stateless container (no instancing) | ❌ | Cheapest, but "no retention" then rests on application behavior instead of container-boundary destruction. Weaker whitepaper. |
+| Serverless (Lambda/Cloud Run) | ❌ | Cold starts, request-scoped not session-scoped, log plumbing you don't control by default. |
+
+## Components
+
+```
+                      ┌────────────────────────── VPS (Hetzner CX32) ──────────────────────────┐
+                      │                                                                        │
+  Browser ── HTTPS ──▶│  Caddy (:443)                                                          │
+                      │   ├── /            → static demo frontend (05)                         │
+                      │   ├── /session/*   → warden API (mint / heartbeat / end)               │
+                      │   └── /i/{token}/* + cookie-routed absolute paths → warden             │
+                      │                                                                        │
+                      │  Warden (FastAPI, drives docker.sock via socket-proxy)                 │
+                      │   ├── warm pool  [inst][inst][inst][inst]   (unassigned, N=4)          │
+                      │   ├── active map {token → container, deadline, last_heartbeat, last_activity, hidden} │
+                      │   ├── RESPONSE: strip X-Frame-Options, CSP frame-ancestors→'self'      │
+                      │   └── REQUEST: route by HttpOnly session cookie, not path-prefix       │
+                      │                                                                        │
+                      │  netcanon instances  (serve :8000, one container per session)          │
+                      │   ├── read-only rootfs, tmpfs, no volumes, no egress, cpu/mem cap      │
+                      │   └── nftables: warden→inst ALLOW, inst→inst/inst→warden DENY (04)     │
+                      └────────────────────────────────────────────────────────────────────────┘
+```
+
+*Box = CX32-class launch default (4 vCPU / 8 GB, EU Falkenstein — EU hosting is
+itself on-message for a privacy demo); the location fork (EU CX32 vs US CPX32),
+MAX_ACTIVE sizing, and the same-day rescale to CX42 live in
+[07](07-budget.md#sizing).*
+
+Caddy never talks to instances directly; the warden is the only path, so token
+checks and lifecycle state live in exactly one place. Because netcanon stamps
+`X-Frame-Options: DENY` and CSP `frame-ancestors 'none'` on every response
+(`main.py:366-374`), a plain iframe would render blank — and Caddy *cannot* relax
+that by **adding** a `frame-ancestors 'self'` header (multiple CSP headers
+intersect to the most restrictive). So the **warden** rewrites each proxied
+instance *response*: it strips `X-Frame-Options` and turns `frame-ancestors
+'none'` into `frame-ancestors 'self'`. And because the netcanon UI uses
+**absolute** URLs (`fetch('/api/v1/migration/plan')`, `href="/migrate"`) with
+**no root-path support**, naive `/i/{t}/` path-prefixing breaks; the warden
+instead routes **by session** — it sets the routing cookie on the `/session/new`
+mint response and re-stamps it on `/i/{t}/…` responses, bound to that instance
+(`Set-Cookie: nc_route=<token>; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=900`
+— defined in [03](03-warden-spec.md#proxying); `Path=/` is load-bearing so the
+cookie rides **every** allowlisted absolute path, and `Max-Age=900` matches
+`HARD_TTL`), and any allowlisted absolute path carrying that cookie is routed to
+the mapped container (one active session per browser is already the model). The
+routing cookie is warden-set (the frontend page itself sets none) and is
+disclosed in the whitepaper's *What we do see* ([06](06-privacy-whitepaper.md)).
+
+## Data flow (happy path)
+
+1. Browser loads static page → `POST /session/new`.
+2. Warden pops a warm-pool instance, mints token `t`, records
+   `deadline = assignment_time + HARD_TTL` (900 s — `now` is the assignment
+   moment) and seeds `last_activity = now`, returns
+   `{token, ttl_seconds, expires_at, idle_ttl_seconds, instance_id}` (`ttl_seconds`
+   = the 900 s hard ceiling the countdown runs to, computed client-side as
+   `receipt_time + ttl_seconds`; `expires_at` is informational only;
+   `idle_ttl_seconds` drives the idle indicator; `instance_id` is a display id,
+   **not** the routing token). Refills pool async.
+3. Browser **iframes** `/i/{t}/migrate` — the netcanon migrate UI, served by
+   *that visitor's* instance on `:8000` (bare `/i/{t}/` maps to the instance's
+   `/`, the default-denied backup dashboard, and is never the iframe target). On
+   that first response the warden strips
+   `X-Frame-Options`, relaxes the instance CSP so the frame renders, and re-stamps
+   the routing cookie (first set on the `/session/new` mint response); the UI's
+   absolute paths (`/migrate`,
+   `/api/v1/migration/plan`) then carry that cookie back through the warden to
+   the same instance. Pasted config → instance → translation + audit banners
+   rendered. **The warden streams bodies; it never logs or buffers them to disk**
+   ([03](03-warden-spec.md#proxying)).
+4. Browser heartbeats `POST /session/{t}/hb` every 30 s.
+5. End of life, whichever comes first:
+   - `POST /session/{t}/end` (sent via `navigator.sendBeacon` on `pagehide`
+     **only** — not `visibilitychange`→hidden, which fires on a tab-switch and
+     would kill the demo's own copy-config-from-another-tab flow) → immediate
+     destroy;
+   - missed heartbeats → reclaimed **≤ 2 min for a closed foreground tab, ≤ ~4
+     min for a throttled background tab** — the warden applies a visibility-aware
+     stale threshold keyed to the `{"hidden": <bool>}` each heartbeat reports:
+     **75 s** while visible (30 s heartbeat + 75 s + ~10 s reaper ≈ 115 s) and
+     **180 s** while hidden to absorb background-timer throttling (30 + 180 + 10 ≈
+     220 s) ([05](05-frontend.md));
+   - **idle TTL** (10 min / 600 s) → an open tab that keeps heartbeating but sends
+     no **allowlisted proxied POST** for `IDLE_TTL` is reclaimed anyway (heartbeats
+     don't reset it — only an allowlisted POST does: `plan`, its sub-plans,
+     `detect`, `sanitize`); tightened to 300 s above 80 % occupancy, loosens back
+     to 600 s below 70 % (hysteresis)
+     ([03](03-warden-spec.md#lifecycle-rules));
+   - **hard TTL** → destroy unconditionally, enforced independently of the
+     in-memory dict: **≤ 15 min after assignment** while the warden is live, and
+     **≤ ~20 min after creation** via the startup sweep + host systemd backstop if
+     the warden is dead (**I3**).
+6. Destroy = `container.remove(v=True, force=True)` (`docker rm -fv`) → container
+   + its tmpfs + any anonymous volume freed. Nothing to scrub because nothing
+   persisted (**I1/I2**).
+
+## Session lifecycle state machine
+
+```
+ POOLED ──assign──▶ ACTIVE ──(end│hb-timeout│idle│hard-ttl│reclaim)──▶ DESTROYED
+   ▲  │                                                                │
+   │  └──── pool-max-age recycle (unassigned > ~290 s) ────────────────┤
+   └───────────────── pool refill (new container) ◀──────────────────────┘
+```
+
+The only exit from `POOLED` other than `assign` is **pool-max-age recycle** — the
+reaper destroys an *unassigned* instance older than ~290 s (`POOL_MAX_AGE − reaper
+tick`) and the pool refills, so no instance is ever assigned older than 300 s
+(`POOLED→DESTROYED`, never through `ACTIVE`). On the `ACTIVE→DESTROYED` edge,
+`reclaim` is the at-cap longest-idle victim (see the `/session/new` row in
+[03](03-warden-spec.md)). `DESTROYED` is terminal; tokens are
+never reused; a returning browser gets a fresh instance via a fresh
+`POST /session/new`.
+
+## Why instancing at the container boundary
+
+netcanon's translate path is stateless per request, so a shared instance would
+*function*. Instancing is chosen because it converts the retention claim from
+"the app behaves well" into "the kernel freed the memory": even an application
+bug that cached a pasted config could only ever leak it into a container that
+is destroyed minutes later and was never reachable by another visitor (**I4**).
+That is what makes [06](06-privacy-whitepaper.md) provable rather than
+promissory.
+
+## Deliverables
+
+- Architecture section of the site (one diagram, links to whitepaper).
+- `docker-compose.yml` expressing: caddy, warden, socket-proxy, and three
+  networks — `demo-int` (`internal: true` for no egress; instances **and** warden),
+  `warden-sock` (warden **and** socket-proxy only — the socket-proxy is on no other
+  network), and the caddy-facing net (warden + caddy). Peer/warden-ward isolation
+  is **not** `enable_icc: false` — that is all-or-nothing and would also block
+  warden→instance; it is explicit **nftables on the `demo-int` bridge** implementing
+  warden→instance ALLOW, instance→instance DENY, instance→warden DENY (see
+  [04](04-container-hardening.md)).
+- This document's diagram reproduced in the repo (`docs/demo-architecture.md`).
+

--- a/docs/demo-plan/02-deployment.md
+++ b/docs/demo-plan/02-deployment.md
@@ -1,0 +1,175 @@
+# 02 — Deployment
+
+## Host
+
+**Launch default: a CX32-class box** (4 vCPU, 8 GB RAM, 40 GB NVMe) running
+Ubuntu 24.04 LTS. Location is an explicit fork — and because the CX line is
+**EU-only**, the originally-drafted "CX22 + Ashburn" is not a real SKU:
+
+- **EU — Hetzner CX32, Falkenstein** (4 vCPU / 8 GB / 40 GB / 20 TB traffic,
+  ~€6.80/mo). Preferred: EU hosting is itself on-message for a privacy demo, and
+  the 20 TB traffic allowance is generous.
+- **US — Hetzner CPX32, Ashburn or Hillsboro** (4 vCPU / 8 GB, shared-vCPU AMD
+  line, US latency for the primary audience). Must be **re-priced** and its
+  much-lower included-traffic allowance **re-verified** before committing — the
+  CX line does not exist in the US regions.
+
+Rationale: fits the operator's existing Hetzner + hardened cloud-init workflow;
+8 GB comfortably holds warden + Caddy + a warm pool + ~32 capped instances, sized
+off *real* held-session RSS rather than the 256 MB hard cap
+([07](07-budget.md#sizing)). Hetzner bills hourly, so the box can be **rescaled
+up same-day** (CX32 → CX42) if the launch lands — a CPU/RAM-only rescale that
+keeps the 40 GB disk, so it stays fully reversible ([07](07-budget.md#sizing)).
+
+## Provisioning (cloud-init)
+
+Reuse the existing hardened Ubuntu 24.04 cloud-init baseline, plus demo-specific
+items:
+
+- Docker Engine (official repo), compose plugin.
+- **Disable swap** (`swapoff -a`, remove from fstab) — closes the "pasted
+  config swapped to disk" hole. With hard per-instance memory caps this is safe;
+  document it as a whitepaper control (**I2**).
+- **Disable core dumps host-wide** — swap-off is not the only RAM→disk path; a
+  crashing process can also spill a pasted config to a core file. In cloud-init
+  set `kernel.core_pattern` to discard, `systemd-coredump` `Storage=none` +
+  `ProcessSizeMax=0`, remove/neuter `apport`, and set `docker.service`
+  `LimitCORE=0`. Documented alongside swap-off as a whitepaper control (**I2**).
+- UFW / nftables: inbound 443 (and 80 for ACME redirect only), SSH restricted
+  to admin IPs or an admin VPN, default-deny otherwise.
+- Unattended-upgrades (security), fail2ban for SSH.
+- `journald` config: `Storage=volatile`, `RuntimeMaxUse=64M` — host logs live
+  in RAM and rotate aggressively; nothing session-derived is in them anyway
+  ([04](04-container-hardening.md#logging)), this is defense in depth.
+- Non-root deploy user in `docker` group; warden is the only Docker-socket
+  consumer ([03](03-warden-spec.md#socket)).
+- Time sync (chrony) — TTL enforcement and audit timestamps depend on it.
+- **`OOMScoreAdjust=-500`** on `docker.service`, the warden, and Caddy (systemd
+  drop-ins) — under host memory pressure the OOM killer then targets an
+  **instance**, never a core service, so a runaway paste is killed in its own
+  container instead of taking down the warden or Caddy
+  ([07](07-budget.md#sizing)).
+- **Host hard-TTL backstop timer** — a `systemd` timer + oneshot service that
+  runs `every 60 s` (`OnUnitActiveSec=60s`, `OnBootSec=60s`) and force-removes
+  any `demo.*`-labeled container whose `demo.created_at` is older than
+  `HARD_TTL + POOL_MAX_AGE = 1200 s` (20 min). This is the warden-independent
+  enforcement domain: it holds the creation-age ceiling even while the warden is
+  dead ([03](03-warden-spec.md#lifecycle-rules),
+  [04](04-container-hardening.md)).
+
+## DNS + TLS
+
+- `demo.netcanon.dev` (or subdomain of whatever the main site domain becomes)
+  → A/AAAA to the VPS.
+- Caddy with automatic Let's Encrypt. HSTS on. TLS ≥ 1.2.
+- Main site (static) can live on the same Caddy or on GitHub Pages; only the
+  demo requires this host.
+
+## Caddy configuration requirements
+
+- Serve static frontend at `/`.
+- Reverse-proxy the warden's surface — `/session/*`, `/i/*`, and the allowlisted
+  netcanon app paths the warden re-routes **by session cookie** (netcanon's UI
+  uses absolute URLs and has no root-path support, so the warden routes by
+  session, not path-prefix; allowlist in [04](04-container-hardening.md),
+  warden detail in [03](03-warden-spec.md#socket)) — **with access-log body
+  capture disabled and URI logging truncated**. Access logs, if enabled at all,
+  log method + status + latency only; simplest compliant setting is access logs
+  **off** for `/i/*`, `/session/*`, **and every allowlisted cookie-routed app
+  path** — everything else stays status-only (**I2**).
+- Request body limit: **2 MB** (largest reasonable running-config; blocks abuse).
+  This one Caddy does natively (`request_body max_size`).
+- **Rate limiting is not at the Caddy layer.** Stock Caddy has *no* native
+  rate-limit directive. Rather than run an unpinned plugin, rate limiting moves
+  **into the warden**, which already holds per-IP state for its concurrent-
+  session cap ([07](07-budget.md#cost-abuse-guards)). If a Caddy-layer limit is
+  ever wanted it must be an `xcaddy` build with the **self-built binary pinned
+  by digest** so `make verify` stays honest (**I6**) — otherwise keep it in the
+  warden.
+- Security headers on the **static page**: HSTS, X-Content-Type-Options, a CSP
+  for the page itself, and **`Referrer-Policy: same-origin` on all demo paths**
+  (session tokens ride in the URL path, so a permissive referrer would leak them
+  on outbound clicks).
+- **Framing is fixed in the warden, not here.** netcanon stamps
+  `X-Frame-Options: DENY` and CSP `frame-ancestors 'none'` on every response
+  (`main.py:366-374`), so a plain iframe renders blank and a Caddy-*added*
+  `frame-ancestors 'self'` cannot relax it (multiple CSP headers intersect). The
+  warden therefore **strips `X-Frame-Options` and rewrites the instance CSP
+  `frame-ancestors 'none'` → `'self'` on every proxied response**
+  ([03](03-warden-spec.md#proxying)).
+
+## Image supply chain
+
+- Pin the netcanon image **by digest** in the warden's config
+  (`ghcr.io/netcanon/netcanon@sha256:…`), not `:latest`. The digest is printed
+  in the whitepaper's reproducibility section and bumped deliberately (**I6**).
+- Base image stays **`python:3.14-slim-bookworm`** with a hash-locked
+  `requirements.lock`; that digest + hash-lock chain is itself a whitepaper
+  reproducibility asset (**I6**). Alpine is deliberately **rejected** — rationale
+  in [07](07-budget.md#sizing).
+- Warden, Caddy, and **socket-proxy** images likewise pinned by digest (the
+  socket-proxy is a TCB component; the authz shim ships as repo source, covered by
+  the compose/repo hash).
+- **The instance image is pulled explicitly.** `docker compose pull` refreshes
+  only the warden + Caddy images (the only ones the compose file references); the
+  netcanon instance image is created **directly by the warden** and is not in the
+  compose file, so the deploy flow adds an explicit
+  `docker pull ghcr.io/netcanon/netcanon@sha256:<PINNED_DIGEST>`, and the warden
+  **refuses to start if that pinned digest is absent locally**
+  ([03](03-warden-spec.md)) — no silent pull-on-demand at the first pool-refill,
+  on a fresh host or after any digest bump.
+- A `make verify` target re-computes and prints all pinned digests + the
+  compose file SHA-256 so any visitor can compare against the published values
+  ([08](08-testing-verification.md)).
+
+## Monitoring
+
+Metadata-only, and consistent with the whitepaper ("no visitor tracking" is not
+"no operator telemetry"):
+
+- An **external uptime monitor** hitting `/` and `/healthz` from off-host, so an
+  outage is visible even if the box wedges.
+- `/healthz` exposes only aggregate counters (sessions started, destroys by
+  reason, 503 count, pool-refill failures) — no tokens, no per-session detail
+  ([03](03-warden-spec.md#socket)).
+- A synthetic **mint → translate-sample → end** probe a few times an hour,
+  exempt from the per-IP session cap, to catch a silently-broken pool.
+
+## Update/redeploy flow
+
+`git pull && docker compose pull && docker pull ghcr.io/netcanon/netcanon@sha256:<PINNED_DIGEST> && docker compose up -d`
+— the explicit instance-image pull is required because the compose file
+references only warden + Caddy (see Image supply chain above).
+
+**Drain and `SIGTERM` are distinct.** **Drain** is a **non-public** operation —
+triggered by a **loopback-only (`127.0.0.1`) control endpoint or a sentinel file
+the reaper watches**, never a routable HTTP path — that stops minting new
+sessions and lets in-flight ones lapse (idle reclaim ~10 min, hard TTL
+≤ 15 min) before recreate; expect a short **capacity dip** (existing sessions
+finish, no new ones start). **`SIGTERM` is fast shutdown, not drain:**
+`docker compose up -d` sends `SIGTERM`, so a redeploy without draining first
+**kills live sessions by design** — no state migration exists, and that is an
+acceptable choice for a demo. For a graceful window, drain first or raise the
+warden container's `stop_grace_period`. Either way, after the redeploy the fresh
+warden's startup label-sweep force-removes any leftover `demo.*` containers (it
+adopts nothing).
+
+## Deliverables
+
+- `deploy/cloud-init.yaml` (hardened baseline + swap-off + core-dump disable +
+  `OOMScoreAdjust=-500` drop-ins + the host hard-TTL backstop `systemd`
+  timer/oneshot: sweep `every 60 s`, creation-age ceiling `1200 s`)
+- `deploy/Caddyfile`
+- `deploy/docker-compose.yml` (caddy + warden + socket-proxy, and three
+  networks: `demo-int` `internal: true` (subnet `172.31.0.0/24`, plus
+  `driver_opts { com.docker.network.bridge.name: demo-int }` for a stable bridge
+  name the `DOCKER-USER` nftables rules can rely on) for instances + warden,
+  `warden-sock` for warden + socket-proxy only, and the caddy-facing net for
+  warden + caddy)
+- `Makefile` with `deploy` (full flow incl. the explicit instance-image
+  `docker pull …@sha256:<PINNED_DIGEST>`), `verify`, and a **host-local**
+  `drain` target — the drain trigger is the loopback-only (`127.0.0.1`) control
+  endpoint / sentinel file (stop minting, let sessions lapse), **not** `SIGTERM`
+  (which is fast shutdown) and not a public route
+- External uptime monitor configured against `/` and `/healthz`
+- DNS + TLS live on the chosen subdomain

--- a/docs/demo-plan/03-warden-spec.md
+++ b/docs/demo-plan/03-warden-spec.md
@@ -1,0 +1,365 @@
+# 03 — Warden Specification
+
+The warden is the only stateful service. Its *live* state is a single in-memory
+dict, but durable lifecycle enforcement does **not** depend on it (container
+labels + a startup sweep + an independent host timer — see Lifecycle). FastAPI +
+`docker` SDK + `httpx` (streaming proxy), run **single-process
+(`uvicorn --workers 1`)** so the session dict is never sharded across workers;
+synchronous `docker` SDK calls run via `asyncio.to_thread` and a single
+`asyncio.Lock` guards the pool + active-map + caps (see Security posture).
+Target: small enough to audit in one sitting (≤500 lines); the whitepaper links
+to its source and counts it — together with the socket-proxy + small create-body
+authz shim (see Security posture) — as the Trusted Computing Base.
+
+## Responsibilities
+
+1. Maintain the **warm pool** (default 4 unassigned instances), refilled
+   **single-flight** — one refill task at a time, guarded by the pool lock — so a
+   burst of assignments cannot thundering-herd N concurrent container-creates on
+   the 2-vCPU box.
+2. Mint sessions: assign instance, generate token, bind a routing cookie, track
+   deadline/heartbeat.
+3. Reverse-proxy to the assigned instance — streaming, never persisting bodies —
+   fixing up framing headers and routing by session cookie (netcanon uses
+   absolute URLs and has no root-path support; see Proxying).
+4. Enforce lifecycle: heartbeat timeout, idle-TTL reclaim, hard TTL, explicit
+   end — across **two independent enforcement domains (the warden and host
+   systemd), three mechanisms**, with the in-memory dict as the warden's live
+   reaper (see
+   Lifecycle).
+5. Enforce global + per-IP caps, occupancy-driven idle-TTL, and expose an
+   operational `/healthz`.
+
+## API
+
+| Route | Method | Behavior |
+|---|---|---|
+| `/session/new` | POST | If the request carries a **valid `nc_route` cookie**, destroy that session first (reason `end`) and mint fresh — **one live session per browser** (the cookie is browser-global). Enforce the per-IP session cap, then pop pool → mint token (`secrets.token_urlsafe(16)`), set the routing cookie → `{token, ttl_seconds, expires_at, idle_ttl_seconds, instance_id}`. Pool empty at cap → reclaim the longest-idle session **older than the 120 s floor** and retry; if every active session is younger than 120 s, or still full → `503 {"reason":"capacity"}`. |
+| `/session/{t}/hb` | POST | Body `{"hidden": <bool>}` (from `document.visibilityState`). Update `last_heartbeat` and the stored visibility (tab-liveness only — does **not** reset the idle timer; only an allowlisted proxied POST does). Returns `{"idle_remaining_seconds": <int>}`. 404 for unknown/dead tokens. |
+| `/session/{t}/end` | POST | Immediate destroy. Idempotent 204. Must accept `sendBeacon` (no CORS preflight — same-origin, `text/plain`). |
+| `/i/{t}/{path:path}` | ANY | Token valid **and `{path}` on the route allowlist** → set the routing cookie, streamed proxy to instance `:{INSTANCE_PORT}` (8000); off-allowlist `{path}` (incl. bare `/i/{t}/` → instance `/`, the blocked backup dashboard) or bad token → 404. Frontend targets `/i/{t}/migrate`. |
+| allowlisted absolute paths (`/migrate`, `/api/v1/migration/*`, …) | ANY | Routed by **routing cookie** to the mapped instance; off-allowlist → 404. Any allowlisted **proxied POST** (`POST /api/v1/migration/plan` and all `/plan/*` sub-plans — `/ports`, `/vlans`, `/local_users`, `/snmp`, `/snmpv3` — plus `POST /api/v1/migration/detect` and `POST /api/v1/sanitize`) also refreshes the session's `last_activity` (resets the idle timer); GETs and `/hb` do not. Allowlist in [04](04-container-hardening.md). |
+| `/healthz` | GET | Pool size, active count, uptime, aggregate counters (see Operational telemetry). **No tokens, no per-session detail.** |
+
+## Lifecycle rules
+
+> Every instance is destroyed **≤ 15 min after assignment** (the warden's in-RAM
+> reaper, `deadline = assignment_time + HARD_TTL`) and **≤ ~20 min after creation
+> even with the warden dead** (an independent host `systemd` timer that
+> force-removes any `demo.*`-labeled container older than
+> `HARD_TTL + POOL_MAX_AGE = 1200 s`, swept every 60 s). Because the reaper
+> recycles any unassigned pool instance whose age exceeds
+> `POOL_MAX_AGE − reaper_period` (290 s), no instance is ever *assigned* more than
+> `POOL_MAX_AGE` (300 s) after its creation; a live session's creation-age deadline
+> is therefore ≤ `HARD_TTL + POOL_MAX_AGE` (1200 s), and the systemd backstop
+> force-removes only containers *older than* 1200 s — strictly after the in-RAM
+> deadline, never before.
+
+- **Two independent TTLs — a session dies at whichever fires first:**
+  - `HARD_TTL = 900 s` (15 min) **hard ceiling** — a monotonic-clock deadline
+    (`deadline = assignment_time + HARD_TTL`, set when the instance is *assigned*
+    out of the pool, not when it was created — see the epoch note under
+    Enforcement); nothing the browser does moves it (**I3**). This is the
+    advertised "self-destructs within 15 minutes"; the frontend countdown runs to
+    it, so the ceiling reads as a feature, not a limitation.
+  - `IDLE_TTL = 600 s` (10 min) **idle reclaim** — destroy a session whose last
+    activity is older than `IDLE_TTL` (`now − last_activity > IDLE_TTL`) **even
+    while it is still heartbeating**. This reclaims the open-but-unused tab — the
+    dominant dwell driver — without touching the hard ceiling. `IDLE_TTL` is a
+    **single global reaper parameter**, compared against every session's
+    `last_activity` at each tick, so a change is **retroactive** (an already-idle
+    session becomes eligible at the next tick). It has **hysteresis**: tighten
+    `600 → 300 s` when occupancy **> 80 %**, loosen `300 → 600 s` when occupancy
+    **< 70 %** (the 70–80 % dead-band prevents thrash). A tightening **takes effect
+    at the next reaper tick, and a session already idle beyond the new threshold is
+    reaped one tick later** (≈ 10–20 s after occupancy crosses 80 %) — at most one
+    heartbeat, and possibly none, lands in that window to surface it (see
+    [05](05-frontend.md)). The hard ceiling is **never** shortened
+    (you reclaim idle
+    sessions faster, you do not renege on the advertised 15 minutes).
+- `last_activity` is updated by **any allowlisted POST proxied to the instance** —
+  `POST /api/v1/migration/plan` and all `/plan/*` sub-plans (`/ports`, `/vlans`,
+  `/local_users`, `/snmp`, `/snmpv3`), `POST /api/v1/migration/detect`, and
+  `POST /api/v1/sanitize`. `last_heartbeat` tracks tab liveness and is updated by
+  `/hb`; GETs and `/hb` do **not** refresh `last_activity`. The two clocks are
+  deliberately separate: a heartbeat keeps a tab clear of the hb-timeout reaper
+  but does **not** stave off the idle reclaim — only actually using netcanon does.
+- Heartbeat interval 30 s; the stale threshold is **visibility-aware** — the
+  `/hb` body carries `{"hidden": <bool>}` and the warden stores the last-reported
+  visibility: **75 s** while visible (2 missed + margin), **180 s** while hidden
+  (a throttled background tab beats at a slower cadence). This bounds no-beacon
+  reclaim to **≤ 2 min for a closed foreground tab, ≤ ~4 min for a throttled
+  background tab**.
+- Reaper loop every 10 s: destroy `now > deadline` (hard-ttl) `|| now −
+  last_activity > IDLE_TTL` (idle) `|| last_heartbeat-stale` (hb, threshold keyed
+  to the reported visibility), and **recycle** any unassigned pool instance whose
+  age exceeds `POOL_MAX_AGE − reaper_period` (290 s) (destroy + refill) — so no
+  instance is ever *assigned* older than `POOL_MAX_AGE` (300 s) — then refill the
+  pool to target. Refill is **single-flight** — one refill task at a time, guarded
+  by the pool lock. The reaper also watches the drain sentinel (see Draining and shutdown)
+  and, when it is set, stops minting and lets sessions lapse.
+- Destroy = `container.remove(v=True, force=True)` — `v=True` also removes the
+  container's anonymous volumes so nothing survives on the host disk. Verify
+  gone; log `session_destroyed duration_s=… reason=hard-ttl|idle|hb|end|reclaim` —
+  `reclaim` is the at-cap longest-idle victim (below); **metadata only**. Pool
+  recycling destroys an *unassigned* instance (no session) and is counted
+  separately as `pool_recycled`.
+- **Enforcement is not the in-memory dict alone** — a warden crash/restart would
+  otherwise orphan live instances. The hard TTL is enforced across **two
+  independent enforcement domains (the warden and host systemd), three
+  mechanisms**: (1) the warden's in-RAM reaper at `deadline = assignment_time +
+  HARD_TTL`; (2) the warden's **startup label-sweep**, which force-removes every
+  `demo.*`-labeled container it did not itself just create (it adopts nothing);
+  and (3) an **independent host `systemd` timer** (sweep cadence 60 s,
+  `OnUnitActiveSec=60s`/`OnBootSec=60s`) that force-removes any `demo.*`-labeled
+  container older than `HARD_TTL + POOL_MAX_AGE` (1200 s), so the creation-age
+  ceiling holds even while the warden is down (a crash can widen the effective
+  ceiling from 15 min-after-assignment to ≤ ~20 min-after-creation, never lift
+  it). Idle and heartbeat reclaim are warden-live-only; the systemd backstop is
+  what covers a wedged/dead warden.
+  - **Epoch note.** Every instance is created with labels
+    `demo.created_at=<unix-ts>` and `demo.instance=<create-time random id>` —
+    **not** the token (it does not exist at create, and labels are immutable). The
+    warden's in-RAM deadline is assignment-relative (900 s from assignment); the
+    warden-dead backstop can only read the create-time label, so it uses the
+    looser creation-relative 1200 s ceiling that provably cannot fire before a
+    live session's 900 s (see the guarantee blockquote above).
+  - Pool recycling (at `POOL_MAX_AGE − reaper_period`, ~290 s) is a **warden**
+    action, which also closes the old "a host timer force-removes the whole idle
+    pool / races a fresh assignment" hazard — recycling is never a systemd race at
+    1200 s.
+- Global cap: `MAX_ACTIVE = 32` (tunable per [07](07-budget.md#sizing); sized off
+  real held-session RSS ≈ 90–140 MB + shim, **not** the 256 MB cap). Plus a
+  warden-enforced **per-IP concurrent-session cap (`PER_IP_MAX_CONCURRENT = 2`)**
+  and a **sliding-window per-IP mint rate limit (≤ 30 mints / 600 s per IP)**.
+  Both share one per-IP record, held in **warden RAM only** and **evicted 600 s
+  (10 min) after that IP's last request** (a rate limiter must outlive a single
+  session), disclosed under
+  [06 "What we do see"](06-privacy-whitepaper.md#what-we-do-see).
+- At cap, `/session/new` reclaims the **longest-idle session older than the 120 s
+  min-age floor** (a session younger than 120 s is never the victim — it protects
+  a seconds-old mid-paste session); if every active session is under the floor, or
+  the pool is drained, `/session/new` → 503 and the frontend shows the busy state.
+  Under heavy load an untouched session may thus be reclaimed early to make room.
+
+## Instance creation parameters
+
+Exact hardening flags in [04](04-container-hardening.md); the warden creates
+containers with those parameters verbatim — they are defined in one constants
+block so the whitepaper can cite a single source location.
+
+The instance image is pinned by digest and is **not** in the compose file (the
+warden creates instances directly), so the warden asserts the pinned digest is
+present locally at startup (`docker image inspect <pinned digest>`) and **refuses
+to start** if it is absent — no silent pull-on-demand. The host deploy flow
+therefore `docker pull`s the pinned instance digest explicitly (see
+[02](02-deployment.md#image-supply-chain)).
+
+Instances start with a per-instance throwaway `NETCANON_API_KEY` that the warden
+generates at create time and injects into proxied `/api/v1` requests. The image
+gates a non-loopback bind on that key **alone** — a key *or*
+`NETCANON_ALLOW_INSECURE_BIND=1` (config.py); we set the key and never set the
+insecure-bind opt-out — so "unauthenticated netcanon API" is kept out of
+existence entirely, which reads better in the whitepaper. `NETCANON_PORT=8000`,
+the RAM-only per-instance `NETCANON_FERNET_KEY` (no key file is ever written),
+and the rest of the env + hardening flags live in the one constants block in
+[04](04-container-hardening.md).
+
+## Proxying
+
+- Stream request and response bodies (`httpx` streaming); **no body ever
+  touches a buffer that outlives the request, no body is ever logged** (**I2**).
+- Strip hop-by-hop headers; add `X-Forwarded-*`.
+- **Fix framing on every instance response.** netcanon stamps
+  `X-Frame-Options: DENY` and a CSP with `frame-ancestors 'none'` on every
+  response (main.py:366-374), so a plain iframe renders blank and a CSP header
+  *added* downstream can't relax it (multiple CSP headers intersect). The warden
+  therefore **strips `X-Frame-Options`** and **rewrites the instance CSP
+  directive `frame-ancestors 'none'` → `frame-ancestors 'self'`** so the demo
+  origin may frame it; the page stays in an iframe (frontend detail:
+  [05](05-frontend.md)).
+- **Route by session cookie, not path prefix.** netcanon's UI uses absolute URLs
+  (`fetch('/api/v1/migration/plan')`, `href="/migrate"`) and has no root-path
+  support, so a `/i/{t}/`-mounted prefix would break every asset and API call.
+  Instead, serving `/i/{t}/…` sets the routing cookie bound to that instance — the
+  exact line is:
+  ```
+  Set-Cookie: nc_route=<token>; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=900
+  ```
+  `Path=/` is mandatory: without it RFC-6265 default-path scoping would restrict
+  the cookie to `/i/…` and the absolute-path routing would never carry it, so the
+  whole cookie-routing scheme would fail at Gate 2. `Max-Age=900` matches
+  `HARD_TTL` (the cookie is dead-on-arrival once the session ends — the warden
+  404s the token regardless). The warden routes any allowlisted absolute path
+  carrying that cookie to the mapped instance (one active session per browser is
+  already the model). The **frontend page itself sets no cookies or localStorage**;
+  this cookie is warden-set and is disclosed under
+  [06 "What we do see"](06-privacy-whitepaper.md#what-we-do-see).
+- **The route allowlist applies to the `{path}` component of `/i/{t}/{path}`
+  exactly as it does to absolute cookie-routed paths.** So `/i/{t}/api/v1/backups`
+  is default-denied just like `/api/v1/backups`, and bare `/i/{t}/` (→ instance
+  `/`, the blocked backup dashboard) is **not** on the allowlist and 404s; the
+  frontend therefore targets `/i/{t}/migrate`, which is allowlisted.
+- netcanon has **no WebSockets** — the UI polls via `fetch`. There is no WS path
+  to proxy, so no WS fallback is carried; the warden stays the only path to
+  instances.
+
+## Security posture of the warden itself
+
+- <a name="socket"></a>Reaches the Docker API through a **socket-proxy / authz
+  filter**, never the raw socket. Running the warden `read_only: true` and
+  non-root does **not** constrain what the socket API can do — a mounted
+  `docker.sock` is root-equivalent on the host — so a minimal path/method filter
+  (e.g. `docker-socket-proxy`) allows **only create, start, list
+  (`GET /containers/json`, including label filters), inspect, and remove**, and
+  denies everything else (`exec`, `commit`, `build`, `images`, `networks`,
+  `volumes`, …). `list` is needed by the startup label-sweep to discover orphaned
+  `demo.*` containers after a crash (no IDs to inspect otherwise); `start` because
+  Docker separates create from start and pool instances must be **running** to
+  serve `:8000`.
+- <a name="shim"></a>The path/method filter cannot inspect a create **body**, so
+  a **small (~50–80-line) create-body authz shim** (an authz plugin in front of
+  the socket proxy) enforces a **whole-body default-deny allowlist** on every
+  `POST /containers/create`. It validates the **raw wire body** (whose keys are
+  `HostConfig`-nested — `ReadonlyRootfs`, `Tmpfs`, `Memory`, `NanoCpus`, `CapDrop`,
+  `NetworkMode`, `LogConfig`, … — not the Python-SDK kwargs) against the
+  **canonical create-body template = `INSTANCE_SPEC` serialized through the pinned
+  Docker-SDK version**, structural defaults included: the body may contain **only**
+  the template's keys — **any other key is rejected outright** — and each must
+  equal the template (image digest, `ReadonlyRootfs: true`, the tmpfs set,
+  `NetworkMode`, `Memory == MemorySwap`, `PidsLimit`, `NanoCpus`,
+  `CapDrop: [ALL]` **with `CapAdd: []`**, `SecurityOpt`). Only the
+  deliberately-variable fields — the `demo.created_at`/`demo.instance` labels and
+  the two per-instance random env keys (`NETCANON_API_KEY`, `NETCANON_FERNET_KEY`)
+  — may differ. **Default-deny is load-bearing:** a positive check of only the
+  fields the shim *knows about* would pass a body that keeps every listed field
+  canonical yet **adds** a root-equivalent one, so the shim explicitly rejects any
+  of `Privileged`, `CapAdd`, `Devices`, `PidMode`/`IpcMode`/`UTSMode`,
+  `NetworkMode: host`, `UsernsMode`, `VolumesFrom`, `HostConfig.Binds` /
+  `HostConfig.Mounts` (bind), `CgroupParent`, `Sysctls`, `Runtime`, or a changed
+  `LogConfig`. That is what makes "create-with-fixed-spec" genuinely enforceable —
+  `Binds:["/:/host"]`, `Privileged:true`, and `CapAdd:[SYS_ADMIN]` are all
+  impossible. The shim is **counted in the Trusted Computing Base** alongside the
+  ≤500-line warden and the socket-proxy; together the socket-proxy + shim are the
+  crown jewel and the main reason the warden stays small and auditable.
+- The **socket-proxy attaches to the dedicated `warden-sock` network only**
+  (warden + socket-proxy, no other network), so instances — on `demo-int` only —
+  cannot reach it by construction, in addition to the nftables instance→warden
+  DENY (see [Network isolation](#network)).
+- The warden container still runs `read_only: true`, non-root where the SDK
+  allows, and `no-new-privileges`. It bridges **three networks** — `demo-int`
+  (`internal: true`, to proxy instances; the warden holds the static address
+  `172.31.0.2`), `warden-sock` (to reach the socket-proxy), and the caddy-facing
+  net — and is **not** on the instance-to-instance path.
+- **Single process, `uvicorn --workers 1`** (multiple workers would shard the
+  session dict). A **single `asyncio.Lock`** guards the pool + active-map + caps,
+  but is held **only for O(1) in-RAM mutations, never across an awaited `docker`
+  SDK call** (holding it across create/remove would block `/hb` and proxied reads
+  — the very heartbeat freeze it must avoid). The two guarantees — never freeze
+  heartbeats **and** never double-assign — coexist only via **reserve-then-fill**:
+  under the lock, mark the chosen instance `RESERVING` (a mint) or `DESTROYING` (a
+  reaper recycle / at-cap reclaim) and remove it from the assignable pool; release
+  the lock; do the container I/O via `asyncio.to_thread` (or `aiodocker`);
+  re-acquire only to commit the O(1) state change. A mint therefore can never pop
+  an instance the reaper is concurrently destroying, and no `docker` call ever runs
+  under the lock.
+- Never executes anything inside instances (`exec` is denied); the socket-proxy
+  verb allowlist is **create, start, list, inspect, remove** only.
+- Token comparison in constant time (`secrets.compare_digest`).
+- All warden logs to stdout → journald (volatile). Log schema is enumerated in
+  the whitepaper; grep-able proof that no payload fields exist
+  ([08](08-testing-verification.md#log-audit)).
+
+## <a name="network"></a>Network isolation
+
+Instances attach to the `demo-int` bridge (`internal: true`, no egress — **I5**);
+instances receive addresses in `172.31.0.0/24` and the **warden holds the static
+address `172.31.0.2`**. The bridge's forward path is **default-drop**, with these
+rules evaluated in order, implementing the three-way policy so instances are never
+publicly routable (**I4**):
+
+```
+1) ct state established,related                      accept   # return path for warden→instance
+2) ip saddr 172.31.0.2  tcp dport 8000               accept   # warden → instance ALLOW
+3) ip daddr 172.31.0.2                               drop     # instance → warden DENY
+4) ip saddr 172.31.0.0/24 ip daddr 172.31.0.0/24     drop     # instance → instance DENY
+5) (default)                                         drop
+```
+
+- **warden → instance: ALLOW** (rules 1–2) — the proxy path.
+- **instance → warden: DENY** (rule 3) — a compromised instance cannot reach the
+  control plane / socket-proxy; it can only answer proxied requests.
+- **instance → instance: DENY** (rule 4) — a compromised instance cannot reach a
+  peer.
+
+`enable_icc=false` is **not** used (it is all-or-nothing and would also cut
+warden→instance). The socket-proxy is unreachable from instances by construction
+— it is on the `warden-sock` network only, which instances never join.
+
+**Interface vs subnet matching, and anti-spoofing.** Rule 4 matches by **subnet**
+(`172.31.0.0/24`), not `iifname "demo-int"`: a Docker-created bridge is named
+`br-<hash>` unless pinned with
+`driver_opts { com.docker.network.bridge.name: demo-int }`, so subnet matching is
+robust regardless of the interface name. The ruleset lives in the `DOCKER-USER`
+chain scoped to the demo bridge, so it never touches the `warden-sock` / caddy
+nets. Rule 2 trusts the source IP `172.31.0.2`; that is safe **because** instances
+run `cap_drop: [ALL]` (no `CAP_NET_RAW`, so a compromised instance cannot
+source-spoof the warden's address) — where the deployment can pin the warden's
+veth name, add an `iifname` match to rule 2 as a second layer rather than relying
+on `cap_drop` alone.
+
+Instances need no outbound egress (netcanon plans offline); host-level egress
+rules are in [04](04-container-hardening.md).
+
+## Draining and shutdown
+
+- The **sole drain trigger** is a **loopback-only control endpoint (bound to
+  `127.0.0.1`)** or a **sentinel file the reaper watches** — not a routable HTTP
+  path. When set, the warden stops minting new sessions and lets existing sessions
+  lapse naturally.
+- **SIGTERM is fast shutdown, not drain.** `docker compose up -d` sends SIGTERM
+  and **kills live sessions by design** — no session-state migration exists. A
+  graceful window, if wanted, comes from raising the container's
+  `stop_grace_period`, not from treating SIGTERM as a drain.
+- This is consistent with **adopt-nothing**: after a redeploy the fresh warden's
+  startup label-sweep force-removes any leftover `demo.*` containers, so a
+  redeploy without draining first is safe (it just kills those live sessions).
+
+## Operational telemetry (`/healthz`)
+
+Metadata-only — "no visitor tracking" is not "no operator telemetry". Beyond
+pool size / active count / uptime, `/healthz` exposes aggregate counters with no
+per-session or per-visitor detail:
+
+- `sessions_started`
+- `destroys_by_reason` (`hard-ttl` / `idle` / `hb` / `end` / `reclaim`)
+- `pool_recycled` (unassigned instances recycled at ~290 s, `POOL_MAX_AGE − reaper_period`)
+- `503_count`
+- `pool_refill_failures`
+
+These back an external uptime monitor and a synthetic
+mint→translate-sample→end probe (a few times/hr, exempt from the per-IP cap);
+verification detail in [08](08-testing-verification.md).
+
+## Deliverables
+
+- `warden/app.py` (+ `warden/Dockerfile`, pinned base image) and the
+  socket-proxy / authz-filter config
+- Constants block, single source of truth: `INSTANCE_PORT = 8000`,
+  `HARD_TTL = 900 s`, `IDLE_TTL = 600 s`, `POOL_MAX_AGE = 300 s`, `HB = 30 s`,
+  `MAX_ACTIVE = 32`, warm-pool size 4, `PER_IP_MAX_CONCURRENT = 2`, per-IP mint
+  rate limit, the 120 s at-cap reclaim floor, container spec / `INSTANCE_SPEC`
+- Host `systemd` timer unit (independent hard-ceiling backstop; force-removes any
+  `demo.*`-labeled container older than `HARD_TTL + POOL_MAX_AGE = 1200 s`, swept
+  `every 60 s` via `OnUnitActiveSec=60s`/`OnBootSec=60s`) + startup-sweep hook +
+  the loopback/sentinel `drain` trigger (SIGTERM = fast shutdown, not drain)
+- Unit tests: lifecycle transitions, **hard-TTL immovability** (an instance aged
+  in the pool to ~250 s then assigned still survives a full 900 s **from
+  assignment**, and the creation+1200 s backstop does not kill it early), **idle
+  reclaim** (heartbeating — including `detect`/sub-plan calls that refresh
+  `last_activity` — but no activity for `IDLE_TTL` → destroyed), startup sweep of
+  orphaned `demo.*`-labeled containers, token unguessability, framing-header
+  rewrite, cookie routing (incl. the `/i/{t}/{path}` allowlist: bare `/i/{t}/` and
+  `/i/{t}/api/v1/backups` → 404, `/i/{t}/migrate` → 200), proxy streams without
+  buffering to disk (tmpdir watch), longest-idle reclaim (never a <120 s session),
+  per-IP cap, 503-at-cap, and concurrent-mint safety under the lock

--- a/docs/demo-plan/04-container-hardening.md
+++ b/docs/demo-plan/04-container-hardening.md
@@ -1,0 +1,221 @@
+# 04 — Instance Hardening (No-Retention Controls)
+
+Every flag here is a whitepaper claim. The warden applies them verbatim from
+one constants block; [08](08-testing-verification.md) proves each on the live
+system.
+
+## Container spec (per instance)
+
+```python
+# warden constants — the single source of truth cited by the whitepaper
+INSTANCE_PORT = 8000  # netcanon's listen port (config.py:266; Dockerfile EXPOSE 8000)
+
+INSTANCE_SPEC = dict(
+    image        = "ghcr.io/netcanon/netcanon@sha256:<PINNED_DIGEST>",
+    #              I6: digest-pinned. Base stays python:3.14-slim-bookworm —
+    #              Alpine is REJECTED (it invalidates the hash-locked
+    #              requirements.lock → musllinux/source builds, for a ~10% RSS
+    #              win that changes no sizing tier). The digest + hash-lock
+    #              chain is itself a whitepaper asset (I6).
+    read_only    = True,                          # I1: read-only rootfs
+    tmpfs        = {                              # every writable path in RAM
+        "/tmp":         "rw,noexec,nosuid,size=64m",  # PASTE path — see note
+        "/app/data":    "rw,noexec,nosuid,size=32m",  # jobs/devices/schedules root
+        "/app/configs": "rw,noexec,nosuid,size=8m",   # image VOLUME — MUST be tmpfs
+    },
+    volumes      = None,                          # I1: zero volumes, ever
+    network      = "demo-int",                    # I4: internal-only network
+    mem_limit    = "256m",
+    memswap_limit= "256m",                        # no swap headroom (I2)
+    nano_cpus    = 500_000_000,                   # 0.5 CPU
+    pids_limit   = 128,
+    cap_drop     = ["ALL"],
+    security_opt = ["no-new-privileges:true"],
+    # No `user` override: the image already runs non-root as uid 1000 via
+    # `USER app` (Dockerfile:96). Forcing a different uid breaks tmpfs
+    # ownership on the mounts above.
+    labels       = {                              # hard-TTL backstop keys
+        "demo.created_at": "<unix-ts>",           # swept on warden startup +
+        "demo.instance":   "<create-time random id>",  # host systemd timer — see 03
+        #              NOT the token: it does not exist at create time and labels
+        #              are immutable. The assignment→token binding + the live
+        #              deadline = assignment_time + HARD_TTL live in warden RAM.
+    },
+    environment  = {
+        "NETCANON_API_KEY":    "<per-instance random>",  # see 03
+        "NETCANON_HOST":       "0.0.0.0",                # internal net only
+        "NETCANON_PORT":       str(INSTANCE_PORT),       # = 8000
+        "NETCANON_LOG_LEVEL":  "warning",               # bodies never logged — see note
+        "NETCANON_FERNET_KEY": "<per-instance random>",  # RAM-only; no key file
+    },
+    log_config   = {"type": "none"},              # I2: Docker captures no stdout
+)
+
+# Teardown: container.remove(v=True, force=True). v=True guarantees no
+# anonymous volume can outlive the instance — the belt to the tmpfs
+# suspenders above.
+```
+
+Notes:
+
+- **`/app/configs` MUST be tmpfs.** The image declares
+  `VOLUME ["/app/configs", "/app/data"]` (Dockerfile:113). Mounting a tmpfs
+  over `/app/data` alone leaves `/app/configs` to Docker's default handling —
+  an **anonymous host-disk volume** that survives the container and falsifies
+  the "zero volumes" claim (**I1**). Both declared VOLUME paths get an explicit
+  in-RAM tmpfs; `remove(v=True, …)` sweeps any anonymous volume regardless.
+- **`/tmp` is on the paste path, not hygiene.** Starlette spools multipart
+  uploads larger than ~1 MB to `/tmp`; a pasted config large enough to spool
+  lands there. Keeping `/tmp` in RAM (`noexec,nosuid`) is therefore a
+  **deliberate no-retention control** for submitted payloads, not incidental
+  cleanliness.
+- **No Fernet key file is ever created (claim 7).** Passing
+  `NETCANON_FERNET_KEY` is Tier 1 of netcanon's key resolution
+  (`security/credentials.py`), so the Tier-3 file fallback at
+  `$NETCANON_DATA_DIR/.fernet_key` is **never written**. The key lives only in
+  the instance's RAM and dies with it — the claim is "no key file is created,"
+  not merely "the file is in tmpfs."
+- **`NETCANON_LOG_LEVEL=warning` is safe.** netcanon never logs request bodies
+  at **any** level; only parsed config *fragments* appear at `debug`. `warning`
+  excludes even those, so no payload can reach a log line regardless of driver.
+- `log_config type=none` is the bluntest correct tool: the daemon keeps **no**
+  container output at all. Operational visibility comes from warden metadata
+  logs, which contain no payloads. If instance stderr is ever needed for
+  debugging, flip to `local` with `max-size=1m` **in a dev environment only** —
+  never in prod; the whitepaper states `none`.
+- **Labels drive the hard-TTL backstop.** `demo.created_at` / `demo.instance`
+  are what the warden's startup sweep and the independent host systemd timer
+  match on to force-remove orphaned instances (see
+  [03](03-warden-spec.md#lifecycle-rules)); without them a warden crash would orphan
+  live containers that the in-memory dict no longer tracks. Neither label is the
+  session token — the token does not exist at create time and labels are
+  immutable, so the live per-instance deadline (`deadline = assignment_time +
+  HARD_TTL`, 900 s) lives only in warden RAM, never in a label. The reaper
+  **recycles any unassigned pool instance older than `POOL_MAX_AGE − reaper_period`
+  (~290 s)** (destroy + refill), so no instance is ever *assigned* more than
+  `POOL_MAX_AGE` (300 s) after creation. The independent host
+  `systemd` timer (sweep cadence `every 60 s`) therefore only needs a
+  creation-age ceiling of `HARD_TTL + POOL_MAX_AGE = 1200 s` (20 min) on
+  `demo.created_at` — provably looser than any live session's 900 s
+  assignment-relative deadline, so it can never fire early. Idle and heartbeat
+  reclaim are **warden-live-only**; this systemd backstop is what bounds the
+  warden-dead path (≤ ~20 min after creation).
+- **Network egress + segmentation:** `demo-int` is created with
+  `internal: true` → no outbound internet (**I5**); instances receive addresses
+  in `172.31.0.0/24` and the **warden holds the static address `172.31.0.2`**.
+  Do **not** reach for `enable_icc=false`: it is all-or-nothing on the bridge and
+  would also cut **warden→instance**, breaking the proxy. Implement the matrix
+  with explicit nftables rules on the bridge's **default-drop** forward path,
+  evaluated in order:
+
+  ```
+  1) ct state established,related                      accept   # return path for warden→instance
+  2) ip saddr 172.31.0.2  tcp dport 8000               accept   # warden → instance ALLOW
+  3) ip daddr 172.31.0.2                               drop     # instance → warden DENY
+  4) ip saddr 172.31.0.0/24 ip daddr 172.31.0.0/24     drop     # instance → instance DENY
+  5) (default)                                         drop
+  ```
+
+  Rule 4 matches by **subnet** (`172.31.0.0/24`), not `iifname "demo-int"`: a
+  Docker-created bridge is named `br-<hash>` unless pinned with
+  `driver_opts { com.docker.network.bridge.name: demo-int }`, so subnet matching is
+  robust regardless of the interface name. The ruleset lives in the `DOCKER-USER`
+  chain scoped to the demo bridge. Rule 2 trusts the source IP; `cap_drop: [ALL]`
+  (no `CAP_NET_RAW`) is what stops a compromised instance source-spoofing
+  `172.31.0.2` — bind the warden's veth with `iifname` as a second layer where the
+  interface name can be pinned.
+
+  The socket-proxy is unreachable from instances **by construction** — it sits on
+  the dedicated `warden-sock` network (warden + socket-proxy only), which
+  instances never join, on top of the instance→warden DENY above (**I4**). See
+  [03](03-warden-spec.md#socket) for the docker-socket proxy that is the true privilege
+  boundary — `read_only` + non-root on the warden container do **not**
+  constrain the socket API, which is root-equivalent on the host.
+
+## <a name="route-allowlist"></a>Feature surface reduction
+
+The demo needs exactly two flows — **migrate/translate** and **sanitize** —
+plus the read-only capability and target-profile lookups their UIs call. It
+must NOT expose netcanon's device-backup, inventory, schedule, saved-config, or
+definition-management surfaces. No-egress makes those inert, but the warden
+also enforces a **default-deny route allowlist** (anything not listed → 404 at
+the warden). netcanon has **no root-path support** and its UI uses absolute
+URLs, so the warden routes allowlisted absolute paths **by session cookie**
+(see [03](03-warden-spec.md)), not by path-prefix. There are **no static assets** to
+allow — all CSS/JS is inlined into the pages — and there is **no
+`/api/v1/translate` route**; translation runs through `POST
+/api/v1/migration/plan` and its typed sub-plans.
+
+**ALLOW** (verified against the image route table):
+
+- `GET  /migrate`
+- `GET  /sanitize`
+- `GET  /health`
+- `GET  /api/v1/migration/adapters`
+- `GET  /api/v1/migration/adapters/{name}/capabilities`
+- `GET  /api/v1/migration/target-profiles` (+ `/{vendor}/{model}`)
+- `POST /api/v1/migration/plan` (+ `/plan/ports`, `/plan/vlans`,
+  `/plan/local_users`, `/plan/snmp`, `/plan/snmpv3`)
+- `POST /api/v1/migration/detect`
+- `POST /api/v1/sanitize`
+
+**BLOCK** (default-deny; called out because a visitor might probe them):
+
+- `/api/v1/backups*`
+- `/api/v1/devices*`
+- `/api/v1/schedules*` — note it exposes `/{id}/toggle` (enable/disable), which
+  is **not** a run-now trigger, but it stays blocked regardless.
+- `/api/v1/configs*`
+- `/api/v1/definitions*`
+- `/api/v1/openapi.json`, `/docs`
+- UI pages: `/` (the **backup dashboard**, *not* migrate), `/jobs`,
+  `/schedules`, `/configs`, `/devices`, `/definitions`
+
+`POST /api/v1/migration/render` is also **not** on the allowlist — the demo's
+translate flow reaches its result through `/plan` and the typed sub-plans, so
+`/render` stays default-denied like everything else unlisted.
+
+## Host-level complements
+
+- Swap disabled host-wide ([02](02-deployment.md#provisioning-cloud-init)) — a
+  tmpfs page can never be written to disk under memory pressure; with
+  `memswap_limit == mem_limit`, an instance hitting its cap is OOM-killed
+  (destroyed), which is the correct failure mode for this design.
+- **Core dumps disabled host-wide** ([02](02-deployment.md#provisioning-cloud-init))
+  — swap-off is not the only RAM→disk path. cloud-init sets
+  `kernel.core_pattern` to discard, `systemd-coredump` `Storage=none` +
+  `ProcessSizeMax=0`, removes/neuters apport, and sets `LimitCORE=0` on
+  `docker.service`, so a crashing instance cannot spill submitted-config bytes
+  into a dump file.
+- journald volatile ([02](02-deployment.md)).
+- Docker daemon: `"log-driver": "none"` as the *default* would be too blunt for
+  caddy/warden; instead set `none` per-instance (above) and `local,max 10m` for
+  the two service containers.
+
+## <a name="logging"></a>Logging policy (system-wide, one table)
+
+| Layer | What is logged | Where | Payload possible? |
+|---|---|---|---|
+| netcanon instance | nothing (driver `none`; `NETCANON_LOG_LEVEL=warning`) | — | No |
+| Warden | session lifecycle metadata: token-hash prefix, timestamps, destroy reason, status codes | stdout → journald (RAM) | No — schema enumerated & tested |
+| Caddy | `/i/*`, `/session/*`, and all allowlisted cookie-routed app paths: **no access logs**; everything else: **status-only** | stdout → journald (RAM) | No |
+| Host | auth/system logs | journald volatile | No |
+
+The whitepaper reproduces this table; [08](08-testing-verification.md#log-audit)
+proves it empirically (paste a canary string through the demo, grep the entire
+host — including any core-dump path — for it).
+
+## Deliverables
+
+- Constants block implemented exactly as above (with verified digest and the
+  final route allowlist filled in); no `user` override; both declared VOLUME
+  paths mounted as tmpfs
+- `demo-int` network definition with `internal: true` + explicit
+  warden→instance-only nftables segmentation (static warden IP `172.31.0.2`,
+  `ct state established,related` accept, instance→instance and instance→warden
+  drop), plus the dedicated `warden-sock` network carrying only the warden and
+  the socket-proxy
+- Daemon/service log-driver configuration; host core-dump + swap disable
+  (cross-check [02](02-deployment.md#provisioning-cloud-init))
+- Route allowlist derived from the actual image and recorded in the repo;
+  instance labels wired to the [03](03-warden-spec.md#lifecycle-rules) hard-TTL sweep

--- a/docs/demo-plan/05-frontend.md
+++ b/docs/demo-plan/05-frontend.md
@@ -1,0 +1,122 @@
+# 05 — Frontend
+
+One static page (no build step required — plain HTML/CSS/JS or a single-file
+Preact if the implementer prefers; keep it auditable). Served by Caddy at `/`.
+
+## Page states
+
+1. **Landing / idle** — one-paragraph pitch, a **Start demo** button, and the
+   ephemerality promise up front (the canonical landing copy, verbatim):
+   *“Your session runs in an isolated instance that **self-destructs within 15
+   minutes** — usually the moment you leave. A tab left open but untouched is
+   reclaimed after about 10 minutes of inactivity (**sooner under heavy load**),
+   so keep translating to hold your session to the full 15. Nothing you paste is
+   stored. [Read how we prove that →](whitepaper)”*
+   (Say “self-destructs **within** 15 minutes,” never “in 15 minutes”:
+   `HARD_TTL = 900 s` (15 min) is the ceiling; real teardown is near-immediate on
+   leave — **≤ 2 min for a closed foreground tab, ≤ ~4 min for a throttled
+   background tab** absent a beacon — and an untouched-but-open tab is reclaimed
+   at `IDLE_TTL = 600 s` (10 min), sooner under heavy load.)
+2. **Provisioning** (sub-second to ~3 s) — spinner; `POST /session/new`.
+3. **Active** — iframe pointed at **`/i/{t}/migrate`** (the instance's own
+   migrate UI — **not** bare `/i/{t}/`, which maps to the instance's blocked
+   backup dashboard and 404s under the route allowlist, which covers the
+   `{path}` component of `/i/{t}/{path}` exactly as it does absolute cookie-routed
+   paths), plus a persistent header bar:
+   - a **hard-TTL countdown** to the **15-min ceiling** (`HARD_TTL = 900 s`),
+     computed **client-side as `receipt_time + ttl_seconds`** from the mint
+     response — server-relative, so it is immune to client-clock skew;
+     `expires_at` is informational only;
+   - a separate **idle indicator** driven by `idle_remaining_seconds` (returned
+     on every `/hb`), with a pre-reclaim warning **~60 s out under normal load** —
+     any allowlisted translate / detect / sanitize POST resets it, so a visitor
+     *actively using* the tool rides the full 15 min while an untouched tab is
+     reclaimed at the idle TTL. Under a load-driven tightening (600 → 300 s) an
+     already-idle tab can be reclaimed with **little or no warning** (the new
+     deadline may fall before the next 30 s heartbeat delivers it) — translate to
+     reset the timer;
+   - an **instance-id chip** showing this session's `instance_id` (a short
+     warden-assigned display id from the mint response — *not* the routing token;
+     it backs live proof 5's “two profiles → two distinct instance ids”);
+   - a **“destroy now”** button (`POST /session/{t}/end`) and a link to the
+     whitepaper.
+4. **At capacity** — on 503: friendly message + auto-retry with backoff +
+   links to `docker run` one-liner and the repo (the demo failing closed is
+   itself on-message). Say so honestly: *“Under heavy load, an untouched session
+   may be reclaimed early to make room.”* The warden reclaims the longest-idle
+   session before returning a 503, but **never one younger than the 120 s
+   min-age floor** — a seconds-old mid-paste session is protected, so at true
+   saturation you get the 503 rather than someone losing a live paste.
+5. **Expired/destroyed** — “Instance destroyed 💥 — everything it held is
+   gone.” + Start again button. Shown on hard-TTL lapse, idle reclaim, heartbeat
+   loss, returning to a dead token, **or when another tab in the same browser
+   started a fresh session** — because a second `POST /session/new` bearing this
+   browser's valid `nc_route` cookie **destroys-and-replaces** the prior session
+   (one live session per browser), the old tab's next `/hb` or translate returns
+   **404** and flips here. This is the same “refreshing gets you a fresh
+   instance” model, just triggered from another tab.
+
+## Session plumbing
+
+- Heartbeat: `setInterval(30 s)` → `POST /session/{t}/hb` with the request body
+  `{"hidden": <bool>}` taken from `document.visibilityState === "hidden"`.
+  **Keep heartbeating while the tab is hidden** — do *not* pause on
+  `visibilitychange`, so a backgrounded-but-still-open tab isn't reaped mid-demo;
+  instead **report** the visibility so the warden can apply the right stale
+  threshold. The warden keys two thresholds off the last-reported visibility:
+  **75 s while visible** (2 missed beats + margin) and **180 s while hidden**
+  (tolerating background-timer throttling). The `/hb` response returns
+  `{"idle_remaining_seconds": <int>}`, which drives the idle indicator (state 3).
+  Update `hidden` on every `visibilitychange`; stop the interval only on
+  `pagehide`.
+- Teardown on leave: `navigator.sendBeacon('/session/'+t+'/end')` on `pagehide`
+  **only**. **Not** `visibilitychange→hidden` — that fires on a mere tab-switch
+  or minimize and would destroy the session during the demo's own
+  copy-a-config-from-another-tab flow. sendBeacon is the mechanism that reliably
+  fires on real tab close / navigation; the heartbeat-timeout reaper is the
+  backstop for the cases it doesn't. Absent any beacon, reclaim is **≤ 2 min for
+  a closed foreground tab** (30 s heartbeat + 75 s visible stale + 10 s reaper)
+  and **≤ ~4 min for a throttled background tab** (30 s + 180 s hidden stale +
+  10 s reaper) — not ≤ 60 s — and the hard TTL covers the rest (**I3**).
+- Countdown computed **client-side as `receipt_time + ttl_seconds`** from the
+  mint response — server-relative and therefore immune to client-clock skew;
+  `expires_at` is informational only. The mint response is
+  `{token, ttl_seconds, expires_at, idle_ttl_seconds, instance_id}`
+  (`idle_ttl_seconds` seeds the idle indicator; `instance_id` feeds the header
+  chip — see state 3).
+- **The page sets no cookies, no localStorage, no analytics, and makes no
+  third-party requests of any kind** — view-source stays consistent with the
+  whitepaper. The one cookie in play is *not* set by this page: it is the
+  warden's **routing** cookie, set on the `/session/new` mint response and
+  re-stamped on the proxied instance responses so absolute-path requests reach the
+  right container, as
+  `Set-Cookie: nc_route=<token>; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=900`
+  (the `Path=/` is load-bearing — without it RFC-6265 default-path scoping would
+  keep the cookie off absolute app paths and break routing; `Max-Age=900` matches
+  `HARD_TTL`). It is unreadable from JS and is disclosed in the whitepaper's
+  *What we do see* ([06](06-privacy-whitepaper.md#what-we-do-see)). State (the
+  token) lives in a JS variable; a refresh simply starts a new session — and so
+  does starting one from another tab in the same browser (the cookie is
+  browser-global, so a second mint destroys-and-replaces the first; see state 5).
+  Say so in the UI (“refreshing gets you a fresh instance”).
+
+## Content requirements
+
+- Preload the demo textarea *inside a “try this sample” button* that pastes
+  the canonical Cisco IOS-XE sample (hostname/vlan/interface/route/snmp) so a
+  visitor gets the GigabitEthernet1/0/1 → ge-1/0/1 payoff in one click.
+- Surface the Tier-3 banner behavior in the sample flow — the amber
+  “surfaced, not silently dropped” moment is the product's core argument.
+- Footer links: GitHub, PyPI, whitepaper, `docker run` one-liner.
+
+## Accessibility / weight budget
+
+- Total page ≤ 50 KB excluding the iframed instance UI. No fonts, no
+  frameworks from CDNs. Works with JS disabled to the extent of showing the
+  pitch + repo links (demo obviously needs JS).
+
+## Deliverables
+
+- `frontend/index.html` (+ minimal css/js, same folder)
+- Caddy static-serve block
+- Whitepaper page rendered from [06](06-privacy-whitepaper.md) (same styling)

--- a/docs/demo-plan/06-privacy-whitepaper.md
+++ b/docs/demo-plan/06-privacy-whitepaper.md
@@ -1,0 +1,195 @@
+# 06 — Privacy & Ephemerality Whitepaper (publishable draft)
+
+This module is both the spec and ~90% of the final text. Publish at
+`/whitepaper` on the demo site and as `docs/DEMO_WHITEPAPER.md` in the repo.
+Fill `<>` placeholders at deploy time. The defining feature: **every claim has
+a Control (a config line you can read) and a Proof (a procedure you can run)** —
+procedures live in [08](08-testing-verification.md) and are excerpted here.
+
+---
+
+# The Netcanon Demo Never Keeps Your Config — Here's the Proof
+
+Network configs are sensitive. A running-config can contain your addressing
+plan, SNMP strings, usernames, and topology. So the netcanon demo runs your
+session in a throwaway instance that **self-destructs within 15 minutes**, built
+so that retaining your data is not just against policy — it is **architecturally
+unavailable**. This page maps every claim to the exact control that enforces it
+and a procedure anyone can use to verify it.
+
+The entire deployment is open source: <REPO_DEPLOY_URL>. The running system is
+reproducible from that repo, and its image digests, lockfile hash, and
+compose-file hash are published below.
+
+## Threat model
+
+We defend the visitor's pasted data against: (a) operator retention (us, by
+design), (b) cross-visitor leakage, (c) post-session forensic recovery from the
+host, (d) log-based leakage at any layer, (e) a compromised or buggy demo
+application instance. Out of scope: a fully compromised host kernel/hypervisor
+(no hosted demo can defend that — if your config is that sensitive, run
+netcanon locally: `docker run …`; we make that path one click away).
+
+### Trusted Computing Base
+
+Every claim below rests on a small set of components we ask you to trust: the
+**warden** (session manager + reverse proxy), the **socket-proxy + create-body
+authz shim** (the capability filter that fronts the Docker socket), **Caddy**
+(TLS termination), **dockerd** (the container runtime), and the **host
+kernel/OS**. These are the TCB. A compromise of any of them — most sharply the
+warden, which reaches the Docker socket — is **host root**, and host root voids
+**all ten claims** below.
+We do not pretend otherwise; we make the TCB as small and as auditable as we can:
+
+- **The warden is ≤ 500 lines** you can read end to end (source: <REPO_DEPLOY_URL>).
+- It runs as a **non-root, read-only container** and reaches Docker only through
+  a **socket-proxy / authz filter** that permits just **create, start, list
+  (`GET /containers/json`, including label filters), inspect, and remove** —
+  denying everything else (`exec`, `commit`, `build`, `images`, `networks`,
+  `volumes`, …), not the arbitrary, root-equivalent Docker API. Because the
+  socket proxy cannot inspect a create *body*, a **small (~50–80-line) create-body
+  authz shim** in front of it enforces a **whole-body default-deny allowlist** on
+  every `POST /containers/create`: the raw wire body may contain **only** the
+  fields of the canonical create-body template (`INSTANCE_SPEC` serialized through
+  the pinned Docker-SDK version), each equal to that template (image digest,
+  read-only rootfs, the tmpfs set, no bind mount, network mode, memory/pids/cpu
+  caps, `CapDrop: [ALL]` with `CapAdd: []`, security-opts) — **any other field is
+  rejected**, so an
+  added `Privileged`, `CapAdd`, bind mount, or `NetworkMode: host` cannot slip
+  through. Only the `demo.*` labels and the two per-instance random env keys may
+  differ. This shim is **counted in the Trusted Computing Base** alongside the
+  ≤ 500-line warden.
+- It **never `exec`s into an instance** and never reads instance memory or
+  tmpfs; its only contact with your instance is proxying HTTP to it.
+- Caddy and dockerd are stock, pinned by digest (below); the host is a single
+  small VPS whose configuration lives in the same public repo.
+
+If you cannot extend that trust, the honest answer is the one on the front page:
+run netcanon locally with `docker run …` and trust nothing of ours.
+
+## Claims, controls, proofs
+
+| # | Claim | Control | Proof (abridged; full: repo `VERIFY.md`) | Tier |
+|---|---|---|---|---|
+| 1 | Your session runs in its own isolated instance | Warden creates one container per session; routing is by the **HttpOnly `nc_route` cookie** — a bearer credential valid for the life of the session, not a single-use token; instances unreachable except via the warden | Two browser profiles: each header shows a **distinct instance-id chip** (`instance_id`, a display id — not the routing token); end session A → A's now-dead cookie 404s every request while B is unaffected | V·O |
+| 2 | The instance cannot write to disk | `read_only: true` rootfs; **both** declared VOLUME paths (`/app/data` *and* `/app/configs`) backed by tmpfs (RAM), so no anonymous host-disk volume is ever created; **zero named or anonymous volumes** | `docker inspect` shows ReadonlyRootfs=true and Mounts = tmpfs only; `docker diff` clean outside tmpfs; `docker volume ls` empty after teardown | O |
+| 3 | Nothing survives the session | Teardown = `container.remove(v=True, force=True)` (container **and** any anonymous volume); tmpfs freed by kernel; the hard TTL is enforced across **two independent enforcement domains (the warden and host systemd), three mechanisms** — (1) the warden's in-RAM reaper at `deadline = assignment_time + HARD_TTL` (900 s from assignment), (2) the warden's startup label-sweep, and (3) an independent host **systemd timer** (swept every 60 s) that force-removes any `demo.*`-labeled container older than `HARD_TTL + POOL_MAX_AGE = 1200 s` even if the warden is dead; sooner in practice via the 10-min idle reclaim (sooner under heavy load), `pagehide` `sendBeacon`, and heartbeat timeout (**≤ 2 min for a closed foreground tab, ≤ ~4 min for a throttled background tab**) | Destroy → `docker ps -a` and `docker volume ls` empty of it; kill the warden mid-session → the systemd timer still removes it within ~20 min of creation; canary paste + host-wide grep finds nothing post-teardown | O |
+| 4 | Your paste appears in no log, anywhere | Instance log driver `none`; warden logs metadata-only (schema enumerated) and **never interpolates a request body — including in exception handlers / error paths**; Caddy access logs disabled on the demo paths (`/i/*`, `/session/*`, and all allowlisted cookie-routed app paths → no access logs; everything else → status-only); journald volatile (RAM) | Canary-string grep across journald + filesystems; warden log-schema test in CI asserts no body field on any path, error paths included | O |
+| 5 | RAM contents can't leak to disk (swap **or** core dump) | Swap disabled host-wide; `memswap_limit == mem_limit`; **core dumps disabled host-wide** — `kernel.core_pattern` set to discard, `systemd-coredump` `Storage=none` + `ProcessSizeMax=0`, apport neutered, `docker.service LimitCORE=0` | `swapon --show` empty; inspect shows limits equal; `cat /proc/sys/kernel/core_pattern` shows the discard sink; force a crash → no core file written | O |
+| 6 | The instance can't phone anywhere | Instances on an `internal: true` network (no egress); ICC is all-or-nothing, so isolation is enforced by **explicit nftables rules**: warden→instance ALLOW, instance→instance DENY, instance→warden DENY | From inside an instance: every outbound connect fails; instance→instance fails; instance→warden fails | O |
+| 7 | Even netcanon's encryption key is never written to disk | The warden injects a **per-instance random `NETCANON_FERNET_KEY`** (Tier-1 of netcanon's key resolution), so the file fallback at `data/.fernet_key` is never reached — **no Fernet key file is ever created**; the key lives only in the instance's RAM | **Proof 13**: from the host via the **raw host Docker socket** (not the warden's path — its allowlist forbids `exec`), `docker exec`/`docker inspect` shows the env key set and no `.fernet_key` on disk (`/app/data` is tmpfs regardless); gone with the instance | O |
+| 8 | The demo can't silently degrade isolation under load | Hard instance cap (`MAX_ACTIVE` = 32); per-IP concurrent-session cap (`PER_IP_MAX_CONCURRENT` = 2); above 80% occupancy the **idle** TTL tightens (600 s → 300 s, applied retroactively within ~10–20 s of the crossing, loosening back below 70% — hysteresis), reclaiming untouched tabs faster while the 15-min hard ceiling is left intact; the longest-idle (never-translated) session is reclaimed before anyone is refused — but **never one younger than 120 s** (a mid-paste session is protected; if every session is under that floor the demo returns 503 rather than reclaiming one); at the cap the demo returns **503** rather than sharing an instance | Saturate the cap; observe 503 + busy UI, never a shared instance (**the third concurrent session from your IP is refused — that you can see**) | O |
+| 9 | The published deployment is exactly reproducible (and the live host is operator-attested to match) | Images pinned by digest; `requirements.lock` hash-locked; compose SHA-256 published | Digests + hashes below; `make verify` reproduces them **from the repo** — it attests the published artifact, **not this live host** (no hosted demo can remotely prove its own runtime; that is what the local `docker run` path is for) | O |
+| 10 | No tracking on the demo page | The **page** sets no cookies, no `localStorage`, no analytics, no third-party requests; the *only* cookie in play is the warden's **HttpOnly, SameSite=Strict, Secure** session-routing cookie — a bare instance binding, not an identifier (disclosed under "What we do see") | View source (self-contained, all CSS/JS inline); devtools **Network** shows no third-party requests and **Application → Cookies** shows only the routing cookie | V |
+
+**Tier — how far you have to trust us.** **V** = *visitor-verifiable now*: you
+can confirm it from your own browser, on the live site, trusting nothing of
+ours. **O** = *operator-attested + locally reproducible*: confirming it needs
+host access, so we commit the exact command output in `VERIFY.md` — and, because
+no hosted demo can remotely prove its own runtime, you can reproduce every **O**
+row yourself by running the identical stack locally with `docker run …`.
+`make verify` attests the **published repo/artifact, not this live host**. A row
+marked **V·O** carries both components: claim 1 is the case — you can watch the
+instance-id chip differ and the dead-cookie 404 from your own browser (**V**),
+while "never a *shared* instance" is attested at the container boundary (**O**).
+
+## What we do see
+
+Honesty section — required. We (the operator) can observe: standard host
+operational metadata (session count, lifecycle timestamps, destroy reasons,
+status codes), Hetzner's infrastructure-level traffic metadata, and whatever a
+TLS-terminating proxy inherently sees **in memory while streaming** your
+request. Two more things, stated outright:
+
+- **A warden-set routing cookie.** netcanon's UI uses absolute URLs
+  (`fetch('/api/v1/migration/plan')`, `href="/migrate"`) and has no root-path
+  support, so the warden routes you to your one instance **by session, not by
+  path**. To do that it sets a single cookie —
+  `Set-Cookie: nc_route=<token>; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=900`
+  — carrying only the opaque session token. That token is a **bearer credential
+  valid for the life of the session** (not single-use), which is exactly why the
+  cookie is HttpOnly, Secure, and SameSite=Strict — JS cannot read or forge it.
+  It is not an analytics identifier and it dies with your session. Because the
+  cookie is browser-global, a browser holds **exactly one live session** (a fresh
+  mint replaces the previous one); the **≤ 2-concurrent-sessions-per-IP** cap is a
+  separate guardrail bounding distinct devices behind one IP. The demo page itself
+  still sets nothing (claim 10).
+- **Per-IP session state, in RAM only.** To enforce the per-IP concurrent-session
+  cap (**≤ 2 concurrent sessions per IP**) and a sliding-window mint rate limit
+  (**≤ 30 mints / 600 s per IP**), the warden keeps a small per-IP record **in
+  memory only** — never logged, **held in memory for up to 10 minutes after your
+  last request, never written to disk, gone on warden restart**. A rate limiter
+  must outlive any single session, so the record is evicted 10 min after your last
+  request rather than on session end.
+
+We keep none of the in-memory transit category — the controls above are what
+make that checkable rather than a promise. If you cannot accept in-memory
+transit through our proxy, run netcanon locally; that path is on the demo's
+front page.
+
+## Reproducibility block (fill at deploy)
+
+```
+netcanon image    : ghcr.io/netcanon/netcanon@sha256:<...>   (base python:3.14-slim-bookworm)
+requirements.lock : sha256:<...>   (hash-locked; glibc/manylinux wheels — not Alpine/musl)
+warden image      : <registry>@sha256:<...>
+socket-proxy image: <registry>@sha256:<...>   (TCB component — the capability filter fronting docker.sock)
+caddy image       : <registry>@sha256:<...>   (self-built via xcaddy if rate-limiting lives in Caddy)
+compose sha256    : <...>
+deployed          : <date>   hard TTL: 900s (15 min)   idle TTL: 600s (10 min)   instance cap (MAX_ACTIVE): 32
+```
+
+## Residual risks, stated plainly
+
+### Trusted Computing Base — the honest worst case
+
+The sharpest residual risk is not exotic: it is us. The warden, the socket-proxy
++ authz shim, Caddy, dockerd, and the host are **trusted** (see the threat model's
+TCB subsection). A
+compromise of the warden — which holds the Docker socket — is **host root**, and
+host root **voids all ten claims** above: it could snapshot RAM, disable the
+reaper, or read into any instance. We *bound* (not eliminate) this by keeping the
+warden tiny (≤ 500 auditable lines), non-root, read-only, reachable to Docker
+only through a capability-filtered socket proxy **plus a small create-body authz
+shim that whole-body default-deny-validates every `POST /containers/create`
+against the canonical `INSTANCE_SPEC` (both counted in the TCB), so create is not
+the arbitrary, root-equivalent Docker API** — and never `exec`ing into
+instances — all of it in the public repo. If that residual is unacceptable for
+your data, run netcanon locally and trust none of it.
+
+- A kernel- or hypervisor-level compromise of the host likewise defeats all
+  guarantees (out of scope in the threat model).
+- `sendBeacon` on `pagehide` is best-effort; when it doesn't fire, the
+  heartbeat-timeout path reclaims your instance in **≤ 2 min for a closed
+  foreground tab, ≤ ~4 min for a throttled background tab**, and a tab left open
+  but untouched is reclaimed at the **10-minute idle TTL** (sooner under heavy
+  load). Both of those only ever *shorten* the session. The guarantee that
+  requires **nothing** from your browser — no beacon, no heartbeat, no activity —
+  is the hard TTL, enforced across **two independent enforcement domains (the
+  warden and host systemd), three mechanisms**, with two honest bounds: while the
+  warden is live it destroys your instance **≤ 15 minutes after it was assigned to
+  you**; and **even if the warden crashes**, an independent host systemd timer
+  (swept every 60 s) force-removes any `demo.*`-labeled container **≤ ~20 minutes
+  after it was created** (older than `HARD_TTL + POOL_MAX_AGE = 1200 s`). A crash
+  can therefore widen the ceiling from 15 to at most ~20 minutes — it can never
+  *lift* it; nothing keeps your instance alive indefinitely.
+- We can change this deployment. That's why the digests and hash are published:
+  trust the artifact you can verify today, not us.
+
+---
+
+## Deliverables
+
+- **This module is the whitepaper _template_.** It lives in-repo as
+  `docs/DEMO_WHITEPAPER.md` with its `<>` placeholders **unfilled**. The
+  **filled** copy is rendered at deploy time (`tools/render_whitepaper.py`),
+  served at `/whitepaper`, and shipped in the signed Release bundle — it is never
+  committed with real digests.
+- **Freshness note** (carried in `/whitepaper` and `VERIFY.md`): the live site
+  may lawfully run an **older published bundle** than the newest Release; the
+  live whitepaper reproducibility block always describes the **currently running**
+  system, and a synthetic probe alerts on live-vs-latest drift (detection, not
+  closure).
+- `VERIFY.md` in the deploy repo = full procedures from [08](08-testing-verification.md)
+- Reproducibility block wired to `make verify` output (filled at deploy time, not
+  in the in-repo template)

--- a/docs/demo-plan/07-budget.md
+++ b/docs/demo-plan/07-budget.md
@@ -1,0 +1,140 @@
+# 07 — Budget & Sizing
+
+## Monthly costs
+
+| Item | Cost | Notes |
+|---|---|---|
+| Hetzner CX32, Falkenstein (4 vCPU / 8 GB / 40 GB / 20 TB) | ~€6.80 (~$7.4) | Launch default; the entire runtime |
+| — US alternative: Hetzner CPX32, Ashburn/Hillsboro | re-price + re-verify traffic | Shared-vCPU AMD line; CX is EU-only and CPX included traffic is much lower ([02](02-deployment.md#host)) |
+| Domain (.dev or similar) | ~$12/yr ≈ $1/mo | Shared with the main site — **not demo-attributable** |
+| TLS | $0 | Let's Encrypt via Caddy |
+| Container registry | $0 | GHCR public |
+| **Total** | **~$7.40/mo demo-attributable** | The CX32 box is the only demo-attributable runtime cost (~€6.80 ≈ $7.40); the ~$1/mo domain is shared with the main site, so it is **not** demo-attributable |
+
+Budget headline: **~$7.40/mo demo-attributable (the domain is shared with the
+main site)**.
+
+Explicit non-costs: no managed k8s, no load balancer, no log/analytics SaaS
+(prohibited by design anyway), no CDN (page is ~50 KB).
+
+## <a name="sizing"></a>Sizing math
+
+Size `MAX_ACTIVE` off the **real held-session RSS**, not the 256 MB hard cap.
+The 256 MB `mem_limit` is a fail-closed OOM guardrail — a runaway instance is
+killed and destroyed, the correct failure mode — **not** the sizing basis. A
+held netcanon session actually resides at **~90–140 MB RSS** (parsing and
+translation are short bursts; between requests the instance is near-idle) plus a
+few MB of container/exec-shim overhead.
+
+- **CX32 (8 GB):** 8192 MB − (OS+Docker ~400) − (caddy+warden ~200) ≈ **7.4 GB
+  usable**. At ~150 MB effective per held session that is ~49 theoretical; set
+  `MAX_ACTIVE = 32` (warm pool 4 counts toward it), leaving headroom so that even
+  a cluster of simultaneous translation bursts stays under RAM and under the
+  per-instance caps.
+- **Deliberate >100 % cap-sum.** The per-instance 256 MB is an OOM guardrail,
+  not a reservation; the cap-sum (`32 × 256 MB = 8 GB`) deliberately exceeds the
+  7.4 GB usable — sizing is off the real ~90–140 MB held RSS, and an instance
+  that tries to reach its cap is OOM-killed (destroyed), the correct failure
+  mode (swap-off + `memswap_limit == mem_limit` means reaching the cap can only
+  end in a kill, never in swap thrash).
+
+Per-box defaults:
+
+| Box | vCPU / RAM | `MAX_ACTIVE` | warm pool | idle / hard TTL |
+|---|---|---|---|---|
+| CX22 | 2 / 4 GB | 14–16 | 3 | 600 / 900 s |
+| **CX32 / CPX32** (launch default) | 4 / 8 GB | **32** | **4** | **600 / 900 s** |
+| CX42 / CPX41 | 8 / 16 GB | 60–80 | 6 | 600 / 900 s |
+
+The fail-closed story (**I7**) still holds: at cap the pool drains and
+`/session/new` returns `503 {"reason":"capacity"}` with client auto-retry — the
+demo refuses rather than degrades isolation. A front-page spike (HN/Reddit) can
+push the arrival rate several-fold above sustained usage; the answer is that 503
++ auto-retry + longest-idle reclaim, not over-provisioning.
+
+### Why not a smaller (Alpine) base image
+
+Shrinking the instance image with Alpine is tempting for RSS, but **rejected**:
+it invalidates the hash-locked, glibc-built `requirements.lock` (forcing
+musllinux/source builds) for a ~10 % RSS win that does **not** change the sizing
+tier above and does **not** speed warm-pool refill (the image is already cached;
+container start is dominated by Python import, and refill is async). The base
+stays **`python:3.14-slim-bookworm`**; its digest + hash-lock chain is a
+whitepaper reproducibility asset (**I6**, pinned in
+[02](02-deployment.md#image-supply-chain)).
+
+## Scale levers (in order, if ever needed)
+
+Concurrent occupancy follows **Little's Law, `L = λ · W`**: the number of live
+instances `L` is the arrival rate `λ` times the mean dwell `W` (session
+lifetime). `W`, not the box, is the highest-leverage term — so tune it first;
+upsize the box last.
+
+1. **Shorten `W` (idle TTL + reliable teardown) — the primary lever, zero cost.**
+   The dwell that binds capacity is set by the **idle TTL**, not the hard
+   ceiling: an open-but-untouched tab lingers at most `IDLE_TTL = 600 s` (10 min),
+   and only a user *actively translating* rides the full `HARD_TTL = 900 s`
+   (15 min) ceiling — rare, and exactly the visitor you want to serve. Take the
+   idle case `W = 10 min`: at `λ = 4` sessions/min that is `L = 4 × 10 = 40`
+   concurrent, over CX32's 32. But real `W` is far below that: most sessions end
+   on `pagehide`, the no-beacon reclaim is **≤ 2 min for a closed foreground tab**
+   (30 s heartbeat + 75 s visible stale + 10 s reaper) and **≤ ~4 min for a
+   throttled background tab** (30 s + 180 s hidden stale + 10 s reaper), and idle
+   tabs are reaped at 600 s regardless of heartbeats. Drop the effective `W` to
+   ~2 min and the same `λ` gives `L = 4 × 2 = 8` concurrent. Reliable teardown
+   plus the idle TTL are what keep `L` small.
+2. **Occupancy-driven tightening (automatic, with hysteresis).** Above **80 %**
+   occupancy, tighten the **idle TTL** (`600 s → 300 s`) so untouched tabs are
+   reclaimed twice as fast; below **70 %** it **loosens back** (`300 s → 600 s`)
+   — the gap between the two thresholds prevents thrash between 70–80 %. The idle
+   TTL is a single global reaper parameter compared at reap time, so a tightening
+   applies **retroactively** to already-idle sessions (~10–20 s: it takes effect at
+   the next reaper tick, and a session already beyond the new threshold is reaped
+   one tick later). The 15-min hard ceiling is left intact (you don't
+   renege on the advertised number); keep the per-IP concurrent-session cap
+   (`PER_IP_MAX_CONCURRENT = 2`); and reclaim the longest-idle (never-translated)
+   session — never one younger than the 120 s min-age floor — before ever
+   returning a 503.
+3. **Warm-pool tuning** — raise the pool only if mint latency (not RAM) is the
+   constraint. Note the recycle floor: pooled instances are recycled at
+   `POOL_MAX_AGE − reaper_period` (~290 s, ≈ every 5 min), so at zero traffic a pool of 4 turns over
+   ~1,150 create/destroy cycles/day — negligible CPU (async, single-flight
+   refill) but real, and a burst landing in a refill gap degrades to a sub-3 s
+   synchronous create, not a failure. A pooled instance's pre-warmed life is thus
+   ≤ `POOL_MAX_AGE`, so the pool is sized for mint latency, not warmth duration.
+4. **Box upsize — last, and reversible.** Rescale CX32 → CX42 (8/16,
+   `MAX_ACTIVE` 60–80, pool 6) same-day; Hetzner bills hourly and a CPU/RAM-only
+   rescale that keeps the 40 GB disk is fully reversible.
+5. **Fly.io Machines port** ([01](01-architecture.md#framework-decision)) for
+   burst/geo scale — only if the demo outgrows a single node, which likely means
+   the project has bigger problems to enjoy.
+
+## Cost-abuse guards
+
+- **Warden-enforced** per-IP concurrent-session cap (`PER_IP_MAX_CONCURRENT = 2`,
+  held in RAM only) plus request rate limiting — the warden already holds the
+  per-IP state, and stock Caddy has no native rate-limit directive
+  ([02](02-deployment.md#caddy-configuration-requirements)). The 2 MB
+  request-body cap *does* stay in Caddy (native `request_body`). These are two
+  distinct guardrails: a single **browser** holds exactly **one** live session
+  (the `nc_route` cookie is browser-global, so a second `POST /session/new` from
+  it destroys-and-replaces the first), while the per-**IP** cap of 2 bounds
+  distinct browsers/devices behind one NAT — a single browser can never
+  self-collide with the cap.
+- Occupancy-driven TTL tightening and longest-idle reclaim (above) keep a burst
+  from turning into runaway spend; the demo returns 503 before it degrades.
+- `pids_limit`, CPU and memory caps make a hostile instance self-limiting;
+  no egress (**I5**) makes it useless as an attack platform.
+- Hetzner's 20 TB EU egress allowance is ~3 orders of magnitude above plausible
+  demo traffic (the US CPX allowance is much lower — re-verify per
+  [02](02-deployment.md#host)).
+
+## Deliverables
+
+- `MAX_ACTIVE` (32), warm-pool size (4), `HARD_TTL` (900 s), `IDLE_TTL` (600 s,
+  tightening to 300 s above 80 % occupancy and loosening back below 70 %), the
+  per-IP concurrent-session cap (`PER_IP_MAX_CONCURRENT = 2`), and the occupancy
+  tighten/loosen thresholds (80 % / 70 %) as env-configurable warden settings
+  with the above defaults committed
+- A one-paragraph "capacity philosophy" note in the whitepaper (fail closed,
+  never degrade isolation)

--- a/docs/demo-plan/08-testing-verification.md
+++ b/docs/demo-plan/08-testing-verification.md
@@ -1,0 +1,124 @@
+# 08 — Testing & Verification
+
+Two tiers: **CI tests** (run on every deploy-repo commit) and **live proofs**
+(runnable on the production host; these are the whitepaper's `VERIFY.md`).
+Each maps to a claim number in [06](06-privacy-whitepaper.md#claims-controls-proofs).
+
+## CI tests (pytest, against a compose stack in CI)
+
+| Test | Claim |
+|---|---|
+| Mint two sessions → containers differ; routing cookie for A + absolute path → served by A only; A's cookie against B's instance → 404 | 1 |
+| `docker inspect`: ReadonlyRootfs, **tmpfs on both `/app/configs` and `/app/data`** (the image declares `VOLUME` for both), no named/anonymous volumes, non-root uid 1000 (native `USER app`, no `user` override), cap_drop ALL, no-new-privileges, pids/mem/cpu limits, log driver `none`, memswap==mem | 2, 4, 5 |
+| Header rewrite: proxied instance response has **no `X-Frame-Options`** and CSP `frame-ancestors 'self'` (netcanon stamps XFO:DENY + `frame-ancestors 'none'`; the warden must strip/rewrite them) | 2 |
+| Volume reap: after a full session + destroy, `docker volume ls` shows **zero** anonymous volumes (destroy uses `remove(v=True, force=True)`) | 2 |
+| Hard-TTL immovable: heartbeat **and** translate continuously; assert destroy at the 900 s (`HARD_TTL`) deadline (`deadline = assignment_time + HARD_TTL`) ±10 s — nothing the session does extends it | 3 |
+| Pool epoch (assignment-relative TTL): age a pooled instance to ~289 s (just under the `POOL_MAX_AGE − reaper_period` ~290 s recycle threshold), **then** assign it; assert it survives a full 900 s from **assignment** (creation-age deadline ≈ 1189 s) and that the creation-relative systemd backstop (`HARD_TTL + POOL_MAX_AGE = 1200 s`, fires only *older than* 1200 s) does not kill it early. Companion: a pooled instance aged past ~290 s is **recycled** (destroyed + refilled), so it is never assigned older than `POOL_MAX_AGE` (300 s) | 3 |
+| Idle reclaim: heartbeat continuously but **never** send an allowlisted POST; assert destroy at ~600 s (`IDLE_TTL`), i.e. a heartbeat alone must not keep a session alive | 3, 8 |
+| Idle hysteresis (retroactive, no thrash): occupancy crosses **> 80 %** → sessions idle > 300 s are reaped **one reaper tick after the tightening takes effect (~10–20 s after the crossing)**; occupancy drops **< 70 %** → threshold returns to 600 s; assert no thrash while occupancy sits between 70–80 % | 3, 8 |
+| Idle activity set (`last_activity`): a session driving only `POST /api/v1/migration/detect` + `POST /api/v1/migration/plan/ports` (never the bare `plan`) survives **past** `IDLE_TTL` — sub-plan and detect calls refresh `last_activity`; GETs and `/hb` do not | 3, 8 |
+| No-beacon reclaim, **visible** tab: `/hb` reports `{"hidden": false}` then stops; assert destroy **≤ 2 min for a closed foreground tab** (30 s hb interval + 75 s visible stale threshold + 10 s reaper ≈ 115 s) | 3 |
+| No-beacon reclaim, **hidden** tab: `/hb` reports `{"hidden": true}` then stops; assert destroy **≤ ~4 min for a throttled background tab** (30 s + 180 s hidden stale threshold + 10 s reaper ≈ 220 s) | 3 |
+| TTL independence: create a `demo`-labeled instance, kill+restart the warden; assert it is force-removed within one startup label-sweep; assert the host systemd timer (sweep cadence 60 s) force-removes a `demo.*`-labeled container older than `HARD_TTL + POOL_MAX_AGE = 1200 s` on **creation** age | 3 |
+| `end` idempotency + sendBeacon content-type accepted | 3 |
+| Warden log schema: run a full session with payload "CANARY-<rand>"; assert canary absent from captured warden/caddy stdout at `NETCANON_LOG_LEVEL=warning` | 4 |
+| Error-path canary: oversized body, malformed body, mid-stream client kill, and a forced 500 — each carrying `CANARY-<rand>`; assert canary absent from all logs (the interesting leaks are on the error paths, not the happy path) | 4 |
+| Egress + isolation: outbound connect from instance netns fails (spawn a probe container on `demo-int`); **instance→warden API port fails**; **instance→instance fails**; **instance→socket-proxy fails** (socket-proxy is on `warden-sock` only, which instances never join) | 6 |
+| Per-IP session cap: one IP opening more than `PER_IP_MAX_CONCURRENT = 2` concurrent sessions is refused past the cap (RAM-only record, evicted 600 s after that IP's last request) | 8 |
+| Cap behavior: fill to `MAX_ACTIVE` (32); next mint reclaims the longest-idle no-translate session **older than the 120 s min-age floor**, else → 503; assert a session younger than 120 s is **never** the reclaim victim; no instance sharing | 8 |
+| Capacity SLO: a closed tab (beacon path) frees its slot ≤ **90 s** | 8 |
+| Proxy allowlist: an allowlisted route (`POST /api/v1/migration/plan`, `POST /api/v1/sanitize`, `GET /migrate`) is proxied; a blocked route (`/api/v1/backups`, `/api/v1/devices`, `/api/v1/configs`, `/docs`, `/jobs`) → 404 at warden | (04) |
+| Proxy allowlist (iframe `{path}` form): the allowlist covers the `{path}` component of `/i/{t}/{path}` exactly as for absolute cookie-routed paths — `/i/{t}/migrate` → 200; `/i/{t}/api/v1/backups` → 404; bare `/i/{t}/` (instance `/`, the backup dashboard) → 404 | 2, (04) |
+| Socket-proxy verb allowlist: probe `exec`, `commit`, `build`, `images`, `networks`, `volumes` through the proxy → each **rejected**; only `create`, `start`, `list`, `inspect`, `remove` pass (the TCB verb boundary Gate 1 asserts) | 3, 9 |
+| Create-body authz shim (whole-body default-deny): a `POST /containers/create` body that deviates from `INSTANCE_SPEC` is **rejected** — an extra bind mount, a changed image digest, a dropped `read_only`, **and** an added `Privileged` / `CapAdd` / `Devices` / `PidMode` / `HostConfig.Mounts` / `VolumesFrom` / `NetworkMode: host` key or a changed `LogConfig`; only the two `demo.*` labels + two per-instance random env keys may vary. This is the CI that makes "create-with-fixed-spec" real | 3, 9 |
+| Create-body authz shim (positive path): the warden's **real canonical create body** (the wire body = `INSTANCE_SPEC` serialized through the pinned SDK, structural defaults included) is **accepted** — proves the template isn't over-strict and the demo can actually launch instances | 3, 9 |
+| Two-tab replacement (one live session per browser): open tab 1 (cookie → instance A); `POST /session/new` bearing A's `nc_route` cookie → A destroyed (reason `end`), instance B minted, cookie now routes to B; a request replaying A's identity → 404; no request ever silently lands on the wrong container | 1 |
+| Concurrency safety: fire N simultaneous `POST /session/new` at a near-empty pool; assert no container is assigned to two tokens and `MAX_ACTIVE` is never exceeded. Separately, run a **reaper recycle of an aging pool instance concurrently with a mint** and assert the mint never lands on a container being destroyed — the reserve-then-fill discipline (mark `RESERVING`/`DESTROYING` and remove from the pool under the lock, do docker I/O outside it) holds, and the lock is **never** held across an `asyncio.to_thread` call | 1, 8 |
+| Fernet key in RAM (claim 7): `docker inspect` shows `NETCANON_FERNET_KEY` present in the instance env (per-instance random); no `.fernet_key` file is created | 7 |
+| Token entropy: mint 10k, assert length/charset/uniqueness | 1 |
+
+## Live proofs (`VERIFY.md` — anyone with host access; several visitor-runnable)
+
+1. **Canary forensics (claims 2, 3, 4).** Start session; paste config containing
+   `CANARY-$(openssl rand -hex 8)`; translate; end session. Then:
+   `docker ps -a | grep <id>` → gone; whole-filesystem sweep
+   `grep -r CANARY- / --binary-files=text` (excluding `/proc /sys /dev`) +
+   `journalctl | grep CANARY-` → zero hits; **raw block-device sweep**
+   `grep -a CANARY- /dev/sda` (catches anything that hit the disk under a
+   filesystem we didn't walk) → zero hits. (Run before TTL too: canary must
+   appear **nowhere on disk even while the session lives**.)
+   - **Error-path canaries (claim 4).** Repeat the sweep after each abnormal
+     path — an oversized body, a malformed body, a mid-stream client kill, and a
+     forced 500 — each carrying a distinct `CANARY-`. The interesting leaks
+     (stack traces, buffered request echoes) live on the error paths, not the
+     happy path; `NETCANON_LOG_LEVEL=warning` keeps parsed fragments out of logs.
+2. **Mount proof (claim 2).** During a live session: `docker inspect <id> |
+   jq '.[0].HostConfig.ReadonlyRootfs, .[0].Mounts'` → `true`, tmpfs-only.
+   `docker diff <id>` → changes confined to tmpfs paths.
+3. **Swap proof (claim 5).** `swapon --show` → empty. `docker inspect | jq
+   .HostConfig.Memory,.HostConfig.MemorySwap` → equal.
+4. **Egress + segmentation proof (claim 6).** `docker network inspect demo-int |
+   jq '.[0].Internal'` → true. From instance netns (`nsenter`): connect to
+   1.1.1.1:443, to a **sibling instance**, to the **warden API port**, and to the
+   **socket-proxy** → all four fail. (The nftables policy on the single `demo-int`
+   bridge is warden→instance ALLOW, instance→instance DENY, instance→warden DENY;
+   the socket-proxy is unreachable by construction — it sits on the `warden-sock`
+   network only, which instances never join. `enable_icc=false` is **not** used —
+   it is all-or-nothing and would also break warden→instance.)
+5. **Proof 5 (isolation, claim 1).** Two browser profiles each start a session;
+   each header shows a **distinct instance-id chip** (`instance_id`, a short
+   warden-assigned id — not the routing token). End (or wait out) session A; A's
+   `nc_route` cookie is now dead, so every subsequent request from A returns
+   **404** (the destroyed state) while B is unaffected. Routing is by the
+   **HttpOnly** `nc_route` cookie, so a visitor cannot forge another session's
+   routing from JS. (A live routing token is a bearer credential for the life of
+   the session — not single-use — which is why the cookie is HttpOnly, Secure, and
+   SameSite=Strict.)
+6. **Capacity proof (claim 8).** Script mints MAX_ACTIVE sessions → next mint
+   first reclaims the longest-idle no-translate session, then (if none) → 503;
+   UI shows busy state. **Per-IP cap:** one IP opening more than the per-IP
+   concurrent-session cap is refused past the cap. **Capacity SLO:** a closed
+   tab (beacon path) frees its slot within ≤ 90 s.
+7. **Reproducibility (claim 9) — visitor-runnable.** `make verify` prints image
+   digests + compose SHA-256; visitor compares against whitepaper block. (This
+   attests the **repo**, not the live host — no hosted demo can remotely prove
+   its own runtime; that is why the local `docker run` path exists.)
+8. **Page cleanliness (claim 10) — visitor-runnable.** Devtools: the page itself
+   sets no cookies/localStorage and makes no third-party requests; source is
+   self-contained. (The warden-set HttpOnly routing cookie is out of page reach
+   and is disclosed in the whitepaper's "What we do see".)
+9. **Framing proof (Gate 2, claim 2).** With a live session in the parent page's
+   iframe: the instance renders (not blank); response headers show no
+   `X-Frame-Options` and CSP `frame-ancestors 'self'` after the warden's
+   header rewrite. Confirms the XFO/CSP neutralization actually works end-to-end.
+10. **Volume-reap proof (claim 2).** After a full session + destroy:
+    `docker volume ls` → no anonymous volume attributable to the instance
+    (destroy uses `remove(v=True, force=True)`; both declared `VOLUME` paths were
+    tmpfs, so none should have been created in the first place).
+11. **TTL-independence proof (claim 3).** Create a `demo`-labeled instance; kill
+    and restart the warden → the startup label-sweep force-removes it (it adopts
+    nothing). Separately, let a `demo.*`-labeled container exceed
+    `HARD_TTL + POOL_MAX_AGE = 1200 s` on creation age with the warden stopped →
+    the host systemd timer (sweep cadence 60 s, `OnUnitActiveSec=60s`) force-removes
+    it. Neither relies on the in-memory dict.
+12. **Core-dump proof (claim 5).** Crash a process inside a live instance (e.g.
+    `kill -SIGSEGV` a worker) → nothing appears under `/var/crash`,
+    `/var/lib/systemd/coredump`, or apport spool (`kernel.core_pattern` discards,
+    `systemd-coredump Storage=none`/`ProcessSizeMax=0`, apport neutered).
+13. **Proof 13 (Fernet key never on disk, claim 7).** From the host, using the
+    **raw host Docker socket** (not the warden's path — its allowlist forbids
+    `exec`): `docker exec <id> sh -c 'ls -la /app/data/.fernet_key'` → no such
+    file; `docker exec <id> printenv NETCANON_FERNET_KEY` → set. `/app/data` is
+    tmpfs regardless, so even had the file existed it never touched disk.
+
+## Pre-launch gate
+
+All CI tests green **and** live proofs 1–13 executed on the production host with
+output pasted into `VERIFY_RESULTS_<date>.md` (committed). The whitepaper links
+to that file. Re-run on every image-digest bump.
+
+## Deliverables
+
+- `tests/` implementing the CI table
+- `VERIFY.md` with copy-paste commands for proofs 1–13
+- `VERIFY_RESULTS_<date>.md` from the real host, committed pre-launch

--- a/docs/demo-plan/09-implementation-order.md
+++ b/docs/demo-plan/09-implementation-order.md
@@ -1,0 +1,144 @@
+# 09 — Implementation Order
+
+Build sequence for the implementing agent. Each phase ends in an acceptance
+gate; do not proceed past a failing gate. Estimated total: one focused
+build session for phases 1–5, plus deploy.
+
+## Phase 0 — Reconnaissance (read-only)
+
+Pull `ghcr.io/netcanon/netcanon:latest` and record the facts the plan
+parameterizes. These have been verified against the netcanon source; the
+implementing agent confirms them against the pinned digest and writes them into
+the warden constants block. **Where a value below corrects an earlier draft
+assumption, the corrected value is authoritative** (Standing rule 2).
+
+- [x] **Listen port = `8000`** (not 8080) — `config.py` `port: int = 8000`,
+      `Dockerfile` `EXPOSE 8000`. `NETCANON_PORT=8000` in the instance spec.
+- [x] **Data dir = `/app/data`** — confirmed. But the image also declares
+      `VOLUME ["/app/configs", "/app/data"]` (Dockerfile:113), so **`/app/configs`
+      needs a tmpfs too** (`rw,noexec,nosuid,size=8m`); a missed one becomes a
+      persistent anonymous host-disk volume that falsifies "zero volumes"
+      ([04](04-container-hardening.md#container-spec-per-instance)).
+- [x] **Route table → allowlist.** There are **no static assets** (all CSS/JS is
+      inline) and **no `/api/v1/translate` route**. Allow only the migrate/
+      sanitize UI + migration-plan/detect/sanitize APIs; block backups, devices,
+      schedules, configs, definitions, `/docs`, and UI pages. Exact list in
+      [04](04-container-hardening.md#feature-surface-reduction) /
+      [03](03-warden-spec.md#proxying). Note `/` is the backup **dashboard**, not
+      migrate.
+- [x] **Log level = `warning`.** Request bodies are never logged at any level;
+      only parsed fragments at `debug`. `NETCANON_LOG_LEVEL=warning` provably
+      excludes them (defense in depth behind driver `none`).
+- [x] **No WebSockets.** The UI polls via `fetch`; the WS-fallback contingency is
+      deleted ([03](03-warden-spec.md#proxying) / [05](05-frontend.md)).
+- [x] **No root-path/base-URL support; the UI uses absolute URLs**
+      (`fetch('/api/v1/migration/plan')`, `href="/migrate"`). The warden
+      therefore **routes by session cookie, not path prefix** — a warden-set
+      HttpOnly + SameSite=Strict + Secure routing cookie is **required**
+      ([03](03-warden-spec.md#proxying) / [05](05-frontend.md)).
+- [x] **The app stamps `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'`**
+      on every response (`main.py` security-headers middleware). The warden
+      **must strip XFO and rewrite `frame-ancestors 'none'` → `'self'`** on every
+      proxied response or the iframe renders blank
+      ([03](03-warden-spec.md#proxying)).
+- [x] **Non-root uid = 1000, native.** The image runs `USER app` (uid 1000);
+      **no `user` override** — a mismatched uid breaks tmpfs ownership.
+      `ALLOW_INSECURE_BIND` is unnecessary: setting `NETCANON_API_KEY` alone
+      satisfies the non-loopback bind gate.
+- [x] Record the image digest to pin (part of the I6 hash-lock chain).
+
+**Gate 0:** all facts recorded and written into the warden constants block; any
+that contradict a module have been reconciled into that module (Standing rule 2).
+
+## Phase 1 — Warden
+
+Implement per [03](03-warden-spec.md) with [04](04-container-hardening.md)'s
+constants. Local compose: warden + `demo-int` + `warden-sock` (socket-proxy) +
+caddy-facing net. Interpose the docker-socket proxy (verb allowlist: **create,
+start, list, inspect, remove** — deny everything else) plus a **small
+(~50–80-line) create-body authz shim** that **whole-body default-deny**-validates
+every `POST /containers/create` body against the canonical `INSTANCE_SPEC` —
+rejecting any field not in the spec (an added `Privileged`/`CapAdd`/bind mount) as
+well as any changed field (the verb filter cannot inspect a create body) — since
+the read-only non-root warden container does **not** by itself constrain the
+socket API, which is root-equivalent on the host.
+
+**Gate 1:** CI test table from [08](08-testing-verification.md#ci-tests) green
+locally, including: egress + segmentation (instance→instance, instance→warden,
+**and instance→socket-proxy** all DENY), per-IP + global cap, **volume-reap clean**
+(`docker volume ls` empty after destroy), **TTL-independence** (warden restart →
+labeled orphan swept; systemd backstop present), **socket-proxy** rejecting any
+verb outside create/start/list/inspect/remove, and the **create-body authz shim**
+(whole-body default-deny) rejecting a create body with an extra bind mount, a
+changed image digest, a dropped `read_only`, **or an added `Privileged` /
+`CapAdd` / `Devices` / `NetworkMode: host`** — the two rows now defined in
+[08](08-testing-verification.md#ci-tests).
+
+## Phase 2 — Proxy & frontend
+
+Caddyfile per [02](02-deployment.md#caddy-configuration-requirements); frontend
+per [05](05-frontend.md). Caddy has no native rate-limit, so either commit an
+xcaddy build with a pinned self-built digest (to keep I6/`make verify` honest)
+or fold rate-limiting into the warden (which already holds per-IP session
+state). `Referrer-Policy: same-origin` on all demo paths (path tokens must not
+leak via `Referer`).
+
+**Gate 2:** Full happy path locally: land → start → the instance **renders
+inside the iframe** (verifying the warden stripped `X-Frame-Options` and
+rewrote CSP `frame-ancestors` → `'self'`; a plain iframe would be blank) →
+sample-config translate with Tier-3 banner visible → countdown → tab close
+(`pagehide` beacon) frees the slot ≤ 90 s, no-beacon reclaim ≤ 2 min for a closed
+foreground tab (≤ ~4 min for a throttled background tab); hard-TTL (900 s) and
+idle-reclaim (600 s) destroys each verified once end-to-end.
+
+## Phase 3 — Host
+
+Cloud-init per [02](02-deployment.md): Hetzner **CX32** (4 vCPU / 8 GB, EU
+Falkenstein — the CX line is EU-only, so "CX22 + Ashburn" is impossible; the US
+alternative is CPX32, re-priced with its lower included traffic). Swap off,
+journald volatile, firewall, DNS, TLS. Also disable **core dumps** host-wide
+(swap-off is not the only RAM→disk path): `kernel.core_pattern` → discard,
+`systemd-coredump` `Storage=none` + `ProcessSizeMax=0`, apport removed/neutered,
+`docker.service LimitCORE=0`.
+
+**Gate 3:** `swapon --show` empty; core dumps disabled (crash a throwaway
+process → nothing under `/var/crash` or `/var/lib/systemd/coredump`); 443 only;
+HTTPS green; `make deploy` from a clean clone converges.
+
+## Phase 4 — Proofs & whitepaper
+
+Run live proofs 1–13 ([08](08-testing-verification.md#live-proofs)) on prod;
+commit `VERIFY_RESULTS_<date>.md`. Fill the whitepaper's reproducibility block
+([06](06-privacy-whitepaper.md#reproducibility-block-fill-at-deploy)); publish
+at `/whitepaper`.
+
+**Gate 4:** every whitepaper claim's proof has real output committed (**live
+proofs 1–13**); `make verify` output matches the published block.
+
+## Phase 5 — Launch wiring
+
+- [ ] Demo URL into the launch assets (`[DEMO LINK]` placeholders in the
+      launch playbook: HI pitch, Show HN, README badges).
+- [ ] Front-page `docker run` one-liner + sanitize-page pointer (ties into
+      BUG_REPORTING flow).
+- [ ] Load sanity: script `MAX_ACTIVE` (32 on CX32) concurrent sessions with
+      translations; confirm no OOM-kill of warden/caddy (size the cap off real
+      held-session RSS ~90–140 MB + shim, not the 256 MB cap), busy-state renders
+      for #33. Idle TTL + reliable teardown is the primary capacity lever
+      (Little's Law `L = λ·W`; idle dwell 600 s, hard ceiling 900 s); box upsize
+      is last. If the launch lands, rescale
+      CX32 → CX42 (8/16, `MAX_ACTIVE` 60–80, pool 6) same-day (Hetzner hourly
+      billing; rescale CPU/RAM only, keep the 40 GB disk so it stays reversible).
+
+**Gate 5 (launch-ready):** capacity behavior observed under synthetic load;
+all links resolve; whitepaper live; VERIFY_RESULTS committed.
+
+## Standing rules for the agent
+
+1. Invariants in [00](00-overview.md#invariants) override any convenience.
+2. Any Phase-0 fact that contradicts a module → update the module, don't
+   silently diverge; the whitepaper must describe reality.
+3. Never introduce a persistence mechanism "temporarily for debugging" on the
+   prod host. Debug in dev compose.
+4. Keep the warden small; if it exceeds ~500 lines, you are building the wrong
+   thing — simplify.

--- a/docs/demo-plan/README.md
+++ b/docs/demo-plan/README.md
@@ -1,0 +1,89 @@
+# Netcanon Ephemeral Demo — Implementation Plan
+
+One-shot plan for a public-facing, **provably ephemeral** live demo of
+[netcanon](https://github.com/netcanon/netcanon). Per-visitor instanced
+execution; no demo persists past the **15-minute hard TTL** (`HARD_TTL = 900 s`;
+≤ ~20 min from creation even if the session manager crashes) or browser close; no
+demo data is ever retained; architecture claims are backed by a verifiable
+whitepaper.
+
+## For the implementation agent
+
+Read the modules **in numeric order**. Each module is self-contained but
+cross-linked. Modules declare their deliverables in a `## Deliverables` section
+— treat those as your task list. `09-implementation-order.md` is the build
+sequence with acceptance gates; do not skip gates.
+
+Global invariants (violating any of these is a build failure) are defined in
+[`00-overview.md`](00-overview.md#invariants). When any module conflicts with an
+invariant, the invariant wins.
+
+## Module map
+
+| # | File | Purpose |
+|---|------|---------|
+| 00 | [`00-overview.md`](00-overview.md) | Goals, invariants, success criteria, glossary |
+| 01 | [`01-architecture.md`](01-architecture.md) | Component design, data flow, session lifecycle |
+| 02 | [`02-deployment.md`](02-deployment.md) | Host, DNS, TLS, cloud-init, reverse proxy |
+| 03 | [`03-warden-spec.md`](03-warden-spec.md) | Session-manager service: API, lifecycle, limits |
+| 04 | [`04-container-hardening.md`](04-container-hardening.md) | Per-instance no-retention controls |
+| 05 | [`05-frontend.md`](05-frontend.md) | Demo page, heartbeat, browser-close teardown |
+| 06 | [`06-privacy-whitepaper.md`](06-privacy-whitepaper.md) | The provable no-retention whitepaper (publishable) |
+| 07 | [`07-budget.md`](07-budget.md) | Costs, sizing, scale ceiling |
+| 08 | [`08-testing-verification.md`](08-testing-verification.md) | Proof procedures mapped to whitepaper claims |
+| 09 | [`09-implementation-order.md`](09-implementation-order.md) | Build sequence + acceptance gates |
+
+## Upstream facts this plan relies on
+
+- netcanon ships on GHCR: `ghcr.io/netcanon/netcanon:latest`; default
+  entrypoint `netcanon serve` binds `0.0.0.0:8000` (`config.py` `port = 8000`,
+  `Dockerfile` `EXPOSE 8000` — **not** 8080).
+- **As of 0.4.0 the container fails closed on a public bind**: it refuses to
+  start unless `NETCANON_API_KEY` is set (gates `/api/v1`) or
+  `NETCANON_ALLOW_INSECURE_BIND=1` is set. Setting `NETCANON_API_KEY` alone
+  satisfies the non-loopback bind gate, so `NETCANON_ALLOW_INSECURE_BIND` is
+  **unnecessary** for the demo; the proxy layer provides the public gate.
+- Netcanon otherwise auto-generates a Fernet key file at `data/.fernet_key` on
+  first run (to encrypt stored device data). Demo instances set a per-instance
+  random `NETCANON_FERNET_KEY` env instead, so **no key file is ever created**
+  and the key stays RAM-only.
+- The UI uses **absolute URLs** (`fetch('/api/v1/migration/plan')`,
+  `href="/migrate"`) and has **no root-path/base-URL support**, so the warden
+  routes by a warden-set session cookie, not a path prefix. Netcanon also stamps
+  `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` on every response, so
+  the warden must strip XFO and rewrite `frame-ancestors` → `'self'` or the
+  demo iframe renders blank (see [03](03-warden-spec.md#proxying)).
+- Relevant endpoints for the demo: the migrate page, the sanitize page
+  (`/sanitize`), the migration-plan APIs (`POST /api/v1/migration/plan` + its
+  `/ports`, `/vlans`, … variants, `POST /api/v1/migration/detect`), and
+  `POST /api/v1/sanitize`. There is **no `/api/v1/translate` route**, and `/` is
+  the backup **dashboard** (out of scope). Device-backup/devices/schedules/
+  configs features are **out of scope** and must be unreachable (see 04).
+
+## Plan currency — reviewed 2026-07-22 (netcanon v0.6.1)
+
+Last reconciled against `main` at **v0.6.1**. The design is unchanged; findings:
+
+- **Upstream facts re-verified, still valid.** `X-Frame-Options: DENY` + CSP
+  `frame-ancestors 'none'` are still stamped on every response (now
+  `main.py:366-374`; the two `_CSP_*` constants at `:97`/`:116`), and the
+  Dockerfile still declares `EXPOSE 8000`,
+  `VOLUME ["/app/configs", "/app/data"]`, `USER app`,
+  `ENTRYPOINT ["netcanon", "serve"]`. The warden strip-XFO / rewrite-CSP design
+  and the tmpfs-**both**-volumes invariant (I1) hold verbatim.
+- **UI is now the unified design language** (ui-design-spec v0.2.1, shipped in
+  v0.6.1) but is **still fully inline** — the vendored CSS/JS are
+  Jinja-`{% include %}`d into `base.html`; there is still **no StaticFiles mount
+  and no static assets**, so the "all-inline, cookie-route, no `/static`
+  allowlist" reconnaissance in [09](09-implementation-order.md#phase-0) holds
+  unchanged. Cosmetic bonus: the demo iframe inherits the visitor's OS
+  light/dark via `prefers-color-scheme`. `/docs` stays self-themed / out of scope.
+- **`deploy/PINNED_PRODUCT_TAG` target = `v0.6.1`** (the current demo-worthy
+  release).
+- **Instancing substrate = self-contained VPS (decision recorded).** An
+  alternative lease-based VM instancing platform was evaluated and set aside for
+  this demo: a low-concurrency private-lab lease pool cannot serve a public,
+  scalable ephemeral demo (VM-granularity, slow cold-start, a small concurrent
+  cap, and private ingress), so the self-contained VPS + container-per-visitor
+  design in [01](01-architecture.md) stays. Revisit only if a separate,
+  low-concurrency "lease a full netcanon VM" demo ever becomes the explicit goal.


### PR DESCRIPTION
## What

Vendors the **ephemeral public-demo build plan** (11 modules, `00`–`09` + `README`) from the private review tree into tracked `docs/demo-plan/`. This is the docs-migration step of the demo CI/CD plan — the plan now lives in the repo that the whitepaper's **I6** ("reproducible from the public repo") claim points at.

## Why

The demo's trust story is "diff the running system against the published config," which requires the plan (and, later, the `deploy/` · `warden/` · `frontend/` trees) to live in the public repo. This lands the design docs first; **nothing is deployed**.

## Scope / safety

- **Explicit 11-file move** — never a directory copy (keeps `BLACKBOARD.md`, the adversarial-review artifacts, and `CICD-RECOMMENDATION.md` out of git by design).
- **No PII / operational leakage:** private-lab and sibling-project references stripped; the SSH admin-access line generalized to "an admin VPN." Hetzner is retained (the whitepaper discloses EU hosting on purpose).
- **Module 06 amended** (both adversary-mandated fixes): the in-repo whitepaper is the **template** (placeholders unfilled); the filled copy is rendered at deploy time → `/whitepaper` + the signed Release bundle. Added the **freshness note** (the live site may run an older published bundle than the newest Release; the live block always describes the running system).
- **Currency:** reconciled against **v0.6.1** (`main.py:366-374` security-header refs; `deploy/PINNED_PRODUCT_TAG` target `v0.6.1`).

## Not in scope

Design-only. The demo build (warden, deploy, frontend, `demo-publish.yml`, host provisioning, Gate-4 proofs) stays **parked** behind its own go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
