### PR TITLE
feat(ui): surface the vendored 10-swatch <nc-theme-picker> in the nav

### DIFF
--- a/netcanon/templates/_partials/palette-popover.js
+++ b/netcanon/templates/_partials/palette-popover.js
@@ -1,0 +1,24 @@
+/* Palette popover — the right-rail <nc-theme-picker> lives inside a native
+   <details> disclosure (#nav-palette in base.html).  <details> toggles on its
+   summary, but does not dismiss on an outside click or Escape the way a
+   menu-like popover should — wire that here.  The only state is the element's
+   own `.open`; nothing else is tracked. */
+(function () {
+  "use strict";
+  var d = document.getElementById("nav-palette");
+  if (!d) return;
+
+  // Outside click closes it (a click inside the summary/panel is ignored).
+  document.addEventListener("click", function (e) {
+    if (d.open && !d.contains(e.target)) d.open = false;
+  });
+
+  // Escape closes it and returns focus to the trigger (APG menu-button model).
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && d.open) {
+      d.open = false;
+      var s = document.getElementById("nav-palette-summary");
+      if (s) s.focus();
+    }
+  });
+})();

--- a/netcanon/templates/base.html
+++ b/netcanon/templates/base.html
@@ -222,7 +222,8 @@
        cheatsheet trigger).  Transparent background, hover lightens.
        Sun/moon and "?" glyphs swap inside via inner spans. */
     #nav-theme-toggle,
-    #nav-kbd-cheatsheet {
+    #nav-kbd-cheatsheet,
+    .nav-palette > summary {
       background: transparent;
       color: var(--nav-fg);
       border: 1px solid transparent;
@@ -238,7 +239,10 @@
     #nav-theme-toggle:hover,
     #nav-theme-toggle:focus-visible,
     #nav-kbd-cheatsheet:hover,
-    #nav-kbd-cheatsheet:focus-visible {
+    #nav-kbd-cheatsheet:focus-visible,
+    .nav-palette > summary:hover,
+    .nav-palette > summary:focus-visible,
+    .nav-palette[open] > summary {
       background: rgba(255,255,255,.08);
       color: var(--nav-fg-hover);
       border-color: rgba(255,255,255,.18);
@@ -265,6 +269,27 @@
     @media (prefers-color-scheme: dark) {
       html:not([data-nc-mode]) #nav-theme-toggle .moon { display: none; }
       html:not([data-nc-mode]) #nav-theme-toggle .sun  { display: inline; }
+    }
+    /* Palette picker disclosure — the right-rail swatch popover.  Native
+       <details>/<summary> drives open/close (the palette-popover.js partial
+       dismisses it on Escape / outside click); the panel holds the vendored
+       <nc-theme-picker compact> — 10 brand palettes that set <html
+       data-nc-theme> and persist localStorage["nc-theme"].  The summary
+       borrows the right-rail icon-button styling above. */
+    .nav-palette { position: relative; }
+    .nav-palette > summary { list-style: none; }
+    .nav-palette > summary::-webkit-details-marker { display: none; }
+    .nav-palette-panel {
+      position: absolute;
+      top: calc(100% + .4rem);
+      right: 0;
+      z-index: 60;
+      width: 190px;
+      background: var(--surface);
+      border: 1px solid var(--border-strong);
+      border-radius: 8px;
+      padding: .75rem;
+      box-shadow: var(--shadow-card);
     }
 
     main { max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }
@@ -428,6 +453,17 @@
             onclick="openKbdCheatsheet()">
       <span aria-hidden="true">?</span>
     </button>
+    <details class="nav-palette" id="nav-palette" data-testid="nav-palette">
+      <summary id="nav-palette-summary"
+               data-testid="nav-palette-summary"
+               aria-label="Choose color theme"
+               title="Choose color theme">
+        <span aria-hidden="true">&#x1F3A8;</span>
+      </summary>
+      <div class="nav-palette-panel" role="group" aria-label="Color theme">
+        <nc-theme-picker compact data-testid="nav-theme-picker"></nc-theme-picker>
+      </div>
+    </details>
     <button type="button"
             id="nav-theme-toggle"
             data-testid="nav-theme-toggle"
@@ -707,6 +743,9 @@
 
   /* ── Theme toggle (extracted to _partials/theme-toggle.js) ── */
   {% include "_partials/theme-toggle.js" %}
+
+  /* ── Palette popover (dismiss the swatch <details> on Escape / outside click) ── */
+  {% include "_partials/palette-popover.js" %}
 
 
   /* ── Keyboard cheatsheet (extracted to _partials/kbd-cheatsheet.js) ── */

--- a/tests/testid_reference.md
+++ b/tests/testid_reference.md
@@ -17,7 +17,10 @@ CSS class names or element structure — so UI refactoring does not break tests.
 | `nav-devices`      | `<a>`   | Link to `/devices`; active on Devices page |
 | `nav-definitions`  | `<a>`   | Link to `/definitions`; active on Definitions page |
 | `nav-api-docs`     | `<a>`   | Link to `/docs` |
-| `kbd-cheatsheet-open-btn` | `<button>` | Right-rail `?` nav button; opens the keyboard-shortcut cheatsheet modal.  Sits immediately before `nav-theme-toggle` |
+| `kbd-cheatsheet-open-btn` | `<button>` | Right-rail `?` nav button; opens the keyboard-shortcut cheatsheet modal.  Sits before the palette picker and theme toggle |
+| `nav-palette` | `<details>` | Right-rail palette-picker disclosure (popover); holds the vendored `<nc-theme-picker compact>`.  Sits between `kbd-cheatsheet-open-btn` and `nav-theme-toggle`; dismissed on outside-click/Escape by `_partials/palette-popover.js` |
+| `nav-palette-summary` | `<summary>` | The 🎨 button that opens/closes the palette popover |
+| `nav-theme-picker` | `<nc-theme-picker>` | Vendored 10-swatch colour-palette control (`_vendor/theme-picker.js`); picking a swatch calls `NcTheme.set(theme, null)` → sets `<html data-nc-theme>` and persists `localStorage["nc-theme"]`, reapplied on load by the vendored boot |
 | `nav-theme-toggle` | `<button>` | Right-aligned sun/moon toggle; calls `NcTheme.set(null, mode)` (vendored `_vendor/theme-picker.js`) to flip `<html data-nc-mode>` between `light`/`dark`, persisted to `localStorage["nc-mode"]` and mirrored one-way into the legacy `localStorage["netcanon.theme.v1"]` for the self-contained `/docs` page.  `aria-label` and `aria-pressed` live-update to reflect the ACTION (next-state), not the current state |
 | `toast`            | `<div>` | Fixed-position toast notification; hidden by default |
 


### PR DESCRIPTION
## What
Surfaces the vendored 10-swatch `<nc-theme-picker>` in the nav, so users can finally pick a **colour palette** — not just light/dark.

## Why
The unified UI (ui-design-spec v0.2.1) shipped the palette runtime + the `<nc-theme-picker>` component and registered it, but netcanon only wired the **mode** toggle. `data-nc-theme` was hardcoded to `indigo` and the picker was placed on no page, so there was no way to choose a colour — the deferred follow-up from the adoption plan.

## Change
- Right-rail **palette disclosure** (`<details>` popover) holding `<nc-theme-picker compact>` next to the mode toggle. Picking a swatch → `NcTheme.set(theme, null)` → sets `<html data-nc-theme>` + persists `localStorage["nc-theme"]`, reapplied on load by the vendored boot.
- New `_partials/palette-popover.js` — dismiss on Escape / outside-click (Escape restores focus to the trigger); open/close is native `<details>`.
- Reuses the existing right-rail icon-button styling; **no change** to the vendored `_vendor/theme-picker.js` (sha256 pin intact).
- `testid_reference.md` updated with the three new testids.

## Verified (live dev server)
10 swatches render; picking **Rose** flips `data-nc-theme` + persists across reload; the accent recolours; Escape/outside-click dismiss, in-panel click does not; the absolutely-positioned panel introduces no body scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
