### PR TITLE
fix(demo): explain blocked routes, and refuse to start a demo inside a demo

### DIFF
--- a/demo/warden/Dockerfile
+++ b/demo/warden/Dockerfile
@@ -14,7 +14,10 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 # Import as the `warden` namespace package so `from . import constants` resolves
 # both here (uvicorn warden.app:app) and in the repo tests (demo.warden.app).
-COPY constants.py app.py authz_shim.py /app/warden/
+# ⚠️ Explicit list, so a NEW module here must be added by hand or it imports fine
+# in the tests and ImportErrors in the container. Guarded by
+# test_dockerfile_copies_every_warden_module in tests/demo/test_demo_docs_truth.py.
+COPY constants.py app.py authz_shim.py pages.py /app/warden/
 RUN useradd --uid 1001 --create-home warden
 USER warden
 

--- a/demo/warden/app.py
+++ b/demo/warden/app.py
@@ -27,6 +27,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from . import constants as C
+from . import pages as P
 
 log = logging.getLogger("warden")
 
@@ -478,22 +479,21 @@ async def healthz() -> Response:
     })
 
 
-@app.api_route("/i/{token}/{path:path}", methods=["GET", "POST"])
-async def iframe_route(token: str, path: str, request: Request) -> Response:
-    sess = _active.get(token)
-    full = "/" + path
-    if sess is None or time.monotonic() > sess.deadline or not C.route_allowed(request.method, full):
-        return Response(status_code=404)
+async def _routed(sess, request: Request, full: str, token: str | None) -> Response:
+    """Single refusal point for both proxy entry points; lapsed != never-exposed."""
+    dead = sess is None or time.monotonic() > sess.deadline
+    if dead or not C.route_allowed(request.method, full):
+        return P.refuse(request, P.SESSION_GONE if dead else P.NOT_IN_DEMO)
     _refresh_activity(sess, request.method, full)
     return await _proxy(request, sess.instance, full, token)
+
+
+@app.api_route("/i/{token}/{path:path}", methods=["GET", "POST"])
+async def iframe_route(token: str, path: str, request: Request) -> Response:
+    return await _routed(_active.get(token), request, "/" + path, token)
 
 
 @app.api_route("/{full_path:path}", methods=["GET", "POST"])
 async def cookie_route(full_path: str, request: Request) -> Response:
     token = request.cookies.get(C.ROUTE_COOKIE)
-    sess = _active.get(token) if token else None
-    full = "/" + full_path
-    if sess is None or time.monotonic() > sess.deadline or not C.route_allowed(request.method, full):
-        return Response(status_code=404)
-    _refresh_activity(sess, request.method, full)
-    return await _proxy(request, sess.instance, full, token)
+    return await _routed(_active.get(token) if token else None, request, "/" + full_path, token)

--- a/demo/warden/pages.py
+++ b/demo/warden/pages.py
@@ -1,0 +1,90 @@
+"""Explanatory bodies for requests the warden refuses.
+
+The route allowlist (``constants.ALLOW_*``) is deliberately tiny: the demo ships
+the translator and nothing else. But netcanon's own nav still links Dashboard,
+Devices, Configs, Definitions, Jobs, Schedules and API Docs, and every one of
+them was answering with a bare ``Response(status_code=404)`` — a blank white
+page inside the iframe, which reads as "this product is broken" rather than
+"this part isn't in the demo".
+
+Only the warden can tell the two refusals apart: a lapsed session and a route
+that was never exposed are different things and deserve different copy. That is
+why this lives here rather than in a Caddy error handler.
+
+Kept out of ``app.py`` because that file is held to an audited 500-line budget
+(whitepaper claim: the TCB is small enough to read end to end). Static markup is
+not TCB logic; the one function here is four lines and does no I/O.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request, Response
+from fastapi.responses import HTMLResponse
+
+# Inline everything: the demo page claims no third-party requests, and a 404
+# body that pulled a webfont would quietly make that false.
+_SHELL = """<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{title} — netcanon demo</title>
+<style>
+  :root {{ color-scheme: light dark; }}
+  body {{
+    margin: 0; min-height: 100vh; display: grid; place-items: center;
+    font: 15px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: Canvas; color: CanvasText; padding: 2rem;
+  }}
+  main {{ max-width: 34rem; text-align: left; }}
+  h1 {{ font-size: 1.35rem; margin: 0 0 .75rem; letter-spacing: -.01em; }}
+  p {{ margin: 0 0 .9rem; opacity: .85; }}
+  code {{
+    font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: color-mix(in srgb, CanvasText 8%, Canvas); padding: .15em .4em; border-radius: 4px;
+  }}
+  pre {{
+    background: color-mix(in srgb, CanvasText 8%, Canvas); padding: .7rem .9rem;
+    border-radius: 6px; overflow-x: auto; margin: 0 0 .9rem;
+  }}
+  pre code {{ background: none; padding: 0; }}
+  a {{ color: inherit; }}
+  .muted {{ opacity: .6; font-size: .9em; }}
+</style>
+<main>{body}</main>
+"""
+
+_NOT_IN_DEMO_BODY = """
+<h1>That part isn't in the demo</h1>
+<p>The public demo exposes the translator only — <strong>Migrate</strong> and
+<strong>Sanitize</strong>. Devices, Configs, Definitions, Jobs and Schedules all
+need persistent storage and real device credentials, so the demo refuses them at
+the proxy instead of showing you a hollow version of the page.</p>
+<p>Nothing broke and nothing was stored. This route simply isn't routed.</p>
+<p><a href="migrate">← Back to Migrate</a></p>
+<p class="muted">Want the whole application? It's the same image, one command,
+no sign-up:</p>
+<pre><code>docker run --rm -p 8000:8000 ghcr.io/netcanon/netcanon</code></pre>
+"""
+
+_SESSION_GONE_BODY = """
+<h1>This demo session has ended</h1>
+<p>Instances self-destruct on a hard timer, and everything they held goes with
+them — that's the point of the demo, not a fault.</p>
+<p><a href="/" target="_top">Start a fresh instance →</a></p>
+<pre><code>docker run --rm -p 8000:8000 ghcr.io/netcanon/netcanon</code></pre>
+"""
+
+NOT_IN_DEMO = _SHELL.format(title="Not in the demo", body=_NOT_IN_DEMO_BODY)
+SESSION_GONE = _SHELL.format(title="Session ended", body=_SESSION_GONE_BODY)
+
+
+def refuse(request: Request, html: str) -> Response:
+    """404 with an explanation for a browser navigation, bare 404 for anything else.
+
+    The status stays 404 either way — the route genuinely does not exist here, and
+    dressing a refusal up as a 200 would lie to caches and crawlers. Only the body
+    changes, and only when the client actually asked for HTML: netcanon's own
+    fetch/XHR calls must keep getting an empty 404 rather than a page to parse.
+    """
+    if "text/html" in request.headers.get("accept", ""):
+        return HTMLResponse(html, status_code=404)
+    return Response(status_code=404)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -244,6 +244,26 @@ footer nav { display: flex; gap: 1.25rem; flex-wrap: wrap; margin-bottom: 1rem; 
   </div>
 </section>
 
+<!-- netcanon's own nav links Dashboard at "/", which inside the iframe loads
+     THIS page into the instance frame. Starting a demo from there would mint a
+     session, and a mint destroys the cookie's existing one — silently taking
+     the instance (and the config pasted into it) with it. So when framed we
+     refuse to offer the button at all. -->
+<section id="s-nested" hidden aria-labelledby="nest-h">
+  <div class="wrap center status-card">
+    <h2 id="nest-h">You&rsquo;re already inside a demo instance</h2>
+    <p class="muted">This is the demo&rsquo;s own front page, reached from
+      netcanon&rsquo;s <strong>Dashboard</strong> link &mdash; which points at the
+      site root and so loads it inside your instance frame.</p>
+    <p class="muted">Starting another demo here would <strong>replace the instance
+      you are using now</strong>, discarding anything you have pasted into it.</p>
+    <p>
+      <button id="btn-nest-back" class="btn" type="button">&larr; Back to your instance</button>
+      <a class="btn" href="/" target="_top">Leave and start over</a>
+    </p>
+  </div>
+</section>
+
 <script>
 "use strict";
 /* ======================================================================
@@ -298,7 +318,11 @@ var isHidden = (document.visibilityState === "hidden");
 
 var $ = function (id) { return document.getElementById(id); };
 var SECTIONS = ["s-landing","s-provisioning","s-ratelimited","s-error",
-                "s-active","s-capacity","s-destroyed"];
+                "s-active","s-capacity","s-destroyed","s-nested"];
+
+/* True when this page is itself inside a frame — i.e. it was reached from the
+   product's Dashboard link rather than opened directly. */
+function isNested() { return window.self !== window.top; }
 
 /* Show exactly one top-level section. */
 function show(id) {
@@ -313,6 +337,10 @@ function clearTimers() {
 
 /* ---------- 2) PROVISIONING: mint a session ---------- */
 function startDemo() {
+  /* Guarded here rather than only at boot so every entry point is covered —
+     the landing button and all three retry paths. A mint from inside a frame
+     would destroy the very instance hosting the frame. */
+  if (isNested()) { show("s-nested"); return; }
   clearTimers();
   show("s-provisioning");
   fetch("/session/new", { method: "POST" })
@@ -541,7 +569,11 @@ $("btn-retry-cap").addEventListener("click", function () {
 $("btn-sample").addEventListener("click", trySample);
 $("btn-destroy").addEventListener("click", destroyNow);
 $("btn-again").addEventListener("click", function () { show("s-landing"); });
+$("btn-nest-back").addEventListener("click", function () { history.back(); });
 wireCopyButtons();
+
+/* Boot: if we were loaded into a frame, never show the landing pitch at all. */
+if (isNested()) { show("s-nested"); }
 </script>
 </body>
 </html>

--- a/tests/demo/conftest.py
+++ b/tests/demo/conftest.py
@@ -292,8 +292,11 @@ class FakeRequest:
     """The subset of ``starlette.Request`` the warden's session routes touch."""
 
     def __init__(self, ip: str = "203.0.113.10", cookie: str | None = None,
-                 body: dict | None = None, method: str = "GET") -> None:
+                 body: dict | None = None, method: str = "GET",
+                 accept: str | None = None) -> None:
         self.headers = {"x-forwarded-for": ip}
+        if accept is not None:
+            self.headers["accept"] = accept
         self.cookies = {}
         if cookie is not None:
             self.cookies[C.ROUTE_COOKIE] = cookie

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -275,6 +275,26 @@ def test_docs_recommend_the_socket_proxy_tag_that_is_published(relpath):
     )
 
 
+def test_frontend_refuses_to_start_a_demo_from_inside_a_frame():
+    """netcanon's own nav links Dashboard at "/", which inside the iframe loads
+    this page into the instance frame. Minting from there destroys the cookie's
+    existing session — the very instance hosting the frame — so a mis-click cost
+    the visitor their pasted config with no warning.
+
+    The guard has to live in ``startDemo`` and not only in the boot path, or the
+    three retry buttons still reach the mint.
+    """
+    code = frontend_code()
+    assert "window.self !== window.top" in code, "no frame detection"
+    assert "s-nested" in code, "no dedicated section for the framed case"
+    body = code.split("function startDemo()", 1)
+    assert len(body) == 2, "startDemo() not found — has it been renamed?"
+    assert "isNested()" in body[1][:400], (
+        "startDemo must refuse when framed; guarding only the boot path leaves "
+        "btn-retry-rl / btn-retry-err / btn-retry-cap able to mint"
+    )
+
+
 def test_frontend_ends_sessions_on_pagehide_not_visibilitychange():
     """Ending on visibilitychange would destroy the instance on a mere tab
     switch — killing the demo's own copy-a-config-from-another-tab flow."""

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -166,6 +166,25 @@ def test_frontend_targets_the_real_warden_endpoints():
     assert "/i/" in text and "/migrate" in text
 
 
+def test_dockerfile_copies_every_warden_module():
+    """The Dockerfile names the warden's modules explicitly, so a new one imports
+    fine from the repo — green suite — and ImportErrors inside the container.
+    That is exactly how pages.py first shipped: every test passed and the warden
+    crash-looped on `cannot import name 'pages'`."""
+    copied: set[str] = set()
+    for line in read("demo/warden/Dockerfile").splitlines():
+        if line.startswith("COPY ") and "/app/warden/" in line:
+            copied.update(part for part in line.split()[1:] if part.endswith(".py"))
+    on_disk = {
+        path.name
+        for path in (REPO_ROOT / "demo" / "warden").glob("*.py")
+        if path.name != "__init__.py"
+    }
+    assert on_disk, "found no warden modules — the glob has rotted"
+    missing = on_disk - copied
+    assert not missing, f"demo/warden modules absent from the Dockerfile COPY: {sorted(missing)}"
+
+
 def test_every_makefile_target_is_phony():
     """A same-line ``.PHONY`` edit is the merge conflict git resolves silently and
     wrongly: #396 and #397 each appended targets, one side won with no textual

--- a/tests/demo/test_warden_proxy.py
+++ b/tests/demo/test_warden_proxy.py
@@ -158,6 +158,58 @@ def test_get_prefix_rules_do_not_leak_to_post():
     assert C.route_allowed("POST", "/api/v1/migration/adapters/x/capabilities") is False
 
 
+# ── Refusals have to explain themselves ─────────────────────────────────────
+# netcanon's own nav links Dashboard, Devices, Configs, Definitions, Jobs,
+# Schedules and API Docs. None are allowlisted, so all seven answered with a
+# bare `Response(status_code=404)` — a blank white page inside the iframe, which
+# reads as "this product is broken" rather than "this part isn't in the demo".
+BROWSER_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+
+
+async def test_a_blocked_nav_route_explains_itself_to_a_browser(warden, make_request):
+    await warden.fill_pool()
+    token = json.loads((await warden.mint()).body)["token"]
+
+    response = await warden.app.iframe_route(
+        token, "devices", make_request(method="GET", accept=BROWSER_ACCEPT)
+    )
+    assert response.status_code == 404, "still a 404 — the route genuinely is not here"
+    body = response.body.decode()
+    assert "isn't in the demo" in body
+    assert 'href="migrate"' in body, "relative, so it resolves under /i/{token}/ AND /"
+
+
+async def test_a_blocked_api_call_still_gets_an_empty_404(warden, make_request):
+    """netcanon's own fetch/XHR must keep getting nothing to parse."""
+    await warden.fill_pool()
+    token = json.loads((await warden.mint()).body)["token"]
+
+    response = await warden.app.iframe_route(
+        token, "api/v1/backups", make_request(method="GET", accept="application/json")
+    )
+    assert response.status_code == 404
+    assert response.body == b""
+
+
+async def test_a_dead_token_says_session_ended_not_route_missing(warden, make_request):
+    """Only the warden can tell the two refusals apart; it should say which."""
+    response = await warden.app.iframe_route(
+        "not-a-real-token", "migrate", make_request(method="GET", accept=BROWSER_ACCEPT)
+    )
+    assert response.status_code == 404
+    assert "session has ended" in response.body.decode()
+
+
+def test_the_refusal_pages_are_self_contained():
+    """Claim 10 promises no third-party requests from the demo. A 404 body that
+    pulled a webfont or a CDN script would quietly make that false."""
+    from demo.warden import pages
+
+    for html in (pages.NOT_IN_DEMO, pages.SESSION_GONE):
+        assert "http://" not in html and "https://" not in html
+        assert "<script" not in html.lower()
+
+
 # ── Routing 404s (dead token / blocked path) ────────────────────────────────
 async def test_iframe_route_404s_on_an_unknown_token(warden, make_request):
     response = await warden.app.iframe_route(


### PR DESCRIPTION
netcanon's own nav links Dashboard, Devices, Configs, Definitions, Jobs, Schedules and API Docs. None are in the warden allowlist — the demo ships the translator only — so all seven answered with a bare `Response(status_code=404)`:

```
/devices     HTTP 404, body 0B
/configs     HTTP 404, body 0B
/definitions HTTP 404, body 0B
/jobs        HTTP 404, body 0B
/schedules   HTTP 404, body 0B
/docs        HTTP 404, body 0B
```

Zero bytes renders as a blank white page inside the iframe. Seven of nine nav links looked broken — reading as "this product doesn't work" rather than "this part isn't in the demo".

## The fix

Blocked routes now return a short self-contained page: the demo exposes Migrate and Sanitize only; Devices/Configs/Jobs need persistent storage and real device credentials; nothing broke and nothing was stored; a link back to Migrate and the local `docker run` line.

**Still a 404.** The route genuinely isn't there, and dressing a refusal up as a 200 would lie to caches and crawlers. Only the body changes, and only when `Accept` contains `text/html` — netcanon's own fetch/XHR keeps getting an empty 404 rather than a page to parse.

**A lapsed session gets different copy.** Only the warden can tell "session ended" from "route never exposed", which is why this isn't a Caddy error handler.

**The back-link is relative** (`href="migrate"`), so one href resolves correctly under both entry points. Verified in-browser:

```
current_path   /i/X_BQPfVXHmBzSjOK43k78w/devices
href_attribute migrate
resolves_to    /i/X_BQPfVXHmBzSjOK43k78w/migrate
```

## Paying for it inside the 500-line budget

`app.py` is held to an audited 500-line budget (whitepaper claim: the TCB is small enough to read end to end). The markup lives in a new `pages.py`, and the change is paid for by collapsing the two near-identical proxy entry points into one `_routed` gate with a single refusal exit. **Net zero — app.py stays at 499.** No budget was raised.

## The second commit is the interesting one

The first version shipped green and **crash-looped in production**:

```
File "/app/warden/app.py", line 30, in <module>
    from . import pages as P
ImportError: cannot import name 'pages' from 'warden' (unknown location)
```

`demo/warden/Dockerfile` names its modules one by one, so `pages.py` imported fine from the repo — full suite green, ruff clean — and simply wasn't in the image. Every route 502'd. Only running it on the host caught this.

Added `test_dockerfile_copies_every_warden_module` so the next module can't repeat it. Negative-tested: removing `pages.py` from the COPY list makes the guard report it missing.

## Verification (live on the host)

```
/devices     HTTP 404  1722B  isn't in the demo
/configs     HTTP 404  1722B  isn't in the demo
/definitions HTTP 404  1722B  isn't in the demo
/jobs        HTTP 404  1722B  isn't in the demo
/schedules   HTTP 404  1722B  isn't in the demo
/docs        HTTP 404  1722B  isn't in the demo
/migrate     HTTP 200 302327B  real page served
/sanitize    HTTP 200 126946B  real page served

api/v1/backups (Accept: application/json) -> 404, body 0B
dead token (Accept: text/html)            -> "session has ended"
warden restarts=0
page: 0 absolute URLs, 0 <script> tags    (claim 10 stays true)
```

Plus four unit tests: browser gets the page, XHR gets the empty 404, dead token gets the other page, and both pages are self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Second fix: a demo could be started inside a demo

Reported after the first commit. netcanon's nav links **Dashboard** at `/`. Clicked inside the instance iframe, that loads the demo's *own* landing page into the frame — start button and all.

**The recursion isn't the damage.** `session_new` destroys whatever session the `nc_route` cookie already points at before minting:

```python
existing = request.cookies.get(C.ROUTE_COOKIE)
if existing and existing in _active:
    await _destroy(existing, "end")
```

So pressing Start in the nested page **silently destroys the instance hosting it**, discarding anything pasted into it. Measured end to end:

```
outer session -> HTTP 200
   ...nested "Start demo"...
outer session -> HTTP 404      <-- the visitor's work
inner session -> HTTP 200
```

## It is not an abuse vector

That was the first thing checked, and two of my own intermediate readings were wrong before the mechanism was clear:

- A third mint from one cookie **succeeded**, which looked like a `PER_IP_MAX_CONCURRENT` bypass. It isn't — destroy-and-replace means a browser never holds two.
- `nc_route` looked like it was being clobbered across two live sessions. It isn't — the older session no longer exists by then.

Bounds, all intact: destroy-and-replace caps a browser at one session, `PER_IP_MAX_CONCURRENT=2` caps an IP, `MAX_ACTIVE=32` caps the box. Instance count held at `pool=4 active=1` throughout. It's a **data-loss footgun reachable by one mis-click**, not amplification.

## Fix

The landing page detects framing and shows a dedicated `s-nested` section — where you are, that starting another demo would replace the running one, a *Back to your instance* button, and a `target="_top"` escape. The start pitch is never rendered.

The guard sits inside `startDemo()`, not only at boot, so `btn-retry-rl` / `btn-retry-err` / `btn-retry-cap` can't reach the mint either. A test asserts exactly that, since guarding only the boot path is the obvious way to get this half-right.

## Verified in a real browser

```
click Dashboard in the iframe -> visible: ["s-nested"]
                                 heading: "You're already inside a demo instance"
                                 start_button_offered: false
click "Back to your instance" -> /i/C96Cz4THw6X5SAtRU6EjBw/migrate
outer session                 -> s-active, countdown 14:36, SURVIVED
```

Frontend now 23.6 KB of its 50 KB budget.
