### PR TITLE
fix(demo): deploy must use the env it just verified, not whatever is on disk

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -10,7 +10,7 @@ BUNDLE  ?= .
 DEMO_TAG ?=
 REPO    ?= netcanon/netcanon
 
-.PHONY: help verify verify-bundle whitepaper deploy drain down dev-up dev-down smoke-up smoke smoke-down
+.PHONY: help verify verify-bundle promote whitepaper deploy drain down dev-up dev-down smoke-up smoke smoke-down
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  %-11s %s\n",$$1,$$2}'
@@ -50,7 +50,26 @@ verify-bundle: ## Gate-4 — cosign-verify SHA256SUMS, then checksum the bundle 
 	cd $(BUNDLE) && sha256sum -c SHA256SUMS
 	@echo "Gate 4 OK — signature valid and every bundle file matches its published hash."
 
-deploy: verify-bundle ## Verify the bundle (Gate 4), then pull pinned images + bring the stack up
+# Verifying a bundle and then deploying whatever `demo.env` happens to contain is
+# theatre: the first real Gate-4 run verified demo-v0.1.0's signed digests and
+# would have brought up the locally-built `:dev` images sitting in deploy/.
+# `deploy` therefore PROMOTES the verified env into place first, and cannot be
+# reached except through verify-bundle.
+#
+# ACME_EMAIL is the one value the bundle deliberately does not carry (operator
+# data, not a build output), so it is preserved from the existing demo.env and
+# the promotion refuses rather than deploying a Caddy that cannot start.
+promote: verify-bundle ## Copy the VERIFIED bundle's digests into demo.env, keeping ACME_EMAIL
+	@test -f demo.env || { echo "no demo.env — cp demo.env.example demo.env and set ACME_EMAIL"; exit 1; }
+	@email="$$(grep '^ACME_EMAIL=' demo.env | cut -d= -f2-)"; \
+	 case "$$email" in ""|REPLACE_WITH_OPERATOR_EMAIL|you@example.com) \
+	   echo "set a real ACME_EMAIL in demo.env before deploying"; exit 1;; esac; \
+	 sed "s|^ACME_EMAIL=.*|ACME_EMAIL=$$email|" $(BUNDLE)/demo.env > demo.env.promoted && \
+	 mv demo.env.promoted demo.env && \
+	 echo "demo.env now carries $(DEMO_TAG)'s verified digests (ACME_EMAIL preserved)."
+	@grep -c '@sha256:' demo.env | xargs -I{} echo "  digest-pinned images in demo.env: {}"
+
+deploy: promote ## Gate 4 → promote the verified env → pull pinned images + bring the stack up
 	docker pull "$$(grep '^NETCANON_INSTANCE_IMAGE=' demo.env | cut -d= -f2-)"
 	$(COMPOSE) pull
 	$(COMPOSE) up -d

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -123,12 +123,20 @@ Unpack the release bundle, then:
 make deploy DEMO_TAG=demo-v0.1.0 BUNDLE=./bundle
 ```
 
-`deploy` depends on `verify-bundle`, so the Gate-4 check cannot be skipped: it
+`deploy` depends on `promote`, which depends on `verify-bundle`, so neither the
+Gate-4 check nor the promotion can be skipped. Verification first: it
 `cosign verify-blob`s `SHA256SUMS` against the **exact** signer identity
 (`demo-publish.yml@refs/tags/<DEMO_TAG>` — which is why the tag has to be passed
 in; it is not recoverable from the bundle), then `sha256sum -c` makes that one
 signed manifest vouch for every other asset. Only then does it pull the
 digest-pinned images and `up -d`.
+
+`promote` is the step that makes the verification mean something: it copies the
+**verified** bundle's digests into `deploy/demo.env`, preserving your
+`ACME_EMAIL` (the one value the bundle deliberately omits, since it is operator
+data rather than a build output). Without it, `deploy` would verify a signed
+bundle and then bring up whatever image refs happened to be sitting in
+`demo.env` — which is exactly what the first real Gate-4 run caught.
 
 Then `make whitepaper` from the unpacked bundle to stamp the deploy date and
 render the copy Caddy serves at `/whitepaper` (CI deliberately leaves that one


### PR DESCRIPTION
Caught by the **first real Gate-4 run**, against the published `demo-v0.1.0` bundle.

## What happened

`verify-bundle` passed for real — first time its success path has ever executed:

```
cosign verify-blob SHA256SUMS --certificate-identity ".../demo-publish.yml@refs/tags/demo-v0.1.0"
Verified OK
demo.env: OK   whitepaper.html: OK   whitepaper-template.html: OK
whitepaper-values.json: OK   index.html: OK   docker-compose.yml: OK
```

And then `deploy` read `deploy/demo.env`, which still held the locally-built dev refs:

```
bundle/demo.env   NETCANON_INSTANCE_IMAGE=ghcr.io/netcanon/netcanon@sha256:0b2eab3b...
                  WARDEN_IMAGE=ghcr.io/netcanon/netcanon-demo-warden@sha256:01ef6b36...
deploy/demo.env   NETCANON_INSTANCE_IMAGE=ghcr.io/netcanon/netcanon:0.6.1
                  WARDEN_IMAGE=netcanon-demo-warden:dev
```

It would have cryptographically verified a signed bundle and then brought up entirely different images. **That is the defect #400 fixed — a deploy target whose verification does not gate what actually ships — reintroduced one level up.** Verification that does not feed the deploy is theatre.

## Fix

`deploy` → `promote` → `verify-bundle`, so neither the check nor the promotion can be skipped:

```
promote: verify-bundle
    copy the VERIFIED bundle demo.env into place, preserving ACME_EMAIL
deploy: promote
    docker pull … ; compose pull ; compose up -d
```

`ACME_EMAIL` is the one value the bundle deliberately omits — operator data, not a build output — so it is carried over from the existing file, and `promote` **refuses** on a missing or placeholder address rather than deploying a Caddy that cannot start.

## Also confirmed in that run

**I6 holds.** `deploy/docker-compose.yml` and the published bundle copy are byte-identical:

```
repo   : 8ff351e167a4367532bbc75c4417230948ae5b78b74633e201e8ce0b5f1ef537
bundle : 8ff351e167a4367532bbc75c4417230948ae5b78b74633e201e8ce0b5f1ef537
```

So the in-repo hash really is the published hash, which is what makes `make verify` meaningful.

## Note

This is the last of the three things that were structurally untestable before a bundle existed. It needed a real signed bundle to surface, and it surfaced on the first attempt — which is the argument for cutting the tag and running Gate 4 rather than reasoning about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)