### PR TITLE
feat(demo): frontend SPA + privacy whitepaper for demo.netcanon.net

### DIFF
--- a/deploy/VERIFY.md
+++ b/deploy/VERIFY.md
@@ -1,0 +1,336 @@
+# VERIFY.md — verifying the netcanon public demo's claims
+
+This file is the runbook for verifying every claim made in the demo whitepaper
+(live at `/whitepaper` on the demo host; source at `docs/DEMO_WHITEPAPER.md`).
+Each proof below is a copy-paste command sequence, not a description. If a
+command's output does not match the "expected" line, the claim is broken — file
+an issue.
+
+Proofs are tagged with one of two tiers:
+
+- **[V] Visitor-verifiable** — runnable from your own browser or machine,
+  trusting nothing served by us. These stand on their own.
+- **[O] Operator-attested** — require SSH access to the demo host. Visitors
+  cannot run them against production, but every [O] proof is **locally
+  reproducible**: the demo stack is built from this repo and pinned by digest,
+  so you can `docker run` the identical images on your own machine and execute
+  every [O] row yourself.
+
+One honest caveat up front: **no hosted demo can remotely prove its own
+runtime**. A server can always lie about what it is running. The [V] proofs
+narrow what a lying server could get away with; the [O] proofs plus digest
+pinning let you reconstruct the exact stack independently. The ultimate proof
+is running netcanon locally — it is a single container.
+
+---
+
+## Reproducibility & signatures
+
+### `make verify` — pin comparison
+
+From `deploy/` in this repo:
+
+```bash
+cd deploy/
+make verify
+```
+
+This prints the pinned image digests (from `demo.env`) and the SHA-256 of the
+compose file. Compare them, byte for byte, against the reproducibility block in
+the whitepaper. If they match, the repo you are reading is the recipe for the
+stack the whitepaper describes. (This attests the *recipe*; proof 7 below
+covers what it does and does not say about the live host.)
+
+### Cosign — netcanon instance image (works today)
+
+The published netcanon image on GHCR is signed keyless via Sigstore, using
+GitHub Actions OIDC. Resolve the digest, then verify against the digest — never
+against a mutable tag:
+
+```bash
+# Resolve the immutable digest for the pinned release
+DIGEST=$(docker buildx imagetools inspect ghcr.io/netcanon/netcanon:vX.Y.Z \
+  --format '{{json .Manifest}}' | jq -r .digest)
+
+cosign verify ghcr.io/netcanon/netcanon@sha256:${DIGEST#sha256:} \
+    --certificate-identity 'https://github.com/netcanon/netcanon/.github/workflows/docker-publish.yml@refs/tags/vX.Y.Z' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Notes:
+
+- Replace `vX.Y.Z` with the exact release tag pinned in `deploy/demo.env`
+  (`NETCANON_INSTANCE_IMAGE`).
+- Verify the **digest**, not the tag. Tags are mutable; digests are not.
+- `--certificate-identity` is the **full pinned signer identity** — the exact
+  workflow file at the exact tag ref — not a regexp. It must match
+  byte-for-byte. A passing verification means: this exact image was built by
+  that exact GitHub Actions workflow, at that exact tag, in the public
+  `netcanon/netcanon` repo, and signed via Sigstore's transparency log.
+
+### Cosign — demo stack images (pending demo-publish — Gate-4)
+
+The demo-specific images (the warden, and the socket-proxy/caddy variants if
+self-built) are **not yet published or signed**. Today they are
+built-from-source-in-repo and pinned by digest in `demo.env` — reproducible,
+but not signature-verifiable.
+
+Once the demo-publish workflow ships (a later Gate-4 milestone), the same
+cosign verification will apply, with the anticipated signer identity of the
+form:
+
+```
+https://github.com/netcanon/netcanon/.github/workflows/demo-publish.yml@refs/tags/demo-vX.Y.Z
+```
+
+**This proof is marked (pending demo-publish — Gate-4).** It does not work
+today, and we do not claim it does. Until then, the digest pins in `demo.env`
+plus `make verify` are the demo-image attestation.
+
+---
+
+## Live proofs
+
+### 1. Canary forensics — pasted configs leave no trace (claims 2, 3, 4) [O]
+
+Start a session, paste a config containing a unique canary
+(`CANARY-$(openssl rand -hex 8)`), translate it, end the session. Then sweep
+the entire host:
+
+```bash
+CANARY="CANARY-$(openssl rand -hex 8)"
+echo "$CANARY"   # paste a config containing this string into a session, translate, end session
+
+docker ps -a | grep <instance-id>
+# expected: no output — the container is gone, not stopped
+
+grep -r CANARY- / --binary-files=text --exclude-dir={proc,sys,dev}
+# expected: zero hits anywhere on the filesystem
+
+journalctl | grep CANARY-
+# expected: zero hits in any journal
+
+grep -a CANARY- /dev/sda
+# expected: zero hits — raw block-device sweep, catches deleted-but-unallocated blocks too
+```
+
+Also run the same sweep **before** the TTL expires, while the session is still
+alive: the canary must appear nowhere on disk even for a live session (it lives
+only in tmpfs and process memory).
+
+Error-path variant: repeat the full sweep after each of (a) an oversized
+request body, (b) a malformed body, (c) a mid-stream client kill, (d) a forced
+500 — each with its own distinct `CANARY-` value. Error paths must be as clean
+as the happy path.
+
+- expected: every sweep, on every path, returns zero hits.
+
+### 2. Mount proof — read-only rootfs, tmpfs-only writes (claim 2) [O]
+
+During a live session:
+
+```bash
+docker inspect <id> | jq '.[0].HostConfig.ReadonlyRootfs, .[0].Mounts'
+# expected: true, and every mount is tmpfs — no bind mounts, no volumes
+
+docker diff <id>
+# expected: only paths under the tmpfs mounts — nothing on the container's root layer changed
+```
+
+### 3. Swap proof — session data cannot be paged to disk (claim 5) [O]
+
+```bash
+swapon --show
+# expected: empty — the host has no swap at all
+
+docker inspect <id> | jq '.[0].HostConfig.Memory, .[0].HostConfig.MemorySwap'
+# expected: two equal non-zero numbers — Memory == MemorySwap means zero swap allowance even if swap existed
+```
+
+### 4. Egress + segmentation — instances can reach nothing (claim 6) [O]
+
+```bash
+docker network inspect demo-int | jq '.[0].Internal'
+# expected: true — the instance network has no route out
+```
+
+From inside an instance's network namespace (via `nsenter -t <pid> -n` or a
+probe container attached to `demo-int`), attempt four connections:
+
+```bash
+# 1. the internet
+timeout 3 bash -c 'cat < /dev/null > /dev/tcp/1.1.1.1/443'; echo "exit=$?"
+# 2. a sibling instance's IP
+timeout 3 bash -c 'cat < /dev/null > /dev/tcp/<sibling-ip>/8000'; echo "exit=$?"
+# 3. the warden API port
+timeout 3 bash -c 'cat < /dev/null > /dev/tcp/<warden-ip>/<api-port>'; echo "exit=$?"
+# 4. the socket-proxy
+timeout 3 bash -c 'cat < /dev/null > /dev/tcp/<socket-proxy-ip>/2375'; echo "exit=$?"
+# expected: all four fail (non-zero exit / timeout)
+```
+
+The nftables policy is directional: warden→instance **ALLOW**,
+instance→instance **DENY**, instance→warden **DENY**. The socket-proxy is
+unreachable *by construction* — it sits only on the `warden-sock` network,
+which no instance is ever attached to.
+
+### 5. Isolation — sessions are distinct and unforgeable (claim 1) [V then O]
+
+[V] part, from your own browser: open two browser profiles (or one normal + one
+private window) and start a session in each. Each page header shows a
+**distinct instance-id chip** — that is the `instance_id`, not the routing
+token. End session A (or wait out its TTL). Session A's `nc_route` cookie is
+now dead: every further request from profile A returns **404**, while profile B
+continues working untouched.
+
+[O] part, confirming the mechanism:
+
+```bash
+docker ps --filter label=demo.instance
+# expected: one container per active session, each with its own id
+```
+
+Routing is by the `HttpOnly` `nc_route` cookie — page JavaScript cannot read or
+forge it, so one session cannot craft its way into another's instance.
+
+- expected: distinct chips; dead session → 404s; live session unaffected.
+
+### 6. Capacity — global cap, per-IP cap, slot reclaim SLO (claim 8) [O, per-IP part V]
+
+```bash
+# script mints MAX_ACTIVE (32) sessions, then attempts one more
+./scripts/mint_sessions.sh 33
+# expected: sessions 1-32 succeed; mint 33 first reclaims the longest-idle
+#           session that has never translated, else returns 503; UI shows the busy state
+```
+
+[V] per-IP part, from your own machine: open 3 concurrent sessions from one IP.
+
+- expected: the 3rd is refused (per-IP cap is 2) — you can watch the refusal
+  yourself in the browser.
+
+Capacity SLO: close a tab (the beacon path fires on unload) and watch the slot.
+
+- expected: the closed tab's slot is freed within **≤ 90 s**.
+
+### 7. Reproducibility — the repo is the recipe (claim 9) [V]
+
+```bash
+cd deploy/
+make verify
+# expected: printed image digests + compose sha256 match the whitepaper's reproducibility block exactly
+```
+
+Honest scope note: this attests **the repo**, not the live host. It proves the
+published recipe matches the published claims; it cannot remotely prove the
+host is running that recipe (see the caveat in the intro).
+
+### 8. Page cleanliness — the page itself stores and leaks nothing (claim 10) [V]
+
+In your browser's devtools on the demo page:
+
+```text
+Application tab -> Cookies / Local Storage / Session Storage
+# expected: the page sets no cookies and no localStorage/sessionStorage
+
+Network tab (reload the page)
+# expected: no third-party requests — every request goes to the demo origin
+
+View source
+# expected: self-contained — no external script/style/font origins
+```
+
+The only cookie present is the warden's `HttpOnly` routing cookie (`nc_route`),
+which is set by the server, unreadable by page JS, and disclosed in the
+whitepaper's "What we do see" section.
+
+### 9. Framing — the instance is embeddable only by us (claim 2) [O]
+
+With a live session rendered in the demo page's iframe: the instance renders
+(not a blank frame), and the proxied response carries the rewritten headers.
+Check via curl through the warden, or in devtools → Network → the iframe
+document's response headers:
+
+```bash
+# a cookie-routed instance page (the warden proxies /migrate to your instance)
+curl -sD - -o /dev/null --cookie 'nc_route=<token>' https://<demo-host>/migrate
+# expected: NO X-Frame-Options header, and CSP contains: frame-ancestors 'self'
+```
+
+The warden strips `X-Frame-Options` and rewrites `Content-Security-Policy`
+`frame-ancestors` to `'self'` — so the instance frames on the demo page but
+nowhere else.
+
+### 10. Volume reap — no orphaned storage (claim 2) [O]
+
+After a full session lifecycle (create → use → destroy):
+
+```bash
+docker volume ls
+# expected: no anonymous volume attributable to the instance — nothing to reap because nothing was created
+```
+
+### 11. TTL independence — cleanup survives warden death (claim 3) [O]
+
+Two independent mechanisms, neither relying on the warden's in-memory session
+dict:
+
+```bash
+# (a) startup label-sweep: create a demo-labeled instance, then kill and restart the warden
+docker kill demo-warden && docker start demo-warden
+docker ps -a --filter label=demo.instance
+# expected: the pre-restart instance is force-removed on warden startup — the warden adopts nothing
+
+# (b) host systemd timer: stop the warden entirely, let a demo.*-labeled container
+#     exceed HARD_TTL + POOL_MAX_AGE = 1200s creation age
+systemctl list-timers | grep demo-ttl-backstop     # sweep cadence: 60s
+docker ps -a --filter label=demo.instance
+# expected: once creation age exceeds 1200s, the timer force-removes it with the warden still stopped
+```
+
+### 12. Core-dump proof — crashes leave no memory image on disk (claim 5) [O]
+
+Crash a process inside a live instance:
+
+```bash
+docker exec <id> sh -c 'kill -SIGSEGV <worker-pid>'
+
+ls -la /var/crash /var/lib/systemd/coredump /var/lib/apport/coredump 2>/dev/null
+# expected: nothing new appears in any of them
+```
+
+Why: `kernel.core_pattern` discards cores, `systemd-coredump` is configured
+`Storage=none` / `ProcessSizeMax=0`, and apport is neutered. A crashing worker
+whose memory contains a pasted config cannot write that memory to disk.
+
+### 13. Fernet key never on disk (claim 7) [O]
+
+Run this from the host using the **raw host docker socket** — not the warden's
+proxied path, whose allowlist forbids `exec` by design:
+
+```bash
+docker exec <id> sh -c 'ls -la /app/data/.fernet_key'
+# expected: "No such file or directory" — the key file does not exist
+
+docker exec <id> printenv NETCANON_FERNET_KEY
+# expected: set — a per-instance random key, injected as env at create time
+```
+
+Belt and braces: `/app/data` is tmpfs regardless (proof 2), so even if the
+file had existed, it would never have touched disk.
+
+---
+
+## Pre-launch gate
+
+The demo does not go (or stay) live on faith:
+
+- **All CI tests green**, and
+- **Proofs 1–13 executed on the production host**, with their raw output
+  committed to `VERIFY_RESULTS_<date>.md`,
+- **re-run on every image-digest bump** — a new pin means a fresh full pass.
+
+Freshness note: this file describes the verification **mechanism**; the live
+`/whitepaper` reproducibility block describes the **exact bundle currently
+running**. When they disagree, the live block is the fresher of the two —
+and `make verify` is how you check it.

--- a/docs/DEMO_WHITEPAPER.md
+++ b/docs/DEMO_WHITEPAPER.md
@@ -1,0 +1,188 @@
+# The netcanon demo never keeps your config — here's the proof
+
+Network configs are sensitive. A running-config can contain your addressing
+plan, SNMP strings, usernames, and topology. So the netcanon demo runs your
+session in a throwaway instance that **self-destructs within 15 minutes**, built
+so that retaining your data is not just against policy — it is
+**architecturally unavailable**. This page maps every claim to the exact control
+that enforces it and a procedure anyone can use to verify it.
+
+The entire deployment is open source:
+[github.com/netcanon/netcanon](https://github.com/netcanon/netcanon).
+The running system is reproducible from that repo, and its image digests,
+lockfile hash, and compose-file hash are published in the reproducibility block
+below.
+
+> This document is the in-repo **template**. The reproducibility block carries
+> placeholders that the deploy step fills with the exact digests, hashes, and
+> date of the running bundle. The live copy at
+> `/whitepaper` describes the running system; this repo copy describes the
+> mechanism. Every procedure below is a copy-paste command in the repo's
+> [`VERIFY.md`](../deploy/VERIFY.md).
+
+## Threat model
+
+We defend the visitor's pasted data against: (a) operator retention (us, by
+design), (b) cross-visitor leakage, (c) post-session forensic recovery from the
+host, (d) log-based leakage at any layer, (e) a compromised or buggy demo
+application instance. Out of scope: a fully compromised host kernel/hypervisor
+(no hosted demo can defend that — if your config is that sensitive, run netcanon
+locally: `docker run --rm -p 8000:8000 ghcr.io/netcanon/netcanon`; we make that
+path one click away).
+
+### Trusted Computing Base
+
+Every claim below rests on a small set of components we ask you to trust: the
+**warden** (session manager + reverse proxy), the **socket-proxy + create-body
+authz shim** (the capability filter that fronts the Docker socket), **Caddy**
+(TLS termination), **dockerd** (the container runtime), and the **host
+kernel/OS**. These are the TCB. A compromise of any of them — most sharply the
+warden, which reaches the Docker socket — is **host root**, and host root voids
+**all ten claims** below. We do not pretend otherwise; we make the TCB as small
+and as auditable as we can:
+
+- **The warden is ≤ 500 lines** you can read end to end
+  (`demo/warden/app.py`, source:
+  [github.com/netcanon/netcanon](https://github.com/netcanon/netcanon)).
+- It runs as a **non-root, read-only container** and reaches Docker only through
+  a **socket-proxy / authz filter** that permits just **create, start, list
+  (`GET /containers/json`, including label filters), inspect, and remove** —
+  denying everything else (`exec`, `commit`, `build`, `images`, `networks`,
+  `volumes`, …), not the arbitrary, root-equivalent Docker API. Because the
+  socket proxy cannot inspect a create *body*, a **small create-body authz
+  shim** (`demo/warden/authz_shim.py`) in front of it enforces a **whole-body
+  default-deny allowlist** on every `POST /containers/create`: the raw wire body
+  may contain **only** the fields of the canonical create-body template (the
+  spec in `demo/warden/constants.py` serialized through the pinned Docker SDK),
+  each pinned to that template (image digest, read-only rootfs, the tmpfs set,
+  no bind mount, network mode, memory/pids/cpu caps, `CapDrop: [ALL]` with no
+  `CapAdd`, security-opts) — **any other field, in any letter case, is
+  rejected**, so an added `Privileged`, `CapAdd`, bind mount, or
+  `NetworkMode: host` cannot slip through. Only the `demo.*` labels and the two
+  per-instance random env keys may differ. This shim is **counted in the Trusted
+  Computing Base** alongside the ≤ 500-line warden. (The case-fold is
+  load-bearing: Docker's Go JSON decoder matches struct fields
+  case-insensitively, so the allowlist folds every key to lower case before
+  checking — a lowercase `binds` cannot smuggle a host mount past it.)
+- It **never `exec`s into an instance** and never reads instance memory or
+  tmpfs; its only contact with your instance is proxying HTTP to it.
+- Caddy and dockerd are stock, pinned by digest (below); the host is a single
+  small VPS whose configuration lives in the same public repo.
+
+If you cannot extend that trust, the honest answer is the one on the front page:
+run netcanon locally with `docker run …` and trust nothing of ours.
+
+## Claims, controls, proofs
+
+| # | Claim | Control | Proof (abridged; full: [`VERIFY.md`](../deploy/VERIFY.md)) | Tier |
+|---|---|---|---|---|
+| 1 | Your session runs in its own isolated instance | Warden creates one container per session; routing is by the **HttpOnly `nc_route` cookie** — a bearer credential valid for the life of the session, not a single-use token; instances unreachable except via the warden | Two browser profiles: each header shows a **distinct instance-id chip** (`instance_id`, a display id — not the routing token); end session A → A's now-dead cookie 404s every request while B is unaffected | V·O |
+| 2 | The instance cannot write to disk | `read_only: true` rootfs; **both** declared VOLUME paths (`/app/data` *and* `/app/configs`) backed by tmpfs (RAM), so no anonymous host-disk volume is ever created; **zero named or anonymous volumes** | `docker inspect` shows ReadonlyRootfs=true and Mounts = tmpfs only; `docker diff` clean outside tmpfs; `docker volume ls` empty after teardown | O |
+| 3 | Nothing survives the session | Teardown = `container.remove(v=True, force=True)` (container **and** any anonymous volume); tmpfs freed by kernel; the hard TTL is enforced across **two independent enforcement domains (the warden and host systemd), three mechanisms** — (1) the warden's in-RAM reaper at `deadline = assignment_time + HARD_TTL` (900 s from assignment), (2) the warden's startup label-sweep, and (3) an independent host **systemd timer** (swept every 60 s) that force-removes any `demo.*`-labeled container older than `HARD_TTL + POOL_MAX_AGE = 1200 s` even if the warden is dead; sooner in practice via the 10-min idle reclaim (sooner under heavy load), `pagehide` `sendBeacon`, and heartbeat timeout (**≤ 2 min for a closed foreground tab, ≤ ~4 min for a throttled background tab**) | Destroy → `docker ps -a` and `docker volume ls` empty of it; kill the warden mid-session → the systemd timer still removes it within ~20 min of creation; canary paste + host-wide grep finds nothing post-teardown | O |
+| 4 | Your paste appears in no log, anywhere | Instance log driver `none`; warden logs metadata-only (schema enumerated) and **never interpolates a request body — including in exception handlers / error paths**; Caddy access logging disabled for the whole demo vhost (`log { output discard }`); journald volatile (RAM) | Canary-string grep across journald + filesystems; warden log-schema test asserts no body field on any path, error paths included | O |
+| 5 | RAM contents can't leak to disk (swap **or** core dump) | Swap disabled host-wide; `memswap_limit == mem_limit`; **core dumps disabled host-wide** — `kernel.core_pattern` set to discard, `systemd-coredump` `Storage=none` + `ProcessSizeMax=0`, apport neutered, `docker.service LimitCORE=0` | `swapon --show` empty; inspect shows limits equal; `cat /proc/sys/kernel/core_pattern` shows the discard sink; force a crash → no core file written | O |
+| 6 | The instance can't phone anywhere | Instances on an `internal: true` network (no egress); ICC is all-or-nothing, so isolation is enforced by **explicit nftables rules**: warden→instance ALLOW, instance→instance DENY, instance→warden DENY | From inside an instance: every outbound connect fails; instance→instance fails; instance→warden fails | O |
+| 7 | Even netcanon's encryption key is never written to disk | The warden injects a **per-instance random `NETCANON_FERNET_KEY`** (Tier-1 of netcanon's key resolution), so the file fallback at `data/.fernet_key` is never reached — **no Fernet key file is ever created**; the key lives only in the instance's RAM | From the host via the **raw host Docker socket** (not the warden's path — its allowlist forbids `exec`), `docker exec`/`docker inspect` shows the env key set and no `.fernet_key` on disk (`/app/data` is tmpfs regardless); gone with the instance | O |
+| 8 | The demo can't silently degrade isolation under load | Hard instance cap (`MAX_ACTIVE` = 32); per-IP concurrent-session cap (`PER_IP_MAX_CONCURRENT` = 2); above 80% occupancy the **idle** TTL tightens (600 s → 300 s, applied retroactively within ~10–20 s of the crossing, loosening back below 70% — hysteresis), reclaiming untouched tabs faster while the 15-min hard ceiling is left intact; the longest-idle (never-translated) session is reclaimed before anyone is refused — but **never one younger than 120 s** (a mid-paste session is protected; if every session is under that floor the demo returns 503 rather than reclaiming one); at the cap the demo returns **503** rather than sharing an instance | Saturate the cap; observe 503 + busy UI, never a shared instance (**the third concurrent session from your IP is refused — that you can see**) | O |
+| 9 | The published deployment is exactly reproducible (and the live host is operator-attested to match) | Images pinned by digest; `requirements.lock` hash-locked; compose SHA-256 published | Digests + hashes below; `make verify` reproduces them **from the repo** — it attests the published artifact, **not this live host** (no hosted demo can remotely prove its own runtime; that is what the local `docker run` path is for) | O |
+| 10 | No tracking on the demo page | The **page** sets no cookies, no `localStorage`, no analytics, no third-party requests; the *only* cookie in play is the warden's **HttpOnly, SameSite=Strict, Secure** session-routing cookie — a bare instance binding, not an identifier (disclosed under "What we do see") | View source (self-contained, all CSS/JS inline); devtools **Network** shows no third-party requests and **Application → Cookies** shows only the routing cookie | V |
+
+**Tier — how far you have to trust us.** **V** = *visitor-verifiable now*: you
+can confirm it from your own browser, on the live site, trusting nothing of
+ours. **O** = *operator-attested + locally reproducible*: confirming it needs
+host access, so we commit the exact command output in
+[`VERIFY.md`](../deploy/VERIFY.md) — and, because no hosted demo can remotely
+prove its own runtime, you can reproduce every **O** row yourself by running the
+identical stack locally with `docker run …`. `make verify` attests the
+**published repo/artifact, not this live host**. A row marked **V·O** carries
+both components: claim 1 is the case — you can watch the instance-id chip differ
+and the dead-cookie 404 from your own browser (**V**), while "never a *shared*
+instance" is attested at the container boundary (**O**).
+
+## What we do see
+
+Honesty section — required. We (the operator) can observe: standard host
+operational metadata (session count, lifecycle timestamps, destroy reasons,
+status codes), our host provider's infrastructure-level traffic metadata, and
+whatever a TLS-terminating proxy inherently sees **in memory while streaming**
+your request. Two more things, stated outright:
+
+- **A warden-set routing cookie.** netcanon's UI uses absolute URLs
+  (`fetch('/api/v1/migration/plan')`, `href="/migrate"`) and has no root-path
+  support, so the warden routes you to your one instance **by session, not by
+  path**. To do that it sets a single cookie —
+  `Set-Cookie: nc_route=<token>; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=900`
+  — carrying only the opaque session token. That token is a **bearer credential
+  valid for the life of the session** (not single-use), which is exactly why the
+  cookie is HttpOnly, Secure, and SameSite=Strict — JS cannot read or forge it.
+  It is not an analytics identifier and it dies with your session. Because the
+  cookie is browser-global, a browser holds **exactly one live session** (a fresh
+  mint replaces the previous one); the **≤ 2-concurrent-sessions-per-IP** cap is
+  a separate guardrail bounding distinct devices behind one IP. The demo page
+  itself still sets nothing (claim 10).
+- **Per-IP session state, in RAM only.** To enforce the per-IP
+  concurrent-session cap (**≤ 2 concurrent sessions per IP**) and a
+  sliding-window mint rate limit (**≤ 30 mints / 600 s per IP**), the warden
+  keeps a small per-IP record **in memory only** — never logged, **held in
+  memory for up to 10 minutes after your last request, never written to disk,
+  gone on warden restart**. A rate limiter must outlive any single session, so
+  the record is evicted 10 min after your last request rather than on session
+  end.
+
+We keep none of the in-memory transit category — the controls above are what
+make that checkable rather than a promise. If you cannot accept in-memory
+transit through our proxy, run netcanon locally; that path is on the demo's
+front page.
+
+## Reproducibility block
+
+The deploy step fills these tokens for the running bundle. In this repo template
+they are placeholders; the live `/whitepaper` shows the real values, and
+`make verify` (run from `deploy/`) prints the same digests + compose hash for you
+to compare.
+
+```
+netcanon image    : ghcr.io/netcanon/netcanon@sha256:<NETCANON_IMAGE_DIGEST>   (base python:3.14-slim-bookworm)
+requirements.lock : sha256:<REQUIREMENTS_LOCK_SHA>   (hash-locked; glibc/manylinux wheels — not Alpine/musl)
+warden image      : <WARDEN_IMAGE_REF>@sha256:<WARDEN_IMAGE_DIGEST>
+socket-proxy image: <SOCKET_PROXY_IMAGE_REF>@sha256:<SOCKET_PROXY_IMAGE_DIGEST>   (TCB component — the capability filter fronting docker.sock)
+caddy image       : <CADDY_IMAGE_REF>@sha256:<CADDY_IMAGE_DIGEST>
+compose sha256    : <COMPOSE_SHA256>
+deployed          : <DEPLOY_DATE>   hard TTL: 900s (15 min)   idle TTL: 600s (10 min)   instance cap (MAX_ACTIVE): 32
+```
+
+## Residual risks, stated plainly
+
+### Trusted Computing Base — the honest worst case
+
+The sharpest residual risk is not exotic: it is us. The warden, the socket-proxy
++ authz shim, Caddy, dockerd, and the host are **trusted** (see the threat
+model's TCB subsection). A compromise of the warden — which holds the Docker
+socket — is **host root**, and host root **voids all ten claims** above: it could
+snapshot RAM, disable the reaper, or read into any instance. We *bound* (not
+eliminate) this by keeping the warden tiny (≤ 500 auditable lines), non-root,
+read-only, reachable to Docker only through a capability-filtered socket proxy
+**plus a small create-body authz shim that whole-body default-deny-validates
+every `POST /containers/create` against the canonical instance spec (both counted
+in the TCB), so create is not the arbitrary, root-equivalent Docker API** — and
+never `exec`ing into instances — all of it in the public repo. If that residual
+is unacceptable for your data, run netcanon locally and trust none of it.
+
+- A kernel- or hypervisor-level compromise of the host likewise defeats all
+  guarantees (out of scope in the threat model).
+- `sendBeacon` on `pagehide` is best-effort; when it doesn't fire, the
+  heartbeat-timeout path reclaims your instance in **≤ 2 min for a closed
+  foreground tab, ≤ ~4 min for a throttled background tab**, and a tab left open
+  but untouched is reclaimed at the **10-minute idle TTL** (sooner under heavy
+  load). Both of those only ever *shorten* the session. The guarantee that
+  requires **nothing** from your browser — no beacon, no heartbeat, no activity —
+  is the hard TTL, enforced across **two independent enforcement domains (the
+  warden and host systemd), three mechanisms**, with two honest bounds: while the
+  warden is live it destroys your instance **≤ 15 minutes after it was assigned to
+  you**; and **even if the warden crashes**, an independent host systemd timer
+  (swept every 60 s) force-removes any `demo.*`-labeled container **≤ ~20 minutes
+  after it was created** (older than `HARD_TTL + POOL_MAX_AGE = 1200 s`). A crash
+  can therefore widen the ceiling from 15 to at most ~20 minutes — it can never
+  *lift* it; nothing keeps your instance alive indefinitely.
+- We can change this deployment. That's why the digests and hash are published:
+  trust the artifact you can verify today, not us.

--- a/docs/demo-architecture.md
+++ b/docs/demo-architecture.md
@@ -1,0 +1,134 @@
+# netcanon public demo — architecture overview
+
+This document is the fast path for a reviewer or contributor who wants to understand the
+trust boundaries and request flow of the public ephemeral demo. The full design lives in
+[`docs/demo-plan/`](demo-plan/); the trust argument and its proof runbook live in the
+[whitepaper](DEMO_WHITEPAPER.md) (served at `/whitepaper`) and [`deploy/VERIFY.md`](../deploy/VERIFY.md).
+
+## Overview
+
+A single small VPS runs Docker plus a hand-built FastAPI **warden** — a session manager and
+reverse proxy that is the only stateful service and the core of the Trusted Computing Base.
+The warden spawns one hardened, throwaway netcanon container per visitor, keeps a small warm
+pool so sessions start instantly, routes each browser to its own instance via a session cookie,
+and destroys every instance on a hard TTL regardless of activity. **Caddy** is the sole TLS
+terminator; Cloudflare is DNS-only (grey-cloud), so no third party ever sees plaintext traffic.
+
+## Privilege chain
+
+Every hop from the browser to `docker.sock` strips privilege. Left to right:
+
+```mermaid
+flowchart LR
+    B["browser"] --> C["Caddy<br/>TLS, static frontend,<br/>reverse proxy"]
+    C --> W["warden<br/>mint / heartbeat / end<br/>+ streaming proxy"]
+    W --> S["authz-shim<br/>whole-body default-deny on<br/>POST /containers/create"]
+    S --> P["docker-socket-proxy<br/>(tecnativa)<br/>coarse verb allowlist:<br/>create/start/list/inspect/remove"]
+    P --> D["docker.sock"]
+    D --> I["per-visitor<br/>netcanon instances"]
+
+    style W stroke-width:3px
+    style S stroke-width:3px
+```
+
+**What is in the TCB.** The warden and the create-body authz shim are counted in the TCB.
+The shim rejects any `POST /containers/create` body that does not byte-for-byte match the
+expected hardened spec (default-deny on the whole body, not a field blocklist); the
+socket-proxy above it only permits the five coarse verbs the warden needs — no exec, no
+attach, no build, no volume or network mutation.
+
+**The honest failure mode.** The warden reaches the Docker socket (through the proxy + shim),
+so a compromised warden is host root, and host root voids every guarantee in this document.
+The design does not eliminate that risk — it **bounds** it:
+
+- the warden is tiny (≤ 500 lines, `demo/warden/app.py`), so it can actually be read;
+- it runs non-root with a read-only filesystem;
+- it can reach Docker only through the capability-filtered socket-proxy plus the create-body shim;
+- it never `exec`s into instances — all interaction is plain HTTP proxying.
+
+If you don't want to trust any of this, the trust-nothing alternative is running netcanon
+locally with `docker run`; the demo exists for convenience, not as a security claim.
+
+## Network topology
+
+Three Docker networks, each carrying exactly one kind of traffic:
+
+```mermaid
+flowchart LR
+    subgraph caddynet["caddy-net (the only path in)"]
+        C["Caddy"] <--> W["warden"]
+    end
+
+    subgraph wardensock["warden-sock (control path to docker.sock)"]
+        W2["warden"] --> S["authz-shim"] --> P["docker-socket-proxy"]
+    end
+
+    subgraph demoint["demo-int (internal: true — no egress)"]
+        W3["warden"] -->|ALLOW| I1["instance A"]
+        W3 -->|ALLOW| I2["instance B"]
+        I1 -.->|DENY| I2
+        I1 -.->|DENY| W3
+    end
+
+    W === W2
+    W === W3
+```
+
+- **caddy-net** — Caddy ↔ warden. The only ingress path.
+- **warden-sock** — warden → authz-shim → socket-proxy. The only route to `docker.sock`.
+- **demo-int** — `internal: true` (no egress). Warden ↔ instances for HTTP proxying only.
+  Explicit nftables rules enforce: warden → instance **ALLOW**, instance → instance **DENY**,
+  instance → warden **DENY** (instances cannot reach the warden's API). The socket-proxy is
+  **not** on demo-int, so an instance can never reach it, even from a compromised container.
+
+## Instance lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> POOL: warden pre-warms (POOL_SIZE = 4)
+    POOL --> ASSIGNED: POST /session/new<br/>deadline = now + HARD_TTL (900 s)
+    ASSIGNED --> ASSIGNED: served via iframe /i/{token}/migrate<br/>30 s heartbeat
+    ASSIGNED --> DESTROYED: hard TTL (900 s)
+    ASSIGNED --> DESTROYED: idle reclaim (IDLE_TTL 600 s,<br/>300 s above 80% occupancy)
+    ASSIGNED --> DESTROYED: heartbeat timeout<br/>(75 s visible / 180 s hidden)
+    ASSIGNED --> DESTROYED: pagehide sendBeacon
+    ASSIGNED --> DESTROYED: "destroy now"
+    ASSIGNED --> DESTROYED: replaced by second tab<br/>in the same browser
+    DESTROYED --> [*]
+```
+
+- The reaper ticks every **10 s** and evaluates all destruction conditions.
+- Caps: **MAX_ACTIVE = 32** concurrent instances, **PER_IP_MAX_CONCURRENT = 2**.
+- The idle window tightens (600 s → 300 s) once occupancy exceeds 80%, so a busy demo
+  reclaims faster instead of queueing.
+
+## Hard-TTL enforcement — two independent domains, three mechanisms
+
+No single failure can lift the lifetime ceiling:
+
+| # | Mechanism | Domain | Behavior |
+|---|-----------|--------|----------|
+| a | In-RAM reaper | warden | Assignment-relative 900 s deadline, checked every 10 s tick. |
+| b | Startup label-sweep | warden | On (re)start the warden destroys every `demo.*`-labeled container it finds — it **adopts nothing**, so a restart cannot resurrect or extend a session. |
+| c | Host systemd timer | host (independent of the warden) | Every 60 s, force-removes any `demo.*`-labeled container older than `HARD_TTL + POOL_MAX_AGE = 1200 s`, even if the warden is dead. |
+
+A warden crash can therefore widen the effective ceiling from ~15 minutes to at most
+~20 minutes — it can never remove it.
+
+## Where the code lives
+
+| Path | What it is |
+|------|------------|
+| `deploy/` | docker-compose, Caddyfile, cloud-init, systemd units, nftables rules |
+| `deploy/VERIFY.md` | The proof runbook — commands to verify every claim above on a live host |
+| `demo/warden/app.py` | The warden (session manager + reverse proxy; the TCB core) |
+| `demo/warden/authz_shim.py` | The create-body gate (whole-body default-deny) |
+| `demo/warden/constants.py` | Single source of truth for every hardening flag and TTL |
+| `frontend/` | `index.html` + `whitepaper.html`, served statically by Caddy |
+| `tools/render_whitepaper.py` | Renders the whitepaper for `/whitepaper` |
+| `docs/DEMO_WHITEPAPER.md` | The trust argument (served at `/whitepaper`) |
+| `docs/demo-plan/` | The full design plan this architecture implements |
+
+Start with `constants.py` if you want to audit the hardening surface, `app.py` if you want
+to audit the TCB, and `deploy/VERIFY.md` if you want to check the running system rather than
+take this document's word for it.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,547 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>netcanon — ephemeral demo</title>
+<link rel="icon" href="data:,">
+<style>
+/* ============ theme ============ */
+:root {
+  --nc-indigo: #4f46e5; --nc-indigo-hover: #4338ca; --nc-indigo-fg: #ffffff;
+  --nc-amber: #b45309; --nc-amber-bg: #fffbeb; --nc-amber-border: #fcd34d;
+  --nc-green: #15803d; --nc-red: #dc2626; --nc-red-hover: #b91c1c;
+  --nc-bg: #ffffff; --nc-surface: #f8fafc; --nc-surface-2: #f1f5f9;
+  --nc-text: #0f172a; --nc-muted: #64748b; --nc-border: #e2e8f0;
+  --nc-radius: 10px; --nc-shadow: 0 1px 3px rgba(15,23,42,.08), 0 1px 2px rgba(15,23,42,.04);
+  --nc-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --nc-sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --nc-indigo: #818cf8; --nc-indigo-hover: #a5b4fc; --nc-indigo-fg: #1e1b4b;
+    --nc-amber: #fbbf24; --nc-amber-bg: #2a2410; --nc-amber-border: #a16207;
+    --nc-green: #4ade80; --nc-red: #f87171; --nc-red-hover: #fca5a5;
+    --nc-bg: #0f172a; --nc-surface: #1e293b; --nc-surface-2: #334155;
+    --nc-text: #e2e8f0; --nc-muted: #94a3b8; --nc-border: #334155;
+    --nc-shadow: 0 1px 3px rgba(0,0,0,.4);
+  }
+}
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body { font-family: var(--nc-sans); color: var(--nc-text); background: var(--nc-bg);
+       line-height: 1.6; margin: 0; }
+
+/* ============ layout primitives ============ */
+.wrap { max-width: 760px; margin: 0 auto; padding: 2.5rem 1.25rem; }
+.center { text-align: center; }
+h1 { font-size: 1.9rem; line-height: 1.25; margin: 0 0 .75rem; }
+h2 { font-size: 1.3rem; margin: 0 0 .5rem; }
+p  { margin: 0 0 1rem; }
+.muted { color: var(--nc-muted); }
+a { color: var(--nc-indigo); }
+a:hover { color: var(--nc-indigo-hover); }
+[hidden] { display: none !important; }
+
+/* ============ buttons ============ */
+button { font: inherit; }
+.btn {
+  display: inline-block; background: var(--nc-indigo); color: var(--nc-indigo-fg);
+  border: none; border-radius: var(--nc-radius); padding: .6rem 1.1rem;
+  cursor: pointer; font-weight: 600; box-shadow: var(--nc-shadow);
+}
+.btn:hover { background: var(--nc-indigo-hover); }
+.btn:focus-visible { outline: 3px solid var(--nc-indigo); outline-offset: 2px; }
+.btn-red { background: var(--nc-red); color: #fff; }
+.btn-red:hover { background: var(--nc-red-hover); }
+.btn-ghost {
+  background: var(--nc-surface-2); color: var(--nc-text);
+  border: 1px solid var(--nc-border); box-shadow: none;
+}
+.btn-ghost:hover { background: var(--nc-surface); }
+.btn-sm { padding: .35rem .75rem; font-size: .85rem; }
+
+/* ============ chips / code ============ */
+code, .chip {
+  font-family: var(--nc-mono); font-size: .85em;
+  background: var(--nc-surface-2); border: 1px solid var(--nc-border);
+  border-radius: 6px; padding: .15em .45em;
+}
+.docker-line {
+  display: inline-flex; align-items: center; gap: .5rem; flex-wrap: wrap;
+  justify-content: center; max-width: 100%;
+}
+.docker-line code { overflow-x: auto; max-width: 100%; white-space: nowrap; padding: .4em .6em; }
+
+/* ============ promise card ============ */
+.promise {
+  background: var(--nc-surface); border: 1px solid var(--nc-border);
+  border-left: 4px solid var(--nc-indigo); border-radius: var(--nc-radius);
+  padding: 1rem 1.25rem; margin: 1.5rem 0; box-shadow: var(--nc-shadow);
+}
+.promise p { margin: 0 0 .5rem; }
+.promise p:last-child { margin: 0; }
+
+/* ============ spinner ============ */
+.spinner {
+  width: 42px; height: 42px; margin: 0 auto 1rem;
+  border: 4px solid var(--nc-surface-2); border-top-color: var(--nc-indigo);
+  border-radius: 50%; animation: nc-spin .9s linear infinite;
+}
+@keyframes nc-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .spinner { animation-duration: 2.5s; } }
+
+/* ============ active view ============ */
+#s-active { display: flex; flex-direction: column; height: 100vh; height: 100dvh; }
+#s-active[hidden] { display: none !important; }
+.toolbar {
+  display: flex; align-items: center; gap: .6rem; flex-wrap: wrap;
+  padding: .5rem .75rem; border-bottom: 1px solid var(--nc-border);
+  background: var(--nc-surface); font-size: .85rem;
+}
+.toolbar .spacer { flex: 1; }
+#countdown { font-family: var(--nc-mono); font-weight: 700; font-variant-numeric: tabular-nums; }
+#countdown.low { color: var(--nc-red); }
+#idle-hint {
+  color: var(--nc-muted);
+}
+#idle-hint.warn {
+  color: var(--nc-amber); background: var(--nc-amber-bg);
+  border: 1px solid var(--nc-amber-border); border-radius: 6px;
+  padding: .1rem .5rem; font-weight: 600;
+}
+#frame { flex: 1; width: 100%; border: 0; background: var(--nc-bg); min-height: 200px; }
+
+/* ============ footer ============ */
+footer { border-top: 1px solid var(--nc-border); margin-top: 2rem; }
+footer .wrap { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+footer nav { display: flex; gap: 1.25rem; flex-wrap: wrap; margin-bottom: 1rem; }
+
+/* ============ status screens ============ */
+.status-card { padding-top: 4rem; }
+@media (max-width: 480px) {
+  .wrap { padding: 1.75rem 1rem; }
+  h1 { font-size: 1.55rem; }
+  .toolbar { font-size: .8rem; gap: .45rem; }
+}
+</style>
+</head>
+<body>
+
+<!-- ================= 1) LANDING ================= -->
+<section id="s-landing" aria-labelledby="landing-h">
+  <div class="wrap">
+    <h1 id="landing-h">netcanon &mdash; translate network configs across vendors</h1>
+    <p>netcanon is an open-source tool that translates device configurations between network
+       vendors &mdash; Cisco, Juniper, Arista, and more &mdash; and backs up configs over SSH.
+       Paste a config, pick a target platform, and see exactly what carries over and what
+       doesn&rsquo;t.</p>
+
+    <div class="promise">
+      <p>Your session runs in an isolated instance that <strong>self-destructs within 15 minutes</strong> &mdash; usually the moment you leave. A tab left open but untouched is reclaimed after about 10 minutes of inactivity (<strong>sooner under heavy load</strong>), so keep translating to hold your session to the full 15. Nothing you paste is stored.</p>
+      <p><a href="/whitepaper">Read how we prove that &rarr;</a></p>
+    </div>
+
+    <p class="center" style="margin-top:2rem">
+      <button id="btn-start" class="btn" type="button">Start demo</button>
+    </p>
+    <noscript>
+      <p class="promise"><strong>JavaScript is off</strong> &mdash; the live demo needs it, but
+         everything else about netcanon doesn&rsquo;t. Grab it from
+         <a href="https://github.com/netcanon/netcanon">GitHub</a> or
+         <a href="https://pypi.org/project/netcanon/">PyPI</a> and run it locally.</p>
+    </noscript>
+  </div>
+
+  <footer>
+    <div class="wrap">
+      <nav aria-label="Project links">
+        <a href="https://github.com/netcanon/netcanon">GitHub</a>
+        <a href="https://pypi.org/project/netcanon/">PyPI</a>
+        <a href="/whitepaper">Whitepaper</a>
+      </nav>
+      <p class="muted" style="margin-bottom:.5rem">Prefer to run it yourself? One line, no sign-up:</p>
+      <div class="docker-line" style="justify-content:flex-start">
+        <code id="docker-cmd">docker run --rm -p 8000:8000 ghcr.io/netcanon/netcanon</code>
+        <button class="btn btn-ghost btn-sm copy-btn" type="button" data-copy="docker-cmd">Copy</button>
+      </div>
+      <p class="muted" style="margin-top:.5rem;font-size:.85rem">&hellip;then open <code>http://localhost:8000</code>.</p>
+    </div>
+  </footer>
+</section>
+
+<!-- ================= 2) PROVISIONING ================= -->
+<section id="s-provisioning" hidden aria-labelledby="prov-h">
+  <div class="wrap center status-card" role="status">
+    <div class="spinner" aria-hidden="true"></div>
+    <h2 id="prov-h">Spinning up your private instance&hellip;</h2>
+    <p class="muted">A fresh, isolated container just for you.</p>
+  </div>
+</section>
+
+<!-- 2a) rate-limited sub-state -->
+<section id="s-ratelimited" hidden aria-labelledby="rl-h">
+  <div class="wrap center status-card">
+    <h2 id="rl-h">Hold on a second</h2>
+    <p>You already have the max sessions open from your network, or you&rsquo;re starting too
+       fast &mdash; close another tab or wait ~30&nbsp;seconds and try again.</p>
+    <p><button id="btn-retry-rl" class="btn" type="button">Retry</button></p>
+  </div>
+</section>
+
+<!-- 2b) network-error sub-state -->
+<section id="s-error" hidden aria-labelledby="err-h">
+  <div class="wrap center status-card">
+    <h2 id="err-h">Couldn&rsquo;t reach the demo</h2>
+    <p class="muted">Something went wrong on the way to the server. It happens.</p>
+    <p><button id="btn-retry-err" class="btn" type="button">Retry</button></p>
+  </div>
+</section>
+
+<!-- ================= 3) ACTIVE ================= -->
+<section id="s-active" hidden aria-label="Live demo instance">
+  <div class="toolbar">
+    <span class="chip" id="instance-chip">instance &mdash;</span>
+    <span aria-live="polite">
+      <span class="muted">self-destructs in</span>
+      <span id="countdown">15:00</span>
+    </span>
+    <span id="idle-hint" aria-live="polite"></span>
+    <span class="spacer"></span>
+    <button id="btn-sample" class="btn btn-sm" type="button">Try this sample</button>
+    <button id="btn-destroy" class="btn btn-red btn-sm" type="button">Destroy now</button>
+    <a href="/whitepaper" style="font-size:.85rem">How we prove this &rarr;</a>
+  </div>
+  <iframe id="frame" title="Your private netcanon translator instance"></iframe>
+</section>
+
+<!-- ================= 4) AT-CAPACITY ================= -->
+<section id="s-capacity" hidden aria-labelledby="cap-h">
+  <div class="wrap status-card">
+    <h2 id="cap-h">The demo is at capacity right now.</h2>
+    <p>Every visitor gets a genuinely isolated instance, and there are only so many to go
+       around. Under heavy load, an untouched session may be reclaimed early to make room.
+       That the demo fails closed instead of quietly sharing instances is kind of the point.</p>
+    <p aria-live="polite"><span class="muted">Retrying automatically in</span>
+       <strong id="cap-countdown">10</strong><span class="muted">s&hellip;</span></p>
+    <p><button id="btn-retry-cap" class="btn" type="button">Try again</button></p>
+    <p class="muted" style="margin-top:2rem">No need to wait &mdash; run it locally instead:</p>
+    <div class="docker-line" style="justify-content:flex-start">
+      <code id="docker-cmd-cap">docker run --rm -p 8000:8000 ghcr.io/netcanon/netcanon</code>
+      <button class="btn btn-ghost btn-sm copy-btn" type="button" data-copy="docker-cmd-cap">Copy</button>
+    </div>
+    <p style="margin-top:1rem"><a href="https://github.com/netcanon/netcanon">netcanon on GitHub &rarr;</a></p>
+  </div>
+</section>
+
+<!-- ================= 5) DESTROYED ================= -->
+<section id="s-destroyed" hidden aria-labelledby="dead-h">
+  <div class="wrap center status-card">
+    <h2 id="dead-h">Instance destroyed &#128165; &mdash; everything it held is gone.</h2>
+    <p class="muted">That&rsquo;s the whole idea. Refreshing gets you a fresh instance.</p>
+    <p><button id="btn-again" class="btn" type="button">Start again</button></p>
+  </div>
+</section>
+
+<script>
+"use strict";
+/* ======================================================================
+ * netcanon ephemeral demo — state machine.
+ * NO cookies, NO localStorage, NO sessionStorage: all state lives in
+ * the variables below and dies with the tab. (View-source proves it.)
+ * ==================================================================== */
+
+/* ---------- sample config injected by "Try this sample" ---------- */
+/* Source option: value containing "iosxe" AND "cli", else first "iosxe".
+ * Target option: first value containing "junos". */
+var SAMPLE_CONFIG =
+"hostname edge-sw1\n" +
+"!\n" +
+"vlan 10\n" +
+" name USERS\n" +
+"vlan 20\n" +
+" name VOICE\n" +
+"!\n" +
+"interface GigabitEthernet1/0/1\n" +
+" description uplink-to-core\n" +
+" switchport mode trunk\n" +
+" switchport trunk allowed vlan 10,20\n" +
+"!\n" +
+"interface GigabitEthernet1/0/2\n" +
+" description user-access\n" +
+" switchport mode access\n" +
+" switchport access vlan 10\n" +
+"!\n" +
+"interface Vlan10\n" +
+" ip address 10.10.10.1 255.255.255.0\n" +
+"!\n" +
+"ip route 0.0.0.0 0.0.0.0 10.10.10.254\n" +
+"!\n" +
+"ip access-list extended BLOCK-GUEST\n" +
+" deny   ip 10.20.0.0 0.0.255.255 10.10.0.0 0.0.255.255\n" +
+" permit ip any any\n" +
+"!\n" +
+"snmp-server community public RO\n" +
+"!\n";
+
+/* ---------- session state (JS variables only) ---------- */
+var token = null;         // current session token
+var instanceId = null;    // display id (never the token)
+var deadlineMs = 0;       // receiptMs + ttl_seconds*1000, computed client-side
+var hbTimer = null;       // 30s heartbeat interval
+var tickTimer = null;     // 1s countdown interval
+var capTimer = null;      // at-capacity auto-retry interval
+var capDelay = 10;        // backoff seconds: 10 -> 20 -> 30 (cap 30)
+var capLeft = 0;
+var isHidden = (document.visibilityState === "hidden");
+
+var $ = function (id) { return document.getElementById(id); };
+var SECTIONS = ["s-landing","s-provisioning","s-ratelimited","s-error",
+                "s-active","s-capacity","s-destroyed"];
+
+/* Show exactly one top-level section. */
+function show(id) {
+  SECTIONS.forEach(function (s) { $(s).hidden = (s !== id); });
+}
+
+function clearTimers() {
+  if (hbTimer)   { clearInterval(hbTimer);   hbTimer = null; }
+  if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+  if (capTimer)  { clearInterval(capTimer);  capTimer = null; }
+}
+
+/* ---------- 2) PROVISIONING: mint a session ---------- */
+function startDemo() {
+  clearTimers();
+  show("s-provisioning");
+  fetch("/session/new", { method: "POST" })
+    .then(function (res) {
+      var receiptMs = Date.now(); // countdown anchor = when the 200 arrived
+      if (res.status === 200) {
+        return res.json().then(function (j) { goActive(j, receiptMs); });
+      }
+      if (res.status === 429) { show("s-ratelimited"); return; }
+      if (res.status === 503) { enterCapacity(); return; }
+      show("s-error");
+    })
+    .catch(function () { show("s-error"); });
+}
+
+/* ---------- 3) ACTIVE ---------- */
+function goActive(j, receiptMs) {
+  token = j.token;
+  instanceId = j.instance_id;
+  deadlineMs = receiptMs + j.ttl_seconds * 1000;
+
+  $("instance-chip").textContent = "instance " + instanceId;
+  $("idle-hint").textContent = "";
+  $("idle-hint").className = "";
+  $("frame").src = "/i/" + encodeURIComponent(token) + "/migrate";
+
+  show("s-active");
+  tick();
+  tickTimer = setInterval(tick, 1000);
+  hbTimer = setInterval(heartbeat, 30000);
+}
+
+/* Hard-TTL countdown, ticking every second. */
+function tick() {
+  var left = Math.max(0, Math.floor((deadlineMs - Date.now()) / 1000));
+  var mm = String(Math.floor(left / 60)).padStart(2, "0");
+  var ss = String(left % 60).padStart(2, "0");
+  var el = $("countdown");
+  el.textContent = mm + ":" + ss;
+  el.className = (left < 60) ? "low" : "";
+  if (left <= 0) destroyed();
+}
+
+/* Heartbeat every 30s — keeps running while hidden, just reports it. */
+function heartbeat() {
+  if (!token) return;
+  var t = token;
+  fetch("/session/" + encodeURIComponent(t) + "/hb", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ hidden: isHidden })
+  }).then(function (res) {
+    if (t !== token) return; // stale response from a previous session
+    if (res.status === 404) { destroyed(); return; }
+    if (res.status === 200) {
+      res.json().then(function (j) {
+        if (t !== token) return;
+        var hint = $("idle-hint");
+        if (j.idle_remaining_seconds < 60) {
+          hint.textContent = "idle — translate to keep your session";
+          hint.className = "warn";
+        } else {
+          hint.textContent = "";
+          hint.className = "";
+        }
+      }).catch(function () {});
+    }
+  }).catch(function () { /* transient network blip: keep going */ });
+}
+
+/* Track hidden-ness for the heartbeat body (never pauses the heartbeat). */
+document.addEventListener("visibilitychange", function () {
+  isHidden = (document.visibilityState === "hidden");
+});
+
+/* Teardown beacon on pagehide ONLY (not on visibilitychange — a tab switch
+ * must not kill the session; the copy-from-another-tab flow depends on it). */
+window.addEventListener("pagehide", function () {
+  if (token) {
+    try { navigator.sendBeacon("/session/" + encodeURIComponent(token) + "/end"); }
+    catch (e) {}
+  }
+  clearTimers();
+});
+
+/* "Destroy now" */
+function destroyNow() {
+  if (token) {
+    fetch("/session/" + encodeURIComponent(token) + "/end", { method: "POST" })
+      .catch(function () {});
+  }
+  destroyed();
+}
+
+/* ---------- 5) DESTROYED ---------- */
+function destroyed() {
+  clearTimers();
+  token = null;
+  instanceId = null;
+  $("frame").src = "about:blank";
+  show("s-destroyed");
+}
+
+/* ---------- 4) AT-CAPACITY: auto-retry with backoff ---------- */
+function enterCapacity() {
+  show("s-capacity");
+  capLeft = capDelay;
+  $("cap-countdown").textContent = String(capLeft);
+  if (capTimer) clearInterval(capTimer);
+  capTimer = setInterval(function () {
+    capLeft--;
+    $("cap-countdown").textContent = String(Math.max(0, capLeft));
+    if (capLeft <= 0) {
+      clearInterval(capTimer); capTimer = null;
+      capDelay = Math.min(30, capDelay + 10); // 10 -> 20 -> 30, capped
+      startDemo();
+    }
+  }, 1000);
+}
+
+/* ---------- TRY-THIS-SAMPLE: drive the same-origin migrate iframe ---------- */
+function trySample() {
+  var iframe = $("frame");
+  var tries = 0, MAX_TRIES = 40; // 40 * 150ms = ~6s
+
+  var poll = setInterval(function () {
+    tries++;
+    try {
+      var doc = iframe.contentWindow.document;
+      var src = doc.querySelector('[data-testid="migrate-source-select"]');
+      // selects are populated async — wait until options exist
+      if (!src || src.options.length === 0) {
+        if (tries >= MAX_TRIES) {
+          clearInterval(poll);
+          console.warn("netcanon demo: migrate page not ready, sample not injected");
+        }
+        return;
+      }
+      clearInterval(poll);
+      injectSample(doc);
+    } catch (e) {
+      clearInterval(poll);
+      console.warn("netcanon demo: cannot reach migrate DOM", e);
+    }
+  }, 150);
+}
+
+function injectSample(doc) {
+  try {
+    var src = doc.querySelector('[data-testid="migrate-source-select"]');
+    var tgt = doc.querySelector('[data-testid="migrate-target-select"]');
+
+    // SOURCE: value containing both "iosxe" and "cli"; fall back to "iosxe"
+    var srcVal = pickOption(src, function (v) { return v.indexOf("iosxe") !== -1 && v.indexOf("cli") !== -1; }) ||
+                 pickOption(src, function (v) { return v.indexOf("iosxe") !== -1; });
+    // TARGET: first value containing "junos"
+    var tgtVal = pickOption(tgt, function (v) { return v.indexOf("junos") !== -1; });
+    if (!srcVal || !tgtVal) {
+      console.warn("netcanon demo: iosxe/junos options not found in migrate selects");
+      return;
+    }
+    src.value = srcVal; src.dispatchEvent(new Event("change", { bubbles: true }));
+    tgt.value = tgtVal; tgt.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // raw-input mode so the textarea is visible
+    var radio = doc.querySelector('[data-testid="migrate-input-mode-raw"]');
+    if (radio) {
+      radio.checked = true;
+      radio.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+    var ta = doc.querySelector('[data-testid="migrate-raw-input"]');
+    if (!ta) { console.warn("netcanon demo: raw-input textarea not found"); return; }
+    ta.value = SAMPLE_CONFIG;
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+
+    var btn = doc.querySelector('[data-testid="migrate-submit-btn"]');
+    if (btn) btn.click();
+  } catch (e) {
+    console.warn("netcanon demo: sample injection failed", e);
+  }
+}
+
+function pickOption(sel, test) {
+  if (!sel) return null;
+  for (var i = 0; i < sel.options.length; i++) {
+    var v = String(sel.options[i].value);
+    if (test(v.toLowerCase())) return v;
+  }
+  return null;
+}
+
+/* ---------- copy-to-clipboard for the docker one-liner ---------- */
+function wireCopyButtons() {
+  var btns = document.querySelectorAll(".copy-btn");
+  Array.prototype.forEach.call(btns, function (btn) {
+    btn.addEventListener("click", function () {
+      var text = $(btn.getAttribute("data-copy")).textContent;
+      var done = function () {
+        btn.textContent = "Copied";
+        setTimeout(function () { btn.textContent = "Copy"; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done).catch(function () {});
+      } else {
+        // very old fallback: select the code element so the user can Ctrl+C
+        var range = document.createRange();
+        range.selectNodeContents($(btn.getAttribute("data-copy")));
+        var s = window.getSelection();
+        s.removeAllRanges(); s.addRange(range);
+      }
+    });
+  });
+}
+
+/* A fresh, user-initiated start resets the at-capacity backoff to its floor. */
+function freshStart() { capDelay = 10; startDemo(); }
+
+/* ---------- wire up ---------- */
+$("btn-start").addEventListener("click", freshStart);
+$("btn-retry-rl").addEventListener("click", startDemo);
+$("btn-retry-err").addEventListener("click", startDemo);
+$("btn-retry-cap").addEventListener("click", function () {
+  if (capTimer) { clearInterval(capTimer); capTimer = null; }
+  startDemo();
+});
+$("btn-sample").addEventListener("click", trySample);
+$("btn-destroy").addEventListener("click", destroyNow);
+$("btn-again").addEventListener("click", function () { show("s-landing"); });
+wireCopyButtons();
+</script>
+</body>
+</html>

--- a/frontend/whitepaper.html
+++ b/frontend/whitepaper.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>netcanon demo — privacy &amp; ephemerality</title>
+<style>
+:root {
+  --nc-indigo: #4f46e5; --nc-indigo-hover: #4338ca; --nc-indigo-fg: #ffffff;
+  --nc-amber: #b45309; --nc-amber-bg: #fffbeb; --nc-amber-border: #fcd34d;
+  --nc-green: #15803d; --nc-red: #dc2626; --nc-red-hover: #b91c1c;
+  --nc-bg: #ffffff; --nc-surface: #f8fafc; --nc-surface-2: #f1f5f9;
+  --nc-text: #0f172a; --nc-muted: #64748b; --nc-border: #e2e8f0;
+  --nc-radius: 10px; --nc-shadow: 0 1px 3px rgba(15,23,42,.08), 0 1px 2px rgba(15,23,42,.04);
+  --nc-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --nc-sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --nc-indigo: #818cf8; --nc-indigo-hover: #a5b4fc; --nc-indigo-fg: #1e1b4b;
+    --nc-amber: #fbbf24; --nc-amber-bg: #2a2410; --nc-amber-border: #a16207;
+    --nc-green: #4ade80; --nc-red: #f87171; --nc-red-hover: #fca5a5;
+    --nc-bg: #0f172a; --nc-surface: #1e293b; --nc-surface-2: #334155;
+    --nc-text: #e2e8f0; --nc-muted: #94a3b8; --nc-border: #334155;
+    --nc-shadow: 0 1px 3px rgba(0,0,0,.4);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: var(--nc-sans); color: var(--nc-text); background: var(--nc-bg);
+  line-height: 1.6; margin: 0;
+}
+.topnav {
+  background: var(--nc-surface); border-bottom: 1px solid var(--nc-border);
+  padding: .75rem 1.25rem;
+}
+.topnav a { color: var(--nc-indigo); text-decoration: none; font-weight: 600; }
+.topnav a:hover { color: var(--nc-indigo-hover); text-decoration: underline; }
+.prose { max-width: 760px; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; }
+.prose a { color: var(--nc-indigo); }
+.prose a:hover { color: var(--nc-indigo-hover); }
+h1, h2, h3, h4, h5, h6 { line-height: 1.25; margin: 2rem 0 .75rem; }
+h1 { font-size: 2rem; margin-top: .5rem; }
+h2 { font-size: 1.5rem; border-bottom: 1px solid var(--nc-border); padding-bottom: .3rem; }
+h3 { font-size: 1.2rem; }
+p, ul, ol, blockquote { margin: 0 0 1rem; }
+ul, ol { padding-left: 1.5rem; }
+li { margin: .25rem 0; }
+code {
+  font-family: var(--nc-mono); font-size: .9em; background: var(--nc-surface-2);
+  padding: .1rem .35rem; border-radius: 6px;
+}
+pre {
+  font-family: var(--nc-mono); font-size: .85rem; background: var(--nc-surface-2);
+  border: 1px solid var(--nc-border); border-radius: var(--nc-radius);
+  padding: 1rem; overflow-x: auto; margin: 0 0 1rem;
+}
+pre code { background: transparent; padding: 0; border-radius: 0; font-size: inherit; }
+blockquote {
+  border-left: 3px solid var(--nc-indigo); padding: .25rem 0 .25rem 1rem;
+  color: var(--nc-muted); background: var(--nc-surface);
+  border-radius: 0 var(--nc-radius) var(--nc-radius) 0;
+}
+blockquote p:last-child { margin-bottom: 0; }
+hr { border: none; border-top: 1px solid var(--nc-border); margin: 2.5rem 0; }
+.table-wrap { overflow-x: auto; margin: 0 0 1rem; }
+table { border-collapse: collapse; width: 100%; font-size: .875rem; }
+th, td {
+  padding: .5rem .75rem; border-bottom: 1px solid var(--nc-border);
+  text-align: left; vertical-align: top;
+}
+th { background: var(--nc-surface-2); font-weight: 600; white-space: nowrap; }
+mark.ph {
+  background: var(--nc-amber-bg); color: var(--nc-amber);
+  border: 1px solid var(--nc-amber-border); border-radius: 4px;
+  padding: 0 .3rem; font-family: var(--nc-mono); font-size: .9em;
+}
+.template-banner {
+  max-width: 760px; margin: 1.5rem auto 0; padding: .9rem 1.1rem;
+  background: var(--nc-amber-bg); color: var(--nc-amber);
+  border: 1px solid var(--nc-amber-border); border-radius: var(--nc-radius);
+  box-shadow: var(--nc-shadow); font-size: .95rem;
+}
+.btn {
+  display: inline-block; background: var(--nc-indigo); color: var(--nc-indigo-fg);
+  border: none; border-radius: var(--nc-radius); padding: .6rem 1.1rem;
+  cursor: pointer; font: inherit; text-decoration: none;
+}
+.btn:hover { background: var(--nc-indigo-hover); }
+.btn-danger { background: var(--nc-red); color: #ffffff; }
+.btn-danger:hover { background: var(--nc-red-hover); }
+.footer {
+  border-top: 1px solid var(--nc-border); color: var(--nc-muted);
+  text-align: center; padding: 1.5rem 1.25rem 2.5rem; font-size: .875rem;
+}
+.footer a { color: var(--nc-indigo); }
+</style>
+</head>
+<body>
+<nav class="topnav"><a href="/">← Back to the demo</a></nav>
+<div class="template-banner"><strong>Template copy.</strong> This is the in-repo TEMPLATE copy of the whitepaper. The live demo fills the reproducibility block (image digests, hashes, deploy date) at deploy time. The live site may run an older published bundle than the newest repo commit — the block on the live site describes the running system.</div>
+<main class="prose">
+<h1 id="the-netcanon-demo-never-keeps-your-config-here-s-the-proof">The netcanon demo never keeps your config — here's the proof</h1>
+<p>Network configs are sensitive. A running-config can contain your addressing plan, SNMP strings, usernames, and topology. So the netcanon demo runs your session in a throwaway instance that <strong>self-destructs within 15 minutes</strong>, built so that retaining your data is not just against policy — it is <strong>architecturally unavailable</strong>. This page maps every claim to the exact control that enforces it and a procedure anyone can use to verify it.</p>
+<p>The entire deployment is open source: <a href="https://github.com/netcanon/netcanon">github.com/netcanon/netcanon</a>. The running system is reproducible from that repo, and its image digests, lockfile hash, and compose-file hash are published in the reproducibility block below.</p>
+<blockquote>
+<p>This document is the in-repo <strong>template</strong>. The reproducibility block carries placeholders that the deploy step fills with the exact digests, hashes, and date of the running bundle. The live copy at <code>/whitepaper</code> describes the running system; this repo copy describes the mechanism. Every procedure below is a copy-paste command in the repo's <a href="../deploy/VERIFY.md"><code>VERIFY.md</code></a>.</p>
+</blockquote>
+<h2 id="threat-model">Threat model</h2>
+<p>We defend the visitor's pasted data against: (a) operator retention (us, by design), (b) cross-visitor leakage, (c) post-session forensic recovery from the host, (d) log-based leakage at any layer, (e) a compromised or buggy demo application instance. Out of scope: a fully compromised host kernel/hypervisor (no hosted demo can defend that — if your config is that sensitive, run netcanon locally: <code>docker run --rm -p 8000:8000 ghcr.io/netcanon/netcanon</code>; we make that path one click away).</p>
+<h3 id="trusted-computing-base">Trusted Computing Base</h3>
+<p>Every claim below rests on a small set of components we ask you to trust: the <strong>warden</strong> (session manager + reverse proxy), the <strong>socket-proxy + create-body authz shim</strong> (the capability filter that fronts the Docker socket), <strong>Caddy</strong> (TLS termination), <strong>dockerd</strong> (the container runtime), and the <strong>host kernel/OS</strong>. These are the TCB. A compromise of any of them — most sharply the warden, which reaches the Docker socket — is <strong>host root</strong>, and host root voids <strong>all ten claims</strong> below. We do not pretend otherwise; we make the TCB as small and as auditable as we can:</p>
+<ul>
+<li><strong>The warden is ≤ 500 lines</strong> you can read end to end</li>
+</ul>
+<p>(<code>demo/warden/app.py</code>, source: <a href="https://github.com/netcanon/netcanon">github.com/netcanon/netcanon</a>).</p>
+<ul>
+<li>It runs as a <strong>non-root, read-only container</strong> and reaches Docker only through</li>
+</ul>
+<p>a <strong>socket-proxy / authz filter</strong> that permits just <strong>create, start, list (<code>GET /containers/json</code>, including label filters), inspect, and remove</strong> — denying everything else (<code>exec</code>, <code>commit</code>, <code>build</code>, <code>images</code>, <code>networks</code>, <code>volumes</code>, …), not the arbitrary, root-equivalent Docker API. Because the socket proxy cannot inspect a create <em>body</em>, a <strong>small create-body authz shim</strong> (<code>demo/warden/authz_shim.py</code>) in front of it enforces a <strong>whole-body default-deny allowlist</strong> on every <code>POST /containers/create</code>: the raw wire body may contain <strong>only</strong> the fields of the canonical create-body template (the spec in <code>demo/warden/constants.py</code> serialized through the pinned Docker SDK), each pinned to that template (image digest, read-only rootfs, the tmpfs set, no bind mount, network mode, memory/pids/cpu caps, <code>CapDrop: [ALL]</code> with no <code>CapAdd</code>, security-opts) — <strong>any other field, in any letter case, is rejected</strong>, so an added <code>Privileged</code>, <code>CapAdd</code>, bind mount, or <code>NetworkMode: host</code> cannot slip through. Only the <code>demo.*</code> labels and the two per-instance random env keys may differ. This shim is <strong>counted in the Trusted Computing Base</strong> alongside the ≤ 500-line warden. (The case-fold is load-bearing: Docker's Go JSON decoder matches struct fields case-insensitively, so the allowlist folds every key to lower case before checking — a lowercase <code>binds</code> cannot smuggle a host mount past it.)</p>
+<ul>
+<li>It <strong>never <code>exec</code>s into an instance</strong> and never reads instance memory or</li>
+</ul>
+<p>tmpfs; its only contact with your instance is proxying HTTP to it.</p>
+<ul>
+<li>Caddy and dockerd are stock, pinned by digest (below); the host is a single</li>
+</ul>
+<p>small VPS whose configuration lives in the same public repo.</p>
+<p>If you cannot extend that trust, the honest answer is the one on the front page: run netcanon locally with <code>docker run …</code> and trust nothing of ours.</p>
+<h2 id="claims-controls-proofs">Claims, controls, proofs</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Claim</th>
+<th>Control</th>
+<th>Proof (abridged; full: <a href="../deploy/VERIFY.md"><code>VERIFY.md</code></a>)</th>
+<th>Tier</th>
+</tr>
+</thead>
+<tbody>
+<tr><td>1</td><td>Your session runs in its own isolated instance</td><td>Warden creates one container per session; routing is by the <strong>HttpOnly <code>nc_route</code> cookie</strong> — a bearer credential valid for the life of the session, not a single-use token; instances unreachable except via the warden</td><td>Two browser profiles: each header shows a <strong>distinct instance-id chip</strong> (<code>instance_id</code>, a display id — not the routing token); end session A → A's now-dead cookie 404s every request while B is unaffected</td><td>V·O</td></tr>
+<tr><td>2</td><td>The instance cannot write to disk</td><td><code>read_only: true</code> rootfs; <strong>both</strong> declared VOLUME paths (<code>/app/data</code> <em>and</em> <code>/app/configs</code>) backed by tmpfs (RAM), so no anonymous host-disk volume is ever created; <strong>zero named or anonymous volumes</strong></td><td><code>docker inspect</code> shows ReadonlyRootfs=true and Mounts = tmpfs only; <code>docker diff</code> clean outside tmpfs; <code>docker volume ls</code> empty after teardown</td><td>O</td></tr>
+<tr><td>3</td><td>Nothing survives the session</td><td>Teardown = <code>container.remove(v=True, force=True)</code> (container <strong>and</strong> any anonymous volume); tmpfs freed by kernel; the hard TTL is enforced across <strong>two independent enforcement domains (the warden and host systemd), three mechanisms</strong> — (1) the warden's in-RAM reaper at <code>deadline = assignment_time + HARD_TTL</code> (900 s from assignment), (2) the warden's startup label-sweep, and (3) an independent host <strong>systemd timer</strong> (swept every 60 s) that force-removes any <code>demo.*</code>-labeled container older than <code>HARD_TTL + POOL_MAX_AGE = 1200 s</code> even if the warden is dead; sooner in practice via the 10-min idle reclaim (sooner under heavy load), <code>pagehide</code> <code>sendBeacon</code>, and heartbeat timeout (<strong>≤ 2 min for a closed foreground tab, ≤ ~4 min for a throttled background tab</strong>)</td><td>Destroy → <code>docker ps -a</code> and <code>docker volume ls</code> empty of it; kill the warden mid-session → the systemd timer still removes it within ~20 min of creation; canary paste + host-wide grep finds nothing post-teardown</td><td>O</td></tr>
+<tr><td>4</td><td>Your paste appears in no log, anywhere</td><td>Instance log driver <code>none</code>; warden logs metadata-only (schema enumerated) and <strong>never interpolates a request body — including in exception handlers / error paths</strong>; Caddy access logging disabled for the whole demo vhost (<code>log { output discard }</code>); journald volatile (RAM)</td><td>Canary-string grep across journald + filesystems; warden log-schema test asserts no body field on any path, error paths included</td><td>O</td></tr>
+<tr><td>5</td><td>RAM contents can't leak to disk (swap <strong>or</strong> core dump)</td><td>Swap disabled host-wide; <code>memswap_limit == mem_limit</code>; <strong>core dumps disabled host-wide</strong> — <code>kernel.core_pattern</code> set to discard, <code>systemd-coredump</code> <code>Storage=none</code> + <code>ProcessSizeMax=0</code>, apport neutered, <code>docker.service LimitCORE=0</code></td><td><code>swapon --show</code> empty; inspect shows limits equal; <code>cat /proc/sys/kernel/core_pattern</code> shows the discard sink; force a crash → no core file written</td><td>O</td></tr>
+<tr><td>6</td><td>The instance can't phone anywhere</td><td>Instances on an <code>internal: true</code> network (no egress); ICC is all-or-nothing, so isolation is enforced by <strong>explicit nftables rules</strong>: warden→instance ALLOW, instance→instance DENY, instance→warden DENY</td><td>From inside an instance: every outbound connect fails; instance→instance fails; instance→warden fails</td><td>O</td></tr>
+<tr><td>7</td><td>Even netcanon's encryption key is never written to disk</td><td>The warden injects a <strong>per-instance random <code>NETCANON_FERNET_KEY</code></strong> (Tier-1 of netcanon's key resolution), so the file fallback at <code>data/.fernet_key</code> is never reached — <strong>no Fernet key file is ever created</strong>; the key lives only in the instance's RAM</td><td>From the host via the <strong>raw host Docker socket</strong> (not the warden's path — its allowlist forbids <code>exec</code>), <code>docker exec</code>/<code>docker inspect</code> shows the env key set and no <code>.fernet_key</code> on disk (<code>/app/data</code> is tmpfs regardless); gone with the instance</td><td>O</td></tr>
+<tr><td>8</td><td>The demo can't silently degrade isolation under load</td><td>Hard instance cap (<code>MAX_ACTIVE</code> = 32); per-IP concurrent-session cap (<code>PER_IP_MAX_CONCURRENT</code> = 2); above 80% occupancy the <strong>idle</strong> TTL tightens (600 s → 300 s, applied retroactively within ~10–20 s of the crossing, loosening back below 70% — hysteresis), reclaiming untouched tabs faster while the 15-min hard ceiling is left intact; the longest-idle (never-translated) session is reclaimed before anyone is refused — but <strong>never one younger than 120 s</strong> (a mid-paste session is protected; if every session is under that floor the demo returns 503 rather than reclaiming one); at the cap the demo returns <strong>503</strong> rather than sharing an instance</td><td>Saturate the cap; observe 503 + busy UI, never a shared instance (<strong>the third concurrent session from your IP is refused — that you can see</strong>)</td><td>O</td></tr>
+<tr><td>9</td><td>The published deployment is exactly reproducible (and the live host is operator-attested to match)</td><td>Images pinned by digest; <code>requirements.lock</code> hash-locked; compose SHA-256 published</td><td>Digests + hashes below; <code>make verify</code> reproduces them <strong>from the repo</strong> — it attests the published artifact, <strong>not this live host</strong> (no hosted demo can remotely prove its own runtime; that is what the local <code>docker run</code> path is for)</td><td>O</td></tr>
+<tr><td>10</td><td>No tracking on the demo page</td><td>The <strong>page</strong> sets no cookies, no <code>localStorage</code>, no analytics, no third-party requests; the <em>only</em> cookie in play is the warden's <strong>HttpOnly, SameSite=Strict, Secure</strong> session-routing cookie — a bare instance binding, not an identifier (disclosed under "What we do see")</td><td>View source (self-contained, all CSS/JS inline); devtools <strong>Network</strong> shows no third-party requests and <strong>Application → Cookies</strong> shows only the routing cookie</td><td>V</td></tr>
+</tbody>
+</table>
+</div>
+<p><strong>Tier — how far you have to trust us.</strong> <strong>V</strong> = <em>visitor-verifiable now</em>: you can confirm it from your own browser, on the live site, trusting nothing of ours. <strong>O</strong> = <em>operator-attested + locally reproducible</em>: confirming it needs host access, so we commit the exact command output in <a href="../deploy/VERIFY.md"><code>VERIFY.md</code></a> — and, because no hosted demo can remotely prove its own runtime, you can reproduce every <strong>O</strong> row yourself by running the identical stack locally with <code>docker run …</code>. <code>make verify</code> attests the <strong>published repo/artifact, not this live host</strong>. A row marked <strong>V·O</strong> carries both components: claim 1 is the case — you can watch the instance-id chip differ and the dead-cookie 404 from your own browser (<strong>V</strong>), while "never a <em>shared</em> instance" is attested at the container boundary (<strong>O</strong>).</p>
+<h2 id="what-we-do-see">What we do see</h2>
+<p>Honesty section — required. We (the operator) can observe: standard host operational metadata (session count, lifecycle timestamps, destroy reasons, status codes), our host provider's infrastructure-level traffic metadata, and whatever a TLS-terminating proxy inherently sees <strong>in memory while streaming</strong> your request. Two more things, stated outright:</p>
+<ul>
+<li><strong>A warden-set routing cookie.</strong> netcanon's UI uses absolute URLs</li>
+</ul>
+<p>(<code>fetch('/api/v1/migration/plan')</code>, <code>href="/migrate"</code>) and has no root-path support, so the warden routes you to your one instance <strong>by session, not by path</strong>. To do that it sets a single cookie — <code>Set-Cookie: nc_route=&lt;token&gt;; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=900</code> — carrying only the opaque session token. That token is a <strong>bearer credential valid for the life of the session</strong> (not single-use), which is exactly why the cookie is HttpOnly, Secure, and SameSite=Strict — JS cannot read or forge it. It is not an analytics identifier and it dies with your session. Because the cookie is browser-global, a browser holds <strong>exactly one live session</strong> (a fresh mint replaces the previous one); the <strong>≤ 2-concurrent-sessions-per-IP</strong> cap is a separate guardrail bounding distinct devices behind one IP. The demo page itself still sets nothing (claim 10).</p>
+<ul>
+<li><strong>Per-IP session state, in RAM only.</strong> To enforce the per-IP</li>
+</ul>
+<p>concurrent-session cap (<strong>≤ 2 concurrent sessions per IP</strong>) and a sliding-window mint rate limit (<strong>≤ 30 mints / 600 s per IP</strong>), the warden keeps a small per-IP record <strong>in memory only</strong> — never logged, <strong>held in memory for up to 10 minutes after your last request, never written to disk, gone on warden restart</strong>. A rate limiter must outlive any single session, so the record is evicted 10 min after your last request rather than on session end.</p>
+<p>We keep none of the in-memory transit category — the controls above are what make that checkable rather than a promise. If you cannot accept in-memory transit through our proxy, run netcanon locally; that path is on the demo's front page.</p>
+<h2 id="reproducibility-block">Reproducibility block</h2>
+<p>The deploy step fills these tokens for the running bundle. In this repo template they are placeholders; the live <code>/whitepaper</code> shows the real values, and <code>make verify</code> (run from <code>deploy/</code>) prints the same digests + compose hash for you to compare.</p>
+<pre><code>netcanon image    : ghcr.io/netcanon/netcanon@sha256:<mark class="ph">&lt;NETCANON_IMAGE_DIGEST&gt;</mark>   (base python:3.14-slim-bookworm)
+requirements.lock : sha256:<mark class="ph">&lt;REQUIREMENTS_LOCK_SHA&gt;</mark>   (hash-locked; glibc/manylinux wheels — not Alpine/musl)
+warden image      : <mark class="ph">&lt;WARDEN_IMAGE_REF&gt;</mark>@sha256:<mark class="ph">&lt;WARDEN_IMAGE_DIGEST&gt;</mark>
+socket-proxy image: <mark class="ph">&lt;SOCKET_PROXY_IMAGE_REF&gt;</mark>@sha256:<mark class="ph">&lt;SOCKET_PROXY_IMAGE_DIGEST&gt;</mark>   (TCB component — the capability filter fronting docker.sock)
+caddy image       : <mark class="ph">&lt;CADDY_IMAGE_REF&gt;</mark>@sha256:<mark class="ph">&lt;CADDY_IMAGE_DIGEST&gt;</mark>
+compose sha256    : <mark class="ph">&lt;COMPOSE_SHA256&gt;</mark>
+deployed          : <mark class="ph">&lt;DEPLOY_DATE&gt;</mark>   hard TTL: 900s (15 min)   idle TTL: 600s (10 min)   instance cap (MAX_ACTIVE): 32</code></pre>
+<h2 id="residual-risks-stated-plainly">Residual risks, stated plainly</h2>
+<h3 id="trusted-computing-base-the-honest-worst-case">Trusted Computing Base — the honest worst case</h3>
+<p>The sharpest residual risk is not exotic: it is us. The warden, the socket-proxy + authz shim, Caddy, dockerd, and the host are <strong>trusted</strong> (see the threat model's TCB subsection). A compromise of the warden — which holds the Docker socket — is <strong>host root</strong>, and host root <strong>voids all ten claims</strong> above: it could snapshot RAM, disable the reaper, or read into any instance. We <em>bound</em> (not eliminate) this by keeping the warden tiny (≤ 500 auditable lines), non-root, read-only, reachable to Docker only through a capability-filtered socket proxy <strong>plus a small create-body authz shim that whole-body default-deny-validates every <code>POST /containers/create</code> against the canonical instance spec (both counted in the TCB), so create is not the arbitrary, root-equivalent Docker API</strong> — and never <code>exec</code>ing into instances — all of it in the public repo. If that residual is unacceptable for your data, run netcanon locally and trust none of it.</p>
+<ul>
+<li>A kernel- or hypervisor-level compromise of the host likewise defeats all</li>
+</ul>
+<p>guarantees (out of scope in the threat model).</p>
+<ul>
+<li><code>sendBeacon</code> on <code>pagehide</code> is best-effort; when it doesn't fire, the</li>
+</ul>
+<p>heartbeat-timeout path reclaims your instance in <strong>≤ 2 min for a closed foreground tab, ≤ ~4 min for a throttled background tab</strong>, and a tab left open but untouched is reclaimed at the <strong>10-minute idle TTL</strong> (sooner under heavy load). Both of those only ever <em>shorten</em> the session. The guarantee that requires <strong>nothing</strong> from your browser — no beacon, no heartbeat, no activity — is the hard TTL, enforced across <strong>two independent enforcement domains (the warden and host systemd), three mechanisms</strong>, with two honest bounds: while the warden is live it destroys your instance <strong>≤ 15 minutes after it was assigned to you</strong>; and <strong>even if the warden crashes</strong>, an independent host systemd timer (swept every 60 s) force-removes any <code>demo.*</code>-labeled container <strong>≤ ~20 minutes after it was created</strong> (older than <code>HARD_TTL + POOL_MAX_AGE = 1200 s</code>). A crash can therefore widen the ceiling from 15 to at most ~20 minutes — it can never <em>lift</em> it; nothing keeps your instance alive indefinitely.</p>
+<ul>
+<li>We can change this deployment. That's why the digests and hash are published:</li>
+</ul>
+<p>trust the artifact you can verify today, not us.</p>
+</main>
+<footer class="footer">netcanon is open source: <a href="https://github.com/netcanon/netcanon">github.com/netcanon/netcanon</a></footer>
+</body>
+</html>

--- a/tools/render_whitepaper.py
+++ b/tools/render_whitepaper.py
@@ -1,0 +1,483 @@
+"""Render the demo whitepaper Markdown into a self-contained, styled HTML page.
+
+Usage::
+
+    python tools/render_whitepaper.py [--in docs/DEMO_WHITEPAPER.md]
+                                      [--out frontend/whitepaper.html]
+                                      [--values path/to/values.json] [--check]
+
+Dependency-free by design: this script runs at deploy time on the demo host,
+and the demo's whole ethos is a tiny, auditable trusted stack -- so it uses
+only the Python 3.11+ standard library.  It implements a *focused*
+Markdown-to-HTML converter covering exactly the constructs the whitepaper
+uses (ATX headings, paragraphs, bold/italic/inline-code, links, flat
+unordered/ordered lists, GitHub-style pipe tables, fenced code blocks,
+horizontal rules, blockquotes).  It is NOT a general-purpose Markdown engine.
+
+Placeholder substitution: the Markdown may contain ``<UPPER_SNAKE>`` tokens
+(e.g. ``<REPO_DEPLOY_URL>``, sha256 digests inside the reproducibility code
+block).  ``--values`` supplies a JSON map of token name -> replacement text;
+any token left unfilled renders visibly as an amber ``<mark class="ph">``
+chip (never silently blanked), and a "template copy" banner is injected at
+the top of the page.  ``--check`` re-renders in memory and exits non-zero if
+the committed ``--out`` file differs (drift detection for CI).
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import html
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Placeholder handling
+# ---------------------------------------------------------------------------
+
+# A placeholder token is ASCII UPPER_SNAKE inside literal angle brackets.
+_TOKEN_RE = re.compile(r"<([A-Z][A-Z0-9_]*)>")
+
+# Unfilled tokens are swapped for control-char sentinels *before* rendering so
+# they survive HTML escaping untouched, then swapped for real <mark> markup in
+# a final pass over the rendered body.  \x00/\x01 never occur in the source.
+_PH_START, _PH_END = "\x00", "\x01"
+_SENTINEL_RE = re.compile("\x00([A-Z][A-Z0-9_]*)\x01")
+
+# Inline-stash sentinels (protect emitted tags from the emphasis regexes).
+_STASH_TOKEN_RE = re.compile("\x02(\\d+)\x03")
+
+
+def fill_placeholders(md: str, values: dict[str, str]) -> tuple[str, set[str]]:
+    """Substitute known ``<KEY>`` tokens; sentinel-mark the rest.
+
+    Returns the transformed Markdown and the set of token names that were
+    left unfilled.  Unfilled tokens become control-char sentinels which the
+    render pipeline later turns into visible ``<mark class="ph">`` chips.
+    """
+    for key, val in values.items():
+        md = md.replace(f"<{key}>", str(val))
+
+    unfilled: set[str] = set()
+
+    def _mark(m: re.Match[str]) -> str:
+        unfilled.add(m.group(1))
+        return f"{_PH_START}{m.group(1)}{_PH_END}"
+
+    return _TOKEN_RE.sub(_mark, md), unfilled
+
+
+# ---------------------------------------------------------------------------
+# Markdown -> HTML converter
+# ---------------------------------------------------------------------------
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*#*\s*$")
+_HR_RE = re.compile(r"^\s*---+\s*$")
+_UL_RE = re.compile(r"^\s{0,3}[-*]\s+(.*)$")
+_OL_RE = re.compile(r"^\s{0,3}\d+\.\s+(.*)$")
+# GitHub table separator row: |---|:---:|---| (leading/trailing pipes optional)
+_TABLE_SEP_RE = re.compile(r"^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|?\s*$")
+
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_STAR_EM_RE = re.compile(r"(?<!\*)\*([^*\s](?:[^*]*[^*\s])?)\*(?!\*)")
+_UNDER_EM_RE = re.compile(r"(?<!\w)_([^_]+)_(?!\w)")
+_CODE_SPAN_RE = re.compile(r"(`[^`]+`)")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+
+
+def _escape(text: str) -> str:
+    """HTML-escape & < > (attribute quoting is handled at emit sites)."""
+    return html.escape(text, quote=False)
+
+
+def _emphasis(s: str) -> str:
+    """Apply bold then italic markup to already-escaped text."""
+    s = _BOLD_RE.sub(r"<strong>\1</strong>", s)
+    s = _STAR_EM_RE.sub(r"<em>\1</em>", s)
+    return _UNDER_EM_RE.sub(r"<em>\1</em>", s)
+
+
+def _render_inline(text: str) -> str:
+    """Render inline Markdown (code spans, links, bold, italic) to HTML.
+
+    Code spans are extracted first and receive no further formatting; links
+    are emitted next and stashed so the emphasis regexes cannot mangle
+    underscores or asterisks inside hrefs.
+    """
+    stash: list[str] = []
+
+    def _keep(rendered: str) -> str:
+        stash.append(rendered)
+        return f"\x02{len(stash) - 1}\x03"
+
+    out: list[str] = []
+    for part in _CODE_SPAN_RE.split(text):
+        if part.startswith("`") and part.endswith("`") and len(part) > 2:
+            out.append(_keep(f"<code>{_escape(part[1:-1])}</code>"))
+        else:
+            out.append(_escape(part))
+    s = "".join(out)
+
+    def _link(m: re.Match[str]) -> str:
+        label, href = m.group(1), m.group(2)
+        href = href.replace('"', "&quot;")
+        return _keep(f'<a href="{href}">{_emphasis(label)}</a>')
+
+    s = _LINK_RE.sub(_link, s)
+    s = _emphasis(s)
+
+    # Restore stashed spans (looped: link labels may contain code tokens).
+    while _STASH_TOKEN_RE.search(s):
+        s = _STASH_TOKEN_RE.sub(lambda m: stash[int(m.group(1))], s)
+    return s
+
+
+def _slugify(text: str, used: dict[str, int]) -> str:
+    """Derive a unique anchor id from heading text (GitHub-ish slugs)."""
+    plain = re.sub(r"[`*_\[\]()]", "", text)
+    slug = re.sub(r"[^a-z0-9]+", "-", plain.lower()).strip("-") or "section"
+    n = used.get(slug, 0)
+    used[slug] = n + 1
+    return slug if n == 0 else f"{slug}-{n}"
+
+
+def _is_block_start(line: str) -> bool:
+    """True when *line* opens a non-paragraph block (terminates a paragraph)."""
+    ls = line.lstrip()
+    return bool(
+        not line.strip()
+        or ls.startswith(("```", ">"))
+        or _HEADING_RE.match(line)
+        or _HR_RE.match(line)
+        or _UL_RE.match(line)
+        or _OL_RE.match(line)
+    )
+
+
+def _split_table_row(line: str) -> list[str]:
+    """Split a pipe-table row into stripped cell strings."""
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|"):
+        line = line[:-1]
+    return [cell.strip() for cell in line.split("|")]
+
+
+def _render_table(lines: list[str], i: int) -> tuple[str, int]:
+    """Render a pipe table starting at ``lines[i]``; return (html, next_i)."""
+    header = _split_table_row(lines[i])
+    i += 2  # skip header + separator rows
+    body_rows: list[list[str]] = []
+    while i < len(lines) and "|" in lines[i] and lines[i].strip():
+        body_rows.append(_split_table_row(lines[i]))
+        i += 1
+
+    parts = ['<div class="table-wrap">\n<table>\n<thead>\n<tr>']
+    parts.extend(f"<th>{_render_inline(cell)}</th>" for cell in header)
+    parts.append("</tr>\n</thead>\n<tbody>")
+    for row in body_rows:
+        # Pad short rows so every <tr> has the header's column count.
+        row = row + [""] * (len(header) - len(row))
+        cells = "".join(f"<td>{_render_inline(c)}</td>" for c in row[: len(header)])
+        parts.append(f"<tr>{cells}</tr>")
+    parts.append("</tbody>\n</table>\n</div>")
+    return "\n".join(parts), i
+
+
+def _render_list(lines: list[str], i: int, marker_re: re.Pattern[str], tag: str) -> tuple[str, int]:
+    """Render a flat list (ul/ol) starting at ``lines[i]``."""
+    items: list[str] = []
+    while i < len(lines):
+        m = marker_re.match(lines[i])
+        if not m:
+            break
+        items.append(f"<li>{_render_inline(m.group(1))}</li>")
+        i += 1
+    return f"<{tag}>\n" + "\n".join(items) + f"\n</{tag}>", i
+
+
+def _render_blocks(lines: list[str], used_slugs: dict[str, int]) -> str:
+    """Render a sequence of Markdown lines to block-level HTML."""
+    out: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+
+        if line.lstrip().startswith("```"):  # fenced code block
+            i += 1
+            code: list[str] = []
+            while i < n and not lines[i].lstrip().startswith("```"):
+                code.append(lines[i])
+                i += 1
+            i += 1  # closing fence (harmless past EOF)
+            out.append(f"<pre><code>{_escape(chr(10).join(code))}</code></pre>")
+            continue
+
+        m = _HEADING_RE.match(line)
+        if m:
+            level, text = len(m.group(1)), m.group(2)
+            slug = _slugify(text, used_slugs)
+            out.append(f'<h{level} id="{slug}">{_render_inline(text)}</h{level}>')
+            i += 1
+            continue
+
+        if _HR_RE.match(line):
+            out.append("<hr>")
+            i += 1
+            continue
+
+        if line.lstrip().startswith(">"):  # blockquote (rendered recursively)
+            quoted: list[str] = []
+            while i < n and lines[i].lstrip().startswith(">"):
+                inner = lines[i].lstrip()[1:]
+                quoted.append(inner[1:] if inner.startswith(" ") else inner)
+                i += 1
+            out.append(f"<blockquote>\n{_render_blocks(quoted, used_slugs)}\n</blockquote>")
+            continue
+
+        if "|" in line and i + 1 < n and "|" in lines[i + 1] and _TABLE_SEP_RE.match(lines[i + 1]):
+            block, i = _render_table(lines, i)
+            out.append(block)
+            continue
+
+        if _UL_RE.match(line):
+            block, i = _render_list(lines, i, _UL_RE, "ul")
+            out.append(block)
+            continue
+
+        if _OL_RE.match(line):
+            block, i = _render_list(lines, i, _OL_RE, "ol")
+            out.append(block)
+            continue
+
+        para = [line.strip()]  # paragraph: gather until blank line / new block
+        i += 1
+        while i < n and not _is_block_start(lines[i]):
+            para.append(lines[i].strip())
+            i += 1
+        out.append(f"<p>{_render_inline(' '.join(para))}</p>")
+
+    return "\n".join(out)
+
+
+def render_markdown(md: str) -> str:
+    """Convert whitepaper-subset Markdown to body HTML."""
+    lines = md.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    return _render_blocks(lines, {})
+
+
+# ---------------------------------------------------------------------------
+# Page shell (doctype + head + inline theme + nav + footer)
+# ---------------------------------------------------------------------------
+
+_CSS = """\
+:root {
+  --nc-indigo: #4f46e5; --nc-indigo-hover: #4338ca; --nc-indigo-fg: #ffffff;
+  --nc-amber: #b45309; --nc-amber-bg: #fffbeb; --nc-amber-border: #fcd34d;
+  --nc-green: #15803d; --nc-red: #dc2626; --nc-red-hover: #b91c1c;
+  --nc-bg: #ffffff; --nc-surface: #f8fafc; --nc-surface-2: #f1f5f9;
+  --nc-text: #0f172a; --nc-muted: #64748b; --nc-border: #e2e8f0;
+  --nc-radius: 10px; --nc-shadow: 0 1px 3px rgba(15,23,42,.08), 0 1px 2px rgba(15,23,42,.04);
+  --nc-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --nc-sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --nc-indigo: #818cf8; --nc-indigo-hover: #a5b4fc; --nc-indigo-fg: #1e1b4b;
+    --nc-amber: #fbbf24; --nc-amber-bg: #2a2410; --nc-amber-border: #a16207;
+    --nc-green: #4ade80; --nc-red: #f87171; --nc-red-hover: #fca5a5;
+    --nc-bg: #0f172a; --nc-surface: #1e293b; --nc-surface-2: #334155;
+    --nc-text: #e2e8f0; --nc-muted: #94a3b8; --nc-border: #334155;
+    --nc-shadow: 0 1px 3px rgba(0,0,0,.4);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  font-family: var(--nc-sans); color: var(--nc-text); background: var(--nc-bg);
+  line-height: 1.6; margin: 0;
+}
+.topnav {
+  background: var(--nc-surface); border-bottom: 1px solid var(--nc-border);
+  padding: .75rem 1.25rem;
+}
+.topnav a { color: var(--nc-indigo); text-decoration: none; font-weight: 600; }
+.topnav a:hover { color: var(--nc-indigo-hover); text-decoration: underline; }
+.prose { max-width: 760px; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; }
+.prose a { color: var(--nc-indigo); }
+.prose a:hover { color: var(--nc-indigo-hover); }
+h1, h2, h3, h4, h5, h6 { line-height: 1.25; margin: 2rem 0 .75rem; }
+h1 { font-size: 2rem; margin-top: .5rem; }
+h2 { font-size: 1.5rem; border-bottom: 1px solid var(--nc-border); padding-bottom: .3rem; }
+h3 { font-size: 1.2rem; }
+p, ul, ol, blockquote { margin: 0 0 1rem; }
+ul, ol { padding-left: 1.5rem; }
+li { margin: .25rem 0; }
+code {
+  font-family: var(--nc-mono); font-size: .9em; background: var(--nc-surface-2);
+  padding: .1rem .35rem; border-radius: 6px;
+}
+pre {
+  font-family: var(--nc-mono); font-size: .85rem; background: var(--nc-surface-2);
+  border: 1px solid var(--nc-border); border-radius: var(--nc-radius);
+  padding: 1rem; overflow-x: auto; margin: 0 0 1rem;
+}
+pre code { background: transparent; padding: 0; border-radius: 0; font-size: inherit; }
+blockquote {
+  border-left: 3px solid var(--nc-indigo); padding: .25rem 0 .25rem 1rem;
+  color: var(--nc-muted); background: var(--nc-surface);
+  border-radius: 0 var(--nc-radius) var(--nc-radius) 0;
+}
+blockquote p:last-child { margin-bottom: 0; }
+hr { border: none; border-top: 1px solid var(--nc-border); margin: 2.5rem 0; }
+.table-wrap { overflow-x: auto; margin: 0 0 1rem; }
+table { border-collapse: collapse; width: 100%; font-size: .875rem; }
+th, td {
+  padding: .5rem .75rem; border-bottom: 1px solid var(--nc-border);
+  text-align: left; vertical-align: top;
+}
+th { background: var(--nc-surface-2); font-weight: 600; white-space: nowrap; }
+mark.ph {
+  background: var(--nc-amber-bg); color: var(--nc-amber);
+  border: 1px solid var(--nc-amber-border); border-radius: 4px;
+  padding: 0 .3rem; font-family: var(--nc-mono); font-size: .9em;
+}
+.template-banner {
+  max-width: 760px; margin: 1.5rem auto 0; padding: .9rem 1.1rem;
+  background: var(--nc-amber-bg); color: var(--nc-amber);
+  border: 1px solid var(--nc-amber-border); border-radius: var(--nc-radius);
+  box-shadow: var(--nc-shadow); font-size: .95rem;
+}
+.btn {
+  display: inline-block; background: var(--nc-indigo); color: var(--nc-indigo-fg);
+  border: none; border-radius: var(--nc-radius); padding: .6rem 1.1rem;
+  cursor: pointer; font: inherit; text-decoration: none;
+}
+.btn:hover { background: var(--nc-indigo-hover); }
+.btn-danger { background: var(--nc-red); color: #ffffff; }
+.btn-danger:hover { background: var(--nc-red-hover); }
+.footer {
+  border-top: 1px solid var(--nc-border); color: var(--nc-muted);
+  text-align: center; padding: 1.5rem 1.25rem 2.5rem; font-size: .875rem;
+}
+.footer a { color: var(--nc-indigo); }
+"""
+
+_BANNER_HTML = (
+    '<div class="template-banner"><strong>Template copy.</strong> '
+    "This is the in-repo TEMPLATE copy of the whitepaper. The live demo fills "
+    "the reproducibility block (image digests, hashes, deploy date) at deploy "
+    "time. The live site may run an older published bundle than the newest "
+    "repo commit — the block on the live site describes the running "
+    "system.</div>\n"
+)
+
+_NAV_HTML = '<nav class="topnav"><a href="/">← Back to the demo</a></nav>\n'
+
+_FOOTER_HTML = (
+    '<footer class="footer">netcanon is open source: '
+    '<a href="https://github.com/netcanon/netcanon">github.com/netcanon/netcanon</a>'
+    "</footer>\n"
+)
+
+
+def build_page(body_html: str, has_unfilled: bool) -> str:
+    """Wrap rendered body HTML in the full standalone document shell."""
+    banner = _BANNER_HTML if has_unfilled else ""
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>netcanon demo — privacy &amp; ephemerality</title>\n"
+        "<style>\n" + _CSS + "</style>\n"
+        "</head>\n"
+        "<body>\n" + _NAV_HTML + banner
+        + '<main class="prose">\n' + body_html + "\n</main>\n"
+        + _FOOTER_HTML + "</body>\n"
+        "</html>\n"
+    )
+
+
+def render_document(md: str, values: dict[str, str]) -> tuple[str, set[str]]:
+    """Full pipeline: placeholders -> Markdown -> page. Returns (html, unfilled)."""
+    md, unfilled = fill_placeholders(md, values)
+    body = render_markdown(md)
+    body = _SENTINEL_RE.sub(lambda m: f'<mark class="ph">&lt;{m.group(1)}&gt;</mark>', body)
+    return build_page(body, bool(unfilled)), unfilled
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render the demo whitepaper Markdown to standalone HTML (stdlib only).",
+    )
+    parser.add_argument("--in", dest="src", type=Path, default=Path("docs/DEMO_WHITEPAPER.md"),
+                        help="input Markdown file (default: docs/DEMO_WHITEPAPER.md)")
+    parser.add_argument("--out", dest="out", type=Path, default=Path("frontend/whitepaper.html"),
+                        help="output HTML file (default: frontend/whitepaper.html)")
+    parser.add_argument("--values", type=Path, default=None,
+                        help="JSON map of placeholder name -> value (fills <NAME> tokens)")
+    parser.add_argument("--check", action="store_true",
+                        help="render in-memory and exit non-zero if --out differs (drift check)")
+    args = parser.parse_args(argv)
+
+    md = args.src.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    if args.values is not None:
+        values = json.loads(args.values.read_text(encoding="utf-8"))
+
+    rendered, unfilled = render_document(md, values)
+
+    if unfilled:
+        names = ", ".join(sorted(unfilled))
+        print(f"note: {len(unfilled)} unfilled placeholder(s) rendered as pending: {names}",
+              file=sys.stderr)
+
+    if args.check:
+        if not args.out.exists():
+            print(f"check FAILED: {args.out} does not exist (run without --check to create it)",
+                  file=sys.stderr)
+            return 1
+        with args.out.open(encoding="utf-8", newline="") as f:
+            current = f.read()
+        if _normalize_newlines(current) == _normalize_newlines(rendered):
+            print(f"check OK: {args.out} is up to date")
+            return 0
+        diff = difflib.unified_diff(
+            _normalize_newlines(current).splitlines(keepends=True),
+            _normalize_newlines(rendered).splitlines(keepends=True),
+            fromfile=str(args.out),
+            tofile="freshly rendered",
+        )
+        print(f"check FAILED: {args.out} differs from a fresh render of {args.src}:",
+              file=sys.stderr)
+        for line in list(diff)[:60]:
+            sys.stderr.write(line)
+        print("\n(re-run without --check to regenerate)", file=sys.stderr)
+        return 1
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8", newline="\n") as f:
+        f.write(rendered)
+    kind = "template copy (banner shown)" if unfilled else "fully filled copy (no banner)"
+    print(f"wrote {args.out}: {kind}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

The visitor-facing half of the `demo.netcanon.net` ephemeral demo — the landing/demo SPA and the privacy whitepaper. Sibling to the warden + deploy TCB (#393) and the design plan (#391).

## Contents

- **`frontend/index.html`** — self-contained SPA (~21 KB; no CDN, fonts, or analytics; sets **zero** cookies/localStorage/sessionStorage). State machine landing → provisioning → active → at-capacity → destroyed, wired to the warden session API.
  - Active view: iframe `/i/{token}/migrate`, client-side hard-TTL countdown (`receiptMs + ttl_seconds*1000`), idle indicator from `/hb`, instance-id chip, Destroy-now, 30 s heartbeat, `pagehide` sendBeacon.
  - **"Try this sample"** drives the same-origin migrate iframe (via `data-testid`s) to the `GigabitEthernet1/0/1 → ge-1/0/1` payoff plus the amber Tier-3 "surfaced, not dropped" banner.
  - `429 {reason:"rate_limited"}` and `503 {reason:"capacity"}` handled as distinct states.
- **`docs/DEMO_WHITEPAPER.md`** — the whitepaper template: 10 claims, each a control + a runnable proof; honest TCB + "what we do see"; reproducibility block with deploy-time placeholders.
- **`tools/render_whitepaper.py`** — stdlib-only Markdown→HTML (pipe tables, placeholder marking, template banner, `--values` fill, `--check` drift guard).
- **`frontend/whitepaper.html`** — the rendered template copy Caddy serves at `/whitepaper` (banner shown; deploy re-renders with real digests via `--values`).
- **`deploy/VERIFY.md`** — copy-paste runbook for proofs 1–13 + the netcanon-image cosign identity (demo-image signing marked *pending demo-publish / Gate-4*).
- **`docs/demo-architecture.md`** — privilege-chain / 3-network / lifecycle Mermaid diagrams.

## Verification

Built by a Fable-agent swarm, then integrated + **live-smoked end-to-end** against the Gate-1 warden stack (Caddy + warden + authz-shim + socket-proxy on one `http://localhost` origin):

- mint → active; iframe loaded same-origin (`Migrate — Netcanon`, 12 codecs)
- cookie-routed translation succeeded → output contains `ge-1/0/1`, Tier-3 banner count = 1 (proves the HttpOnly `nc_route` routing **and** the CSP `frame-ancestors`/XFO rewrite both work)
- page set **zero** cookies / localStorage / sessionStorage
- Destroy-now → `active=0`, `end=1`, frame `about:blank`
- `/whitepaper` renders: template banner + 10-row claims table + marked repro tokens + "← Back to the demo"
- render tool: `--values` fill drops the banner; `--check` passes; `ruff` clean; compiles on 3.11 floor

Frontend targets the **live-verified** warden contract (no `expires_at`; 429-vs-503; `pagehide`-only beacon).

## Cross-PR notes

- `deploy/Caddyfile` (serves `/srv/frontend`) and `deploy/Makefile` (`make verify`, referenced by `VERIFY.md`) land in #393 — both PRs touch `deploy/` with disjoint files and merge additively.
- Deploy-time: `render_whitepaper.py --values <digests.json>` regenerates `whitepaper.html` with the running bundle's digests (removes the template banner).
- Nothing auto-deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
