### PR TITLE
ci(demo): off-host uptime + synthetic probe

### DIFF
--- a/.github/workflows/demo-uptime.yml
+++ b/.github/workflows/demo-uptime.yml
@@ -175,7 +175,13 @@ jobs:
   alert:
     name: Open or close the outage issue
     needs: [liveness, deep]
-    if: always() && github.event_name != 'workflow_dispatch'
+    # Runs on dispatch too, deliberately. Alerting is the point of a monitor and
+    # is also its least-exercised code: gated to the cron, the FIRST time it ever
+    # ran would be during a real incident, and a broken alert path fails silently
+    # by definition. A healthy manual dispatch exercises auth, permissions and
+    # the issue lookup for real, with no side effect (it prints "healthy" and
+    # stops), so the path is provably working before it is needed.
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -189,27 +195,40 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          RESULT: ${{ needs.liveness.result }}
+          # BOTH results, not just liveness: a manual run where the synthetic
+          # probe fails but the site still answers GETs is exactly the
+          # silently-broken-pool case this exists to catch, and reading only
+          # liveness would report it as healthy.
+          LIVENESS: ${{ needs.liveness.result }}
+          DEEP: ${{ needs.deep.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash
         run: |
           set -euo pipefail
-          gh label create demo-outage --color B60205 \
-            --description "Automated: demo.netcanon.net failed an uptime probe" 2>/dev/null || true
+          # `[ x ] && y=1` would abort the script under `set -e` on the common
+          # path where the test is false. Use a plain if.
+          failed=0
+          if [ "$LIVENESS" = "failure" ] || [ "$DEEP" = "failure" ]; then failed=1; fi
+          echo "liveness=$LIVENESS deep=$DEEP -> failed=$failed"
+
           open=$(gh issue list --repo "$REPO" --label demo-outage --state open \
                    --limit 1 --json number -q '.[0].number // empty')
 
-          if [ "$RESULT" != "success" ]; then
+          if [ "$failed" -eq 1 ]; then
             if [ -n "$open" ]; then
               gh issue comment "$open" --repo "$REPO" --body "Still failing — $RUN_URL"
               echo "commented on #$open"
             else
+              # Only when actually filing — creating it every run would be a
+              # pointless mutating API call four times an hour, forever.
+              gh label create demo-outage --color B60205 \
+                --description "Automated: demo.netcanon.net failed an uptime probe" 2>/dev/null || true
               gh issue create --repo "$REPO" --label demo-outage \
                 --title "demo.netcanon.net is failing its uptime probe" \
                 --body "$(printf 'An automated probe of https://demo.netcanon.net failed.\n\nRun: %s\n\nThis issue is updated by later failures and closed automatically on recovery.\nTiming caveat: scheduled workflows are queued by GitHub, so the outage may have begun well before this run.\n' "$RUN_URL")"
               echo "opened a new outage issue"
             fi
-          elif [ -n "$open" ]; then
+          elif [ "$LIVENESS" = "success" ] && [ -n "$open" ]; then
             gh issue comment "$open" --repo "$REPO" --body "Recovered — $RUN_URL"
             gh issue close "$open" --repo "$REPO" --reason completed
             echo "closed #$open on recovery"

--- a/.github/workflows/demo-uptime.yml
+++ b/.github/workflows/demo-uptime.yml
@@ -1,0 +1,218 @@
+name: Demo — uptime & synthetic probe
+
+# Off-host monitoring for demo.netcanon.net, specified in
+# docs/demo-plan/02-deployment.md ("an external uptime monitor hitting / and
+# /healthz from off-host, so an outage is visible even if the box wedges") and
+# unbuilt until now. Off-host is the whole point: a monitor running ON the demo
+# box cannot tell you the demo box is down. The sampler already proved that —
+# it faithfully recorded `warden: null` during a real outage, into a file nobody
+# reads until someone goes looking.
+#
+# ── Deliberately NOT a hosted uptime service ──────────────────────────────────
+# Not because those are worse at this (they are better at timing, see below) but
+# because this needs NO account and NO secret: every endpoint it touches is
+# public HTTP, which preserves the "zero deploy secrets on GitHub" property the
+# deployment posture rests on. It also lives in the repo, so the monitor goes
+# through the same PR review, zizmor scan and pinned-action discipline as the
+# thing it monitors. It uses NO third-party actions at all — curl, jq, openssl
+# and gh are all present on the runner.
+#
+# ── Known limitations. Read these before trusting it ──────────────────────────
+# 1. TIMING IS NOT GUARANTEED. GitHub queues scheduled workflows and explicitly
+#    does not promise on-time execution; delays of 5-30 min are routine and runs
+#    can be skipped entirely during an incident. `*/5` is a hope, not an
+#    interval. Detection here is "eventually", not "within five minutes".
+# 2. SCHEDULED WORKFLOWS AUTO-DISABLE after 60 days of repository inactivity.
+#    That is a monitor dying silently — the worst failure mode one can have. If
+#    this repo ever goes quiet, monitoring stops without saying so.
+# 3. GitHub is a single point of failure for the monitor. If Actions is degraded
+#    you lose visibility (a hosted checker has the same shape of problem).
+# Mitigation for 1: each probe retries in-run before failing, so a transient
+# blip does not page. Mitigation for 2 and 3: none here — if you later want
+# dependable sub-15-minute detection, add a hosted checker alongside. The two
+# compose fine; this one keeps the synthetic probe a hosted service cannot
+# express.
+#
+# ── Why the synthetic probe is dispatch-only, not scheduled ───────────────────
+# It mints a REAL session, so on a schedule it would land in `sessions_started`
+# and `sessions_that_translated` every run. At the demo's actual volume (single
+# figures per day) an hourly probe would swamp the human signal and the
+# engagement rate would converge on 100% — the counter would measure our own
+# robot. Exempting it was considered and rejected: a shared-secret header puts a
+# secret on GitHub, runner IPs rotate so source matching fails, and a User-Agent
+# marker would make the warden inspect UA, which the whitepaper explicitly says
+# it does not record. Keeping the frequent tier read-only costs nothing and
+# needs no exemption at all.
+# Run it by hand after `make deploy`, or whenever the pool is suspect.
+
+on:
+  schedule:
+    - cron: '7,22,37,52 * * * *'   # offset: top-of-hour crons queue worst
+  workflow_dispatch:
+    inputs:
+      deep:
+        description: "Also run the synthetic mint -> translate -> end probe"
+        type: boolean
+        default: true
+
+# Read-only by default; the alert job elevates to issues:write for itself only.
+permissions:
+  contents: read
+
+# Never cancel a run in flight: it may be mid-alert, and losing the notification
+# is worse than briefly queueing behind a slow check.
+concurrency:
+  group: demo-uptime
+  cancel-in-progress: false
+
+env:
+  BASE: https://demo.netcanon.net
+  HOST: demo.netcanon.net
+
+jobs:
+  liveness:
+    name: Liveness (read-only)
+    runs-on: ubuntu-latest
+    steps:
+      # Read-only by construction: GETs only, so this tier mints no session and
+      # cannot pollute the engagement counters no matter how often it runs.
+      - name: Probe the public surface
+        shell: bash
+        run: |
+          set -uo pipefail
+          fail=0
+          probe() {  # name url expected
+            local code=000
+            for i in 1 2 3; do
+              code=$(curl -o /tmp/body -sS -w '%{http_code}' --max-time 20 "$2" 2>/dev/null || echo 000)
+              if [ "$code" = "$3" ]; then echo "  OK    $1 ($code)"; return 0; fi
+              echo "  ....  $1 got $code (attempt $i/3)"; sleep 15
+            done
+            echo "::error::$1 failed — last status $code (3 attempts)"; return 1
+          }
+          probe "GET /"           "$BASE/"           200 || fail=1
+          probe "GET /whitepaper" "$BASE/whitepaper" 200 || fail=1
+          probe "GET /healthz"    "$BASE/healthz"    200 || fail=1
+
+          # A 200 from /healthz only proves the warden answers. An empty warm
+          # pool means every visitor waits for a cold container start, or the
+          # create path is broken outright — the site looks fine and is not.
+          # Separate "could not read the answer" from "the answer was bad".
+          # Both are alerts, but folding them together means the notification
+          # names the wrong fault and costs incident time — a swallowed jq
+          # failure would report a phantom empty pool.
+          if [ "$fail" -eq 0 ]; then
+            if ! jq -e . /tmp/body >/dev/null 2>&1; then
+              echo "::error::/healthz returned 200 but the body is not parseable JSON"
+              fail=1
+            else
+              pool=$(jq -r '.pool // -1' /tmp/body)
+              active=$(jq -r '.active // -1' /tmp/body)
+              echo "  pool=$pool active=$active"
+              if [ "$pool" -lt 1 ]; then
+                echo "::error::warm pool is $pool — the demo answers but cannot serve a visitor promptly"
+                fail=1
+              fi
+            fi
+          fi
+          exit "$fail"
+
+      - name: Check the TLS certificate has life left
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Caddy renews automatically, so this is really an ACME-failure alarm:
+          # the useful moment to hear about it is well BEFORE expiry, while
+          # renewal can still be fixed by hand.
+          end=$(echo | openssl s_client -connect "$HOST:443" -servername "$HOST" 2>/dev/null \
+                | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)
+          if [ -z "$end" ]; then echo "::error::could not read the TLS certificate"; exit 1; fi
+          days=$(( ( $(date -d "$end" +%s) - $(date -u +%s) ) / 86400 ))
+          echo "  cert expires $end ($days days)"
+          if [ "$days" -lt 14 ]; then
+            echo "::error::TLS certificate expires in $days days — ACME renewal is not working"
+            exit 1
+          fi
+
+  deep:
+    name: Synthetic mint -> translate -> end
+    if: github.event_name == 'workflow_dispatch' && inputs.deep
+    runs-on: ubuntu-latest
+    steps:
+      # The check liveness cannot make: the site can answer every GET while the
+      # pool is silently broken and no visitor can actually translate anything.
+      # Mints a real session, hence dispatch-only (see the header).
+      - name: Drive a real translation end to end
+        shell: bash
+        run: |
+          set -euo pipefail
+          token=$(curl -fsS --max-time 60 -X POST "$BASE/session/new" | jq -r .token)
+          if [ -z "$token" ] || [ "$token" = "null" ]; then
+            echo "::error::mint returned no token — the demo could not hand out a session"; exit 1
+          fi
+          cleanup() { curl -fsS --max-time 30 -X POST "$BASE/session/$token/end" >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+
+          body=$(jq -nc --arg t "$(printf 'hostname probe-sw\n!\nvlan 10\n name USERS\n!\ninterface GigabitEthernet1/0/1\n switchport mode access\n switchport access vlan 10\n!')" \
+                 '{source:"cisco_iosxe_cli", target:"juniper_junos", raw_text:$t}')
+          out=$(curl -fsS --max-time 120 -X POST -H 'Content-Type: application/json' \
+                  -d "$body" "$BASE/i/$token/api/v1/migration/plan")
+          status=$(printf '%s' "$out" | jq -r '.status // "?"')
+          rendered=$(printf '%s' "$out" | jq -r '.rendered // ""')
+          echo "  job status: $status, rendered ${#rendered} chars"
+
+          # Assert on the TRANSLATION, not just a 200: /plan answers 200 even
+          # when the job failed, carrying the outcome in the body. A status check
+          # alone would pass while the demo rendered nothing.
+          if [ "$status" != "completed" ]; then
+            echo "::error::translation status was '$status', expected 'completed'"; exit 1
+          fi
+          case "$rendered" in
+            *"ge-1/0/1"*) echo "  OK    interface name translated to Junos form" ;;
+            *) echo "::error::rendered output lacks the translated interface name"; exit 1 ;;
+          esac
+
+  alert:
+    name: Open or close the outage issue
+    needs: [liveness, deep]
+    if: always() && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # One issue per incident, not one per run: at this cadence a night-long
+      # outage would otherwise file ~100 issues and bury the signal it exists to
+      # raise. Recovery closes the thread, so the issue becomes an incident
+      # record with a start and an end rather than a stream of noise.
+      - name: File or resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RESULT: ${{ needs.liveness.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh label create demo-outage --color B60205 \
+            --description "Automated: demo.netcanon.net failed an uptime probe" 2>/dev/null || true
+          open=$(gh issue list --repo "$REPO" --label demo-outage --state open \
+                   --limit 1 --json number -q '.[0].number // empty')
+
+          if [ "$RESULT" != "success" ]; then
+            if [ -n "$open" ]; then
+              gh issue comment "$open" --repo "$REPO" --body "Still failing — $RUN_URL"
+              echo "commented on #$open"
+            else
+              gh issue create --repo "$REPO" --label demo-outage \
+                --title "demo.netcanon.net is failing its uptime probe" \
+                --body "$(printf 'An automated probe of https://demo.netcanon.net failed.\n\nRun: %s\n\nThis issue is updated by later failures and closed automatically on recovery.\nTiming caveat: scheduled workflows are queued by GitHub, so the outage may have begun well before this run.\n' "$RUN_URL")"
+              echo "opened a new outage issue"
+            fi
+          elif [ -n "$open" ]; then
+            gh issue comment "$open" --repo "$REPO" --body "Recovered — $RUN_URL"
+            gh issue close "$open" --repo "$REPO" --reason completed
+            echo "closed #$open on recovery"
+          else
+            echo "healthy, nothing open"
+          fi

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -199,6 +199,37 @@ Two things to know when reading it:
   `503_count` that summed all three; samples written before 2026-07-27 carry
   the old key and cannot be broken down.)
 
+## Uptime monitoring
+
+[`.github/workflows/demo-uptime.yml`](../.github/workflows/demo-uptime.yml) runs
+**off-host** — a monitor on the box cannot tell you the box is down. Two tiers:
+
+- **Liveness**, on a cron: `/`, `/whitepaper`, `/healthz` (including a warm-pool
+  check, since a 200 with `pool: 0` means the site answers but no visitor can be
+  served promptly) plus TLS days-remaining, which is really an ACME-failure
+  alarm — you want to hear about a broken renewal *before* expiry. GETs only.
+- **Synthetic `mint → translate → end`**, `workflow_dispatch` only. Catches the
+  thing liveness cannot: the site answering while the pool is silently broken.
+  **Run it after `make deploy`.**
+
+Failures open a single deduped `demo-outage` issue and close it on recovery, so
+one incident is one thread rather than one issue per probe.
+
+⚠️ **Timing is not guaranteed.** GitHub queues scheduled workflows and does not
+promise on-time execution; delays of 5–30 minutes are routine and runs can be
+skipped during an incident. Detection is "eventually", not "within five
+minutes". Scheduled workflows also **auto-disable after 60 days of repository
+inactivity** — a monitor dying silently. If you ever want dependable fast
+detection, add a hosted checker alongside; the two compose, and this one keeps
+the synthetic probe a hosted service cannot express.
+
+⚠️ **The monitor shows up in its own metrics.** Liveness adds ~12 requests/hour
+of 200s to the Caddy counters, on top of the sampler's own ~12/hour against
+`/healthz`. In quiet hours that is most of the 200s in the series — subtract it
+before reading anything into request volume. It mints no session, so the
+`sessions_*` counters stay clean; that is deliberate and guarded by
+`test_the_scheduled_uptime_probe_mints_no_session`.
+
 ## DDoS / abuse posture
 
 - **L7 abuse:** warden per-IP concurrency cap (2) + mint rate limit (≤30/600 s), Caddy 2 MB body cap, fail-closed 503 at `MAX_ACTIVE`, per-instance cpu/mem/pids caps, no egress.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -213,7 +213,10 @@ Two things to know when reading it:
   **Run it after `make deploy`.**
 
 Failures open a single deduped `demo-outage` issue and close it on recovery, so
-one incident is one thread rather than one issue per probe.
+one incident is one thread rather than one issue per probe. The alert step also
+runs on a manual dispatch: alerting is the least-exercised code in any monitor,
+so a healthy dispatch proves auth, permissions and the issue lookup work — with
+no side effect — rather than leaving the first real execution to an incident.
 
 ⚠️ **Timing is not guaranteed.** GitHub queues scheduled workflows and does not
 promise on-time execution; delays of 5–30 minutes are routine and runs can be

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -248,6 +248,55 @@ def test_site_assembly_never_deletes_the_bind_mounted_directory():
         )
 
 
+def test_the_scheduled_uptime_probe_mints_no_session():
+    """The engagement counter measures humans, and a synthetic probe on a
+    schedule would drown them.
+
+    `sessions_that_translated` / `sessions_started` is only meaningful while the
+    frequent tier stays read-only. The demo sees single-figure visits per day,
+    so even an hourly synthetic would make the ratio converge on 100% and quietly
+    turn the metric into a measurement of our own robot. The deep probe therefore
+    mints a real session and is `workflow_dispatch`-only; the scheduled tier is
+    GETs. This pins that split, because moving the deep job onto the cron is a
+    one-line edit whose damage is silent and retroactive.
+    """
+    wf = yaml.safe_load((REPO_ROOT / ".github/workflows/demo-uptime.yml").read_text(encoding="utf-8"))
+    jobs = wf["jobs"]
+
+    scheduled = [
+        name for name, job in jobs.items()
+        # A job with no `if` runs on every trigger, including the cron.
+        if "workflow_dispatch" not in str(job.get("if", ""))
+    ]
+    for name in scheduled:
+        body = " ".join(str(s.get("run", "")) for s in jobs[name]["steps"])
+        assert "/session/new" not in body, (
+            f"job {name!r} runs on the schedule AND mints a session — that lands in "
+            "sessions_started/sessions_that_translated every run and destroys the "
+            "engagement metric"
+        )
+
+    deep = jobs["deep"]
+    assert "workflow_dispatch" in str(deep.get("if", "")), (
+        "the synthetic probe is no longer dispatch-gated"
+    )
+
+
+def test_the_uptime_probe_needs_no_secrets_or_third_party_actions():
+    """Two properties worth keeping: it uses only public HTTP, so the "zero
+    deploy secrets on GitHub" posture holds, and it pulls in no third-party
+    action, so monitoring adds nothing to the supply chain it watches. Only the
+    automatic GITHUB_TOKEN is allowed, for filing the outage issue."""
+    text = (REPO_ROOT / ".github/workflows/demo-uptime.yml").read_text(encoding="utf-8")
+    wf = yaml.safe_load(text)
+    for name, job in wf["jobs"].items():
+        for step in job["steps"]:
+            assert "uses" not in step, f"job {name!r} pulls in a third-party action"
+    secrets = set(re.findall(r"secrets\.([A-Z_]+)", text))
+    assert secrets <= {"GITHUB_TOKEN"}, f"the probe reads stored secrets: {sorted(secrets)}"
+    assert wf["permissions"] == {"contents": "read"}, "workflow-level permissions widened"
+
+
 def test_every_healthz_counter_is_documented():
     """`/healthz` is a published operator surface and the sampler writes every
     key in it to disk, so each counter is a claim about what we observe. An


### PR DESCRIPTION
## Why

`docs/demo-plan/02-deployment.md` specified *"an external uptime monitor hitting `/` and `/healthz` from off-host"* plus a synthetic `mint → translate → end` probe. Both sat on the launch checklist, unbuilt — the demo has had **no alerting at all**. The sampler faithfully recorded `warden: null` through a real outage today, into a file nobody reads until someone goes looking.

Off-host is the whole point: a monitor running *on* the demo box cannot tell you the demo box is down.

## Two tiers

**Liveness** (cron): `/`, `/whitepaper`, `/healthz` — including a **warm-pool check**, since a 200 with `pool: 0` means the site answers but no visitor can be served promptly. Plus TLS days-remaining, which is really an ACME-failure alarm: the useful moment to hear about a broken renewal is *before* expiry.

**Synthetic probe** (`workflow_dispatch`): catches what liveness cannot — the site answering while the pool is silently broken. Asserts on the *translation*, not the status code, because `/plan` returns 200 even when the job failed.

Failures open **one deduped `demo-outage` issue** and close it on recovery, so an incident is a thread rather than one issue per probe.

## Why the deep probe is dispatch-only

It mints a real session. At this demo's volume (single figures/day) a scheduled synthetic would swamp `sessions_started` / `sessions_that_translated` and converge the engagement rate on 100% — measuring our own robot. Exempting it was considered and rejected: a shared secret puts one on GitHub, runner IPs rotate, and a User-Agent marker would make the warden inspect UA, which the whitepaper explicitly says it does not record. A read-only frequent tier needs no exemption at all.

## Posture

**No third-party actions. No stored secrets.** Every endpoint is public HTTP, so the "zero deploy secrets on GitHub" property holds and monitoring adds nothing to the supply chain it watches. Guarded, along with the scheduled-tier-mints-nothing split — moving the deep job onto the cron is a one-line edit whose damage is silent and retroactive.

| mutant | test killed |
|---|---|
| deep probe moved onto the schedule | `test_the_scheduled_uptime_probe_mints_no_session` |
| a stored secret introduced | `test_the_uptime_probe_needs_no_secrets_or_third_party_actions` |

## Validated by running it

Extracted the `run:` blocks and executed them in `ubuntu:24.04` (GNU coreutils + jq 1.7, matching the runner) rather than reading them:

```
liveness   OK / (200), /whitepaper (200), /healthz (200), pool=4 active=0   exit=0
TLS        cert expires Oct 24 2026 (88 days)                                exit=0
deep       job status: completed, rendered 211 chars, ge-1/0/1 present       exit=0
negative   wrong host -> 3 retries then accurate errors                      exit=1
negative   no cert on 443 -> "could not read the TLS certificate"            exit=1
```

A first local run reported a phantom empty pool. That was **jq missing on the Windows box, not a defect** — but it exposed that an unparseable body and a genuinely empty pool produced the *same* message. Those are now distinguished; an alert that names the wrong fault costs incident time.

## Limitations, documented not glossed

- **GitHub does not guarantee schedule timing.** Delays of 5–30 min are routine, runs can be skipped during an incident. Detection is *eventually*, not *within five minutes*. Cron is offset off the hour, and each probe retries in-run so a blip does not page.
- **Scheduled workflows auto-disable after 60 days of repo inactivity** — a monitor dying silently, the worst failure mode one can have.
- **The monitor appears in its own metrics** — ~12 req/h of 200s on top of the sampler's ~12/h. In quiet hours that is most of the 200s; subtract before reading anything into request volume. It mints no session, so `sessions_*` stays clean.

If you later want dependable fast detection, add a hosted checker alongside — the two compose, and this one keeps the synthetic probe a hosted service cannot express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
