### PR TITLE
feat(demo): split the warden's refusal counter by cause

### DIFF
--- a/demo/warden/app.py
+++ b/demo/warden/app.py
@@ -45,7 +45,7 @@ _counters = {
     "sessions_started": 0,
     "destroys_by_reason": dict.fromkeys(("hard-ttl", "idle", "hb", "end", "reclaim"), 0),
     "pool_recycled": 0,
-    "503_count": 0,
+    "refusals_by_reason": dict.fromkeys(("rate_limited", "capacity", "create_failed"), 0),
     "pool_refill_failures": 0,
 }
 _bg_tasks: set[asyncio.Task] = set()
@@ -202,9 +202,7 @@ async def _destroy(token: str, reason: str) -> None:
         if rec and rec.active > 0:
             rec.active -= 1
     await asyncio.to_thread(_docker_remove, sess.instance.container_id)
-    _counters["destroys_by_reason"][reason] = (
-        _counters["destroys_by_reason"].get(reason, 0) + 1
-    )
+    _counters["destroys_by_reason"][reason] = _counters["destroys_by_reason"].get(reason, 0) + 1
     log.info("session_destroyed reason=%s", reason)
 
 
@@ -376,7 +374,7 @@ async def session_new(request: Request) -> Response:
         rec.last_seen = now
         rec.mints = [t for t in rec.mints if now - t < C.PER_IP_MINT_WINDOW]
         if len(rec.mints) >= C.PER_IP_MINT_MAX or rec.active >= C.PER_IP_MAX_CONCURRENT:
-            _counters["503_count"] += 1
+            _counters["refusals_by_reason"]["rate_limited"] += 1
             return JSONResponse({"reason": "rate_limited"}, status_code=429)
         # Cap-check the POOL-HIT path too: a refill can land between another
         # mint's room check and this pop, so a warm instance != a free slot.
@@ -394,7 +392,7 @@ async def session_new(request: Request) -> Response:
                 _reserving += 1
         if not headroom:  # true saturation: reclaim the longest-idle session
             if await _reclaim_one(now) is None:
-                _counters["503_count"] += 1
+                _counters["refusals_by_reason"]["capacity"] += 1
                 return JSONResponse({"reason": "capacity"}, status_code=503)
             async with _lock:
                 _reserving += 1
@@ -404,7 +402,9 @@ async def session_new(request: Request) -> Response:
             async with _lock:
                 _reserving -= 1
             log.warning("inline instance create failed: %s", exc)
-            _counters["503_count"] += 1
+            # Separate from real saturation: this means Docker or the image is
+            # broken, not that the box is too small. Wire reason stays "capacity".
+            _counters["refusals_by_reason"]["create_failed"] += 1
             return JSONResponse({"reason": "capacity"}, status_code=503)
     token = secrets.token_urlsafe(C.TOKEN_NBYTES)
     async with _lock:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -155,8 +155,11 @@ without sampling there is no answer to "how much traffic did this get". A
 # last sample
 tail -1 /var/log/demo-stats.jsonl | jq .
 
-# sessions and refusals over the file
-jq -r '[.ts, (.warden.sessions_started//0), (.warden."503_count"//0)] | @tsv' /var/log/demo-stats.jsonl
+# sessions and refusals over the file, refusals broken out by cause
+jq -r '[.ts, (.warden.sessions_started//0),
+        (.warden.refusals_by_reason.rate_limited//0),
+        (.warden.refusals_by_reason.capacity//0),
+        (.warden.refusals_by_reason.create_failed//0)] | @tsv' /var/log/demo-stats.jsonl
 
 # requests by status code
 jq -r '[.ts, .http_requests_total, (.http_by_code|tostring)] | @tsv' /var/log/demo-stats.jsonl
@@ -170,9 +173,14 @@ Two things to know when reading it:
 - **`warden: null` means the demo was unreachable** at that timestamp. That is a
   recorded outage, deliberately distinct from a missing sample (timer not run).
 
-⚠️ **`503_count` is not a capacity signal.** It increments for per-IP rate limits
-(429), true saturation (503), *and* instance-create failures. Only the second
-means "the box is too small". Splitting it is open work.
+- **Refusals are split by cause**, because the three mean different things:
+  `rate_limited` is one visitor being greedy (a **429**, not a 503 at all),
+  `capacity` is genuine saturation — the only one that means "the box is too
+  small" — and `create_failed` is Docker or the pinned image being broken. A
+  create failure still answers `capacity` on the wire, so read the counter, not
+  the status code, when deciding whether to resize. (These replaced a single
+  `503_count` that summed all three; samples written before 2026-07-27 carry
+  the old key and cannot be broken down.)
 
 ## DDoS / abuse posture
 

--- a/docs/demo-plan/03-warden-spec.md
+++ b/docs/demo-plan/03-warden-spec.md
@@ -334,7 +334,10 @@ per-session or per-visitor detail:
 - `sessions_started`
 - `destroys_by_reason` (`hard-ttl` / `idle` / `hb` / `end` / `reclaim`)
 - `pool_recycled` (unassigned instances recycled at ~290 s, `POOL_MAX_AGE − reaper_period`)
-- `503_count`
+- `refusals_by_reason` (`rate_limited` — a 429 / `capacity` — true saturation /
+  `create_failed` — Docker or the image is broken). Split by cause because only
+  `capacity` means the box is undersized; a create failure still reports
+  `capacity` on the wire, so the counter is the authority, not the status code.
 - `pool_refill_failures`
 
 These back an external uptime monitor and a synthetic

--- a/tests/demo/conftest.py
+++ b/tests/demo/conftest.py
@@ -347,7 +347,9 @@ def warden(monkeypatch) -> Warden:
             ("hard-ttl", "idle", "hb", "end", "reclaim"), 0
         ),
         "pool_recycled": 0,
-        "503_count": 0,
+        "refusals_by_reason": dict.fromkeys(
+            ("rate_limited", "capacity", "create_failed"), 0
+        ),
         "pool_refill_failures": 0,
     })
 

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -200,6 +200,41 @@ def test_backstop_cannot_fire_before_a_live_session_deadline():
     )
 
 
+@pytest.mark.parametrize(
+    "doc", ("docs/demo-plan/03-warden-spec.md", "deploy/README.md")
+)
+def test_every_refusal_reason_is_documented(doc):
+    """`/healthz` splits refusals by cause, and an operator reads those numbers
+    to decide whether the box needs resizing. A reason that exists in the code
+    but in no document is a number nobody can interpret.
+
+    This is the exact drift that already happened here: deploy/README.md carried
+    a caveat calling the split "open work" after it had shipped. Adding a fourth
+    reason without saying what it means now fails instead.
+    """
+    import ast
+
+    src = (REPO_ROOT / "demo/warden/app.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    # Read the reasons out of the `_counters` literal rather than importing the
+    # module: app.py imports the docker SDK, which CI deliberately does not have.
+    reasons: list[str] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and ast.unparse(node.func) == "dict.fromkeys"):
+            continue
+        names = {n.value for n in ast.walk(node.args[0]) if isinstance(n, ast.Constant)}
+        if "rate_limited" in names:
+            reasons = sorted(names)
+    assert reasons, "could not find the refusals_by_reason literal in app.py"
+
+    text = (REPO_ROOT / doc).read_text(encoding="utf-8")
+    missing = [r for r in reasons if r not in text]
+    assert not missing, (
+        f"{doc} never mentions refusal reason(s) {missing} — an operator reading "
+        "these counters would have no way to know what they mean"
+    )
+
+
 def test_warden_stays_under_the_audited_line_count():
     """The whitepaper asks for trust on the grounds that the warden is small
     enough to read end to end (<=500 lines). Keep that claim true."""

--- a/tests/demo/test_warden_caps.py
+++ b/tests/demo/test_warden_caps.py
@@ -131,7 +131,7 @@ async def test_empty_pool_below_the_cap_creates_inline_instead_of_refusing(warde
     assert warden.counters["destroys_by_reason"]["reclaim"] == 0, (
         "no live session may be sacrificed while slots are free"
     )
-    assert warden.counters["503_count"] == 0
+    assert sum(warden.counters["refusals_by_reason"].values()) == 0
 
 
 async def test_a_burst_larger_than_the_pool_is_fully_served(warden):
@@ -283,8 +283,71 @@ async def test_per_ip_table_is_capped_under_a_unique_ip_flood(warden, monkeypatc
 # ── Counters (the /healthz operational surface) ─────────────────────────────
 async def test_refusals_are_counted(warden):
     await saturate(warden)
-    before = warden.counters["503_count"]
+    before = sum(warden.counters["refusals_by_reason"].values())
 
     await warden.mint(ip="198.51.100.220")
 
-    assert warden.counters["503_count"] == before + 1
+    assert sum(warden.counters["refusals_by_reason"].values()) == before + 1
+
+
+# The three refusals below mean completely different things to an operator:
+# rate_limited is one visitor being greedy, capacity is the box being too small,
+# create_failed is Docker or the image being broken. The old single `503_count`
+# summed all three (and counted a 429 as a 503), so it could not answer the one
+# question it existed for — it read 33 on a box that had never been near its
+# cap. Each test asserts the OTHER buckets stay put; that isolation is the whole
+# point of the split, and a shared counter would pass the increment half alone.
+def _refusals(warden) -> dict:
+    return dict(warden.counters["refusals_by_reason"])
+
+
+async def test_a_rate_limited_visitor_is_counted_apart(warden):
+    """One IP over PER_IP_MAX_CONCURRENT. This is a 429, not a 503 at all."""
+    await warden.fill_pool()
+    for _ in range(C.PER_IP_MAX_CONCURRENT):
+        assert (await warden.mint(ip="198.51.100.7")).status_code == 200
+    before = _refusals(warden)
+
+    resp = await warden.mint(ip="198.51.100.7")
+
+    assert resp.status_code == 429, body_of(resp)
+    after = _refusals(warden)
+    assert after["rate_limited"] == before["rate_limited"] + 1
+    assert after["capacity"] == before["capacity"]
+    assert after["create_failed"] == before["create_failed"]
+
+
+async def test_a_capacity_refusal_is_counted_apart(warden):
+    """Genuine saturation: every slot taken and nothing reclaimable."""
+    await saturate(warden)
+    before = _refusals(warden)
+
+    resp = await warden.mint(ip="198.51.100.221")
+
+    assert resp.status_code == 503, body_of(resp)
+    after = _refusals(warden)
+    assert after["capacity"] == before["capacity"] + 1
+    assert after["rate_limited"] == before["rate_limited"]
+    assert after["create_failed"] == before["create_failed"]
+
+
+async def test_a_broken_docker_is_not_counted_as_capacity(warden):
+    """The refusal the old counter hid: plenty of headroom, but the create
+    fails. Reported as `capacity` on the wire (the frontend keys its states on
+    that, and "try again shortly" is right either way) while the counter says
+    `create_failed` — otherwise a broken image reads as "buy a bigger box"."""
+    warden.docker.create_fails = True
+    assert not warden.pool, "the create path is only reached with an empty pool"
+    before = _refusals(warden)
+
+    resp = await warden.mint(ip="198.51.100.222")
+
+    assert resp.status_code == 503, body_of(resp)
+    assert body_of(resp)["reason"] == "capacity", "wire contract must not move"
+    after = _refusals(warden)
+    assert after["create_failed"] == before["create_failed"] + 1, (
+        "a create failure must not be filed under capacity — that is the "
+        "conflation the split exists to remove"
+    )
+    assert after["capacity"] == before["capacity"]
+    assert after["rate_limited"] == before["rate_limited"]


### PR DESCRIPTION
## Why

`503_count` summed three unrelated events — and counted a 429 as a 503 — so it could not answer the one question it existed for. The **live demo** right now reads:

```
sessions_started: 11    503_count: 33    active: 0    pool: 4
```

33 refusals on a box that has never been near its cap, with no way to tell whether that is abuse, saturation, or a broken image.

## What

Replaced with `refusals_by_reason`, mirroring the `destroys_by_reason` counter already there:

| reason | meaning | wire |
|---|---|---|
| `rate_limited` | one visitor over the per-IP cap | **429** — not a 503 at all |
| `capacity` | genuine saturation — the only "box too small" signal | 503 |
| `create_failed` | Docker or the pinned image is broken | 503 |

**The wire contract does not move.** A create failure still answers `capacity`, because the frontend's 5-state machine is keyed on that reason and "try again shortly" is the honest advice either way. The counter, not the status code, is the authority when deciding whether to resize — the README says this explicitly.

## On the line budget

`app.py` stays at **499**. The swap was line-neutral on its own (a dict-valued counter replaces the scalar 1-for-1); the added comment was paid for by collapsing the sibling `destroys_by_reason` increment, which had been wrapped across three lines for a limit that is actually 120. The `<=500` claim is not relaxed — the guard's own message says to simplify rather than raise it, so that is what happened.

## Tests

Each reason is mutation-tested; filing a refusal under the wrong bucket fails exactly its own test:

| mutant | test killed |
|---|---|
| `rate_limited` filed as `capacity` | `test_a_rate_limited_visitor_is_counted_apart` |
| `capacity` filed as `create_failed` | `test_a_capacity_refusal_is_counted_apart` |
| `create_failed` filed as `capacity` *(the old conflation)* | `test_a_broken_docker_is_not_counted_as_capacity` |

Each test also asserts the *other* buckets stay put — that isolation is the point, and a shared counter would pass the increment half on its own.

`test_every_refusal_reason_is_documented` parses the reasons out of `app.py`'s AST (CI has no docker SDK, so the module cannot be imported) and fails if one is missing from the warden spec or the deploy README. That drift is not hypothetical: the README caveat calling this split "open work" is what this PR had to correct. Verified to fail when a fourth undocumented reason is added.

Verified the real `/healthz` JSON rather than assuming the shape, so the README's new `jq` path is known-correct:

```json
"refusals_by_reason": {"rate_limited": 0, "capacity": 0, "create_failed": 0}
```

`tests/demo` 273 passed, ruff clean.

## Note

Samples written before today carry the old `503_count` key and cannot be broken down. The README states that rather than leaving a silent discontinuity in the series. This reaches the live demo only when a `demo-v*` tag is next cut and deployed — nothing auto-deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
