### PR TITLE
test(demo): make a load-sanity render shortfall diagnose itself

### DIFF
--- a/tests/demo/load_sanity.py
+++ b/tests/demo/load_sanity.py
@@ -199,11 +199,19 @@ def translate(base_url: str, token: str) -> dict:
     except httpx.HTTPError as exc:
         return {"ok": False, "error": str(exc)}
     payload = response.json() if response.status_code == 200 else {}
+    # `/plan` is SYNCHRONOUS — it returns the finished job, so a 200 with no
+    # `rendered` is a real failure, not a job still in flight. It also always
+    # answers 200 and carries the outcome in `status` (completed / partial /
+    # failed), which is why `job_status` and `error` are captured here: without
+    # them a shortfall in the summary is a bare count with its cause discarded,
+    # and the run that produced it is gone by the time anyone reads the number.
     return {
         "ok": response.status_code == 200,
         "status": response.status_code,
         "job_status": payload.get("status"),
         "renders": bool(payload.get("rendered")),
+        "error": (payload.get("error") or "")[:400] if response.status_code == 200
+                 else response.text[:400],
         "seconds": round(time.monotonic() - started, 3),
     }
 
@@ -385,6 +393,21 @@ def run(base_url: str, sessions: int, slo_seconds: int) -> dict:
     print(f"  translated={len(ok)}/{len(granted)} rendered_output={len(rendered)}")
     report["translations_ok"] = len(ok)
     report["translations_rendered"] = len(rendered)
+    # A session that minted but could not translate is a visitor who reached a
+    # broken demo, so a shortfall must not reduce to a count. A 31/32 was
+    # recorded once at saturation and could not be explained afterwards --
+    # nothing had kept the failing job's status or error. Keep them now, and say
+    # so loudly enough that the next occurrence arrives already diagnosed.
+    shortfall = [r for r in results if not r.get("renders")]
+    report["translations_failed"] = [
+        {k: r.get(k) for k in ("status", "job_status", "error", "seconds")}
+        for r in shortfall
+    ]
+    if shortfall:
+        print(f"  !!    {len(shortfall)}/{len(granted)} session(s) produced NO rendered output:")
+        for r in shortfall:
+            print(f"          http={r.get('status')} job={r.get('job_status')!r} "
+                  f"after {r.get('seconds')}s :: {r.get('error') or '(no error reported)'}")
     if granted and not ok:
         fail("no translation succeeded — RSS below reflects IDLE instances, "
              "so it is NOT a valid sizing basis")


### PR DESCRIPTION
## Why

A saturation run once recorded **31/32** sessions producing rendered output, and the cause could not be recovered afterwards. `translate()` captured *whether* a job rendered but threw away the job's `status` and `error`, and the summary printed a bare count. A session that mints but cannot translate is a visitor reaching a broken demo — that number has to arrive explained.

## What

`/api/v1/migration/plan` is **synchronous**: it returns the finished job and always answers 200, carrying the outcome in `status` (`completed` / `partial` / `failed`). So a 200 with no `rendered` is a real failure, not a job still in flight — worth stating because the async-job contract elsewhere in this repo makes the opposite assumption tempting.

`job_status` and `error` are now captured, and every session that produced no output is listed with its HTTP status, job status, elapsed time and error text.

## Did it reproduce?

**No.** Re-ran 34 sessions against the real deploy composition:

```
granted=32 refused=2 unexpected=0
OK  32 distinct containers, none shared
OK  2 capacity refusal(s), at genuine saturation
translated=32/32 rendered_output=32
ASSIGNED (worked) RSS median 72.6 MiB  ->  2465 MiB projected at MAX_ACTIVE=32
OK  no OOM-kill
```

So the 31/32 stays **unexplained rather than claimed fixed** — but it is now bounded: not reproducible on a 32-core host, consistent with the original being CPU starvation on the 4-vCPU class.

## Validating the new path

That clean run left the new code unexercised, so it was forced with an invalid target:

```
translated=0/2 rendered_output=0
!!    2/2 session(s) produced NO rendered output:
        http=422 job=None after 0.282s :: {"detail":"unknown target adapter: ...}
```

Previously that was `rendered_output=0` and nothing else.

## Incidental

The same run validated #411's counters live: `rate_limited 2, capacity 3, create_failed 0`, where the old counter would have shown an uninterpretable `503_count: 5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
