### PR TITLE
fix(demo): publish the authz-shim digest — a TCB component was unverifiable

### DIFF
--- a/.github/workflows/demo-publish.yml
+++ b/.github/workflows/demo-publish.yml
@@ -499,6 +499,8 @@ jobs:
             "REQUIREMENTS_LOCK_SHA": "${lock_sha}",
             "WARDEN_IMAGE_REF": "ghcr.io/${REPO_OWNER}/netcanon-demo-warden",
             "WARDEN_IMAGE_DIGEST": "${WARDEN_DIGEST#sha256:}",
+            "SHIM_IMAGE_REF": "ghcr.io/${REPO_OWNER}/netcanon-demo-warden-shim",
+            "SHIM_IMAGE_DIGEST": "${SHIM_DIGEST#sha256:}",
             "SOCKET_PROXY_IMAGE_REF": "ghcr.io/tecnativa/docker-socket-proxy",
             "SOCKET_PROXY_IMAGE_DIGEST": "${SOCKET_PROXY_DIGEST#sha256:}",
             "CADDY_IMAGE_REF": "docker.io/library/caddy",

--- a/docs/DEMO_WHITEPAPER.md
+++ b/docs/DEMO_WHITEPAPER.md
@@ -145,6 +145,7 @@ to compare.
 netcanon image    : ghcr.io/netcanon/netcanon@sha256:<NETCANON_IMAGE_DIGEST>   (base python:3.14-slim-bookworm)
 requirements.lock : sha256:<REQUIREMENTS_LOCK_SHA>   (hash-locked; glibc/manylinux wheels — not Alpine/musl)
 warden image      : <WARDEN_IMAGE_REF>@sha256:<WARDEN_IMAGE_DIGEST>
+authz-shim image  : <SHIM_IMAGE_REF>@sha256:<SHIM_IMAGE_DIGEST>   (TCB component — the whole-body default-deny gate on container create)
 socket-proxy image: <SOCKET_PROXY_IMAGE_REF>@sha256:<SOCKET_PROXY_IMAGE_DIGEST>   (TCB component — the capability filter fronting docker.sock)
 caddy image       : <CADDY_IMAGE_REF>@sha256:<CADDY_IMAGE_DIGEST>
 compose sha256    : <COMPOSE_SHA256>

--- a/frontend/whitepaper.html
+++ b/frontend/whitepaper.html
@@ -170,6 +170,7 @@ mark.ph {
 <pre><code>netcanon image    : ghcr.io/netcanon/netcanon@sha256:<mark class="ph">&lt;NETCANON_IMAGE_DIGEST&gt;</mark>   (base python:3.14-slim-bookworm)
 requirements.lock : sha256:<mark class="ph">&lt;REQUIREMENTS_LOCK_SHA&gt;</mark>   (hash-locked; glibc/manylinux wheels — not Alpine/musl)
 warden image      : <mark class="ph">&lt;WARDEN_IMAGE_REF&gt;</mark>@sha256:<mark class="ph">&lt;WARDEN_IMAGE_DIGEST&gt;</mark>
+authz-shim image  : <mark class="ph">&lt;SHIM_IMAGE_REF&gt;</mark>@sha256:<mark class="ph">&lt;SHIM_IMAGE_DIGEST&gt;</mark>   (TCB component — the whole-body default-deny gate on container create)
 socket-proxy image: <mark class="ph">&lt;SOCKET_PROXY_IMAGE_REF&gt;</mark>@sha256:<mark class="ph">&lt;SOCKET_PROXY_IMAGE_DIGEST&gt;</mark>   (TCB component — the capability filter fronting docker.sock)
 caddy image       : <mark class="ph">&lt;CADDY_IMAGE_REF&gt;</mark>@sha256:<mark class="ph">&lt;CADDY_IMAGE_DIGEST&gt;</mark>
 compose sha256    : <mark class="ph">&lt;COMPOSE_SHA256&gt;</mark>

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -66,6 +66,46 @@ def test_docs_do_not_quote_the_superseded_backstop_formula(relpath):
     assert stale not in text, f"{relpath} still quotes the superseded '{stale}'"
 
 
+# Claim 9 is "the published deployment is exactly reproducible". That holds only
+# if EVERY image the stack pins appears in the reproducibility block. For
+# demo-v0.1.0 the authz-shim did not: the workflow computed its digest and wrote
+# it to demo.env, but never emitted it into whitepaper-values.json, and the block
+# had no line for it — while VERIFY.md called it Trusted Computing Base and gave
+# readers a cosign command for it. Five of six digests were verifiable.
+PINNED_IMAGE_TO_WHITEPAPER_TOKEN = {
+    "NETCANON_INSTANCE_IMAGE": "NETCANON_IMAGE_DIGEST",
+    "WARDEN_IMAGE": "WARDEN_IMAGE_DIGEST",
+    "WARDEN_SHIM_IMAGE": "SHIM_IMAGE_DIGEST",
+    "SOCKET_PROXY_IMAGE": "SOCKET_PROXY_IMAGE_DIGEST",
+    "CADDY_IMAGE": "CADDY_IMAGE_DIGEST",
+}
+
+
+def test_every_pinned_image_is_reproducible_from_the_whitepaper():
+    """Three-way: the env template pins it, the whitepaper has a token for it,
+    and the workflow actually emits that token's value."""
+    env_keys = set(
+        re.findall(r"^([A-Z_]*IMAGE)=", read("deploy/demo.env.example"), re.MULTILINE)
+    )
+    assert env_keys == set(PINNED_IMAGE_TO_WHITEPAPER_TOKEN), (
+        "deploy/demo.env.example pins a different set of images than this map "
+        f"knows about: {sorted(env_keys ^ set(PINNED_IMAGE_TO_WHITEPAPER_TOKEN))}. "
+        "A new pinned image must also become publicly verifiable."
+    )
+
+    whitepaper = read("docs/DEMO_WHITEPAPER.md")
+    workflow = read(".github/workflows/demo-publish.yml")
+    for env_key, token in PINNED_IMAGE_TO_WHITEPAPER_TOKEN.items():
+        assert f"<{token}>" in whitepaper, (
+            f"{env_key} is pinned in the stack but <{token}> is absent from the "
+            "whitepaper's reproducibility block — readers cannot verify it"
+        )
+        assert f'"{token}"' in workflow, (
+            f"the whitepaper asks for <{token}> but demo-publish.yml never emits it "
+            "into whitepaper-values.json, so it renders as an unfilled placeholder"
+        )
+
+
 def test_rendered_whitepaper_is_regenerated_from_the_markdown():
     """Every other ratchet in this file reads the MARKDOWN — but Caddy serves
     ``frontend/whitepaper.html``, and demo-publish.yml ships it as


### PR DESCRIPTION
Caught cross-checking the deployed `demo-v0.1.0` whitepaper against `make verify`. Five of six pinned digests matched. The sixth was absent:

```
MATCH  01ef6b3697e4facf…   warden
MATCH  0b2eab3b9cf6a3b5…   netcanon
MATCH  1f3a6f303320723d…   socket-proxy
ABSENT 40758d987a16d8c7…   authz-shim   <--
MATCH  844f60b64e4724a5…   caddy
MATCH  compose 8ff351e167a43675…
```

## Why it matters

The authz-shim is the **whole-body default-deny gate on container create** — after the warden, the most security-critical component in the chain. `VERIFY.md:73` calls it Trusted Computing Base and hands readers a `cosign verify` command for it.

But `demo-publish.yml` computed `SHIM_DIGEST`, wrote it into `demo.env`, and **never emitted it into `whitepaper-values.json`** — and the reproducibility block had no line for it. So claim 9, *"the published deployment is exactly reproducible"*, held for everything except the component the threat model leans on hardest. The two documents contradicted each other about it.

Nothing published was wrong. A TCB component was simply missing from the trust document.

## Fix

- `SHIM_IMAGE_REF` / `SHIM_IMAGE_DIGEST` added to the values JSON
- an `authz-shim image` line added to the reproducibility block
- committed template copy regenerated (the drift guard from #402 requires it)

## Ratchet

`test_every_pinned_image_is_reproducible_from_the_whitepaper` closes the loop three ways: **`demo.env.example` pins it → the whitepaper has a token for it → the workflow emits that token's value.** Adding a pinned image without making it publicly verifiable now fails CI, and so does adding a whitepaper token nothing fills.

Negative-tested — dropping `<SHIM_IMAGE_DIGEST>` flags `WARDEN_SHIM_IMAGE`.

## Needs a new tag

`demo-v0.1.0`'s bundle is signed and immutable; its `whitepaper-values.json` can never carry these keys. This ships in **`demo-v0.1.1`**, which is exactly what a patch tag is for — and the reason `demo-v0.1.0` beat `demo-v1`.

The running stack is unaffected and correct; this is completeness in the published trust argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)