### PR TITLE
ci: lint the demo warden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,21 @@ jobs:
           pip install "ruff>=0.15,<0.16"
 
       - name: Run ruff
-        # Scope: the shipping package, the desktop shell, the dev tools, and
-        # the tests -- all driven lint-clean (netcanon/ + tests/ in the v0.2.0
-        # Stage-1 baseline; tools/ + netcanon_desktop/ added afterward).
+        # Scope: the shipping package, the desktop shell, the dev tools, the
+        # tests, and the demo warden -- all driven lint-clean (netcanon/ +
+        # tests/ in the v0.2.0 Stage-1 baseline; tools/ + netcanon_desktop/
+        # added afterward; demo/ added once the warden shipped).
+        #
+        # demo/ is here because it is the demo's TRUSTED COMPUTING BASE -- the
+        # session manager and the authz shim that stand between a visitor and
+        # the docker socket. It was lint-clean the whole time it was outside
+        # this list, which is precisely the problem: nothing was checking, so
+        # that was luck rather than a property. The warden is also the one file
+        # the whitepaper asks people to read end to end.
+        #
         # Config (rule set, ignores, line-length) lives in pyproject.toml
-        # [tool.ruff].
-        run: ruff check netcanon netcanon_desktop tools tests
+        # [tool.ruff]. Keep this list in sync with test_ci_lints_the_warden.
+        run: ruff check netcanon netcanon_desktop tools tests demo
 
   test:
     name: Tests (Python ${{ matrix.python-version }})

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -200,6 +200,25 @@ def test_backstop_cannot_fire_before_a_live_session_deadline():
     )
 
 
+def test_ci_lints_the_warden():
+    """`demo/` is the demo's trusted computing base — the session manager and the
+    authz shim standing between a visitor and the docker socket — and for its
+    whole life it sat outside CI's ruff scope. It happened to be clean, which is
+    luck, not a property. Pin the scope so narrowing it fails here.
+    """
+    data = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
+    steps = [s for job in data["jobs"].values() for s in (job.get("steps") or [])]
+    ruff = [s for s in steps if "ruff check" in str(s.get("run", ""))]
+    assert ruff, "ci.yml no longer runs `ruff check` at all"
+    for step in ruff:
+        # Compare tokens, not a substring: "demo" appears inside other words.
+        targets = str(step["run"]).split("ruff check", 1)[1].split()
+        assert "demo" in targets, (
+            f"ci.yml lints {targets} — `demo` is missing, so the warden (the TCB, "
+            "and the one file the whitepaper asks people to read) is unlinted"
+        )
+
+
 @pytest.mark.parametrize(
     "doc", ("docs/demo-plan/03-warden-spec.md", "deploy/README.md")
 )


### PR DESCRIPTION
`demo/` — the demo's **trusted computing base** (session manager + authz shim, the two things standing between a visitor and the docker socket) — was never in CI's ruff scope.

It was lint-clean the whole time it sat outside the gate, which is exactly the problem: nothing was checking, so that was luck rather than a property. Adding it required **no fixes**.

`test_ci_lints_the_warden` pins the scope by tokenising the ruff command (a substring check would match `demo` inside other words), verified to fail when `demo` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)