### PR TITLE
feat(demo): aggregate traffic stats — Caddy metrics + a 5-min sampler

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -14,6 +14,15 @@
 	log {
 		exclude http.log.access
 	}
+
+	# Per-request HTTP metrics, off by default. These are counters aggregated by
+	# {server, handler, code, method} — there is no client-IP, path, user-agent
+	# or referrer label, so this is traffic volume without a visitor dimension
+	# and does not weaken claim 4. Exposed only on the admin endpoint (:2019),
+	# which is bound inside the container and never published to the host.
+	servers {
+		metrics
+	}
 }
 
 demo.netcanon.net {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -143,6 +143,37 @@ render the copy Caddy serves at `/whitepaper` (CI deliberately leaves that one
 value blank — it cannot know when you deploy). Until you run it, `/whitepaper`
 serves the committed template, banner and all.
 
+## Traffic stats
+
+The demo keeps no access log (claim 4) and the warden's counters are in-RAM, so
+without sampling there is no answer to "how much traffic did this get". A
+`demo-stats.timer` writes aggregate totals to `/var/log/demo-stats.jsonl` every
+5 minutes — **totals only, no visitor dimension**, disclosed in the whitepaper's
+*What we do see*.
+
+```bash
+# last sample
+tail -1 /var/log/demo-stats.jsonl | jq .
+
+# sessions and refusals over the file
+jq -r '[.ts, (.warden.sessions_started//0), (.warden."503_count"//0)] | @tsv' /var/log/demo-stats.jsonl
+
+# requests by status code
+jq -r '[.ts, .http_requests_total, (.http_by_code|tostring)] | @tsv' /var/log/demo-stats.jsonl
+```
+
+Two things to know when reading it:
+
+- **Counters reset.** They are cumulative-since-process-start, so a restart
+  zeroes them. `warden_uptime_s` drops at the same moment — treat that as the
+  reset marker, exactly like a Prometheus counter.
+- **`warden: null` means the demo was unreachable** at that timestamp. That is a
+  recorded outage, deliberately distinct from a missing sample (timer not run).
+
+⚠️ **`503_count` is not a capacity signal.** It increments for per-IP rate limits
+(429), true saturation (503), *and* instance-create failures. Only the second
+means "the box is too small". Splitting it is open work.
+
 ## DDoS / abuse posture
 
 - **L7 abuse:** warden per-IP concurrency cap (2) + mint rate limit (≤30/600 s), Caddy 2 MB body cap, fail-closed 503 at `MAX_ACTIVE`, per-instance cpu/mem/pids caps, no egress.

--- a/deploy/cloud-init.yaml
+++ b/deploy/cloud-init.yaml
@@ -116,9 +116,16 @@ runcmd:
   # demo-int isolation (I4): apply the nftables rules into DOCKER-USER after docker.
   - install -m 0755 /opt/demo/deploy/systemd/demo-firewall.sh /usr/local/bin/demo-firewall.sh
   - install -m 0644 /opt/demo/deploy/systemd/demo-firewall.service /etc/systemd/system/
+  # Aggregate traffic sampler. The demo keeps no access log, and the warden's
+  # counters are in-RAM and die with the process, so without this "how much
+  # traffic did we get" has no answer at all. Totals only — no visitor dimension.
+  - install -m 0755 /opt/demo/deploy/systemd/demo-stats.sh /usr/local/bin/demo-stats.sh
+  - install -m 0644 /opt/demo/deploy/systemd/demo-stats.service /etc/systemd/system/
+  - install -m 0644 /opt/demo/deploy/systemd/demo-stats.timer /etc/systemd/system/
   - systemctl daemon-reload
   - systemctl enable --now demo-ttl-backstop.timer
   - systemctl enable --now demo-firewall.service
+  - systemctl enable --now demo-stats.timer
   # Gate-3 tripwire: prove both units are actually active. cloud-init logs to
   # /var/log/cloud-init-output.log — check it before trusting the host.
   - systemctl is-active --quiet demo-ttl-backstop.timer || echo "FATAL demo-ttl-backstop.timer inactive"

--- a/deploy/systemd/demo-stats.service
+++ b/deploy/systemd/demo-stats.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=netcanon demo — sample aggregate traffic counters to disk
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/demo-stats.sh

--- a/deploy/systemd/demo-stats.sh
+++ b/deploy/systemd/demo-stats.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# netcanon demo — aggregate traffic sampler.
+#
+# The demo keeps no access log by design (claim 4), so the only traffic signal
+# that exists is the warden's in-RAM counters plus Caddy's aggregate request
+# metrics. Both are wiped by a restart, which means "how much traffic did the
+# demo get?" is unanswerable without sampling them to disk.
+#
+# What this writes is deliberately narrow: totals only. No client IP, no path,
+# no user-agent, no referrer, no per-session row — nothing with a visitor
+# dimension. The warden's per-IP records stay in RAM and are never touched here.
+# Disclosed in the whitepaper's "What we do see".
+#
+# Counters are cumulative-since-process-start and reset on restart, so
+# `warden_uptime_s` is emitted alongside them: a consumer computing rates must
+# treat a drop in uptime as a counter reset, exactly like a Prometheus counter.
+set -euo pipefail
+
+OUT=${DEMO_STATS_FILE:-/var/log/demo-stats.jsonl}
+MAX_BYTES=${DEMO_STATS_MAX_BYTES:-10485760}   # 10 MiB, ~6 months at 5-min samples
+HEALTH_URL=${DEMO_HEALTH_URL:-https://demo.netcanon.net/healthz}
+
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Validate before handing anything to --argjson: a partial response or a changed
+# upstream shape must degrade to a null/empty field, never abort the sample or —
+# worse — write a malformed line into the series.
+json_or() {  # stdin -> stdout, falling back to $1 when the input is not JSON
+  local fallback=$1 buf
+  buf=$(cat)
+  if [ -n "$buf" ] && printf '%s' "$buf" | jq empty >/dev/null 2>&1; then
+    printf '%s' "$buf"
+  else
+    printf '%s' "$fallback"
+  fi
+}
+
+# `|| true` is load-bearing: under `pipefail` a failed curl aborts the whole
+# script, so an outage would leave a GAP in the series — indistinguishable from
+# the timer not firing. Recording `warden: null` instead makes "the demo was
+# down at this timestamp" an actual data point.
+health=$( { curl -fsS --max-time 10 "$HEALTH_URL" 2>/dev/null || true; } | json_or 'null')
+
+# Caddy's admin endpoint is not published; reach it inside the container.
+metrics=$(docker exec deploy-caddy-1 wget -qO- http://127.0.0.1:2019/metrics 2>/dev/null || echo '')
+
+# Status codes are NOT on caddy_http_requests_total (that carries only
+# {handler,server}); they live on the duration histogram's _count series, which
+# is labelled {code,handler,method,server}. Match the label by name rather than
+# by position so a label-order change upstream cannot silently zero this.
+http_by_code=$(printf '%s\n' "$metrics" | awk '
+  /^caddy_http_request_duration_seconds_count\{/ {
+    if (match($0, /code="[0-9]+"/)) {
+      code = substr($0, RSTART + 6, RLENGTH - 7)
+      total[code] += $NF
+    }
+  }
+  END {
+    printf "{"; sep = ""
+    for (c in total) { printf "%s\"%s\":%d", sep, c, total[c]; sep = "," }
+    printf "}"
+  }' | json_or '{}')
+
+http_total=$(printf '%s\n' "$metrics" \
+  | awk '/^caddy_http_requests_total\{/ { n += $NF } END { print n + 0 }')
+
+started=$(docker inspect deploy-warden-1 -f '{{.State.StartedAt}}' 2>/dev/null || echo '')
+uptime_s=0
+if [ -n "$started" ]; then
+  uptime_s=$(( $(date -u +%s) - $(date -u -d "$started" +%s) ))
+fi
+
+# Rotate before appending so the file can never exceed the cap by more than one
+# sample; keep one previous generation so a rotation does not lose a whole window.
+if [ -f "$OUT" ] && [ "$(stat -c %s "$OUT")" -ge "$MAX_BYTES" ]; then
+  mv -f "$OUT" "${OUT}.1"
+fi
+
+jq -cn \
+  --arg ts "$ts" \
+  --argjson health "$health" \
+  --argjson http "$http_by_code" \
+  --argjson http_total "${http_total:-0}" \
+  --argjson uptime "$uptime_s" \
+  '{ts: $ts, warden_uptime_s: $uptime, http_requests_total: $http_total,
+    http_by_code: $http, warden: $health}' >> "$OUT"

--- a/deploy/systemd/demo-stats.timer
+++ b/deploy/systemd/demo-stats.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Sample the netcanon demo traffic counters every 5 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/docs/DEMO_WHITEPAPER.md
+++ b/docs/DEMO_WHITEPAPER.md
@@ -107,6 +107,14 @@ status codes), our host provider's infrastructure-level traffic metadata, and
 whatever a TLS-terminating proxy inherently sees **in memory while streaming**
 your request. Two more things, stated outright:
 
+- **Aggregate traffic counters, sampled to disk.** The operational metadata above
+  lives in RAM and dies with the process, so a sampler writes it to a host file
+  every 5 minutes: session/destroy/refusal totals from the warden, and Caddy
+  request counts grouped by HTTP status. Totals only — **no client IP, no path,
+  no user-agent, no referrer, no per-session row**. Nothing in it can be traced
+  to a visitor, and the per-IP records behind the concurrency cap stay in memory
+  and are never sampled. This is how we tell whether the instance cap is set
+  correctly; it is not analytics and there is no visitor dimension to analyse.
 - **A warden-set routing cookie.** netcanon's UI uses absolute URLs
   (`fetch('/api/v1/migration/plan')`, `href="/migrate"`) and has no root-path
   support, so the warden routes you to your one instance **by session, not by

--- a/frontend/whitepaper.html
+++ b/frontend/whitepaper.html
@@ -157,6 +157,10 @@ mark.ph {
 <h2 id="what-we-do-see">What we do see</h2>
 <p>Honesty section — required. We (the operator) can observe: standard host operational metadata (session count, lifecycle timestamps, destroy reasons, status codes), our host provider's infrastructure-level traffic metadata, and whatever a TLS-terminating proxy inherently sees <strong>in memory while streaming</strong> your request. Two more things, stated outright:</p>
 <ul>
+<li><strong>Aggregate traffic counters, sampled to disk.</strong> The operational metadata above</li>
+</ul>
+<p>lives in RAM and dies with the process, so a sampler writes it to a host file every 5 minutes: session/destroy/refusal totals from the warden, and Caddy request counts grouped by HTTP status. Totals only — <strong>no client IP, no path, no user-agent, no referrer, no per-session row</strong>. Nothing in it can be traced to a visitor, and the per-IP records behind the concurrency cap stay in memory and are never sampled. This is how we tell whether the instance cap is set correctly; it is not analytics and there is no visitor dimension to analyse.</p>
+<ul>
 <li><strong>A warden-set routing cookie.</strong> netcanon's UI uses absolute URLs</li>
 </ul>
 <p>(<code>fetch('/api/v1/migration/plan')</code>, <code>href="/migrate"</code>) and has no root-path support, so the warden routes you to your one instance <strong>by session, not by path</strong>. To do that it sets a single cookie — <code>Set-Cookie: nc_route=&lt;token&gt;; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=900</code> — carrying only the opaque session token. That token is a <strong>bearer credential valid for the life of the session</strong> (not single-use), which is exactly why the cookie is HttpOnly, Secure, and SameSite=Strict — JS cannot read or forge it. It is not an analytics identifier and it dies with your session. Because the cookie is browser-global, a browser holds <strong>exactly one live session</strong> (a fresh mint replaces the previous one); the <strong>≤ 2-concurrent-sessions-per-IP</strong> cap is a separate guardrail bounding distinct devices behind one IP. The demo page itself still sets nothing (claim 10).</p>

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -283,6 +283,43 @@ def test_frontend_targets_the_real_warden_endpoints():
     assert "/i/" in text and "/migrate" in text
 
 
+def test_cloud_init_installs_every_systemd_unit_in_the_repo():
+    """`deploy/systemd/` is installed by an explicit, hand-maintained list in
+    cloud-init — the same shape as the Dockerfile COPY list, and it rots the same
+    way. A unit added to the repo but not to cloud-init simply never runs on the
+    host, silently."""
+    cloud_init = read("deploy/cloud-init.yaml")
+    on_disk = {path.name for path in (REPO_ROOT / "deploy" / "systemd").iterdir()}
+    assert on_disk, "found no systemd units — the glob has rotted"
+    missing = {name for name in on_disk if name not in cloud_init}
+    assert not missing, (
+        f"deploy/systemd units never installed by cloud-init: {sorted(missing)}"
+    )
+
+
+def test_the_traffic_sampler_records_no_visitor_dimension():
+    """The sampler is the one thing on this host that persists anything at all,
+    so what it may collect is pinned rather than trusted to review. The whitepaper
+    promises totals only; these are the fields that would break that promise."""
+    # Strip comments first: the script's own comment promises "no user-agent, no
+    # referrer", and a raw substring check reads that promise as a violation —
+    # the same trap the claim-10 frontend guard hit.
+    script = "\n".join(
+        line.split("#", 1)[0]
+        for line in read("deploy/systemd/demo-stats.sh").splitlines()
+    )
+    forbidden = (
+        "remote_ip", "X-Forwarded-For", "x-forwarded-for", "client_ip",
+        "user-agent", "User-Agent", "referer", "Referer", "_per_ip",
+    )
+    for field in forbidden:
+        assert field not in script, (
+            f"demo-stats.sh references {field!r} — the whitepaper says the sampler "
+            "records no visitor dimension"
+        )
+    assert "healthz" in script, "the sampler no longer reads the aggregate counters"
+
+
 def test_dockerfile_copies_every_warden_module():
     """The Dockerfile names the warden's modules explicitly, so a new one imports
     fine from the repo — green suite — and ImportErrors inside the container.


### PR DESCRIPTION
You had no answer to "how much traffic did this get", and that was structural rather than an oversight:

| source | state |
|---|---|
| Caddy access log | discarded (claim 4) |
| instance logs | driver `none` |
| warden log | **0 lines** written in the container's entire life |
| journald | volatile, RAM only |
| `/healthz` | the only signal — in-RAM, zeroed by every restart including every deploy |

Two additions, both aggregate-only so claim 4 is untouched.

**Caddy per-request metrics**, which were off. Verified on the host that the labels are `{handler,server}` and `{code,handler,method,server}` — **no client IP, path, user-agent or referrer**. The admin endpoint stays bound inside the container and unpublished.

**A `demo-stats` timer** sampling both to `/var/log/demo-stats.jsonl` every 5 minutes — warden lifecycle totals plus request counts by status:

```json
{"ts":"2026-07-27T00:53:59Z","warden_uptime_s":4022,"http_requests_total":8,
 "http_by_code":{"200":7,"404":1},"warden":{"pool":4,"active":0,...}}
```

Disclosed in the whitepaper's *What we do see*. That section already covered **observing** this metadata but not **retaining** it, and retention is what's new.

## Three defects, all found by running it

**Status codes aren't where I assumed.** `caddy_http_requests_total` carries only `{handler,server}`; codes live on the duration histogram's `_count` series. The first parser assumed otherwise, and its `sed` passed non-matching lines through unchanged — producing garbage that crashed `jq`. Now matches the label by name and validates every fragment before `--argjson`, so a changed upstream shape degrades to `{}` rather than writing a malformed row.

**`set -euo pipefail` defeated the degradation path entirely.** A failed `curl` aborted the script, so an outage left a **gap** — indistinguishable from the timer not firing. Now records `warden: null`:

```
outage    exit=0  lines 2 -> 3   warden: None  http_requests_total: 0  http_by_code: {}
recovery  warden: PRESENT        http_requests_total: 1   <- Caddy restart reset the counter
```

"The demo was down at this timestamp" is now a data point.

**My first degradation test reported a false pass** — exit 0 and healthy numbers, because `docker stop` hadn't taken effect before the sample ran. Re-tested controlled: exit 7, no line written. That's what exposed the bug above. Worth noting because a monitoring script that reports healthy during an outage is worse than none.

## Guards

- every unit in `deploy/systemd/` must be installed by cloud-init — same explicit-list rot as the Dockerfile `COPY` that shipped a crash-looping warden
- the sampler must reference no visitor-identifying field. **This one strips comments first**: the script's own comment promises "no user-agent, no referrer", and a raw substring check read that promise as a violation — the identical trap the claim-10 frontend guard hit

## Still worth knowing

⚠️ **`503_count` is not a capacity signal.** It increments for per-IP rate limits (429), true saturation (503), *and* instance-create failures. Only the middle one means "the box is too small" — it currently reads 33 on a box that has never been near capacity. Documented in the README; splitting it needs warden line budget and is left as open work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)