### PR TITLE
fix(demo): make whitepaper reads the bundle via $(BUNDLE)

### DIFF
--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -24,10 +24,13 @@ verify: ## Print pinned digests + compose sha256 (compare against the whitepaper
 # but deliberately NOT the deploy date — CI cannot know when you deploy, and a
 # wrong date in a trust document is worse than a visibly pending one. This target
 # stamps today's date and renders the copy Caddy serves at /whitepaper.
-# Run it from the unpacked bundle directory (needs whitepaper-values.json).
-whitepaper: ## Fill the deploy date + render frontend/whitepaper.html for /whitepaper
-	@test -f whitepaper-values.json || { echo "whitepaper-values.json not found — run from the unpacked bundle dir"; exit 1; }
-	@jq --arg d "$$(date -u +%Y-%m-%d)" '. + {DEPLOY_DATE: $$d}' whitepaper-values.json > .wp-values.filled.json
+# Reads the bundle's values via $(BUNDLE), like verify-bundle and promote: the
+# recipe itself must run from deploy/ (its ../tools, ../docs and ../frontend
+# paths are relative to here), so "run it from the bundle dir" was never a thing
+# that could work.
+whitepaper: ## Fill the deploy date + render frontend/whitepaper.html (BUNDLE=<dir>)
+	@test -f $(BUNDLE)/whitepaper-values.json || { echo "$(BUNDLE)/whitepaper-values.json not found — pass BUNDLE=<unpacked bundle dir>"; exit 1; }
+	@jq --arg d "$$(date -u +%Y-%m-%d)" '. + {DEPLOY_DATE: $$d}' $(BUNDLE)/whitepaper-values.json > .wp-values.filled.json
 	python3 ../tools/render_whitepaper.py \
 		--in ../docs/DEMO_WHITEPAPER.md \
 		--out ../frontend/whitepaper.html \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -138,7 +138,7 @@ data rather than a build output). Without it, `deploy` would verify a signed
 bundle and then bring up whatever image refs happened to be sitting in
 `demo.env` — which is exactly what the first real Gate-4 run caught.
 
-Then `make whitepaper` from the unpacked bundle to stamp the deploy date and
+Then `make whitepaper DEMO_TAG=demo-v0.1.0 BUNDLE=./bundle` to stamp the deploy date and
 render the copy Caddy serves at `/whitepaper` (CI deliberately leaves that one
 value blank — it cannot know when you deploy). Until you run it, `/whitepaper`
 serves the committed template, banner and all.

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -209,6 +209,38 @@ def test_dockerfile_copies_every_warden_module():
     assert not missing, f"demo/warden modules absent from the Dockerfile COPY: {sorted(missing)}"
 
 
+def test_bundle_assets_are_read_through_the_bundle_variable():
+    """Twice now the deploy flow reached for a bundle asset in the wrong place:
+    ``deploy`` read ``demo.env`` from deploy/ after verifying the bundle's copy,
+    and ``whitepaper`` looked for ``whitepaper-values.json`` in the cwd while the
+    unpacked bundle put it in ./bundle. Both only surfaced by running the real
+    Gate-4 flow. Any recipe naming a bundle-only asset must reach it via
+    ``$(BUNDLE)``.
+    """
+    text = read("deploy/Makefile")
+    recipes: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        match = re.match(r"^([a-z][a-z0-9-]*):", line)
+        if match:
+            current = match.group(1)
+            recipes[current] = []
+        elif current and line.startswith("\t"):
+            recipes[current].append(line)
+        elif line.strip() and not line.startswith((" ", "\t")):
+            current = None
+
+    assert recipes, "no Makefile recipes parsed — the parser has rotted"
+    for name, body in recipes.items():
+        joined = "\n".join(body)
+        for asset in ("whitepaper-values.json", "SHA256SUMS"):
+            if asset in joined:
+                assert "$(BUNDLE)" in joined, (
+                    f"`make {name}` reads {asset} but never mentions $(BUNDLE) — it "
+                    "will look in deploy/ while the unpacked bundle put it elsewhere"
+                )
+
+
 def test_every_makefile_target_is_phony():
     """A same-line ``.PHONY`` edit is the merge conflict git resolves silently and
     wrongly: #396 and #397 each appended targets, one side won with no textual


### PR DESCRIPTION
Second instance of the defect the real Gate-4 deploy exposed, one target over.

`whitepaper` tested for `whitepaper-values.json` in the cwd, and its comment said *"run it from the unpacked bundle directory"* — which was never possible: the recipe's `../tools`, `../docs` and `../frontend` paths only resolve from `deploy/`. So the documented final step of the deploy could not run as written:

```
$ make whitepaper
whitepaper-values.json not found — run from the unpacked bundle dir
make: *** [Makefile:29: whitepaper] Error 1
```

Now reads `$(BUNDLE)/whitepaper-values.json`, consistent with `verify-bundle` and `promote`, defaulting to `.` so the old placement still works.

## Guard

`test_bundle_assets_are_read_through_the_bundle_variable` — any recipe naming a bundle-only asset must reach it through `$(BUNDLE)`. Both misses so far were exactly this shape:

- `deploy` read `demo.env` from `deploy/` after verifying the bundle's copy (#404)
- `whitepaper` read `whitepaper-values.json` from the cwd (this PR)

Neither was visible without a published bundle to actually deploy. Negative-tested: stripping `$(BUNDLE)` flags `whitepaper`.

## Context

The stack is already live on the signed digest-pinned images from `demo-v0.1.0` — all four services plus instances, 0 restarts. This is the last step, stamping the deploy date into the served whitepaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)