### PR TITLE
ci(msi): pre-publish gate — verify the asset GitHub stored before freezing it

### DIFF
--- a/.github/workflows/desktop-msi-publish.yml
+++ b/.github/workflows/desktop-msi-publish.yml
@@ -277,21 +277,36 @@ jobs:
       - name: Sanity-check MSI exists + reasonable size
         shell: bash
         run: |
-          msi=$(ls dist/*.msi 2>/dev/null | head -1)
-          if [ -z "$msi" ]; then
-            echo "FAIL: no MSI produced under dist/"
+          set -euo pipefail
+          # EXACTLY one MSI, not "at least one": the attach step below globs
+          # `dist/*.msi`, so a second MSI would be uploaded too and then frozen
+          # by publication.  The old `ls | head -1` inspected one file while a
+          # different set shipped.
+          shopt -s nullglob
+          msis=(dist/*.msi)
+          if [ "${#msis[@]}" -ne 1 ]; then
+            echo "::error::expected exactly 1 MSI under dist/, found ${#msis[@]} — refusing to build a release from an ambiguous artefact set."
             ls -la dist/ || true
             exit 1
           fi
+          msi="${msis[0]}"
           # PySide6 + Chromium WebEngine + Python interpreter should
           # produce ~200-300 MB.  Anything under 50 MB suggests
           # cx_Freeze silently dropped a major package.
           size=$(stat -c%s "$msi" 2>/dev/null || wc -c <"$msi")
-          printf "MSI: %s\nSize: %s bytes\n" "$msi" "$size"
+          sha=$(sha256sum "$msi" | cut -d' ' -f1)
+          printf "MSI: %s\nSize: %s bytes\nSHA256: %s\n" "$msi" "$size" "$sha"
           if [ "$size" -lt 52428800 ]; then
             echo "FAIL: MSI suspiciously small ($size < 50MB).  cx_Freeze probably skipped a critical package."
             exit 1
           fi
+          # Carried to the pre-publish gate so it compares GitHub's stored copy
+          # against what this job actually built, not against a re-read of disk.
+          {
+            echo "MSI_NAME=$(basename "$msi")"
+            echo "MSI_SIZE=$size"
+            echo "MSI_SHA256=$sha"
+          } >> "$GITHUB_ENV"
 
       - name: Upload MSI as workflow artefact
         # Diagnostic copy — survives 30 days regardless of whether the
@@ -338,8 +353,60 @@ jobs:
           # / `-dev1` tag take the "Latest release" slot (P3).
           prerelease: ${{ contains(env.RELEASE_TAG, '-') }}
 
-      # Publish only after the MSI is attached. `--draft=false` does not touch
-      # the prerelease flag or the generated notes set above.
+      # The draft is the LAST moment these assets can be changed.  Everything
+      # checked so far was checked against the local `dist/` copy — not against
+      # what GitHub actually stored.  Download the release's own copy back and
+      # compare it byte-for-byte with what this job built, so a truncated or
+      # mangled upload is caught while it is still fixable.
+      #
+      # This is the MSI analogue of demo-publish.yml's "re-verify the assets
+      # GitHub stored" gate.  There is no signed SHA256SUMS manifest here, so
+      # the comparison is against MSI_SHA256 recorded at build time instead.
+      - name: Gate — re-verify the asset GitHub stored, before freezing it
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.RELEASE_TAG }}
+          # One MSI and nothing else.  A backfill re-run against a tag whose
+          # draft already carries a stale MSI would otherwise publish both, and
+          # under immutable releases that pairing is permanent.
+          EXPECTED_ASSETS: "1"
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `gh --jq` uses gh's own embedded jq, so this needs no jq on PATH
+          # (the Windows runner's toolchain is not guaranteed to carry one).
+          summary="$(gh release view "$TAG" --json isDraft,assets \
+            --jq '"isDraft=\(.isDraft) assets=\(.assets|length)"')"
+          names="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+          found="$(gh release view "$TAG" --json assets --jq '.assets | length')"
+          printf 'release %s %s\n%s\n' "$TAG" "$summary" "$(printf '%s\n' "$names" | sed 's/^/  /')"
+          if [ "$found" -ne "$EXPECTED_ASSETS" ]; then
+            echo "::error::release has $found assets, expected $EXPECTED_ASSETS — refusing to publish an incomplete or polluted release."
+            exit 1
+          fi
+          if [ "$names" != "$MSI_NAME" ]; then
+            echo "::error::attached asset is '$names', expected '$MSI_NAME'."
+            exit 1
+          fi
+          rm -rf roundtrip && mkdir roundtrip
+          gh release download "$TAG" --dir roundtrip --clobber
+          got="roundtrip/$MSI_NAME"
+          got_size=$(stat -c%s "$got" 2>/dev/null || wc -c <"$got")
+          got_sha=$(sha256sum "$got" | cut -d' ' -f1)
+          if [ "$got_size" != "$MSI_SIZE" ] || [ "$got_sha" != "$MSI_SHA256" ]; then
+            echo "::error::stored asset does not match what was built."
+            echo "  built:  $MSI_SIZE bytes  $MSI_SHA256"
+            echo "  stored: $got_size bytes  $got_sha"
+            exit 1
+          fi
+          echo "OK: what GitHub stored is byte-identical to the MSI this job built ($got_sha)."
+
+      # Publish only after the MSI is attached AND verified in place.  Under
+      # immutable releases this transition is what freezes the asset, and it is
+      # the last thing the workflow does, so a failure anywhere above leaves an
+      # unpublished draft rather than a permanently wrong public release.
+      # `--draft=false` does not touch the prerelease flag or the generated
+      # notes set above.
       - name: Publish the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/demo/test_demo_tag_namespace.py
+++ b/tests/demo/test_demo_tag_namespace.py
@@ -238,6 +238,45 @@ def test_releases_are_built_as_a_draft_then_published(wf):
     )
 
 
+@pytest.mark.parametrize("wf", ["demo-publish.yml", "desktop-msi-publish.yml"])
+def test_a_gate_runs_between_attaching_assets_and_publishing(wf):
+    """Publishing is the irreversible step: under immutable releases it freezes
+    the assets, so a release that ships wrong can only be superseded by a new
+    tag. The draft window is therefore the last point at which anything can be
+    checked, and every check up to the attach ran against a LOCAL copy — not
+    against what GitHub actually stored.
+
+    Both workflows close that with a gate that reads the assets back off the
+    release. This pins the ORDER, which is the part that carries the guarantee:
+    attach → verify → publish. A gate that ran after publication would be a
+    report, not a gate.
+    """
+    data = yaml.safe_load((WORKFLOWS / wf).read_text(encoding="utf-8"))
+    steps = [s for job in data["jobs"].values() for s in (job.get("steps") or [])]
+
+    attach = next(
+        i for i, s in enumerate(steps) if "action-gh-release" in str(s.get("uses", ""))
+    )
+    publish = next(
+        i for i, s in enumerate(steps) if "--draft=false" in str(s.get("run", ""))
+    )
+    assert attach < publish, f"{wf} publishes before attaching assets"
+
+    between = steps[attach + 1 : publish]
+    gates = [
+        s
+        for s in between
+        if "gh release download" in str(s.get("run", ""))
+        or "gh release view" in str(s.get("run", ""))
+    ]
+    assert gates, (
+        f"{wf} goes from attaching assets straight to publishing with nothing "
+        "reading them back off the release. Every earlier check inspected the "
+        "local copy, so a truncated or polluted upload would be frozen by "
+        "publication with no way to correct it."
+    )
+
+
 def test_demo_publish_declares_least_privilege_at_workflow_level():
     data = workflow("demo-publish.yml")
     assert data["permissions"] == {"contents": "read"}

--- a/tests/demo/test_msi_publish_gate.py
+++ b/tests/demo/test_msi_publish_gate.py
@@ -1,0 +1,168 @@
+"""Execute `desktop-msi-publish.yml`'s pre-publish gate, rather than reading it.
+
+The MSI workflow only ever runs on a `v*.*.*` tag push, so PR CI never
+exercises a single line of it. Every defect this repo has shipped in a publish
+path shared one shape: a check scoped to a source file instead of the artefact
+that actually ships. Asserting "the gate step exists" would repeat that mistake
+at one remove — it proves the YAML has a step, not that the step works.
+
+So these tests pull the gate's `run:` block straight out of the parsed workflow
+and run it under bash against a stubbed `gh`. The script takes all of its input
+from `env:` and contains no `${{ }}` expansion (there is a test below pinning
+that), which is what makes running it verbatim possible: what executes here is
+byte-identical to what executes on the runner.
+
+Under immutable releases the publish step freezes the asset permanently, so the
+failure this gate has to catch — GitHub storing something other than what was
+built — is not recoverable after the fact. It has to be caught in the draft
+window or not at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github/workflows/desktop-msi-publish.yml"
+
+GATE_STEP = "Gate — re-verify the asset GitHub stored, before freezing it"
+MSI_NAME = "netcanon-9.9.9-win64.msi"
+BUILT = b"pretend this is 250 MB of cx_Freeze output"
+
+# The stub stands in for `gh`, dispatching on the argument shapes the gate uses.
+# `release download` writes into the `roundtrip/` dir the gate itself created.
+GH_STUB = """#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"release download"*)   printf '%s' "$STUB_BODY" > "roundtrip/$STUB_STORED_NAME" ;;
+  *".assets[].name"*)     printf '%s\\n' "$STUB_NAMES" ;;
+  *".assets | length"*)   printf '%s\\n' "$STUB_COUNT" ;;
+  *)                      printf 'isDraft=true assets=%s\\n' "$STUB_COUNT" ;;
+esac
+"""
+
+
+def find_bash() -> str | None:
+    """A bash that can actually run the gate.
+
+    `shutil.which("bash")` on Windows finds `System32\\bash.exe` — the WSL shim,
+    which fails with `execvpe(/bin/bash)` when no distro is installed. Probing
+    for the coreutils the gate uses is the only reliable test, and it doubles as
+    a check that `sha256sum`/`stat` exist (the runner's git-bash has them; the
+    workflow already relies on that).
+    """
+    candidates = [shutil.which("bash"), r"C:\Program Files\Git\bin\bash.exe"]
+    for cand in candidates:
+        if not cand or not Path(cand).exists():
+            continue
+        try:
+            probe = subprocess.run(
+                [cand, "-c", "command -v sha256sum >/dev/null && printf ok"],
+                capture_output=True, text=True, timeout=30,
+            )
+        except OSError:
+            continue
+        if probe.stdout.strip() == "ok":
+            return cand
+    return None
+
+
+BASH = find_bash()
+
+
+def gate_script() -> str:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = data["jobs"]["build-msi"]["steps"]
+    matching = [s for s in steps if s.get("name") == GATE_STEP]
+    assert matching, (
+        f"no step named {GATE_STEP!r} in desktop-msi-publish.yml — if it was "
+        "renamed, update GATE_STEP so these tests keep exercising the real gate"
+    )
+    return matching[0]["run"]
+
+
+def run_gate(tmp_path: Path, **stub) -> subprocess.CompletedProcess:
+    """Run the real gate script with a stubbed `gh` on PATH."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(GH_STUB, encoding="utf-8", newline="\n")
+    gh.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "GH_TOKEN": "stub",
+        "TAG": "v9.9.9",
+        "EXPECTED_ASSETS": "1",
+        # What the build step recorded into $GITHUB_ENV.
+        "MSI_NAME": MSI_NAME,
+        "MSI_SIZE": str(len(BUILT)),
+        "MSI_SHA256": hashlib.sha256(BUILT).hexdigest(),
+        # Stub knobs — what GitHub is pretending to hold.
+        "STUB_NAMES": stub.get("names", MSI_NAME),
+        "STUB_STORED_NAME": stub.get("stored_name", MSI_NAME),
+        "STUB_COUNT": stub.get("count", "1"),
+        "STUB_BODY": stub.get("body", BUILT).decode("latin-1"),
+    }
+    return subprocess.run(
+        [BASH, "-c", gate_script()],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+pytestmark = [
+    pytestmark,
+    pytest.mark.skipif(BASH is None, reason="needs a bash with coreutils"),
+]
+
+
+def test_gate_passes_when_github_stored_what_was_built(tmp_path):
+    r = run_gate(tmp_path)
+    assert r.returncode == 0, f"gate rejected a good release:\n{r.stdout}\n{r.stderr}"
+    assert "byte-identical" in r.stdout
+
+
+def test_gate_refuses_a_corrupted_upload(tmp_path):
+    """The failure the gate exists for: the upload truncated or mangled, so what
+    users would download is not what was built and tested."""
+    r = run_gate(tmp_path, body=BUILT + b"tail garbage")
+    assert r.returncode != 0
+    assert "does not match what was built" in r.stdout
+
+
+def test_gate_refuses_an_extra_asset(tmp_path):
+    """A backfill re-run against a draft that already carries a stale MSI would
+    otherwise publish both, and under immutability that pairing is permanent."""
+    r = run_gate(tmp_path, count="2")
+    assert r.returncode != 0
+    assert "expected 1" in r.stdout
+
+
+def test_gate_refuses_an_asset_under_the_wrong_name(tmp_path):
+    r = run_gate(tmp_path, names="netcanon-0.0.1-win64.msi")
+    assert r.returncode != 0
+    assert "attached asset is" in r.stdout
+
+
+def test_gate_script_is_self_contained(tmp_path):
+    """The gate takes every input from `env:`. A `${{ }}` expression in the
+    `run:` block would be substituted by the runner before bash ever sees it,
+    which would make the tests above exercise a different script than ships."""
+    assert not re.search(r"\$\{\{.*?\}\}", gate_script()), (
+        "the gate's run: block gained a ${{ }} expression — move it into env: "
+        "so what these tests execute stays identical to what the runner executes"
+    )


### PR DESCRIPTION
## Why

`desktop-msi-publish.yml` was the only release path left without a pre-publish gate. It creates releases under the same immutability rules `demo-publish.yml` operates under, where publication **freezes the assets permanently** — a release that ships wrong can only be superseded by a new tag, never corrected. Its draft → publish shape was already correct; what was missing was anything checking *what was in the draft*.

Every check it had ran against the local `dist/` copy. Nothing confirmed that what GitHub actually stored matched what the job built — the same shape as four defects already shipped in this tree: **a check scoped to a source file rather than the artefact that ships.**

## What

Between the draft attach and the publish:

- **Asset-set check** — exactly `EXPECTED_ASSETS` (1), under the expected name. A `workflow_dispatch` backfill re-run against a draft still holding a stale MSI would otherwise publish both, and under immutability that pairing is permanent.
- **Byte-identity check** — the asset is downloaded back off the release and compared against the SHA256 recorded at build time. There is no signed `SHA256SUMS` manifest here as there is for the demo bundle, so the build-time hash is the reference.

Also tightens the build-side sanity check from "at least one MSI" to **exactly one**: the attach step globs `dist/*.msi`, so a second MSI would ship, while the old `ls | head -1` inspected only the first.

Uses `gh --jq` (gh's embedded jq) rather than a `jq` binary — the Windows runner's toolchain doesn't guarantee one.

## How it's tested

This workflow only runs on a `v*.*.*` tag, so **PR CI never executes a line of it**. Asserting "the gate step exists" would repeat the very mistake being fixed, so `tests/demo/test_msi_publish_gate.py` pulls the gate's `run:` block out of the parsed workflow and **executes it** under bash against a stubbed `gh`. The script draws every input from `env:` and contains no `${{ }}` expansion — pinned by its own test — which is what makes running it verbatim sound: what the test executes is byte-identical to what the runner executes.

Each assertion is mutation-tested; disabling it fails exactly its own case:

| mutant | test killed |
|---|---|
| drop sha/size compare | `test_gate_refuses_a_corrupted_upload` |
| drop asset-count check | `test_gate_refuses_an_extra_asset` |
| drop name check | `test_gate_refuses_an_asset_under_the_wrong_name` |

`test_a_gate_runs_between_attaching_assets_and_publishing` pins the ordering for **both** release workflows — a gate that ran after publication would be a report, not a gate. Verified to fail when the new step is deleted.

`tests/demo` 270 passed, ruff clean.

## Not in scope

Publishing a checksum *asset* alongside the MSI so downloaders can verify independently. That changes what the release contains and is a separate call — this PR only gates what already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
