### PR TITLE
docs(demo): replace the cron-timing guess with measured reality

### DIFF
--- a/.github/workflows/demo-uptime.yml
+++ b/.github/workflows/demo-uptime.yml
@@ -18,10 +18,15 @@ name: Demo — uptime & synthetic probe
 # and gh are all present on the runner.
 #
 # ── Known limitations. Read these before trusting it ──────────────────────────
-# 1. TIMING IS NOT GUARANTEED. GitHub queues scheduled workflows and explicitly
-#    does not promise on-time execution; delays of 5-30 min are routine and runs
-#    can be skipped entirely during an incident. `*/5` is a hope, not an
-#    interval. Detection here is "eventually", not "within five minutes".
+# 1. TIMING IS NOT GUARANTEED, AND ON THIS REPO IT IS BAD. Measured, not
+#    assumed: zizmor.yml runs `17 4 * * 1` and over eight weeks fired 189-761
+#    minutes late EVERY time (median ~4.4 h), never once within three hours of
+#    its slot. This workflow's first scheduled run had not appeared 57 minutes
+#    after merge. The cadence below is aspirational; real detection latency is
+#    measured in hours. Not a defect here — the same file via workflow_dispatch
+#    finishes in ~30 s. If you need timely detection, add a hosted checker for
+#    the liveness tier and keep this one for the synthetic probe, which a hosted
+#    service cannot express.
 # 2. SCHEDULED WORKFLOWS AUTO-DISABLE after 60 days of repository inactivity.
 #    That is a monitor dying silently — the worst failure mode one can have. If
 #    this repo ever goes quiet, monitoring stops without saying so.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -218,10 +218,21 @@ runs on a manual dispatch: alerting is the least-exercised code in any monitor,
 so a healthy dispatch proves auth, permissions and the issue lookup work — with
 no side effect — rather than leaving the first real execution to an incident.
 
-⚠️ **Timing is not guaranteed.** GitHub queues scheduled workflows and does not
-promise on-time execution; delays of 5–30 minutes are routine and runs can be
-skipped during an incident. Detection is "eventually", not "within five
-minutes". Scheduled workflows also **auto-disable after 60 days of repository
+⚠️⚠️ **Timing is not guaranteed, and on THIS repository it is bad — measured,
+not assumed.** `zizmor.yml` has run on `17 4 * * 1` for eight weeks. Every single
+firing was late, by **189 to 761 minutes** (median ~4.4 h); not one landed within
+three hours of its slot. The first scheduled run of this workflow had likewise
+not appeared 57 minutes after it was merged.
+
+So treat the cron cadence as **aspirational**. Detection here is measured in
+hours, and the `7,22,37,52` schedule buys far less than it looks like it does.
+That is a GitHub scheduling property, not a defect in this workflow — the same
+file run via `workflow_dispatch` completes in about 30 seconds.
+
+**If you want timely outage detection, put a hosted checker on the liveness
+tier** (UptimeRobot, Healthchecks.io — five minutes, no code) and keep this
+workflow for what a hosted service cannot express: the synthetic
+mint → translate → end probe, and the alert plumbing. Scheduled workflows also **auto-disable after 60 days of repository
 inactivity** — a monitor dying silently. If you ever want dependable fast
 detection, add a hosted checker alongside; the two compose, and this one keeps
 the synthetic probe a hosted service cannot express.


### PR DESCRIPTION
The uptime monitor's docs claimed *"delays of 5–30 minutes are routine"*. That was a general statement about GitHub, not an observation about **this** repository — and it is measurably wrong here.

## The measurement

`zizmor.yml` has run on `17 4 * * 1` for eight weeks:

| run | minutes late |
|---|---|
| 2026-07-27 | 210 |
| 2026-07-20 | 189 |
| 2026-07-13 | 198 |
| 2026-07-06 | 263 |
| 2026-06-29 | 288 |
| 2026-06-22 | 357 |
| 2026-06-15 | 375 |
| 2026-06-08 | 761 |

**Every firing late. Median ~4.4 h. Not one within three hours of its slot.** The new workflow's first scheduled run had likewise not appeared 57 minutes after merge, across ~4 missed slots.

## What it means

The `7,22,37,52` cadence is **aspirational**; real detection latency here is measured in hours.

This is a GitHub scheduling property, not a defect in the workflow — the same file via `workflow_dispatch` finishes in ~30 s, and both dispatches passed with all three jobs green. The workflow is fine; the schedule is not a schedule.

The practical consequence is now stated rather than implied: **for timely outage detection, put a hosted checker on the liveness tier** and keep this workflow for what a hosted service cannot express — the synthetic mint → translate → end probe, and the alert plumbing.

Docs-only. The claim being corrected is one I wrote yesterday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)