### PR TITLE
fix(demo): Gate-3 findings from the real host — socket-proxy pin + guards

### DIFF
--- a/.github/workflows/demo-publish.yml
+++ b/.github/workflows/demo-publish.yml
@@ -431,7 +431,14 @@ jobs:
           echo "socket_proxy=$socket_proxy" >> "$GITHUB_OUTPUT"
           echo "caddy=$caddy" >> "$GITHUB_OUTPUT"
         env:
-          SOCKET_PROXY_TAG: ghcr.io/tecnativa/docker-socket-proxy:0.3
+          # ⚠️ The socket-proxy tag is load-bearing, not cosmetic. Its entrypoint
+          # renders haproxy.cfg at startup, and the service runs `read_only: true`
+          # with only /run + /tmp as tmpfs. Versions <= 0.3 write the rendered
+          # config to /usr/local/etc/haproxy/ and therefore crash-loop, taking the
+          # whole privilege chain down. v0.4.0+ writes to /tmp. Do not bump this
+          # without adding the new tag to SOCKET_PROXY_TMPFS_SAFE in
+          # tests/demo/test_demo_docs_truth.py (which will fail CI until you do).
+          SOCKET_PROXY_TAG: ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
           CADDY_TAG: docker.io/library/caddy:2
 
       - name: Render the deploy bundle

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,7 +11,7 @@ warden/shim live in [`demo/warden/`](../demo/warden/).
 | `docker-compose.yml` | Production stack: caddy + warden + authz-shim + socket-proxy, 3 networks. Image refs are env-interpolated so the file stays digest-free — its in-repo hash **is** the published hash (**I6**). |
 | `docker-compose.dev.yml` | Local Gate-1 override — builds warden+shim from source. |
 | `Caddyfile` | TLS termination (Let's Encrypt; DNS-only Cloudflare → Caddy is the sole terminator), static landing/whitepaper, reverse-proxy to the warden, 2 MB body cap, no request logs on demo paths. |
-| `cloud-init.yaml` | Hardened Ubuntu 24.04: docker, **key-only SSH**, **swap-off + core-dumps-off + journald-volatile** (I2), **fail2ban (SSH)**, unattended-upgrades, host firewall (443/80 + admin-only SSH, ICMPv6 allowed), chrony, OOM protection. Clones this repo to `/opt/demo` and installs the TTL-backstop + demo-firewall units from it. |
+| `cloud-init.yaml` | Hardened Ubuntu 24.04: docker, **key-only SSH**, **swap-off + core-dumps-off + journald-volatile** (I2), **fail2ban (SSH)**, unattended-upgrades, host firewall (443/80 + admin-only SSH, ICMPv6 allowed), chrony, `make` + `jq` for the deploy runbook, OOM protection. Clones this repo to `/opt/demo` and installs the TTL-backstop + demo-firewall units from it. |
 | `systemd/` | `demo-ttl-backstop.{sh,service,timer}` — the warden-independent hard-TTL backstop (removes any `demo.*` container older than **1320 s** = `HARD_TTL + POOL_MAX_AGE + 120 s slack`, swept every 60 s). |
 | `nftables/demo-int.nft` | The demo-int isolation rules (warden→instance ALLOW, instance→instance DENY, instance→warden DENY). |
 | `Makefile` | `verify` / `whitepaper` / `deploy` / `drain` / `down` + `dev-up` / `dev-down` for local Gate-1. |
@@ -22,8 +22,12 @@ warden/shim live in [`demo/warden/`](../demo/warden/).
 
 ```bash
 cd deploy
-cp demo.env.example demo.env    # edit: CADDY_IMAGE=caddy:2, SOCKET_PROXY_IMAGE=tecnativa/docker-socket-proxy,
-                                #       NETCANON_INSTANCE_IMAGE=ghcr.io/netcanon/netcanon:0.6.1, ACME_EMAIL=...
+cp demo.env.example demo.env    # edit: CADDY_IMAGE=caddy:2, ACME_EMAIL=...
+                                #       SOCKET_PROXY_IMAGE=ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
+                                #       NETCANON_INSTANCE_IMAGE=ghcr.io/netcanon/netcanon:0.6.1
+                                # socket-proxy must be v0.4.0+ — older tags render
+                                # haproxy.cfg outside the tmpfs and crash-loop
+                                # against the service's read-only rootfs.
 docker pull ghcr.io/netcanon/netcanon:0.6.1
 make dev-up
 ```
@@ -116,24 +120,43 @@ value blank — it cannot know when you deploy).
 - **SSH:** fail2ban jail (above).
 - **Volumetric L3/L4:** ⚠️ **not mitigated** — DNS-only Cloudflare exposes the origin IP and adds no scrubbing; only Hetzner's free network-edge protection applies. A conscious residual of the DNS-only trust-model choice (orange-cloud would fix it but adds Cloudflare to the TCB). The no-log privacy design also limits fail2ban-on-HTTP.
 
-## Status — Gate 1 ✅ verified, Gate 3/4 pending a real host
+## Status — Gate 1 ✅, Gate 3 ✅ (real host), Gate 4 pending a release
 
 **Gate 1 passed** on Docker Desktop: the stack runs end to end (mint → iframed
 `/migrate` with XFO stripped and CSP `frame-ancestors` rewritten → allowlist 404s
 → destroy), instance hardening is verified *as applied by dockerd*, and the
 instance network has no egress. `tests/demo/test_live_stack_smoke.py` scripts
-those proofs (28 pass / 2 skip); `tests/demo/load_sanity.py` measures capacity.
+those proofs; `tests/demo/load_sanity.py` measures capacity.
 
-**Still unverified — needs the real Linux host (Gate 3):**
+**Gate 3 passed** on the CPX32 (Ubuntu 24.04, bare dockerd), 2026-07-26 — the
+proofs Docker Desktop structurally cannot run:
 
-- **I4 host nftables** — instance→instance and instance→warden DENY live in the
-  host's `DOCKER-USER` chain and cannot be exercised on Docker Desktop, where
-  dockerd runs inside a VM. Run the smoke there with
-  `NETCANON_DEMO_HOST_NFTABLES=1`.
-- `DOCKER-USER` rule ordering/idempotency and survival across `daemon-reload`.
-- `make deploy`'s signature / `SHA256SUMS` gate (Gate 4).
-- Re-measure capacity on the box: the numbers in
-  [07](../docs/demo-plan/07-budget.md#sizing) came from Docker Desktop, whose
-  accounting differs from bare metal.
+- **I4 host nftables** — instance→instance and instance→warden both blocked, and
+  warden→instance still reachable, so the ALLOW rule is not over-broad. The two
+  denials surface as connect *timeouts* (a silent nftables `drop`), whereas I5
+  egress fails immediately with no-route — different signatures for the two
+  different mechanisms, which is itself corroboration.
+- **I5 no egress** — instances cannot reach `1.1.1.1:443` or `8.8.8.8:53`.
+- **`DOCKER-USER` idempotency and survival** — exactly one jump and four rules
+  after a `demo-firewall` restart *and* after a full `dockerd` restart. The
+  latter matters in production: `unattended-upgrades` bumping `docker.io` would
+  otherwise be able to drop I4 silently.
+- **Capacity re-measured on the box** — 2420 MiB projected at `MAX_ACTIVE = 32`
+  against 7745 MiB total; worked-instance RSS median 72.0 MiB, 28% of the 256 MiB
+  per-instance guardrail; fails closed at saturation; swap still empty. Within 2%
+  of the Docker Desktop estimate in [07](../docs/demo-plan/07-budget.md#sizing).
+  One caveat worth recording: at full saturation `31/32` sessions rendered output
+  — a ~3% shortfall at the cap, not reproduced below it.
+
+Gate 3 also caught a release blocker: `demo-publish.yml` pinned a socket-proxy
+version that crash-loops under the service's read-only rootfs. Gate 1 had passed
+only because it ran an untagged image. See `SOCKET_PROXY_TMPFS_SAFE` in
+`tests/demo/test_demo_docs_truth.py`.
+
+**Still unverified — needs a published release (Gate 4):**
+
+- `make deploy`'s signature / `SHA256SUMS` gate.
+- The digest-pinned production stack end to end. Gate 3 exercised the
+  source-built dev stack, which is the same compose file with `build:` overlaid.
 
 Nothing is deployed. Nothing auto-deploys.

--- a/deploy/cloud-init.yaml
+++ b/deploy/cloud-init.yaml
@@ -17,6 +17,7 @@ packages:
   - docker.io
   - docker-compose-v2
   - git                 # clones this repo to /opt/demo (runcmd installs from it)
+  - make                # the deploy runbook is `make deploy` / `make whitepaper`
   - fail2ban            # SSH brute-force protection (see jail below)
   - unattended-upgrades # automatic security patches
   - nftables            # host firewall + the demo-int isolation rules

--- a/deploy/demo.env.example
+++ b/deploy/demo.env.example
@@ -5,8 +5,13 @@
 # compose file itself stays digest-free so its in-repo hash is the published hash.
 #
 # For LOCAL GATE-1 (docker-compose.dev.yml builds warden+shim): plain tags are
-# fine, e.g.  CADDY_IMAGE=caddy:2  SOCKET_PROXY_IMAGE=tecnativa/docker-socket-proxy:0.3
-# NETCANON_INSTANCE_IMAGE=ghcr.io/netcanon/netcanon:0.6.1
+# fine, e.g.  CADDY_IMAGE=caddy:2
+#             SOCKET_PROXY_IMAGE=ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
+#             NETCANON_INSTANCE_IMAGE=ghcr.io/netcanon/netcanon:0.6.1
+#
+# ⚠️ socket-proxy must be v0.4.0+. Earlier tags render haproxy.cfg into
+# /usr/local/etc/haproxy/, which the service's `read_only: true` forbids — it
+# crash-loops and takes the whole privilege chain with it. v0.4.0+ writes /tmp.
 
 ACME_EMAIL=you@example.com
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,7 +10,9 @@
 # on demo-int is enforced by nftables (deploy/nftables/demo-int.nft), NOT
 # enable_icc:false (which would also cut warden->instance).
 #
-# ⚠️ Draft — not yet Gate-1 verified (docs/demo-plan/08-testing-verification.md).
+# Gate-1 (Docker Desktop) and Gate-3 (real Linux host) verified — including the
+# host-nftables I4 rules, which only a bare-metal dockerd can exercise
+# (docs/demo-plan/08-testing-verification.md).
 
 networks:
   demo-int:
@@ -123,7 +125,12 @@ services:
       # boundary is the verb allowlist above + the authz-shim's create-body gate.
       - /var/run/docker.sock:/var/run/docker.sock:ro
     read_only: true
-    tmpfs: ["/run", "/tmp"]     # tecnativa proxy (haproxy) writes /tmp/haproxy.cfg
+    # ⚠️ Pairs with a v0.4.0+ socket-proxy tag and nothing older. The entrypoint
+    # renders haproxy.cfg at startup: v0.4.0+ writes /tmp/haproxy.cfg (covered by
+    # the tmpfs below), <= 0.3 writes /usr/local/etc/haproxy/haproxy.cfg and
+    # crash-loops against read_only. Guarded by SOCKET_PROXY_TMPFS_SAFE in
+    # tests/demo/test_demo_docs_truth.py.
+    tmpfs: ["/run", "/tmp"]
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
     logging: { driver: local, options: { max-size: "10m" } }

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -19,6 +19,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from demo.warden import constants as C
 
@@ -163,6 +164,77 @@ def test_frontend_targets_the_real_warden_endpoints():
     assert "/session/new" in text
     assert "/hb" in text and "/end" in text
     assert "/i/" in text and "/migrate" in text
+
+
+# ── The socket-proxy tag is load-bearing, and it already shipped wrong ───────
+# demo-publish.yml pinned :0.3, whose entrypoint renders haproxy.cfg into
+# /usr/local/etc/haproxy/ — forbidden by that service's ``read_only: true``, so
+# the socket-proxy crash-looped and took the whole privilege chain with it.
+# Gate 1 passed only because it happened to run an untagged (latest) image that
+# writes /tmp instead. Nothing could catch it: every document agreed with the
+# workflow, and all of them disagreed with what had actually been tested. Only
+# Gate 3 on a real host surfaced it. These tests make the constraint mechanical.
+SOCKET_PROXY_TMPFS_SAFE = {"v0.4.0", "v0.4.1", "v0.4.2"}
+
+TAG_DOCS = ("deploy/demo.env.example", "deploy/README.md")
+
+
+def workflow_socket_proxy_tag() -> str:
+    """The tag demo-publish.yml resolves to a digest for the deploy bundle.
+
+    Read from the PARSED yaml rather than the raw text: the comment sitting above
+    the key names the broken versions, so a regex over the file would happily
+    match those and pass while the real pin was wrong.
+    """
+    document = yaml.safe_load(read(".github/workflows/demo-publish.yml"))
+    found: list[str] = []
+
+    def walk(node) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "SOCKET_PROXY_TAG" and isinstance(value, str):
+                    found.append(value)
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(document)
+    assert len(found) == 1, f"expected exactly one SOCKET_PROXY_TAG, found {found}"
+    return found[0].rsplit(":", 1)[1]
+
+
+def test_published_socket_proxy_tag_survives_a_read_only_rootfs():
+    tag = workflow_socket_proxy_tag()
+    assert tag in SOCKET_PROXY_TMPFS_SAFE, (
+        f"demo-publish.yml pins socket-proxy {tag!r}, which is not known to render "
+        "haproxy.cfg onto a tmpfs path. Versions <= 0.3 write it to "
+        "/usr/local/etc/haproxy/ and crash-loop under `read_only: true`. Confirm "
+        "the new tag writes /tmp, then add it to SOCKET_PROXY_TMPFS_SAFE."
+    )
+
+
+def test_socket_proxy_tmpfs_covers_where_the_config_is_written():
+    """The hardening and the tag are one decision; assert them together."""
+    compose = yaml.safe_load(read("deploy/docker-compose.yml"))
+    proxy = compose["services"]["socket-proxy"]
+    assert proxy.get("read_only") is True, "socket-proxy lost its read-only rootfs"
+    assert "/tmp" in proxy.get("tmpfs", []), (
+        "socket-proxy renders haproxy.cfg to /tmp at startup; without a /tmp tmpfs "
+        "the read-only rootfs makes it crash-loop"
+    )
+
+
+@pytest.mark.parametrize("relpath", TAG_DOCS)
+def test_docs_recommend_the_socket_proxy_tag_that_is_published(relpath):
+    """A local stack built on a different version than the published one is how
+    the crash-loop got past Gate 1 in the first place."""
+    tag = workflow_socket_proxy_tag()
+    assert tag in read(relpath), (
+        f"{relpath} never mentions socket-proxy {tag!r} — the version it steers "
+        "operators toward can drift from the one demo-publish.yml pins"
+    )
 
 
 def test_frontend_ends_sessions_on_pagehide_not_visibilitychange():

--- a/tests/demo/test_live_stack_smoke.py
+++ b/tests/demo/test_live_stack_smoke.py
@@ -102,6 +102,29 @@ def exec_python(container: str, code: str) -> tuple[int, str]:
     return result.returncode, (result.stdout + result.stderr).strip()
 
 
+def mint(source_ip: str | None = None) -> dict:
+    """Mint a session, optionally presenting a distinct simulated visitor address.
+
+    ``PER_IP_MAX_CONCURRENT`` is 2 and the module-scoped ``session`` fixture holds
+    one slot for the whole run, so any test needing two *further* concurrent
+    sessions is already over the cap and gets a 429 on the second mint. Presenting
+    per-visitor addresses is the same shortcut ``load_sanity.visitor_ip`` documents:
+    the warden trusts the first ``X-Forwarded-For`` hop because in production only
+    Caddy can reach it (instances on demo-int are denied the warden's port), and
+    ``load_sanity.check_per_ip_cap`` still proves the cap itself works — so this
+    simulates N visitors rather than defeating a control.
+
+    Asserts on the mint so a refusal surfaces as "mint refused: 429 rate_limited"
+    instead of a ``KeyError: 'token'`` three lines later in a cleanup block.
+    """
+    headers = {"X-Forwarded-For": source_ip} if source_ip else {}
+    response = httpx.post(f"{BASE_URL}/session/new", headers=headers, timeout=60.0)
+    assert response.status_code == 200, (
+        f"mint refused: {response.status_code} {response.text}"
+    )
+    return response.json()
+
+
 # ── fixtures ────────────────────────────────────────────────────────────────
 @pytest.fixture(scope="module")
 def stack() -> dict:
@@ -395,9 +418,15 @@ def test_fernet_key_is_in_env_and_no_key_file_exists(session):
     ),
 )
 def test_instance_cannot_reach_a_sibling_instance(stack):
-    """warden→instance ALLOW, instance→instance DENY (I4)."""
-    first = httpx.post(f"{BASE_URL}/session/new", timeout=60.0).json()
-    second = httpx.post(f"{BASE_URL}/session/new", timeout=60.0).json()
+    """warden→instance ALLOW, instance→instance DENY (I4).
+
+    Two distinct visitor addresses: this test needs two concurrent sessions on top
+    of the module-scoped one, which is three against a per-IP cap of two. Running
+    it from a single address refused the second mint with 429 and surfaced as a
+    KeyError in the cleanup block — see ``mint``.
+    """
+    first = mint("198.51.100.201")
+    second = mint("198.51.100.202")
     try:
         sibling_ip = inspect(container_for_instance(second["instance_id"]))[
             "NetworkSettings"]["Networks"][INSTANCE_NETWORK]["IPAddress"]


### PR DESCRIPTION
Gate 3 ran on the real host (Hetzner CPX32, Ubuntu 24.04, bare dockerd) before cutting `demo-v1`. It passed — and it caught a release blocker that would have shipped inside an immutable, signed bundle.

## 🔴 The blocker

`demo-publish.yml` pinned `ghcr.io/tecnativa/docker-socket-proxy:0.3`. That version's entrypoint renders `haproxy.cfg` into `/usr/local/etc/haproxy/`, but the service runs `read_only: true` with only `/run` + `/tmp` as tmpfs:

```
docker-entrypoint.sh: line 18: can't create /usr/local/etc/haproxy/haproxy.cfg: Read-only file system
```

It crash-looped, taking `warden → authz-shim → socket-proxy` down with it. `v0.4.0+` writes to `/tmp`, which is what the existing `tmpfs` declaration and its comment already assumed.

Gate 1 passed only because it ran the **untagged** image, which is `v0.4.2`. So every document agreed with the workflow, and all of them disagreed with what had actually been tested — there was no drift for CI to detect.

Pinned to `v0.4.2` (verified on both `docker.io` and `ghcr.io`) and made it mechanical rather than a comment:

- `SOCKET_PROXY_TMPFS_SAFE = {"v0.4.0", "v0.4.1", "v0.4.2"}` in the docs-truth ratchet
- reads the **parsed** YAML, because the explanatory comment I added right above the key names the broken versions and a regex would match those instead
- asserts the compose service still has `read_only: true` *and* `/tmp` in its tmpfs, since the tag and the hardening are one decision
- asserts `demo.env.example` and `deploy/README.md` steer operators to the same tag that gets published

Negative-tested — regressing the pin to `:0.3` fails with:

```
AssertionError: demo-publish.yml pins socket-proxy '0.3', which is not known to
render haproxy.cfg onto a tmpfs path. Versions <= 0.3 write it to
/usr/local/etc/haproxy/ and crash-loop under `read_only: true`.
assert '0.3' in {'v0.4.0', 'v0.4.1', 'v0.4.2'}
```

## Also fixed

**`cloud-init.yaml` never installed `make`** — the runbook is `make deploy` / `make whitepaper` on a box that had no make.

**The two host-nftables tests failed after the full suite, passed in isolation.** Not an I4 defect: the module-scoped `session` fixture holds one of the two `PER_IP_MAX_CONCURRENT` slots for the whole run, so a test needing two more concurrent sessions is asking for a third — the second mint returned `429 rate_limited` and surfaced three lines later as `KeyError: 'token'` in a cleanup block. They now present distinct visitor addresses, the same shortcut `load_sanity.visitor_ip` already documents and justifies, and `mint()` asserts so a refusal reports itself.

## Gate-3 results recorded in `deploy/README.md`

| Proof | Result |
|---|---|
| I4 instance→instance | blocked (timeout) |
| I4 instance→warden | blocked (timeout) |
| I4 warden→instance | reachable — ALLOW rule not over-broad |
| I5 egress | `1.1.1.1:443` and `8.8.8.8:53` both blocked |
| `DOCKER-USER` idempotency | 1 jump / 4 rules after `demo-firewall` restart **and** full `dockerd` restart |
| capacity | 2420 MiB projected @ `MAX_ACTIVE=32` vs 7745 MiB total; RSS median 72.0 MiB (28% of the 256m guardrail); fails closed; swap empty |

Two details worth keeping rather than smoothing over:

- The I4 denials surface as connect **timeouts** (silent nftables `drop`) while I5 fails immediately with no-route. Different signatures for the two different mechanisms — that's corroboration, not noise.
- The `dockerd`-restart check matters in production specifically because `unattended-upgrades` is enabled: a `docker.io` bump restarts the daemon, and if the jump didn't survive, I4 would disappear silently. It survives.
- At full saturation `31/32` sessions rendered output. Recorded as a ~3% shortfall at the cap; not reproduced below it.

`docker-compose.yml`'s stale `⚠️ Draft — not yet Gate-1 verified` header is also gone.

## Verification

- `tests/demo` full suite green (live-smoke tests skip without `NETCANON_DEMO_SMOKE=1`)
- new guards green; negative-tested as above
- `ruff check` clean
- all three edited YAML files parse; `#cloud-config` still line 1
- confirmed nothing pins a literal compose sha256 that the comment edits would invalidate — it's computed at publish time into a `<COMPOSE_SHA256>` placeholder

Nothing is deployed. No tag cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
