### PR TITLE
docs: point the front page at the live demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,5 +125,6 @@ LABEL org.opencontainers.image.title="Netcanon" \
       org.opencontainers.image.description="Multi-vendor network config translator with a verifiable cross-vendor audit" \
       org.opencontainers.image.source="https://github.com/netcanon/netcanon" \
       org.opencontainers.image.documentation="https://github.com/netcanon/netcanon/blob/main/README.md" \
+      org.opencontainers.image.url="https://demo.netcanon.net" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.vendor="Netcanon contributors"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/netcanon)](https://pypi.org/project/netcanon/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Container: GHCR](https://img.shields.io/badge/ghcr.io-netcanon%2Fnetcanon-2496ED?logo=docker&logoColor=white)](https://github.com/netcanon/netcanon/pkgs/container/netcanon)
+[![Live demo](https://img.shields.io/badge/live_demo-demo.netcanon.net-2ea44f)](https://demo.netcanon.net)
 
 **Multi-vendor network config translator with a verifiable cross-vendor audit.**
 
@@ -32,7 +33,36 @@ drops or transforms a field — before they ship.
 
 ---
 
-## See it in 10 seconds
+## Try it in your browser — nothing to install
+
+### **[demo.netcanon.net](https://demo.netcanon.net)**
+
+Paste a config, pick a target vendor, read the translation. It is the real
+application, not a video or a sandbox with the interesting parts removed.
+
+Because you are being asked to paste a network config into someone else's
+website, here is exactly what happens to it:
+
+- Every visitor gets their **own throwaway container**, destroyed when you close
+  the tab or after 15 minutes, whichever comes first.
+- Instances run with a **read-only root filesystem, tmpfs-only writes, and no
+  network egress at all** — the container that holds your config cannot reach
+  the internet.
+- **No access log, no analytics, no tracking cookies** (one session-routing
+  cookie, nothing else). The host has swap disabled and discards core dumps, so
+  your config cannot reach disk even indirectly.
+
+None of that is a promise you have to take on trust. The
+[demo whitepaper](docs/DEMO_WHITEPAPER.md) states each claim, and
+[`deploy/VERIFY.md`](deploy/VERIFY.md) gives you the commands to check them
+yourself — including a canary sweep of the entire host filesystem. The stack is
+built from this repo, pinned by digest, and cosign-signed, so you can rebuild
+the identical thing locally and audit it.
+
+> **Handling something sensitive?** Don't paste it. Run the container yourself —
+> it is one command, below, and it is the same image the demo runs.
+
+## See it in 10 seconds — locally
 
 ```bash
 docker run --rm --entrypoint netcanon ghcr.io/netcanon/netcanon:latest demo --pair cisco__junos
@@ -425,6 +455,12 @@ tests/fixtures/real/    Real-capture validation corpus (see RESULTS.md)
 
 ## See also
 
+* **[demo.netcanon.net](https://demo.netcanon.net)** — the live hosted demo;
+  no install, private throwaway instance per visitor
+* [`docs/DEMO_WHITEPAPER.md`](docs/DEMO_WHITEPAPER.md) — what the demo does with
+  your config, claim by claim
+* [`deploy/VERIFY.md`](deploy/VERIFY.md) — the commands to verify those claims
+  yourself
 * [`ARCHITECTURE.md`](ARCHITECTURE.md) — the four-layer model + canonical
   bridge + codec types
 * [`AGENTS.md`](AGENTS.md) — contributor directives, hard rules, doc-sync

--- a/deploy/VERIFY.md
+++ b/deploy/VERIFY.md
@@ -96,10 +96,11 @@ Notes:
 - Demo tags are `demo-v<major>.<minor>.<patch>`. The workflow's ref guard refuses
   anything else before it builds, because a tag like `demo-v1-rc1` would produce
   a signature no identity above can match.
-- **Honest status:** the workflow exists and is gated, but no `demo-v<semver>` tag has
-  been cut yet, so there is nothing signed to verify until the first demo release
-  (Gate 4). The digest pins in `demo.env` plus `make verify` are what you check
-  before then.
+- **Status:** live. Demo releases have been cut and published, so the signatures
+  above are real and verifiable today — Gate 4 (verifying a published bundle with
+  the operator's own cosign commands before deploying it) has been run. Use the
+  tag the running bundle came from; `deploy/demo.env` on the host records the
+  digests actually deployed, and `make verify` prints them.
 
 ### Verify the deploy bundle itself
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,9 @@ netcanon = "netcanon.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/netcanon/netcanon"
+# Rendered in PyPI's sidebar — the fastest path from "found the package" to
+# "watched it translate a config", with no install step in between.
+Demo = "https://demo.netcanon.net"
 Repository = "https://github.com/netcanon/netcanon"
 Issues = "https://github.com/netcanon/netcanon/issues"
 Changelog = "https://github.com/netcanon/netcanon/blob/main/CHANGELOG.md"


### PR DESCRIPTION
The demo has been public since the first demo tag and the README never mentioned it. The fastest path from "found this project" to "watched it translate a config" was a `docker run`; now it is a link.

## README

- A **Live demo** badge alongside CI/PyPI/GHCR.
- A lead section **above** the local quickstart (which is now "See it in 10 seconds — locally").
- See-also entries for the demo, the whitepaper, and VERIFY.md.

The section leads with what a network engineer actually wants to know before pasting a running-config into a stranger's website:

- private throwaway container, destroyed on tab close or at the 15-minute ceiling
- read-only rootfs, tmpfs-only writes, **no egress at all**
- no access log, no analytics, no tracking cookies
- swap off, core dumps discarded — it cannot reach disk indirectly

…then links the whitepaper and VERIFY.md rather than asking for trust, and tells anyone holding something sensitive to run the container themselves instead. Overclaiming here would be worse than not advertising at all, so **every claim was checked against the implementation before publishing**:

| claim | verified against |
|---|---|
| no access log | `deploy/Caddyfile` — `log { output discard }` on the demo site **and** `exclude http.log.access` on the default logger |
| no swap / no core dumps | `deploy/cloud-init.yaml` — `swapoff -a`, `kernel.core_pattern=\|/bin/false`, `Storage=none` |
| 15-minute ceiling | `HARD_TTL = 900` |

## Stale claim fixed

`deploy/VERIFY.md` still said no `demo-v<semver>` tag had been cut and there was *"nothing signed to verify until the first demo release"*. That has been false since the first demo release, and it undersold the strongest thing the demo has — real, verifiable signatures.

## Elsewhere

- `pyproject.toml` — a `Demo` URL, rendered in PyPI's sidebar.
- `Dockerfile` — `org.opencontainers.image.url`, so the GHCR package page points at the demo too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
