### PR TITLE
feat(demo): pre-publish gates — an immutable release must be complete

### DIFF
--- a/.github/workflows/demo-publish.yml
+++ b/.github/workflows/demo-publish.yml
@@ -532,6 +532,34 @@ jobs:
           echo "compose_sha=$compose_sha" >> "$GITHUB_OUTPUT"
           cat bundle/SHA256SUMS
 
+      # demo-v0.1.0 published with the authz-shim digest in demo.env but nowhere
+      # in the whitepaper: a TCB component the stack runs and no reader could
+      # verify. Under immutable releases the remedy is a whole new tag, so the
+      # completeness of the trust document has to be a build-time gate, not
+      # something noticed afterwards by cross-checking a deployed host.
+      - name: Gate — every digest the stack runs is publicly verifiable
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          while read -r digest; do
+            if ! grep -q "$digest" bundle/whitepaper.html; then
+              echo "::error::${digest:0:16}… is pinned in demo.env but absent from the whitepaper — a component nobody could verify"
+              missing=1
+            fi
+          done < <(grep -oE '@sha256:[0-9a-f]{64}' bundle/demo.env | cut -d: -f2 | sort -u)
+          [ "$missing" -eq 0 ] || exit 1
+
+          # DEPLOY_DATE is the only token CI cannot know. Anything else still
+          # pending means a placeholder nothing fills — a hole in the block.
+          pending="$(grep -oE '<mark class="ph">&lt;[A-Z0-9_]+&gt;</mark>' bundle/whitepaper.html \
+                     | grep -oE '[A-Z0-9_]{4,}' | sort -u | tr '\n' ' ' | xargs || true)"
+          if [ "$pending" != "DEPLOY_DATE" ]; then
+            echo "::error::unexpected unfilled whitepaper placeholders: '${pending}' (expected exactly DEPLOY_DATE)"
+            exit 1
+          fi
+          echo "OK: $(grep -c '@sha256:' bundle/demo.env) pinned images, all present in the whitepaper; only DEPLOY_DATE pending."
+
       # SHA256SUMS was the one mutable, unsigned link in the chain. sign-blob
       # closes it; immutable releases are the second belt.
       - name: Sign SHA256SUMS (cosign sign-blob, keyless)
@@ -539,6 +567,23 @@ jobs:
           cosign sign-blob --yes \
             --bundle bundle/SHA256SUMS.cosign.bundle \
             bundle/SHA256SUMS
+
+      # Run Gate 4 against our own output before anyone else has to. If the
+      # operator's documented verification cannot pass here, it must not become
+      # an immutable release.
+      - name: Gate — self-verify the bundle exactly as the operator will
+        env:
+          TAG: ${{ steps.tag.outputs.name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd bundle
+          cosign verify-blob SHA256SUMS \
+            --bundle SHA256SUMS.cosign.bundle \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/demo-publish.yml@refs/tags/${TAG}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          sha256sum -c SHA256SUMS
+          echo "OK: the bundle verifies against its own published identity."
 
       - name: Upload bundle as an Actions artifact (debugging)
         uses: actions/upload-artifact@v5.0.0
@@ -589,10 +634,40 @@ jobs:
             by hand (`make deploy`).
           fail_on_unmatched_files: true
 
-      # Flip draft -> published only once every asset is attached. Under
-      # immutable releases this transition is what freezes the assets and the
-      # tag, and it is the last thing the workflow does, so a failure earlier
-      # leaves an unpublished draft rather than a half-signed public release.
+      # The draft is the LAST moment these assets can be changed. Everything
+      # verified so far was verified against the local `bundle/` directory —
+      # not against what GitHub actually stored. Download the release's own
+      # copies back and re-run the operator's verification on those, so a
+      # truncated or mangled upload is caught while it is still fixable.
+      - name: Gate — re-verify the assets GitHub stored, before freezing them
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.name }}
+          EXPECTED_ASSETS: "8"
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf roundtrip && mkdir roundtrip
+          gh release download "$TAG" --dir roundtrip --clobber
+          found="$(find roundtrip -maxdepth 1 -type f | wc -l)"
+          if [ "$found" -ne "$EXPECTED_ASSETS" ]; then
+            echo "::error::draft has $found assets, expected $EXPECTED_ASSETS — refusing to publish an incomplete release"
+            find roundtrip -maxdepth 1 -type f -printf '  %f\n'
+            exit 1
+          fi
+          cd roundtrip
+          cosign verify-blob SHA256SUMS \
+            --bundle SHA256SUMS.cosign.bundle \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/demo-publish.yml@refs/tags/${TAG}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          sha256sum -c SHA256SUMS
+          echo "OK: what GitHub stored is byte-identical to what was signed."
+
+      # Flip draft -> published only once every asset is attached AND verified
+      # in place. Under immutable releases this transition is what freezes the
+      # assets and the tag, and it is the last thing the workflow does, so a
+      # failure anywhere above leaves an unpublished draft rather than a
+      # half-signed public release.
       - name: Publish the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -106,6 +106,59 @@ def test_every_pinned_image_is_reproducible_from_the_whitepaper():
         )
 
 
+# ── The release is immutable, so its completeness is a build-time property ───
+def release_attach_list() -> list[str]:
+    match = re.search(
+        r"files: \|\n((?:\s+bundle/\S+\n)+)", read(".github/workflows/demo-publish.yml")
+    )
+    assert match, "could not find the release attach list in demo-publish.yml"
+    return [line.strip() for line in match.group(1).splitlines() if line.strip()]
+
+
+def test_release_asset_count_gate_matches_the_attach_list():
+    """The pre-publish gate refuses to freeze a draft that does not hold exactly
+    EXPECTED_ASSETS files. Add an asset and forget the counter and the gate either
+    blocks every release or, worse, stops being able to notice a missing one."""
+    workflow = read(".github/workflows/demo-publish.yml")
+    expected = re.search(r'EXPECTED_ASSETS: "(\d+)"', workflow)
+    assert expected, "the pre-publish asset-count gate is gone"
+    attached = release_attach_list()
+    assert len(attached) == int(expected.group(1)), (
+        f"{len(attached)} assets are attached but the gate expects "
+        f"{expected.group(1)} — these two move together"
+    )
+
+
+def test_every_published_asset_is_covered_by_sha256sums():
+    """An asset attached to the release but missing from SHA256SUMS ships
+    *unverifiable*: the cosign signature vouches for the manifest, and the
+    manifest for everything it lists. Since the release is immutable, an asset
+    that slips out uncovered can never be brought under the signature.
+
+    SHA256SUMS and its own signature bundle are the two that cannot cover
+    themselves.
+    """
+    workflow = read(".github/workflows/demo-publish.yml")
+    block = re.search(r"sha256sum \\\n(.*?)> SHA256SUMS", workflow, re.DOTALL)
+    assert block, "could not find the SHA256SUMS manifest generation"
+    manifest = {
+        line.strip().rstrip(" \\")
+        for line in block.group(1).splitlines()
+        if line.strip().rstrip(" \\")
+    }
+    attached = {Path(name).name for name in release_attach_list()}
+    self_covering = {"SHA256SUMS", "SHA256SUMS.cosign.bundle"}
+    uncovered = attached - manifest - self_covering
+    assert not uncovered, (
+        f"attached but not in SHA256SUMS, so published unverifiable: {sorted(uncovered)}"
+    )
+    orphaned = manifest - attached
+    assert not orphaned, (
+        f"in SHA256SUMS but never attached, so `sha256sum -c` fails for the "
+        f"operator: {sorted(orphaned)}"
+    )
+
+
 def test_rendered_whitepaper_is_regenerated_from_the_markdown():
     """Every other ratchet in this file reads the MARKDOWN — but Caddy serves
     ``frontend/whitepaper.html``, and demo-publish.yml ships it as


### PR DESCRIPTION
Immutable releases are now **on**, so "fix it afterwards" no longer exists — a release that ships wrong is fixed only by a new tag.

`demo-v0.1.0` did exactly that: it published the authz-shim digest in `demo.env` and **nowhere in the whitepaper**, so a TCB component the stack actually runs was unverifiable by any reader. The remedy was `demo-v0.1.1`. That was caught by hand, cross-checking a deployed host against `make verify`. It should have been caught by the build.

## Three gates, all inside the draft window

The draft is the last moment the assets can still change, so that is where the checks belong.

**1 — every digest the stack runs is publicly verifiable**
Every `@sha256` in the generated `demo.env` must appear in the rendered whitepaper, and the only unfilled placeholder may be `DEPLOY_DATE`. This is precisely the `demo-v0.1.0` defect, now fatal at build time.

**2 — self-verify with the operator's own commands**
`cosign verify-blob` against the published identity, then `sha256sum -c`. If Gate 4 cannot pass in CI, it must not become an immutable release.

**3 — re-verify what GitHub actually stored**
Everything above checks the local `bundle/` directory. Only this downloads the draft's own copies back and verifies *those* — catching a truncated or mangled upload while it is still fixable.

Every gate fails toward **leaving an unpublished draft**, never toward a bad public release.

## Two ratchets for the drift these invite

- `EXPECTED_ASSETS` must equal the attach list
- every attached asset must appear in `SHA256SUMS`, and vice versa

That second one matters more than it reads: an asset outside the manifest ships **unverifiable**, because the signature vouches for the manifest and the manifest for what it lists. Under immutability it could never be brought back under the signature.

Negative-tested — adding an asset without updating the counter or the manifest:

```
(a) counter drift    attached=9 gate=8      -> FLAGGED
(b) uncovered asset  ["NEWTHING.txt"]       -> FLAGGED
(c) orphaned entry   ["ghost.json"]         -> FLAGGED
(d) real workflow clean                     -> True
```

## Scope

`demo-publish.yml` only. `desktop-msi-publish.yml` also creates releases and already does draft → publish, but it has no bundle or manifest, so it needs a different (smaller) check — worth a follow-up rather than bolting on something ill-fitting here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)