### PR TITLE
feat(demo): carry Tier-3 material in the demo scenarios so the refusal is visible

### DIFF
--- a/docs/walkthroughs/cisco_iosxe_to_junos.md
+++ b/docs/walkthroughs/cisco_iosxe_to_junos.md
@@ -78,6 +78,12 @@ ip name-server 192.168.1.10
 ip name-server 192.168.1.11
 ntp server 192.168.1.20
 !
+ip access-list extended MGMT-PROTECT
+ permit tcp 192.168.99.0 0.0.0.255 any eq 22
+ deny   ip any any log
+!
+ip nat inside source list MGMT-PROTECT interface GigabitEthernet1/0/24 overload
+!
 ip route 0.0.0.0 0.0.0.0 192.168.1.1
 
 OUTPUT (juniper_junos)
@@ -107,6 +113,12 @@ Interface-name translations applied
   GigabitEthernet1/0/1 -> ge-1/0/1
   GigabitEthernet1/0/2 -> ge-1/0/2
   GigabitEthernet1/0/24 -> ge-1/0/24
+
+========================================================================
+Tier-3 sections detected but NOT translated
+========================================================================
+  - ip access-list extended MGMT-PROTECT
+  - ip nat inside source list MGMT-PROTECT interface GigabitEthernet1/0/24 overload
 ```
 
 The demo runs the rename-aware pipeline (the same path the browser UI
@@ -115,6 +127,12 @@ translated to native Junos form (`GigabitEthernet1/0/1` → `ge-1/0/1`)
 rather than left verbatim.
 
 ## Tier-3 boundary
+
+The demo scenario demonstrates this live: its source carries an
+`ip access-list extended MGMT-PROTECT` and an `ip nat inside source`
+rule, and the output above ends with both listed under "Tier-3
+sections detected but NOT translated" — nothing from either stanza
+appears in the Junos output.
 
 If your IOS-XE configs include `ip access-list extended`, `crypto ...`,
 `router bgp`, `service-policy ...`, or zone-based firewall config,
@@ -158,6 +176,12 @@ verify:
 - [ ] **Routing-protocol stanzas**: `router ospf`, `router bgp`,
       `router eigrp` are parse-tolerant but NOT auto-rendered.  Plan
       separate hand-translation for protocol config.
+- [ ] **Every Tier-3 section listed in the demo/banner output**: each
+      named stanza (ACLs, NAT, crypto, QoS) needs a hand-translation
+      plan of its own — in the demo scenario that means recreating
+      `MGMT-PROTECT` as a Junos firewall filter and replacing the NAT
+      overload rule with Junos source NAT, then binding both where the
+      original config bound them.
 
 ## See also
 

--- a/docs/walkthroughs/fortigate_to_mikrotik.md
+++ b/docs/walkthroughs/fortigate_to_mikrotik.md
@@ -46,7 +46,11 @@ python tools/demo.py --pair fortigate__mikrotik
 ```
 
 The embedded scenario covers system global (hostname), system dns,
-two interfaces (`internal1`, `internal2`), and a DHCP server pool.
+two interfaces (`internal1`, `internal2`), and a DHCP server pool —
+plus a `config firewall policy` block that is deliberately NOT
+translated: the demo output ends by listing it under "Tier-3 sections
+detected but NOT translated", so you see the refusal working before
+you ever feed it a real config.
 
 ## Tier-3 boundary in this scenario
 
@@ -62,6 +66,11 @@ typically splits into:
 That's the matrix-honesty discipline working as designed: the
 operator sees explicitly what didn't translate, with a count and the
 section names, rather than getting silently-truncated output.
+
+The embedded demo scenario now exercises exactly this split: its
+`config firewall policy` stanza is detected and listed, while the
+system/interface/DHCP surfaces translate — the same behaviour you
+will see on a real backup, at miniature scale.
 
 ## Manual review checklist
 

--- a/netcanon/tools/demo.py
+++ b/netcanon/tools/demo.py
@@ -85,6 +85,12 @@ ip name-server 192.168.1.10
 ip name-server 192.168.1.11
 ntp server 192.168.1.20
 !
+ip access-list extended MGMT-PROTECT
+ permit tcp 192.168.99.0 0.0.0.255 any eq 22
+ deny   ip any any log
+!
+ip nat inside source list MGMT-PROTECT interface GigabitEthernet1/0/24 overload
+!
 ip route 0.0.0.0 0.0.0.0 192.168.1.1
 """
 
@@ -118,6 +124,19 @@ config system dhcp server
                 set end-ip 192.168.10.200
             next
         end
+    next
+end
+config firewall policy
+    edit 1
+        set name "lan-to-wan"
+        set srcintf "internal1"
+        set dstintf "wan1"
+        set srcaddr "all"
+        set dstaddr "all"
+        set action accept
+        set schedule "always"
+        set service "ALL"
+        set nat enable
     next
 end
 """
@@ -185,7 +204,10 @@ SCENARIOS: dict[str, Scenario] = {
             "hostname, VLAN definitions, switchport access + trunk ports "
             "with their VLAN membership, an SNMP community, DNS / NTP "
             "servers, and a default static route - including cross-vendor "
-            "interface-name translation (GigabitEthernet1/0/1 -> ge-1/0/1)."
+            "interface-name translation (GigabitEthernet1/0/1 -> ge-1/0/1). "
+            "The source also carries an ACL and a NAT rule, which are "
+            "detected and deliberately NOT translated (the Tier-3 boundary) "
+            "- they are listed by name instead."
         ),
         source_text=_CISCO_IOSXE,
     ),
@@ -196,7 +218,10 @@ SCENARIOS: dict[str, Scenario] = {
         description=(
             "Translate FortiGate's nested config / edit / set / next / end "
             "model (system global, system dns, system interface, system "
-            "dhcp server) into RouterOS's `/path` slash-prefixed form."
+            "dhcp server) into RouterOS's `/path` slash-prefixed form. "
+            "The source also carries a firewall policy, which is detected "
+            "and deliberately NOT translated (the Tier-3 boundary) - "
+            "stateful policy does not move between vendors by find-replace."
         ),
         source_text=_FORTIGATE,
     ),


### PR DESCRIPTION
## What

Extends the embedded demo scenarios so the product's defining behaviour — the honest Tier-3 refusal — is actually visible in the 30-second `demo --pair` path:

- `_CISCO_IOSXE`: + `ip access-list extended MGMT-PROTECT` and an `ip nat inside source … overload` rule → both listed under **"Tier-3 sections detected but NOT translated"**, job stays `completed`.
- `_FORTIGATE`: + `config firewall policy` block → same honest listing.
- Scenario descriptions name the boundary; paired walkthroughs synced per the `AGENTS.md` doc-sync row (regenerated embedded output, live-demonstration pointers, new checklist items).

## Why

Until now every scenario printed `(none -- input was Tier-1/2 only)` — an operator running the hero command never saw the refusal that is the project's whole differentiator, and `docs/assets/migrate.png`'s banner was only reproducible with a hand-pasted config. This also unblocks the netcanon.net landing page's hero, which must be the *true* output of the printed command, refusal included (no curation, no staging — extending the input is the only honest fix).

## Verification

- `py -m netcanon.tools.demo --pair cisco__junos` → refusal listed, exit 0
- `py -m netcanon.tools.demo --pair fortigate__mikrotik` → refusal listed, exit 0
- `tests/unit/tools/test_demo.py` 10/10 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
