### PR TITLE
fix(demo): make deploy actually verify (Gate 4), stop logging scanner IPs

### DIFF
--- a/demo/warden/app.py
+++ b/demo/warden/app.py
@@ -264,12 +264,12 @@ _HOP_BY_HOP = {
 
 
 def _fix_response_headers(headers: httpx.Headers) -> list[tuple[str, str]]:
-    """Strip XFO and rewrite CSP frame-ancestors 'none' -> 'self' so the demo
-    origin may iframe the instance; drop hop-by-hop headers."""
+    """Strip XFO, rewrite CSP frame-ancestors 'none' -> 'self' so the demo origin
+    may iframe the instance, drop hop-by-hop + Date (uvicorn emits its own)."""
     out: list[tuple[str, str]] = []
     for k, v in headers.multi_items():
         kl = k.lower()
-        if kl in _HOP_BY_HOP or kl == "x-frame-options":
+        if kl in _HOP_BY_HOP or kl in ("x-frame-options", "date"):
             continue
         if kl == "content-security-policy":
             v = re.sub(r"frame-ancestors\s+'none'", "frame-ancestors 'self'", v, flags=re.IGNORECASE)

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -3,6 +3,17 @@
 # third party sees plaintext, so the whitepaper TCB stays our own stack).
 {
 	email {env.ACME_EMAIL}
+
+	# A request whose Host does not match the site block below never enters it,
+	# so that block's `log { output discard }` does not apply and Caddy's DEFAULT
+	# logger writes the entry — client IP included — to the container log, which
+	# the `local` driver persists to disk. A public IP is scanned constantly, and
+	# the first bot to reach this host arrived within a minute of Caddy starting.
+	# Drop access logs at the default logger too; runtime and ACME logs, which
+	# carry no visitor data and are needed to debug issuance, still flow.
+	log {
+		exclude http.log.access
+	}
 }
 
 demo.netcanon.net {

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -3,7 +3,14 @@
 SHELL := /bin/bash
 COMPOSE := docker compose --env-file demo.env
 
-.PHONY: help verify whitepaper deploy drain down dev-up dev-down smoke-up smoke smoke-down
+# Gate-4 inputs. BUNDLE is the unpacked release bundle; DEMO_TAG is the exact
+# demo-v<N> tag whose workflow run signed it (the cosign identity is the
+# workflow file AT that tag, so it cannot be inferred from the bundle).
+BUNDLE  ?= .
+DEMO_TAG ?=
+REPO    ?= netcanon/netcanon
+
+.PHONY: help verify verify-bundle whitepaper deploy drain down dev-up dev-down smoke-up smoke smoke-down
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  %-11s %s\n",$$1,$$2}'
@@ -28,13 +35,34 @@ whitepaper: ## Fill the deploy date + render frontend/whitepaper.html for /white
 	@rm -f .wp-values.filled.json
 	@echo "Rendered ../frontend/whitepaper.html — Caddy serves it at /whitepaper."
 
-deploy: ## Pull pinned images + bring the stack up (TODO Gate-4: verify signatures/SHA256SUMS first)
+# Gate 4. SHA256SUMS is the one mutable, unsigned link in the chain, so
+# demo-publish.yml cosign sign-blob's it; verify that signature FIRST and let the
+# manifest vouch for every other asset. Fails closed — no cosign, no deploy —
+# because a deploy target that silently skips verification is worse than one that
+# never claimed to verify at all.
+verify-bundle: ## Gate-4 — cosign-verify SHA256SUMS, then checksum the bundle (DEMO_TAG=demo-v<N>)
+	@test -n "$(DEMO_TAG)" || { echo "usage: make verify-bundle DEMO_TAG=demo-v1 [BUNDLE=<dir>]"; exit 1; }
+	@command -v cosign >/dev/null || { echo "cosign is not installed — Gate 4 cannot pass. See deploy/README.md."; exit 1; }
+	cd $(BUNDLE) && cosign verify-blob SHA256SUMS \
+		--bundle SHA256SUMS.cosign.bundle \
+		--certificate-identity "https://github.com/$(REPO)/.github/workflows/demo-publish.yml@refs/tags/$(DEMO_TAG)" \
+		--certificate-oidc-issuer https://token.actions.githubusercontent.com
+	cd $(BUNDLE) && sha256sum -c SHA256SUMS
+	@echo "Gate 4 OK — signature valid and every bundle file matches its published hash."
+
+deploy: verify-bundle ## Verify the bundle (Gate 4), then pull pinned images + bring the stack up
 	docker pull "$$(grep '^NETCANON_INSTANCE_IMAGE=' demo.env | cut -d= -f2-)"
 	$(COMPOSE) pull
 	$(COMPOSE) up -d
 
-drain: ## Stop minting new sessions (loopback control); let sessions lapse
-	@echo "TODO(Gate-1): trip the warden drain sentinel (loopback-only). SIGTERM != drain."
+# Deliberately exits non-zero. The warden has no drain sentinel yet, and a target
+# that prints a TODO and returns success is exactly what someone reaches for
+# mid-incident and believes.
+drain: ## NOT IMPLEMENTED — no warden drain sentinel exists; use `make down` (kills live sessions)
+	@echo "make drain is NOT IMPLEMENTED — the warden exposes no drain sentinel."
+	@echo "Intended design: loopback-only control (docs/demo-plan/02-deployment.md)."
+	@echo "Today your options are: wait out HARD_TTL, or 'make down' (SIGTERM != drain)."
+	@exit 1
 
 down: ## Stop the stack (SIGTERM — kills live sessions by design)
 	$(COMPOSE) down

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,7 +14,7 @@ warden/shim live in [`demo/warden/`](../demo/warden/).
 | `cloud-init.yaml` | Hardened Ubuntu 24.04: docker, **key-only SSH**, **swap-off + core-dumps-off + journald-volatile** (I2), **fail2ban (SSH)**, unattended-upgrades, host firewall (443/80 + admin-only SSH, ICMPv6 allowed), chrony, `make` + `jq` for the deploy runbook, OOM protection. Clones this repo to `/opt/demo` and installs the TTL-backstop + demo-firewall units from it. |
 | `systemd/` | `demo-ttl-backstop.{sh,service,timer}` — the warden-independent hard-TTL backstop (removes any `demo.*` container older than **1320 s** = `HARD_TTL + POOL_MAX_AGE + 120 s slack`, swept every 60 s). |
 | `nftables/demo-int.nft` | The demo-int isolation rules (warden→instance ALLOW, instance→instance DENY, instance→warden DENY). |
-| `Makefile` | `verify` / `whitepaper` / `deploy` / `drain` / `down` + `dev-up` / `dev-down` for local Gate-1. |
+| `Makefile` | `verify` / `verify-bundle` (Gate 4) / `whitepaper` / `deploy` / `down` + `dev-up` / `dev-down` / `smoke-*`. ⚠️ `drain` is **not implemented** and exits non-zero — the warden has no drain sentinel. |
 | `demo.env.example` | Env template (image digests + ACME email). Copy → `demo.env` (**gitignored**; real values never commit). |
 | `PINNED_PRODUCT_TAG` | The netcanon version the demo pins (`v0.6.1`). Bumped by ordinary PR. |
 
@@ -108,11 +108,32 @@ the ACME HTTP-01 challenge fails and Caddy will not serve.
 
 ## Deploy (human-pulled, on the host)
 
-`make deploy` (verify signatures/SHA256SUMS — Gate-4 — then pull pinned images + `up -d`). No GitHub deploy secret exists; the operator SSHes in and runs it, then executes the Gate-4 live proofs.
+No GitHub deploy secret exists; the operator SSHes in and runs this by hand.
+
+**`cosign` is required** — `make deploy` fails closed without it:
+
+```bash
+curl -sSLo /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+chmod +x /usr/local/bin/cosign && cosign version
+```
+
+Unpack the release bundle, then:
+
+```bash
+make deploy DEMO_TAG=demo-v1 BUNDLE=./bundle
+```
+
+`deploy` depends on `verify-bundle`, so the Gate-4 check cannot be skipped: it
+`cosign verify-blob`s `SHA256SUMS` against the **exact** signer identity
+(`demo-publish.yml@refs/tags/<DEMO_TAG>` — which is why the tag has to be passed
+in; it is not recoverable from the bundle), then `sha256sum -c` makes that one
+signed manifest vouch for every other asset. Only then does it pull the
+digest-pinned images and `up -d`.
 
 Then `make whitepaper` from the unpacked bundle to stamp the deploy date and
 render the copy Caddy serves at `/whitepaper` (CI deliberately leaves that one
-value blank — it cannot know when you deploy).
+value blank — it cannot know when you deploy). Until you run it, `/whitepaper`
+serves the committed template, banner and all.
 
 ## DDoS / abuse posture
 

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -166,6 +166,25 @@ def test_frontend_targets_the_real_warden_endpoints():
     assert "/i/" in text and "/migrate" in text
 
 
+def test_every_makefile_target_is_phony():
+    """A same-line ``.PHONY`` edit is the merge conflict git resolves silently and
+    wrongly: #396 and #397 each appended targets, one side won with no textual
+    conflict, and three targets went missing. Assert the invariant, don't rely on
+    catching it by eye at merge time."""
+    text = read("deploy/Makefile")
+    declared: set[str] = set()
+    for line in text.splitlines():
+        if line.startswith(".PHONY:"):
+            declared.update(line.split(":", 1)[1].split())
+    targets = {
+        match.group(1)
+        for match in re.finditer(r"^([a-z][a-z0-9-]*):(?!=)", text, re.MULTILINE)
+    }
+    assert targets, "no Makefile targets matched — the parser regex has rotted"
+    missing = targets - declared
+    assert not missing, f"deploy/Makefile targets missing from .PHONY: {sorted(missing)}"
+
+
 # ── The socket-proxy tag is load-bearing, and it already shipped wrong ───────
 # demo-publish.yml pinned :0.3, whose entrypoint renders haproxy.cfg into
 # /usr/local/etc/haproxy/ — forbidden by that service's ``read_only: true``, so


### PR DESCRIPTION
Follow-up to #399. Standing the real Caddy up for the first time (it had never been started — the smoke override parks it behind `profiles: ["tls"]`) surfaced three of these; the fourth is the `make deploy` gap called out earlier.

## `make deploy` did not verify anything

[README:107](deploy/README.md) described it as *"verify signatures/SHA256SUMS — Gate-4 — then pull pinned images"*. The target carried a `TODO` and went straight to `docker pull`. **Gate 4 is that verification** — we'd have passed the gate by running a command that skips it.

`deploy` now depends on a real `verify-bundle`:

```
cosign verify-blob SHA256SUMS \
  --bundle SHA256SUMS.cosign.bundle \
  --certificate-identity ".../demo-publish.yml@refs/tags/<DEMO_TAG>" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
sha256sum -c SHA256SUMS
```

`DEMO_TAG` is passed in because the signer identity is the workflow file *at that tag* and isn't recoverable from the bundle. Signature first, then one signed manifest vouches for every other asset. Fails closed with no cosign — a deploy target that silently skips verification is worse than one that never claimed to verify.

## Caddy wrote client IPs to disk

A request whose `Host` doesn't match the site block never enters it, so that block's `log { output discard }` never applies and Caddy's **default** logger records it — client IP included — through the `local` driver onto disk. The first scanner arrived within a minute of Caddy starting, with a malformed `Host: demo.netcanon.net,`.

Excluded `http.log.access` at the default logger. ACME/runtime logs still flow — they carry no visitor data and you need them when issuance misbehaves.

Whitepaper claim 4 is **accurate as written** (it scopes the discard to the demo vhost), so this is hardening, not a correction.

## `make drain` returned success while doing nothing

It printed a TODO and exited 0. Nothing claim-bearing depends on drain, but a no-op that reports success is exactly what someone reaches for mid-incident and believes. Now states that no warden drain sentinel exists and exits non-zero. Implementing one needs warden code, and `app.py` is at **499 of its 500-line audited budget**.

## Duplicate `Date` header

The warden passed the instance's `Date` through while uvicorn added its own — two on every proxied response, where RFC 9110 permits at most one. Added to the stripped set; the change is net-zero lines, keeping the budget at 499.

## `.PHONY` completeness guard

#396 and #397 each appended Makefile targets, git auto-merged that single line with no textual conflict, and three targets vanished. Caught by hand that time; mechanical now.

## Validation

Local: demo suite green, `ruff` clean, warden 499 lines, guard sees all 12 targets.

On the host (`make` and Caddy can't be tested on Windows):

| check | result |
|---|---|
| `make drain` | exits 2 with the explanation |
| `make verify-bundle` (no `DEMO_TAG`) | usage error, exit 2 |
| `make verify-bundle` (no cosign) | fails closed, exit 2 |
| `make deploy` | stops at the `verify-bundle` prerequisite — never reaches `docker pull` |
| Caddyfile | `Valid configuration` |
| non-vhost requests | 0 logged, 0 `remote_ip`, **0 on disk** (was 5 / 12 KB) |
| tls/runtime logs | still flowing |
| vhost traffic | HTTP 200, still unlogged |
| `/migrate` `Date` headers | 1 (was 2) |
| full mint → migrate → end | 200 / 204, CSP and `nc_route` unchanged |

One process note: my first log test was invalid — I checked before restarting Caddy, which doesn't hot-reload a bind-mounted Caddyfile, so I was reading the old config's behaviour. Re-ran after `--force-recreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
