### PR TITLE
feat(demo): demo tags are semver (demo-vX.Y.Z), not bare integers

### DIFF
--- a/.github/workflows/demo-publish.yml
+++ b/.github/workflows/demo-publish.yml
@@ -2,7 +2,7 @@ name: Demo — build & publish bundle
 
 # Builds and signs the ephemeral-demo artifacts for demo.netcanon.net.
 #
-# Fires ONLY on a `demo-v<N>` tag (or a workflow_dispatch naming one). Demo tags
+# Fires ONLY on a `demo-vX.Y.Z` tag (or a workflow_dispatch naming one). Demo tags
 # are cut deliberately by the maintainer and are decoupled from product semver:
 # the product version the demo pins is read from the tracked file
 # `deploy/PINNED_PRODUCT_TAG`, never from the tag name. So "this release is
@@ -89,19 +89,25 @@ jobs:
       actions: read          # read CI / PII-guard run conclusions
     steps:
       # The `demo-v*` TRIGGER glob is broader than the cosign identity this
-      # workflow signs with (`@refs/tags/demo-v[0-9]+$`). A tag like
+      # workflow signs with (`@refs/tags/demo-vX.Y.Z$`). A tag like
       # `demo-v1-rc1` would fire the build but produce a signature no
       # documented verify command can ever match. GitHub's tag_name_pattern
       # ruleset rule is unavailable on this repo's plan, so this regex IS the
-      # enforcement point for the `demo-v<N>`-integers-only convention.
+      # enforcement point for the demo-v<semver> convention.
+      #
+      # ⚠️ The mismatch is asymmetric and unrecoverable in one direction: the
+      # `refs/tags/demo-v*` ruleset (deletion + update + non_fast_forward, empty
+      # bypass) matches ANY shape this regex refuses. So a malformed demo tag is
+      # a permanently undeletable tag that publishes nothing. Widen the glob and
+      # this regex together, never one alone.
       # $REF via env: — never `${{ }}` inside run: (template injection).
       - name: Refuse non-demo-tag refs
         shell: bash
         env:
           REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
         run: |
-          if [[ ! "$REF" =~ ^refs/tags/demo-v[0-9]+$ ]]; then
-            echo "::error::demo-publish requires a demo-v<N> tag ref (integers only, e.g. demo-v1), got: $REF"
+          if [[ ! "$REF" =~ ^refs/tags/demo-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::demo-publish requires a demo-v<major>.<minor>.<patch> tag ref (e.g. demo-v0.1.0), got: $REF"
             exit 1
           fi
           echo "OK: publishing from '$REF'."

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 COMPOSE := docker compose --env-file demo.env
 
 # Gate-4 inputs. BUNDLE is the unpacked release bundle; DEMO_TAG is the exact
-# demo-v<N> tag whose workflow run signed it (the cosign identity is the
+# demo-v<semver> tag whose workflow run signed it (the cosign identity is the
 # workflow file AT that tag, so it cannot be inferred from the bundle).
 BUNDLE  ?= .
 DEMO_TAG ?=
@@ -40,8 +40,8 @@ whitepaper: ## Fill the deploy date + render frontend/whitepaper.html for /white
 # manifest vouch for every other asset. Fails closed — no cosign, no deploy —
 # because a deploy target that silently skips verification is worse than one that
 # never claimed to verify at all.
-verify-bundle: ## Gate-4 — cosign-verify SHA256SUMS, then checksum the bundle (DEMO_TAG=demo-v<N>)
-	@test -n "$(DEMO_TAG)" || { echo "usage: make verify-bundle DEMO_TAG=demo-v1 [BUNDLE=<dir>]"; exit 1; }
+verify-bundle: ## Gate-4 — cosign-verify SHA256SUMS, then checksum the bundle (DEMO_TAG=demo-vX.Y.Z)
+	@test -n "$(DEMO_TAG)" || { echo "usage: make verify-bundle DEMO_TAG=demo-v0.1.0 [BUNDLE=<dir>]"; exit 1; }
 	@command -v cosign >/dev/null || { echo "cosign is not installed — Gate 4 cannot pass. See deploy/README.md."; exit 1; }
 	cd $(BUNDLE) && cosign verify-blob SHA256SUMS \
 		--bundle SHA256SUMS.cosign.bundle \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -120,7 +120,7 @@ chmod +x /usr/local/bin/cosign && cosign version
 Unpack the release bundle, then:
 
 ```bash
-make deploy DEMO_TAG=demo-v1 BUNDLE=./bundle
+make deploy DEMO_TAG=demo-v0.1.0 BUNDLE=./bundle
 ```
 
 `deploy` depends on `verify-bundle`, so the Gate-4 check cannot be skipped: it

--- a/deploy/VERIFY.md
+++ b/deploy/VERIFY.md
@@ -68,7 +68,7 @@ Notes:
   that exact GitHub Actions workflow, at that exact tag, in the public
   `netcanon/netcanon` repo, and signed via Sigstore's transparency log.
 
-### Cosign — demo stack images (live from the first `demo-v<N>` tag)
+### Cosign — demo stack images (live from the first `demo-v<semver>` tag)
 
 The warden and the create-body authz shim are both Trusted Computing Base, and
 both are built, signed, SBOM-attested and provenance-attested by
@@ -78,25 +78,25 @@ The signer identity is the workflow file at the exact demo tag:
 ```bash
 # Digests come from the bundle's demo.env; verify each against its tag identity.
 cosign verify ghcr.io/netcanon/netcanon-demo-warden@sha256:<digest> \
-    --certificate-identity 'https://github.com/netcanon/netcanon/.github/workflows/demo-publish.yml@refs/tags/demo-v1' \
+    --certificate-identity 'https://github.com/netcanon/netcanon/.github/workflows/demo-publish.yml@refs/tags/demo-v0.1.0' \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 cosign verify ghcr.io/netcanon/netcanon-demo-warden-shim@sha256:<digest> \
-    --certificate-identity 'https://github.com/netcanon/netcanon/.github/workflows/demo-publish.yml@refs/tags/demo-v1' \
+    --certificate-identity 'https://github.com/netcanon/netcanon/.github/workflows/demo-publish.yml@refs/tags/demo-v0.1.0' \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
 Notes:
 
-- Replace `demo-v1` with the demo tag the running bundle came from, and each
+- Replace `demo-v0.1.0` with the demo tag the running bundle came from, and each
   `<digest>` with the value in that bundle's `demo.env`.
 - This is a **second, separate** signer identity from the product image's
   (`docker-publish.yml@refs/tags/vX.Y.Z`). Two artifacts, two identities, two
   verify commands. Never widen either regexp to cover both.
-- Demo tags are `demo-v<N>` integers only. The workflow's ref guard refuses
+- Demo tags are `demo-v<major>.<minor>.<patch>`. The workflow's ref guard refuses
   anything else before it builds, because a tag like `demo-v1-rc1` would produce
   a signature no identity above can match.
-- **Honest status:** the workflow exists and is gated, but no `demo-v<N>` tag has
+- **Honest status:** the workflow exists and is gated, but no `demo-v<semver>` tag has
   been cut yet, so there is nothing signed to verify until the first demo release
   (Gate 4). The digest pins in `demo.env` plus `make verify` are what you check
   before then.
@@ -109,7 +109,7 @@ bundle is not a mutable, unsigned link in the chain:
 ```bash
 cosign verify-blob SHA256SUMS \
     --bundle SHA256SUMS.cosign.bundle \
-    --certificate-identity 'https://github.com/netcanon/netcanon/.github/workflows/demo-publish.yml@refs/tags/demo-v1' \
+    --certificate-identity 'https://github.com/netcanon/netcanon/.github/workflows/demo-publish.yml@refs/tags/demo-v0.1.0' \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 sha256sum -c SHA256SUMS      # then confirm every asset matches

--- a/tests/demo/test_demo_tag_namespace.py
+++ b/tests/demo/test_demo_tag_namespace.py
@@ -1,6 +1,6 @@
 """The `demo-v*` tag namespace must stay disjoint from the product release train.
 
-The whole demo release design rests on one property: a `demo-v<N>` tag fires
+The whole demo release design rests on one property: a `demo-vX.Y.Z` tag fires
 `demo-publish.yml` and **nothing else**. If a demo tag ever matched a product
 publish glob it would push a PyPI release / move a Docker `:latest`; if it
 matched the changelog regex it would demand a CHANGELOG section that will never
@@ -28,9 +28,20 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO_ROOT / ".github/workflows"
 
 # Representative demo tags, including the ones a slip of the finger produces.
-DEMO_TAGS = ["demo-v1", "demo-v2", "demo-v10", "demo-v99"]
+DEMO_TAGS = ["demo-v0.1.0", "demo-v1.0.0", "demo-v1.2.3", "demo-v10.20.30"]
 # Shapes the ref guard must REFUSE even though they match the trigger glob.
-MALFORMED_DEMO_TAGS = ["demo-v1-rc1", "demo-vfoo", "demo-v", "demo-v1.0", "demo-v01a"]
+# Refusing them matters more than it looks: the `refs/tags/demo-v*` ruleset
+# (deletion + update + non_fast_forward, empty bypass) matches every one of
+# these, so pushing one creates an undeletable tag that publishes nothing.
+MALFORMED_DEMO_TAGS = [
+    "demo-v1",          # the old integers-only shape
+    "demo-v1.0",        # two components
+    "demo-v1.2.3.4",    # four
+    "demo-v1.2.3-rc1",  # pre-release suffix — the identity must stay exact
+    "demo-vfoo",
+    "demo-v",
+    "demo-v01a",
+]
 
 
 def workflow(name: str) -> dict:
@@ -121,21 +132,40 @@ def test_ref_guard_refuses_malformed_demo_tags(tag):
     no documented `cosign verify` command can match — so the guard must stop the
     build before anything is pushed or signed."""
     assert not re.match(ref_guard_regex(), f"refs/tags/{tag}"), (
-        f"{tag!r} would pass the ref guard but is not a demo-v<N> tag"
+        f"{tag!r} would pass the ref guard but is not a demo-v<major>.<minor>.<patch> tag"
     )
 
 
 def test_ref_guard_refuses_branch_and_product_tag_refs():
     guard = ref_guard_regex()
-    for ref in ("refs/heads/main", "refs/tags/v0.6.1", "refs/heads/demo-v1", "refs/pull/1/merge"):
+    for ref in ("refs/heads/main", "refs/tags/v0.6.1", "refs/heads/demo-v0.1.0", "refs/pull/1/merge"):
         assert not re.match(guard, ref), f"ref guard would accept {ref!r}"
 
 
 def test_ref_guard_matches_the_cosign_identity_shape():
     """The guard exists to keep every signed demo tag inside the identity the
-    verify commands are anchored to (`demo-v[0-9]+`). If the two drift, builds
-    succeed but their signatures are unverifiable."""
-    assert "demo-v[0-9]+$" in ref_guard_regex()
+    verify commands are anchored to. If the two drift, builds succeed but their
+    signatures are unverifiable."""
+    assert r"demo-v[0-9]+\.[0-9]+\.[0-9]+$" in ref_guard_regex()
+
+
+def test_the_ruleset_glob_is_wider_than_the_ref_guard():
+    """Why a malformed demo tag is unrecoverable rather than merely annoying.
+
+    The `refs/tags/demo-v*` ruleset carries deletion + update + non_fast_forward
+    with an empty bypass list, and its glob matches every shape the ref guard
+    refuses. Pushing one therefore yields a permanently undeletable tag that
+    publishes nothing. This asserts the asymmetry is understood, so anyone
+    widening the trigger glob has to come here and think about the guard too.
+    """
+    globs = tag_globs("demo-publish.yml")
+    for tag in MALFORMED_DEMO_TAGS:
+        if any(fnmatch.fnmatch(tag, glob) for glob in globs):
+            assert not re.match(ref_guard_regex(), f"refs/tags/{tag}"), (
+                f"{tag!r} matches the trigger glob AND passes the ref guard — if that "
+                "is intended, the cosign verify commands in deploy/VERIFY.md must "
+                "accept its identity shape too"
+            )
 
 
 # ── Signer-identity hygiene ──────────────────────────────────────────────────


### PR DESCRIPTION
Requested: cut `demo-v0.1.0` rather than `demo-v1`. Under the current scheme that would have been **unrecoverable, not merely rejected** — so this changes the scheme first.

## Why it could not just be pushed

The three layers disagree in the worst possible direction:

| layer | pattern | `demo-v0.1.0` |
|---|---|---|
| trigger glob | `demo-v*` | ✅ **matches — the run starts** |
| ref guard | `^refs/tags/demo-v[0-9]+$` | ❌ fails → nothing published |
| tag ruleset | `refs/tags/demo-v*`, bypass 0 | ✅ matches → **cannot be deleted** |

Result: a permanently undeletable tag that publishes nothing, and a burned version number. The ruleset was confirmed against the live API rather than recalled:

```
id=19706745 include=["refs/tags/demo-v*"]
rules=["deletion","update","non_fast_forward"] bypass=0
```

The test suite already encoded the old intent — `demo-v1.0` sat in `MALFORMED_DEMO_TAGS` with a test asserting the guard refuses it.

## Change

Guard widened to `^refs/tags/demo-v[0-9]+\.[0-9]+\.[0-9]+$`:

```
demo-v0.1.0      ACCEPT        demo-v1           refuse
demo-v1.0.0      ACCEPT        demo-v1.0         refuse
demo-v10.20.30   ACCEPT        demo-v1.2.3.4     refuse
                               demo-v1.2.3-rc1   refuse
                               demo-vfoo         refuse
```

Full semver only. It matches the product's own `vX.Y.Z` train, and `0.x` says *early* where `demo-v1` implies a milestone the demo has not reached. **Pre-release suffixes stay refused** — the cosign identity is pinned exactly, so every accepted shape must be one a documented verify command can match.

Disjointness is unaffected and still asserted: `demo-` does not begin with `v`, so no product publish glob and no changelog regex can match.

## What else moved

Operator-facing docs follow the code — `Makefile` usage string, `README` deploy line, and the three `VERIFY.md` cosign commands. `local/` is gitignored design notes and stays as the historical record.

New: `test_the_ruleset_glob_is_wider_than_the_ref_guard`, so the asymmetry is asserted rather than rediscovered. Anyone widening the trigger glob now has to come look at the guard.

## Note on the cosign identity

No change needed — `demo-publish.yml` builds it from `${{ steps.tag.outputs.name }}`, so it is tag-shape agnostic and stays exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)