### PR TITLE
Say what Netcanon is for: switches and routers, firewalls at L2/L3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,50 @@ tests use these exclusively — never CSS classes or element structure.  See
   "the docs lied to me" is what differentiates Netcanon's
   matrix-honesty discipline from the over-claiming alternatives in
   this space.
+- **Never** author or change a codec's `device_classes[0]` without applying
+  the scope test.  A codec's **first** entry in `device_classes` — declared in
+  `netcanon/migration/vendors/<vendor>.yaml` and mirrored in its
+  `CapabilityMatrix` — is its **primary device class**, and that single field
+  is the project's authoritative scope declaration for the platform.  Order is
+  therefore load-bearing: re-ordering an existing codec's classes is a scope
+  change, not a tidy-up.
+
+  A platform is **`firewall`-primary** when **both** hold:
+  **(a)** the modal *real* config of that platform is majority Tier-3 by
+  volume — the canonical model covers a minority of what an operator actually
+  wrote; **and**
+  **(b)** the platform is not deployed as a switching or routing NOS in its own
+  right, so its L2/L3 surface is incidental rather than the reason the box
+  exists.
+
+  Both clauses are required.  Clause (a) alone would take `cisco_iosxr`
+  (MPLS / IS-IS / route-policy dominate real SP configs) — clause (b) saves it.
+  Clause (b) alone would take nothing.  Junos is the worked example of why the
+  test is two-clause and not one: Junos ships on SRX firewalls and declares
+  `firewall`, but it is `switch`-primary because EX / QFX / MX are Junos boxes
+  in their own right.
+
+  **What `firewall`-primary means, operationally.**  Netcanon translates that
+  platform's L2/L3 layer only.  Such a codec **must not** be a landing-page
+  hero pane, **must not** be the landing-page capability-matrix excerpt, and
+  **must not** be more than one of the four `netcanon/tools/demo.py` scenarios.
+  It **may** ship, be certified, hold fixtures, be auto-detected, be
+  sanitisable, and participate fully in the cross-mesh audit as a source.
+  Enforced by [`tests/unit/migration/test_scope_boundary.py`](tests/unit/migration/test_scope_boundary.py),
+  which pins the roster, asserts the codec ↔ vendor-YAML agreement, and
+  ratchets the demo-scenario count.  ⚠️ The scenario clause is **not yet met**:
+  HEAD carries two firewall-primary scenarios (`fortigate__mikrotik`,
+  `opnsense__junos`) and the guard ratchets at 2 with a target of 1, because
+  closing it re-authors a demo scenario and drags the hero pane, `og.png` and
+  the paired walkthrough with it.  Lower the ratchet when that wave lands;
+  never raise it.
+
+  Rationale: the scope complaint this rule answers was *perception weight*,
+  not correctness — nothing over-claimed, but two of twelve codecs held a
+  disproportionate share of the product's shop window.  Encoding the answer in
+  `device_classes[0]` means it is read from a declaration rather than
+  re-derived from a measurement every time someone asks.  Full workings in
+  `docs/reviews/2026-08-10-firewall-scope-exit/`.
 - **Never** push to an online / public repository (GitHub, GitLab,
   Bitbucket, GHCR, Docker Hub, PyPI, or any other off-machine
   destination — including private repos that may later go public,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -579,10 +579,15 @@ profile currently declares `max_vlans`; per-vendor rationale:
 
 `max_local_users` is declared only where the datasheet number is
 small enough to matter and the codec actually round-trips users
-(Aruba 2930F family = 16; 6300M = 64).  OPNsense + FortiGate
-profiles leave it unset because their codecs list `local_users`
-in `unsupported_rename_categories` — the compatibility banner
-handles that UX.  MikroTik leaves it unset because RouterOS's
+(Aruba 2930F family = 16; 6300M = 64).  OPNsense leaves it unset
+because its user count is software-unbounded in practice and so
+carries no useful fit-check signal; FortiGate leaves it unset
+because the admin-account cap varies materially by FortiOS version
+and isn't a reliable datasheet number.  **Both codecs round-trip
+`CanonicalLocalUser` end-to-end** — see the
+`unsupported_rename_categories` discussion above, where the
+incorrect `{"local_users"}` entry and its compat-banner rationale
+were removed.  MikroTik leaves it unset because RouterOS's
 user count is software-unbounded.  Shipped-profile lock-in tests
 in
 [`tests/unit/migration/test_target_profile_shipped.py`](tests/unit/migration/test_target_profile_shipped.py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,59 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+### Added
+
+- **Scope advisory when translating into a firewall platform.**  A
+  switch/router -> FortiGate or OPNsense job now raises a banner on the
+  migrate page saying that Netcanon emits no policy plane, and that policy
+  already on the appliance binds to interface names this output may rename or
+  invent.  Nothing on the page said so before: the Tier-3 banner reads the
+  SOURCE config, so it is silent when the source is a switch, and
+  `/filter/rule` / `/nat/rule` are declared `unsupported` but no canonical
+  field walks to them, so `validate_against` -- a loss detector, not an
+  absence detector -- cannot fire on them either.  New
+  `MigrationJob.scope_advisories` (additive; no existing `/api/v1` shape
+  changes) and `check_scope_advisory()`.  Fires on 22 of 169 ordered codec
+  pairs; firewall->firewall is excluded because that direction is already
+  loud.  Notice only -- it never refuses a job or changes its status.
+
+- **The product's scope is now a declaration rather than an argument.**  A
+  codec's first `device_classes` entry is its **primary device class** and is
+  the authoritative scope statement for that platform.  Two-clause test for
+  setting it in `AGENTS.md` § Hard Rules; `Primary class` column and a
+  Platform-fit section in `docs/CAPABILITIES.md`; definition in
+  `docs/glossary.md`; guarded by
+  `tests/unit/migration/test_scope_boundary.py`.
+
+### Changed
+
+- **netcanon.net and README state the device-class gradient** instead of a
+  flat vendor list: switches and routers first, firewall platforms declared
+  as L2/L3-layer-only.  No codec was removed and none lost capability -- both
+  firewall platforms remain first-class parse sources, auto-detected and
+  fully audited.  The landing page's capability-matrix excerpt moved off the
+  `fortigate_cli` panel onto `cisco_iosxe_cli`, so the page no longer proves
+  its central claim exclusively with a platform it translates only in part.
+
+### Fixed
+
+- **`juniper_junos` declared the wrong device classes.**  The codec listed
+  `[switch, router]` while `vendors/juniper_junos.yaml` listed
+  `[switch, router, firewall]` and named the SRX series.  The codec was the
+  wrong side -- it parses a vSRX fixture to 15 interfaces with 36
+  `set security *` stanzas surfaced as Tier 3 -- so it gained the class.
+  Junos remains switch-primary.  A new agreement guard makes the two sides
+  unable to drift again.
+
+- **Four doc-truth defects**, all pre-existing: a stale `CODEC_BUG` triage row
+  naming a `juniper_junos -> fortigate_cli` cell that exists nowhere in the
+  mesh (the real fifth cell is `juniper_junos -> cisco_iosxe_cli`, and it is
+  the real-fixture twin of the synthetic row beside it); `ARCHITECTURE.md`
+  contradicting itself on `unsupported_rename_categories`; and unguarded
+  prose counts ("the 8 migration vendors" when there are 12, "50+ profiles"
+  when there are 54, "twelve codecs") deleted per the AGENTS.md rule rather
+  than updated.
+
 ## [0.6.2] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Multi-vendor network config translator with a verifiable cross-vendor audit.**
 
-Translates running-config across twelve codecs spanning Cisco (IOS-XE,
+Translates running-config across the shipped codecs — Cisco (IOS-XE,
 NX-OS, IOS-XR), Juniper Junos, Arista EOS, Aruba (AOS-S, AOS-CX),
 Fortinet FortiGate, MikroTik RouterOS, OPNsense, and VyOS — see
 [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md) for the full per-codec list.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@
 
 **Multi-vendor network config translator with a verifiable cross-vendor audit.**
 
-Translates running-config across the shipped codecs — Cisco (IOS-XE,
-NX-OS, IOS-XR), Juniper Junos, Arista EOS, Aruba (AOS-S, AOS-CX),
-Fortinet FortiGate, MikroTik RouterOS, OPNsense, and VyOS — see
-[`docs/CAPABILITIES.md`](docs/CAPABILITIES.md) for the full per-codec list.
+**Built for switches and routers.**  Translates running-config across
+Cisco (IOS-XE, NX-OS, IOS-XR), Juniper Junos, Arista EOS, Aruba
+(AOS-S, AOS-CX), MikroTik RouterOS, and VyOS.
+
+**Fortinet FortiGate and OPNsense are supported at the L2/L3 layer
+only:** that covers interface addressing, VLAN interfaces and local
+users; the policy table, NAT, VPN and UTM are out of scope in either
+direction.  See [`docs/CAPABILITIES.md`](docs/CAPABILITIES.md) for the
+full per-codec list.
 You point Netcanon at a config from one vendor and it renders the
 equivalent config for another — through a shared canonical model, with
 every translatable field declared as supported, lossy, or unsupported.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -23,20 +23,38 @@ The migration codecs listed below ship today, plus a `_mock` adapter
 used in tests.  Backup-side device definitions are listed under
 [`../netcanon/definitions/library/`](../netcanon/definitions/library/) (one YAML per vendor/OS family).
 
-| Codec | Vendor | Wire format | Direction | Certainty |
-|---|---|---|---|---|
-| `cisco_iosxe_cli` | Cisco IOS-XE | `show running-config` text | bidirectional | certified |
-| `cisco_iosxe`     | Cisco IOS-XE | NETCONF / OpenConfig XML  | bidirectional | best_effort (Phase 0.5 stub render) |
-| `cisco_nxos`      | Cisco NX-OS  | `show running-config` text | bidirectional | certified (all 4 phases — L1/L3 + L2 switchport/LAG + SNMP/users + HSRP + VRF RD/RT + per-VRF static + VXLAN-EVPN/L3VNI + IPv4 Distributed Anycast Gateway; round-trip-validated against a 6-config `batfish/lab-validation` corpus across 4 NX-OS 9.x scenarios; IPv6 anycast, plus a documented set of Tier-2/Tier-3 surfaces, remain unsupported — see the live matrix / §A) |
-| `cisco_iosxr`     | Cisco IOS-XR | `show running-config` text | bidirectional | certified (all 4 phases — interfaces (4-segment) + VRF + RT + RD-from-`router bgp` + per-iface VRF + Bundle-Ether LAGs + local users + per-VRF static + dot1q→VLAN; SP-routing/route-policy/MPLS/IS-IS surfaced via the Tier-3 banner; round-trip-validated against a 10-config corpus from two sources — `batfish/lab-validation` + `ios-xr/xrd-tools` SR/SRv6/IS-IS) |
-| `arista_eos`      | Arista EOS    | EOS CLI text              | bidirectional | certified |
-| `aruba_aoss`      | Aruba AOS-S   | AOS-S CLI banner + positional port lists | bidirectional | certified |
-| `aruba_aoscx`     | Aruba AOS-CX  | `show running-config` text | bidirectional | certified (all 4 phases — hostname + interfaces (multi-token names `interface vlan 11` / `lag 1` / `1/1/1`; L3 + L2 switchport `no routing` / `vlan access` / `vlan trunk`) + VLANs (id/name/description + port projection) + LAGs (`interface lag` + `lacp mode`) + local users + SNMP (community / system-location / system-contact / v3 USM) + `active-gateway` anycast (VSX/EVPN distributed gateway) + top-level `vrf` + default-VRF static + VXLAN L2 VLAN↔VNI binding (`interface vxlan` / `vni` / `vlan`); round-trip-validated against a 4-config `aruba/aoscx-ansible-dcn-workflows` corpus (VXLAN leaves + active-gateway cores) on AOS-CX 10.04 / 10.13; per-VLAN L2VNI RD/RT + symmetric-IRB L3VNI + VSX + VRRP remain unsupported) |
-| `juniper_junos`   | Juniper Junos | `set`-form CLI            | bidirectional | certified |
-| `fortigate_cli`   | Fortinet FortiGate | nested `config / edit / set / next / end` CLI | bidirectional | certified |
-| `mikrotik_routeros` | MikroTik RouterOS | `/path` slash-prefixed CLI export | bidirectional | certified |
-| `opnsense`        | OPNsense      | `config.xml`              | bidirectional | certified |
-| `vyos`            | VyOS          | `config.boot` curly-brace **or** `set`-form text | bidirectional | certified (Phases 1-6 — `system host-name` + ethernet / loopback / dummy interfaces (address IPv4+IPv6 CIDR / `dhcp` / description / `disable` / mtu) + `vif` VLAN sub-interfaces (`ethN.<vid>`) + `protocols static` routes + `system login` local users + `system`/`service` ntp servers (bare + 1.4 block form) + `bonding` LAGs (`mode 802.3ad` LACP + both member forms) + `service snmp` (v1/v2c community / location / contact + v3 USM users) + VRF (`vrf name` routing-instances + per-interface `vrf` binding) + `interfaces vxlan` netdevs (one VNI each — vni / source / mcast or remote / port); round-trip-validated against a 10-config real corpus from 4 sources spanning VyOS 1.3/1.4/1.5 (`cisagov/prescup-challenges` MIT IPv4/OSPF + IPv6/BGP, `zhouleyan/wcni-kind` Apache-2.0 VXLAN pair, `scottlaird/vyos-parser` + `rapid7/metasploit-framework` for `service snmp`); accepts BOTH the native curly-brace `config.boot` AND `set`-form input (`show configuration commands`, converted to curly-brace up front; the probe disambiguates VyOS set-form from the `set`-form `juniper_junos` codec); per-VRF static routes + symmetric-IRB L3VNI remain later phases) |
+**Platform fit.**  The canonical model covers the shared network-function
+layer.  On a switch or router that is most of the device's configuration;
+on a firewall appliance it is a minority of it.  The policy table, NAT, VPN
+and UTM profiles are Tier 3 and are out of scope **in either direction** —
+when a firewall is the *source* they are detected and listed by name; when a
+firewall is the *target*, nothing is emitted for them at all and no banner
+says so (Tier-3 detection is parse-side only).  If your migration's centre of
+gravity is policy, Netcanon is the wrong tool — see
+[`COMPARISON.md`](COMPARISON.md).
+
+A codec's **primary device class** — the `Primary class` column below, and
+the first entry in its `device_classes` — is the authoritative scope
+declaration for that platform: `firewall`-primary codecs are translated at
+the L2/L3 layer only.  The two-clause test for setting it lives in
+[`../AGENTS.md`](../AGENTS.md) § Hard Rules; the term is defined in
+[`glossary.md`](glossary.md); the boundary is guarded by
+[`../tests/unit/migration/test_scope_boundary.py`](../tests/unit/migration/test_scope_boundary.py).
+
+| Codec | Vendor | Primary class | Wire format | Direction | Certainty |
+|---|---|---|---|---|---|
+| `cisco_iosxe_cli` | Cisco IOS-XE | router | `show running-config` text | bidirectional | certified |
+| `cisco_iosxe`     | Cisco IOS-XE | router | NETCONF / OpenConfig XML  | bidirectional | best_effort (Phase 0.5 stub render) |
+| `cisco_nxos`      | Cisco NX-OS  | switch | `show running-config` text | bidirectional | certified (all 4 phases — L1/L3 + L2 switchport/LAG + SNMP/users + HSRP + VRF RD/RT + per-VRF static + VXLAN-EVPN/L3VNI + IPv4 Distributed Anycast Gateway; round-trip-validated against a 6-config `batfish/lab-validation` corpus across 4 NX-OS 9.x scenarios; IPv6 anycast, plus a documented set of Tier-2/Tier-3 surfaces, remain unsupported — see the live matrix / §A) |
+| `cisco_iosxr`     | Cisco IOS-XR | router | `show running-config` text | bidirectional | certified (all 4 phases — interfaces (4-segment) + VRF + RT + RD-from-`router bgp` + per-iface VRF + Bundle-Ether LAGs + local users + per-VRF static + dot1q→VLAN; SP-routing/route-policy/MPLS/IS-IS surfaced via the Tier-3 banner; round-trip-validated against a 10-config corpus from two sources — `batfish/lab-validation` + `ios-xr/xrd-tools` SR/SRv6/IS-IS) |
+| `arista_eos`      | Arista EOS    | switch | EOS CLI text              | bidirectional | certified |
+| `aruba_aoss`      | Aruba AOS-S   | switch | AOS-S CLI banner + positional port lists | bidirectional | certified |
+| `aruba_aoscx`     | Aruba AOS-CX  | switch | `show running-config` text | bidirectional | certified (all 4 phases — hostname + interfaces (multi-token names `interface vlan 11` / `lag 1` / `1/1/1`; L3 + L2 switchport `no routing` / `vlan access` / `vlan trunk`) + VLANs (id/name/description + port projection) + LAGs (`interface lag` + `lacp mode`) + local users + SNMP (community / system-location / system-contact / v3 USM) + `active-gateway` anycast (VSX/EVPN distributed gateway) + top-level `vrf` + default-VRF static + VXLAN L2 VLAN↔VNI binding (`interface vxlan` / `vni` / `vlan`); round-trip-validated against a 4-config `aruba/aoscx-ansible-dcn-workflows` corpus (VXLAN leaves + active-gateway cores) on AOS-CX 10.04 / 10.13; per-VLAN L2VNI RD/RT + symmetric-IRB L3VNI + VSX + VRRP remain unsupported) |
+| `juniper_junos`   | Juniper Junos | switch | `set`-form CLI            | bidirectional | certified |
+| `fortigate_cli`   | Fortinet FortiGate | firewall | nested `config / edit / set / next / end` CLI | bidirectional | certified |
+| `mikrotik_routeros` | MikroTik RouterOS | router | `/path` slash-prefixed CLI export | bidirectional | certified |
+| `opnsense`        | OPNsense      | firewall | `config.xml`              | bidirectional | certified |
+| `vyos`            | VyOS          | router | `config.boot` curly-brace **or** `set`-form text | bidirectional | certified (Phases 1-6 — `system host-name` + ethernet / loopback / dummy interfaces (address IPv4+IPv6 CIDR / `dhcp` / description / `disable` / mtu) + `vif` VLAN sub-interfaces (`ethN.<vid>`) + `protocols static` routes + `system login` local users + `system`/`service` ntp servers (bare + 1.4 block form) + `bonding` LAGs (`mode 802.3ad` LACP + both member forms) + `service snmp` (v1/v2c community / location / contact + v3 USM users) + VRF (`vrf name` routing-instances + per-interface `vrf` binding) + `interfaces vxlan` netdevs (one VNI each — vni / source / mcast or remote / port); round-trip-validated against a 10-config real corpus from 4 sources spanning VyOS 1.3/1.4/1.5 (`cisagov/prescup-challenges` MIT IPv4/OSPF + IPv6/BGP, `zhouleyan/wcni-kind` Apache-2.0 VXLAN pair, `scottlaird/vyos-parser` + `rapid7/metasploit-framework` for `service snmp`); accepts BOTH the native curly-brace `config.boot` AND `set`-form input (`show configuration commands`, converted to curly-brace up front; the probe disambiguates VyOS set-form from the `set`-form `juniper_junos` codec); per-VRF static routes + symmetric-IRB L3VNI remain later phases) |
 
 Backup-side device-definition YAMLs ship for every codec family above
 (plus per-OS-version overlays).  Cisco and Aruba each span two NOSes with
@@ -306,7 +324,7 @@ output.
 | `/routing/bgp` | Unsupported | BGP / IS-IS / OSPF / MPLS stanzas parse-and-ignore in v1; Junos routing-options grammar warrants a dedicated follow-up. |
 | `/firewall/filter` | Unsupported | Junos firewall filters (family / term / from / then) are Tier 3 — distinct from ACL models in other codecs. |
 
-#### `fortigate_cli` (bidirectional)
+#### `fortigate_cli` (bidirectional) — L2/L3 layer only (firewall policy is Tier 3, never translated)
 
 | Path | Class | Reason |
 |---|---|---|
@@ -340,7 +358,7 @@ output.
 | `/nat/rule` | Unsupported | NAT rules are Tier 3 — informational only. |
 | `/vxlan-vnis/{vni,source-interface,udp-port}` | Unsupported | RouterOS VXLAN exists but is rare in canonical scope and not modelled in v1. |
 
-#### `opnsense` (bidirectional)
+#### `opnsense` (bidirectional) — L2/L3 layer only (firewall policy is Tier 3, never translated)
 
 | Path | Class | Reason |
 |---|---|---|

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -28,10 +28,10 @@ layer.  On a switch or router that is most of the device's configuration;
 on a firewall appliance it is a minority of it.  The policy table, NAT, VPN
 and UTM profiles are Tier 3 and are out of scope **in either direction** —
 when a firewall is the *source* they are detected and listed by name; when a
-firewall is the *target*, nothing is emitted for them at all and no banner
-says so (Tier-3 detection is parse-side only).  If your migration's centre of
-gravity is policy, Netcanon is the wrong tool — see
-[`COMPARISON.md`](COMPARISON.md).
+firewall is the *target*, nothing is emitted for them at all and the migrate
+page raises a **scope advisory** saying so (see § Scope advisories below).
+If your migration's centre of gravity is policy, Netcanon is the wrong tool —
+see [`COMPARISON.md`](COMPARISON.md).
 
 A codec's **primary device class** — the `Primary class` column below, and
 the first entry in its `device_classes` — is the authoritative scope
@@ -583,6 +583,32 @@ fields.  The migrate page reflects this in the status banner and
 
 Job status reaches `failed` only when a stage actually raises;
 validation alone never fails the job.
+
+### D2. Scope advisories (target-platform notices)
+
+Separate from the severity ladder above, and deliberately so: that ladder
+grades **per-xpath** loss for fields the source actually carried, whereas a
+scope advisory reports something about the **target platform** that no field
+can express — the absence of a whole configuration plane.
+
+`job.scope_advisories` is populated by `run_plan` when the target's *primary
+device class* is `firewall` and the source's is not (see § Platform fit).  It
+is a notice, never a gate: `job.status` and `job.validation.severity` are
+untouched, the render proceeds, and the operator may ignore it.
+
+It exists because that direction was otherwise unreported.  The Tier-3 banner
+reads the **source** config, so it says nothing when the source is a switch;
+and `/filter/rule` / `/nat/rule` are declared `unsupported` but no canonical
+field walks to them, so `validate_against` — which is a *loss* detector, not
+an *absence* detector — cannot fire on them either.  Building a canonical
+firewall surface would not change that: with `firewall_rules == []` the walker
+still yields nothing.  So the notice is stated where it can be stated at all.
+
+Firewall→firewall pairs deliberately raise no advisory: there the source
+codec's Tier-3 detector already names the lost policy stanzas.
+
+Rendered on the migrate page as `migrate-scope-advisory-banner`, beneath the
+Tier-3 banner.
 
 ### E. Compatibility-banner per rename pane
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -19,8 +19,8 @@ lives in [`../tests/fixtures/real/RESULTS.md`](../tests/fixtures/real/RESULTS.md
 
 ## Supported vendors
 
-Twelve migration codecs ship today, plus a `_mock` adapter used in
-tests.  Backup-side device definitions are listed under
+The migration codecs listed below ship today, plus a `_mock` adapter
+used in tests.  Backup-side device definitions are listed under
 [`../netcanon/definitions/library/`](../netcanon/definitions/library/) (one YAML per vendor/OS family).
 
 | Codec | Vendor | Wire format | Direction | Certainty |

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -128,7 +128,10 @@ same engine that parses a config also scrubs it.
 ## See also
 
 - [`docs/CAPABILITIES.md`](CAPABILITIES.md) — what's supported,
-  lossy, or out-of-scope per vendor pair
+  lossy, or out-of-scope per vendor pair, and § Platform fit for the
+  per-device-class scope gradient the table above summarises
+- [`docs/glossary.md`](glossary.md) — "primary device class" and the
+  rest of the vocabulary used here
 - [`docs/METHODOLOGY.md`](METHODOLOGY.md) — the matrix-honesty
   discipline that backs the accuracy claim
 - [`docs/IDENTITY.md`](IDENTITY.md) — tagline / GitHub

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -27,6 +27,23 @@ per-field capability declarations.
 
 ---
 
+## What device classes this is for
+
+The table below answers *which tool*.  This section answers *which
+box* — the axis a vendor list alone never settles.
+
+| Device class | Netcanon's fit |
+|---|---|
+| **Switches** — campus / DC access, aggregation, leaf-spine | Primary target.  Most of what such a box carries is inside the canonical model: interfaces, VLANs and L2 membership, LAGs, SVIs, static routes, VRFs, SNMP, local users. |
+| **Routers** — branch, edge, service-provider | Primary target.  Same canonical surface.  Dynamic-routing protocol stanzas (BGP / OSPF / IS-IS) are Tier 3 — detected when parsing, never rendered. |
+| **Firewall platforms** — FortiGate, OPNsense | **The L2/L3 layer only.**  That covers interface addressing, VLAN interfaces and local users.  The policy table, NAT, VPN and UTM are out of scope in either direction — and on a firewall appliance those are the majority of the configuration.  If your migration's centre of gravity is policy, Netcanon is the wrong tool; Capirca / Aerleon render that layer for the same targets. |
+
+Each codec declares its own device classes, most specific first, in
+`netcanon/migration/vendors/<vendor>.yaml` (`device_classes`).  A codec
+whose first declared class is `firewall` sits in the third row above.
+
+---
+
 ## Comparison table
 
 | Tool | Scope | Direction | Multi-vendor? | Translation accuracy posture |

--- a/docs/IDENTITY.md
+++ b/docs/IDENTITY.md
@@ -31,7 +31,7 @@ surface.
 ## GitHub repo description (extended)
 
 ```
-Multi-vendor network config translator — Cisco / Juniper / Fortinet / Aruba / Arista / MikroTik / OPNsense / VyOS. Cross-mesh audit catches silent translation errors before they ship.
+Multi-vendor switch & router config translator — Cisco / Juniper / Arista / Aruba / MikroTik / VyOS. Cross-mesh audit catches silent translation errors before they ship. Firewall platforms (Fortinet FortiGate, OPNsense) are supported at the L2/L3 layer only — policy, NAT and VPN are out of scope.
 ```
 
 (Fits comfortably under GitHub's 350-char limit.  Names the vendor

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -65,6 +65,18 @@ by concern and listed alphabetically within each section.
 - **INPUT_FORMATS** — codec ClassVar string family (e.g. `cli`,
   `netconf-xml`, `xml`) shown in the target dropdown to disambiguate
   variants of the same vendor (e.g. Cisco IOS-XE NETCONF vs CLI).
+- **Primary device class** — the **first** entry in a codec's
+  `device_classes` (declared in `netcanon/migration/vendors/<vendor>.yaml`
+  and mirrored in its `CapabilityMatrix`).  It is the project's
+  authoritative scope declaration for that platform, so the order of
+  the list is load-bearing, not cosmetic.  A `firewall`-primary codec
+  (`fortigate_cli`, `opnsense`) is one Netcanon translates at the
+  L2/L3 layer only, and one that does not front the product — see the
+  two-clause scope test in [`AGENTS.md`](../AGENTS.md) § Hard Rules,
+  guarded by
+  [`tests/unit/migration/test_scope_boundary.py`](../tests/unit/migration/test_scope_boundary.py).
+  Distinct from the *set* of device classes, which is only used by the
+  cross-device-class compatibility guard.
 - **Probe** — `classmethod probe(raw_prefix) -> (confidence, reason) | None`.
   Each codec votes on a candidate input; the orchestrator picks the
   highest-confidence match for source detection.

--- a/netcanon/api/routes/ui.py
+++ b/netcanon/api/routes/ui.py
@@ -414,13 +414,13 @@ def definitions_page(request: Request) -> HTMLResponse:
        ``Fortigate`` etc.).  Excludes overlays.
     2. **Version / model overlays** — the extra variants loaded
        alongside family bases (e.g. ``Cisco 17.12`` version-pin).
-       Explains the "loaded 5 but only 4 top-level rows" split.
-    3. **Migration target profiles** — the 50+ hardware-aware
-       profiles under ``definitions/target_profiles/``: per-model
-       port layouts, module variants (NM-8X etc.), stacking caps,
+       Explains the "loaded more than there are top-level rows" split.
+    3. **Migration target profiles** — the hardware-aware profiles
+       under ``definitions/target_profiles/``: per-model port
+       layouts, module variants (NM-8X etc.), stacking caps,
        VLAN/user limits.  Previously only reachable through the
        Tier-3 rename modal's dropdown.
-    4. **Vendors + codec capabilities** — the 8 migration vendors
+    4. **Vendors + codec capabilities** — the migration vendors
        with their shipped codecs (direction, certainty tier,
        device classes).
     """

--- a/netcanon/migration/codecs/juniper_junos/codec.py
+++ b/netcanon/migration/codecs/juniper_junos/codec.py
@@ -118,7 +118,16 @@ class JunosCodec(CodecBase):
         adapter="juniper_junos",
         vendor_id="juniper_junos",
         version_range="18.x+",
-        device_classes=[DeviceClass.switch, DeviceClass.router],
+        # `firewall` is third, not first: Junos ships on EX / QFX switches and
+        # MX routers as well as SRX firewalls, so it is switch-primary under
+        # the scope test in AGENTS.md (clause (b) fails — Junos IS a switching
+        # NOS in its own right).  It is declared at all because the codec does
+        # cover SRX: `jnprautomate_mnha_vsrx_a_junos.set` parses to 15
+        # interfaces with 36 `set security *` stanzas surfaced as Tier 3.
+        # Was missing here while `vendors/juniper_junos.yaml` (which names the
+        # SRX series in its header) had it — drift closed by the agreement
+        # guard in tests/unit/migration/test_scope_boundary.py.
+        device_classes=[DeviceClass.switch, DeviceClass.router, DeviceClass.firewall],
         supported=[
             "/system/hostname",
             # `set system syslog host <ip>` — parse+render; was implicit-

--- a/netcanon/models/migration.py
+++ b/netcanon/models/migration.py
@@ -480,6 +480,8 @@ class MigrationJob(BaseModel):
             parse so the migrate page can render a "Detected in
             source but not translated" banner.  Notification surface
             only — never read by any render-side code or transform.
+            See also ``scope_advisories``, which reports the TARGET
+            platform rather than the source.
             Populated by every codec's ``parse()``; see
             :mod:`netcanon.migration._tier3_detection` for the per-
             vendor detectors.
@@ -638,6 +640,15 @@ class MigrationJob(BaseModel):
     #: ``parse()``; see :mod:`netcanon.migration._tier3_detection` for
     #: the per-vendor detectors.
     dropped_tier3_sections: list[str] = Field(default_factory=list)
+
+    #: Scope notices about the TARGET platform, as opposed to
+    #: :attr:`dropped_tier3_sections` which reports the SOURCE.  Populated by
+    #: ``run_plan`` from :func:`netcanon.services.migration_validate
+    #: .check_scope_advisory` when translating into a firewall-primary
+    #: platform, where Netcanon emits no policy plane and nothing else on the
+    #: page would say so.  Notification surface only — never read by render-
+    #: side code.  Empty for every switch/router target.
+    scope_advisories: list[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/netcanon/services/migration_pipeline.py
+++ b/netcanon/services/migration_pipeline.py
@@ -111,7 +111,11 @@ from ..models.migration import (
     MigrationJobStatus,
     TransformSpec,
 )
-from .migration_validate import check_class_compat, validate_against
+from .migration_validate import (
+    check_class_compat,
+    check_scope_advisory,
+    validate_against,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +266,14 @@ def run_plan(
             " ".join(class_compat.reasons),
         )
         return job
+
+    # Stage 0b — scope advisory.  A NOTICE, not a gate: it never refuses and
+    # never changes job.status.  Kept separate from the guard above because
+    # that function's `warn` severity is already claimed by "an adapter
+    # declared no device_classes", which is a different statement entirely.
+    scope_advisory = check_scope_advisory(source, target)
+    if scope_advisory is not None:
+        job.scope_advisories.extend(scope_advisory.reasons)
 
     try:
         # Stage 2 — parse

--- a/netcanon/services/migration_validate.py
+++ b/netcanon/services/migration_validate.py
@@ -19,6 +19,7 @@ from ..migration.codecs.base import CodecBase
 from ..models.diff import CompatibilityReport
 from ..models.migration import (
     CapabilityMatrix,
+    DeviceClass,
     LossyPath,
     UnsupportedPath,
     ValidationReport,
@@ -179,6 +180,11 @@ def check_class_compat(
     :mod:`netcanon.models.diff` so the UI banner component stays the
     same regardless of which layer surfaced the mismatch.
 
+    This function is a **gate**: its answer decides whether the job runs.
+    Scope *notices* — which never refuse anything — live in
+    :func:`check_scope_advisory`.  Keep the two separate; the reasoning is
+    in the comment above this function's final ``return``.
+
     Args:
         source: Adapter that will parse the input.
         target: Adapter that will render the output.
@@ -236,8 +242,109 @@ def check_class_compat(
             ],
         )
 
+    # NOTE — do not add a firewall-target arm here, or anywhere above this
+    # point.  Every codec declares ``router``, so a switch-only source and a
+    # firewall-primary target still intersect and reach this line; but a
+    # genuinely disjoint pair (a source declaring only ``switch`` against a
+    # target declaring only ``firewall``) matches BOTH the block arm above and
+    # any firewall-target predicate.  Hoisting one above the other makes this
+    # guard's only refusal unreachable for every firewall target.  The scope
+    # advisory is therefore a SEPARATE function — see
+    # :func:`check_scope_advisory` — which also keeps this function's
+    # gate semantics (block/allow) from being confused with a notice.
     return CompatibilityReport(
         compatible=True,
         severity="ok",
         reasons=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scope advisory (notice, not a gate)
+# ---------------------------------------------------------------------------
+
+#: Per-target policy-binding grammar, named so the advisory never prints
+#: FortiOS syntax on an OPNsense job.  Keyed by ``CapabilityMatrix.adapter``.
+_POLICY_BINDING_PHRASE = {
+    "fortigate_cli": "FortiOS policies bind to interface names (set srcintf / set dstintf)",
+    "opnsense": "OPNsense rules bind to interface zone tags (<interface>lan</interface>)",
+}
+_POLICY_BINDING_FALLBACK = "Firewall policy binds to interface names"
+
+
+def _primary_class(caps: CapabilityMatrix) -> DeviceClass | None:
+    """First declared device class — the platform's scope declaration.
+
+    See ``AGENTS.md`` § Hard Rules ("Never author or change a codec's
+    ``device_classes[0]`` without applying the scope test").
+    """
+    classes = caps.device_classes
+    return classes[0] if classes else None
+
+
+def _is_firewall_primary(caps: CapabilityMatrix) -> bool:
+    """``True`` iff this adapter's PRIMARY device class is ``firewall``.
+
+    Keyed on position 0 deliberately, not on membership: ``mikrotik_routeros``,
+    ``vyos`` and ``juniper_junos`` all declare ``firewall`` as a secondary
+    class and are full-scope router/switch platforms.  A membership test
+    misfires on all three.
+    """
+    return _primary_class(caps) is DeviceClass.firewall
+
+
+def check_scope_advisory(
+    source: CodecBase, target: CodecBase
+) -> CompatibilityReport | None:
+    """Notice for translations INTO a firewall-primary platform.
+
+    This is deliberately **not** part of :func:`check_class_compat`.  That
+    function is a gate whose contract is block-or-allow; this is a notice that
+    never refuses anything.  Merging them would force the caller to demux on
+    ``severity == "warn"``, which three of ``check_class_compat``'s own arms
+    already return for an unrelated reason (an adapter that declares no
+    classes at all) — and their text would then be rendered under this
+    advisory's heading.
+
+    Fires only when the target is firewall-primary and the source is not.
+    A firewall-to-firewall pair is excluded on purpose: that direction is
+    already loud, because the source codec's Tier-3 detector names the lost
+    policy stanzas in ``dropped_tier3_sections``.  The silent direction — and
+    the only one this covers — is switch/router into firewall.
+
+    Args:
+        source: Adapter that will parse the input.
+        target: Adapter that will render the output.
+
+    Returns:
+        A ``warn``-severity, ``compatible=True`` report, or ``None`` when the
+        pair does not warrant one.  ``None`` rather than an ``ok`` report so
+        the caller needs no severity parsing to tell "no advisory" from
+        "advisory that happens to be mild".
+    """
+    if not _is_firewall_primary(target.capabilities):
+        return None
+    if _is_firewall_primary(source.capabilities):
+        return None
+
+    adapter = target.capabilities.adapter
+    binding = _POLICY_BINDING_PHRASE.get(adapter, _POLICY_BINDING_FALLBACK)
+    return CompatibilityReport(
+        compatible=True,
+        severity="warn",
+        reasons=[
+            f"Target {adapter} is a firewall platform; Netcanon translates "
+            f"its L2/L3 layer only.  It carries interface addressing, VLAN "
+            f"interfaces and local users onto a firewall target - the policy "
+            f"table, NAT, VPN and UTM are not emitted.  No banner reports the "
+            f"target's missing policy plane: the Tier-3 banner reads your "
+            f"source config, not the target.",
+            f"{binding}, and the interface names in this output come from the "
+            f"source config, rewritten by Netcanon's cross-vendor "
+            f"interface-name translation - and by any target profile you "
+            f"applied in the rename panel.  If you merge it into an appliance "
+            f"that already carries policy, check every rule binding: a rule "
+            f"can end up on a different interface than it was written for, or "
+            f"on one this config does not define.",
+        ],
     )

--- a/netcanon/templates/definitions.html
+++ b/netcanon/templates/definitions.html
@@ -5,9 +5,9 @@
   Definitions browser — four sections:
     1. Backup-side device definitions (family-base YAMLs).
     2. Version / model overlays (loaded but filtered out of load_all).
-    3. Migration target profiles (per-model hardware; 50+ entries
-       previously only accessible via the Tier-3 rename modal).
-    4. Vendors + codec capabilities (the 8 migration vendors with
+    3. Migration target profiles (per-model hardware; previously
+       only accessible via the Tier-3 rename modal).
+    4. Vendors + codec capabilities (the migration vendors with
        shipped codecs, direction, certainty tier).
 
   Every section carries a `section-<name>` testid on the container

--- a/netcanon/templates/migrate.html
+++ b/netcanon/templates/migrate.html
@@ -439,6 +439,16 @@
          class="mig-banner mig-banner-warn"
          style="display:none; margin-top:.5rem"></div>
 
+    <!-- Scope advisory: reports the TARGET platform, where the tier-3
+         banner above reports the SOURCE.  Fires when translating into a
+         firewall-primary platform, whose policy plane netcanon never
+         emits and which no other banner on this page mentions.
+         Populated by JS from job.scope_advisories; rendered via
+         renderScopeAdvisoryBanner(). -->
+    <div id="mig-scope-banner" data-testid="migrate-scope-advisory-banner"
+         class="mig-banner mig-banner-warn"
+         style="display:none; margin-top:.5rem"></div>
+
     <div id="mig-stats" class="mig-stats"
          data-testid="migrate-stats" style="margin-top:.5rem"></div>
   </div>
@@ -840,6 +850,7 @@
   var summary    = document.getElementById('mig-status-summary');
   var banner     = document.getElementById('mig-banner');
   var tier3Banner = document.getElementById('mig-tier3-banner');
+  var scopeBanner = document.getElementById('mig-scope-banner');
   var stats      = document.getElementById('mig-stats');
   var outputSec  = document.getElementById('mig-output-section');
   var output     = document.getElementById('mig-output');
@@ -1451,6 +1462,7 @@
     // translate them.  See ARCHITECTURE.md "Cross-cutting render-time
     // policies" for the Tier-3 boundary rationale.
     renderTier3Banner(job);
+    renderScopeAdvisoryBanner(job);
 
     // Counts strip.
     if (job.validation) {
@@ -1571,6 +1583,35 @@
       + 'Operator must apply them manually on the target device.'
       + '</div>'
       + '<ul style="margin-top:.4rem">' + rows + '</ul>';
+  }
+
+  /** Render the scope-advisory banner.
+   *
+   * Reads job.scope_advisories (populated by run_plan via
+   * check_scope_advisory()).  Distinct from the tier-3 banner above:
+   * that one reports what the SOURCE carried and we dropped, this one
+   * reports what the TARGET platform will not receive at all.  Without
+   * it, a switch -> firewall translation says nothing anywhere about the
+   * missing policy plane.  Notification only.
+   */
+  function renderScopeAdvisoryBanner(job) {
+    if (!scopeBanner) return;
+    var notes = (job && job.scope_advisories) || [];
+    if (!notes.length) {
+      scopeBanner.style.display = 'none';
+      scopeBanner.innerHTML = '';
+      return;
+    }
+    var rows = notes.map(function(note, idx) {
+      return '<li data-testid="migrate-scope-advisory-' + idx + '">'
+           + escapeHtml(note) + '</li>';
+    }).join('');
+    scopeBanner.style.display = '';
+    scopeBanner.innerHTML =
+      '<div style="flex:1">'
+      + '<strong>&#9888; Target is a firewall platform</strong>'
+      + '<ul style="margin-top:.4rem;font-size:.82rem">' + rows + '</ul>'
+      + '</div>';
   }
 
   /** Render a bucket of validation findings.

--- a/site/index.html
+++ b/site/index.html
@@ -79,6 +79,8 @@ pre code { background: none; border: none; padding: 0; }
 .hero { margin-top: 48px; display: flex; flex-direction: column; }
 .hero .sub { font-size: var(--nc-fs-lg); line-height: var(--nc-lh-base); max-width: 46em; }
 .vendor-row { color: var(--nc-text-muted); font-size: var(--nc-fs-base); margin: 12px 0 0; }
+.device-frame { margin: 12px 0 0; }
+.vendor-row strong { color: var(--nc-text); }
 .doors { display: flex; gap: 12px; flex-wrap: wrap; margin: 28px 0 8px; }
 .btn {
   display: inline-block; padding: 10px 20px; border-radius: var(--nc-r-md);
@@ -144,11 +146,12 @@ footer { border-top: 1px solid var(--nc-border); margin-top: 64px; padding: 32px
 @media (max-width: 640px) {
   section { margin: 48px auto; }
   .hero > h1 { order: 1; }
-  .hero > .sub { order: 3; }
-  .hero > .vendor-row { order: 2; }
+  .hero > .device-frame { order: 2; }
+  .hero > .vendor-row { order: 3; }
+  .hero > .sub { order: 4; }
   .hero > .doors { order: 0; margin: 0 0 20px; }
-  .hero > .tabs { order: 4; }
-  .hero > .capacity { order: 5; }
+  .hero > .tabs { order: 5; }
+  .hero > .capacity { order: 6; }
   .pane-grid { grid-template-columns: 1fr; }
   .btn { width: 100%; text-align: center; }
 }
@@ -163,9 +166,14 @@ footer { border-top: 1px solid var(--nc-border); margin-top: 64px; padding: 32px
   <p class="sub">Netcanon parses one vendor&rsquo;s running-config, renders another&rsquo;s, and declares
   every field it translates as <span class="ok">supported</span>, <span class="warn">lossy</span>,
   or <span class="unsup">unsupported</span> &mdash; with the reason.</p>
-  <p class="vendor-row">Cisco IOS-XE &middot; Cisco NX-OS &middot; Cisco IOS-XR &middot; Juniper Junos &middot;
-  Arista EOS &middot; Aruba AOS-S &middot; Aruba AOS-CX &middot; FortiGate &middot; MikroTik RouterOS &middot;
-  OPNsense &middot; VyOS</p>
+  <p class="device-frame"><strong>Built for switches and routers.</strong> Netcanon translates the
+  network-function layer those platforms share. It is not a firewall-policy tool.</p>
+  <p class="vendor-row"><strong>Switches and routers</strong> &mdash; Cisco IOS-XE &middot; Cisco NX-OS &middot;
+  Cisco IOS-XR &middot; Juniper Junos &middot; Arista EOS &middot; Aruba AOS-S &middot; Aruba AOS-CX &middot;
+  MikroTik RouterOS &middot; VyOS
+  <br><strong>Firewall platforms &mdash; the L2/L3 layer only</strong> &mdash; FortiGate &middot; OPNsense
+  <span class="small">(on a firewall that covers interface addressing, VLAN interfaces and local users;
+  the policy table, NAT, VPN and UTM are out of scope in either direction)</span></p>
 
   <div class="doors">
     <a class="btn btn-primary" href="https://demo.netcanon.net">Try it in the browser</a>

--- a/site/index.html
+++ b/site/index.html
@@ -386,23 +386,31 @@ set servers=192.168.1.10,192.168.1.11</code></pre>
 <!-- ============================ matrix slice ============================ -->
 <section class="col wide" id="matrix">
   <h2>Every field has a declared fate</h2>
-  <p>An excerpt from the capability matrix &mdash; the <code>fortigate_cli</code> panel, verbatim:</p>
+  <p>An excerpt from the capability matrix &mdash; the <code>cisco_iosxe_cli</code> panel of
+  <a href="https://github.com/netcanon/netcanon/blob/main/docs/CAPABILITIES.md">docs/CAPABILITIES.md</a>,
+  verbatim:</p>
   <div class="tbl-wrap">
   <table>
     <tr><th>Canonical path</th><th>Class</th><th>Reason</th></tr>
-    <tr><td><code>&hellip;/vrrp-groups/group</code></td><td class="ok">supported</td>
-        <td>Nested-edit form: <code>config system interface / edit X / config vrrp / edit N / set vrip Y &hellip;</code></td></tr>
-    <tr><td><code>&hellip;/interface/config/description</code></td><td class="warn">lossy</td>
-        <td>FortiOS limits the interface alias to 25 characters; longer descriptions from other vendors are truncated.</td></tr>
-    <tr><td><code>&hellip;/vrrp-groups/group/virtual-ips</code></td><td class="warn">lossy</td>
-        <td>FortiOS <code>config vrrp / edit N</code> accepts a single <code>set vrip</code> per group. Multi-IP canonical
-        groups (IOS-XE repeated <code>vrrp N ip X</code>, Junos <code>virtual-address [ X Y Z ]</code>) emit the first VIP
-        and drop the tail with a <code># review:</code> line &mdash; operator must split into multiple groups manually.</td></tr>
-    <tr><td><code>&hellip;/filter/rule</code></td><td class="unsup">unsupported</td>
-        <td><code>config firewall policy</code> is Tier&nbsp;3 &mdash; session-based, zone-aware, UTM-enabled semantics
-        don&rsquo;t translate cleanly.</td></tr>
-    <tr><td><code>&hellip;/nat/rule</code></td><td class="unsup">unsupported</td>
-        <td>FortiGate NAT lives inside firewall policy and address / VIP objects &mdash; not auto-translatable.</td></tr>
+    <tr><td><code>/routing/static-route/vrf</code></td><td class="ok">supported</td>
+        <td>Per-VRF static routes: <code>ip route vrf &lt;NAME&gt; &lt;dest&gt; &lt;mask&gt; &lt;gw&gt;</code> round-trips
+        through parse + render onto <code>CanonicalStaticRoute.vrf</code>. Administrative-distance is harvested onto
+        <code>metric</code> (and re-emitted) and a trailing <code>name &lt;X&gt;</code> onto <code>description</code>;
+        only the <code>global</code> route-leak / <code>tag</code> / <code>track</code> tokens are not modelled and
+        parse-and-ignore.</td></tr>
+    <tr><td><code>&hellip;/interface/config/type</code></td><td class="warn">lossy</td>
+        <td>CLI parser infers IANA type from name prefix (GigabitEthernet &rarr; ethernetCsmacd, Loopback &rarr;
+        softwareLoopback) but cannot detect all IANA types.</td></tr>
+    <tr><td><code>&hellip;/interface/ipv4/address/virtual-gateway-address</code></td><td class="warn">lossy</td>
+        <td>SD-Access anycast-gateway (<code>virtual_gateway_address == the interface primary IP</code>) round-trips via
+        <code>fabric forwarding mode anycast-gateway</code>, but a SEPARATE cross-vendor VARP virtual IP (the Arista/Junos
+        shape, <code>virtual_gateway_address != the interface IP</code>) has no IOS-XE equivalent and drops on render
+        (review comment only). Demoted from supported to <strong>lossy</strong> so the separate-VIP loss surfaces instead
+        of reporting <code>severity:ok</code> (silent-loss guard).</td></tr>
+    <tr><td><code>/firewall</code></td><td class="unsup">unsupported</td>
+        <td>Zone-based firewall (zone-pair / policy-map type inspect) is Tier&nbsp;3.</td></tr>
+    <tr><td><code>/nat</code></td><td class="unsup">unsupported</td>
+        <td>NAT is Tier&nbsp;3 &mdash; semantics are tightly coupled to interface zone designations.</td></tr>
   </table>
   </div>
   <p style="margin-top:12px">Round-trip validated against real configs. The output is a draft for your review,

--- a/tests/demo/test_demo_docs_truth.py
+++ b/tests/demo/test_demo_docs_truth.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+from html import unescape
 from pathlib import Path
 
 import pytest
@@ -719,4 +720,63 @@ def test_every_printed_serve_command_actually_starts(relpath):
     assert not bad, (
         f"{relpath}: printed serve command(s) that exit 'Refusing to start' "
         f"as pasted: {bad}"
+    )
+
+# ---------------------------------------------------------------------------
+# The landing page prints a capability-matrix excerpt and calls it "verbatim".
+# That word is a claim, and a claim on that page must not outlive its truth:
+# a reason string can be reworded in docs/CAPABILITIES.md by a codec PR that
+# never opens site/index.html, and nothing would notice.  This is the A5
+# transcription guard (review finding R10).
+#
+# Normalisation is deliberately asymmetric because the two sides are different
+# languages: site/ is HTML (strip tags, unescape entities), CAPABILITIES.md is
+# markdown (strip ` and ** only).  Stripping "tags" from the markdown side
+# would eat the <NAME>/<dest>/<mask> placeholders that appear literally in the
+# reason text -- a bug this guard was written after hitting.
+# ---------------------------------------------------------------------------
+
+_MATRIX_ROW_RE = re.compile(
+    r'<tr><td><code>(?P<path>.*?)</code></td>'
+    r'<td class="(?:ok|warn|unsup)">(?P<klass>.*?)</td>\s*'
+    r"<td>(?P<reason>.*?)</td></tr>",
+    re.S,
+)
+
+
+def _squash(text: str) -> str:
+    for a, b in (("\u2192", "->"), ("\u2014", "-"), ("\u00a0", " ")):
+        text = text.replace(a, b)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _matrix_rows() -> list[tuple[str, str, str]]:
+    page = read("site/index.html")
+    section = page.split('id="matrix"', 1)[1].split("</table>", 1)[0]
+    rows = []
+    for m in _MATRIX_ROW_RE.finditer(section):
+        strip_html = lambda s: _squash(unescape(re.sub(r"<[^>]+>", "", s)))  # noqa: E731
+        rows.append((strip_html(m["path"]), m["klass"].strip(), strip_html(m["reason"])))
+    return rows
+
+
+def test_matrix_excerpt_rows_are_transcribed_not_composed():
+    """Every reason string on the page appears verbatim in CAPABILITIES.md."""
+    caps = _squash(read("docs/CAPABILITIES.md").replace("`", "").replace("**", ""))
+    rows = _matrix_rows()
+    assert rows, "no capability-matrix rows found in site/index.html #matrix"
+    missing = [path for path, _klass, reason in rows if reason not in caps]
+    assert not missing, (
+        "site/index.html calls the matrix excerpt 'verbatim', but these rows' "
+        f"reason strings are not in docs/CAPABILITIES.md: {missing}.  Either "
+        "re-transcribe the row or stop calling the excerpt verbatim."
+    )
+
+
+def test_matrix_excerpt_shows_at_least_one_lossy_row():
+    """An all-green slice is the wrong slice (landing-page design brief)."""
+    classes = [klass for _path, klass, _reason in _matrix_rows()]
+    assert "lossy" in classes, (
+        f"matrix excerpt must carry at least one lossy row with its full "
+        f"reason; got {classes}"
     )

--- a/tests/e2e/test_migrate_page.py
+++ b/tests/e2e/test_migrate_page.py
@@ -531,3 +531,50 @@ class TestPathListDeduplication:
         assert entries.count() < int(stat), (
             "de-dup should collapse ≥2 entries for the 3-interface input"
         )
+
+
+class TestScopeAdvisoryBanner:
+    """A1 -- the target-platform scope advisory, proven in a real browser.
+
+    The unit tests prove ``check_scope_advisory`` returns the right object and
+    that ``run_plan`` attaches it.  Neither proves an operator can SEE it, and
+    the design's first candidate channel (``job.warnings``) was rejected
+    precisely because it is populated, serialized and then discarded by the
+    UI.  These two tests are the live proof that this channel is not.
+    """
+
+    def test_banner_visible_translating_into_a_firewall_target(
+        self, page: Page, live_server_url: str,
+    ):
+        mp = MigratePage(page)
+        page.goto(live_server_url + "/migrate")
+        mp.source_select.wait_for(state="visible", timeout=5_000)
+        mp.pick_source("cisco_iosxe_cli")
+        mp.pick_target("fortigate_cli")
+        mp.fill_raw(
+            "hostname edge-01\n!\n"
+            "interface GigabitEthernet0/0\n ip address 10.0.0.1 255.255.255.0\n!\n"
+        )
+        mp.submit_and_wait()
+        banner = page.locator('[data-testid="migrate-scope-advisory-banner"]')
+        expect(banner).to_be_visible()
+        expect(banner).to_contain_text("firewall platform")
+        # The per-target binding grammar, not a generic sentence.
+        expect(banner).to_contain_text("set srcintf")
+        expect(
+            page.locator('[data-testid="migrate-scope-advisory-0"]')
+        ).to_be_visible()
+
+    def test_banner_hidden_translating_into_a_switch_target(
+        self, page: Page, live_server_url: str,
+    ):
+        mp = MigratePage(page)
+        page.goto(live_server_url + "/migrate")
+        mp.source_select.wait_for(state="visible", timeout=5_000)
+        mp.pick_source("cisco_iosxe_cli")
+        mp.pick_target("juniper_junos")
+        mp.fill_raw("hostname access-01\n!\nvlan 10\n name DATA\n!\n")
+        mp.submit_and_wait()
+        expect(
+            page.locator('[data-testid="migrate-scope-advisory-banner"]')
+        ).to_be_hidden()

--- a/tests/fixtures/real/phase4_findings_residuals.md
+++ b/tests/fixtures/real/phase4_findings_residuals.md
@@ -9,8 +9,15 @@ an anycast-**unsupported** target as `EXPECTED_UNSUPPORTED` rather than
 
 > **Cell/fixture counts are as-of this 2026-06-13 triage.**  The mesh has since
 > grown (1224 cells at HEAD); the live totals + the current residual cell list
-> are in [`PHASE4_RECONCILIATION.md`](PHASE4_RECONCILIATION.md).  The 5-cell
-> triage below still matches HEAD's 5 `CODEC_BUG` cells.
+> are in [`PHASE4_RECONCILIATION.md`](PHASE4_RECONCILIATION.md).  The cell list
+> below was **re-verified against `_phase4_runs/latest.json` on 2026-08-13**:
+> the count still holds at 5, but row #4 had drifted and is corrected here —
+> the `juniper_junos → fortigate_cli` / `vlans[].id` cell named by the previous
+> revision **exists nowhere in the mesh**, and `fortigate_cli` does not appear
+> in the residual set at all.  Re-verify this list against `latest.json`
+> whenever the count is quoted: the 2026-07-12 HEAD review (finding D19)
+> refreshed the *count* and explicitly asserted the cell list still matched,
+> which was already untrue.
 
 All 5 were triaged and are **benign methodology / modelling artifacts — not
 codec defects.**  Documented here (per the Phase 4b convention) so the count
@@ -29,7 +36,7 @@ alarms.
 | 1 | arista_eos → cisco_iosxe_cli | `batfish_eos_evpn_vlan_based_leaf.txt` | `vlans` | Arista synthesises a content-free SVI placeholder address record (`ip=""`, no anycast) on the VLAN for VARP SVIs whose only real address lives on the sibling `interface VlanN`. cisco_iosxe_cli doesn't reproduce the empty marker. No data lost. | benign — empty-SVI-marker modelling |
 | 2 | arista_eos → cisco_iosxe_cli | `batfish_labval_dc1_leaf2a_eos4230.txt` | `vlans` | Same as #1. | benign |
 | 3 | juniper_junos → aruba_aoss | `ksator_labmgmt_qfx10k2_junos173.set` | `vlans[].ipv4_addresses` | Junos carries the SVI address on the `irb` **interface**; Aruba's SVI-on-VLAN model (`absorbs_svi_into_vlan`) relocates it onto the **VLAN** record. The address survives — it's on a different canonical field (`source=[]`, `target=[10.231.0.7]`). | benign — SVI projection asymmetry |
-| 4 | juniper_junos → fortigate_cli | `ksator_labmgmt_qfx10k2_junos173.set` | `vlans[].id` | Junos `irb` units materialise as FortiGate VLAN interfaces on round-trip; the target **gains** VLAN records (`count drift: 6 → 9`). Nothing dropped. | benign — structural projection |
+| 4 | juniper_junos → cisco_iosxe_cli | `jnprautomate_mnha_vsrx_a_junos.set` | `interfaces[].ipv4_addresses` | Junos `lo0.10` carries three /32 addresses, all primary (`is_secondary=false`). IOS-XE permits one primary address per interface, so the CLI render correctly demotes the 2nd and 3rd to `secondary`. All three addresses survive with identical prefix lengths — only the `is_secondary` flag differs. | benign — correct multi-primary → primary+secondary normalisation (same class as #5) |
 | 5 | cisco_iosxe → cisco_iosxe_cli | `kitchen_sink.xml` (synthetic) | `interfaces[].ipv4_addresses` | The synthetic fixture lists 3 *primary* addresses on one interface; the CLI render correctly demotes the 2nd/3rd to `secondary` (IOS permits one primary per interface). Correct normalisation, not loss. | benign — correct NETCONF→CLI normalisation (synthetic-fixture shape) |
 
 ## Why these aren't auto-reclassified (and aren't worth forcing)
@@ -48,9 +55,11 @@ comparison:
   deferred as a low-priority nit.
 * **#3** — needs interface↔VLAN cross-field awareness (the address moved,
   it wasn't lost).
-* **#4** — needs "target gained records" to be recognised as a modelling
-  expansion, not a defect.
-* **#5** — a synthetic-fixture artifact plus correct CLI normalisation.
+* **#4 / #5** — correct multi-primary → primary+secondary normalisation.  The
+  comparator diffs each address record field-by-field and sees the
+  `is_secondary` flag flip; telling "demoted per a target-platform rule" apart
+  from "lost" needs target-capability awareness it doesn't have.  #4 is the
+  real-fixture instance, #5 the synthetic one — one root cause, two cells.
 
 None block any user-facing translation; they are reconciler-taxonomy edge
 cases.  Left as low-volume, **documented** signal rather than masked with

--- a/tests/testid_reference.md
+++ b/tests/testid_reference.md
@@ -517,6 +517,8 @@ diff page's banner severity palette (`diff-banner-*` / `mig-banner-*`).
 | `migrate-tier3-banner`                | `<div>`    | Notification banner — visible iff `MigrationJob.dropped_tier3_sections` is non-empty.  Surfaces source-side stanza headers the parser deliberately drops (ACLs, NAT, QoS, route-maps, IPsec, etc).  See `netcanon/migration/_tier3_detection.py` |
 | `migrate-tier3-count`                 | `<strong>` | Detected-section count rendered inside the Tier-3 banner |
 | `migrate-tier3-section-N`             | `<li>`     | One row per detected stanza header, indexed `N=0..len-1`.  Children are `<code>` elements with the literal label |
+| `migrate-scope-advisory-banner`       | `<div>`    | Notification banner — visible iff `MigrationJob.scope_advisories` is non-empty.  Reports the TARGET platform (the Tier-3 banner above reports the source): fires when translating into a firewall-primary platform, whose policy plane is never emitted.  See `check_scope_advisory` in `netcanon/services/migration_validate.py` |
+| `migrate-scope-advisory-N`            | `<li>`     | One row per advisory reason, indexed `N=0..len-1`.  Plain escaped text, no `<code>` children |
 | `migrate-stats`                       | `<div>`    | Supported/lossy/unsupported path counts |
 | `migrate-stat-supported`              | `<strong>` | Count number |
 | `migrate-stat-lossy`                  | `<strong>` | Count number |

--- a/tests/unit/migration/test_device_class.py
+++ b/tests/unit/migration/test_device_class.py
@@ -16,13 +16,14 @@ import pytest
 
 from netcanon.migration.codecs._mock import MockCodec
 from netcanon.migration.codecs.base import CodecBase
+from netcanon.migration.codecs.registry import get_codec, list_codecs
 from netcanon.models.migration import (
     CapabilityMatrix,
     DeviceClass,
     MigrationJobStatus,
 )
 from netcanon.services.migration_pipeline import run_plan
-from netcanon.services.migration_validate import check_class_compat
+from netcanon.services.migration_validate import check_class_compat, check_scope_advisory
 
 pytestmark = pytest.mark.unit
 
@@ -243,3 +244,126 @@ class TestRunPlanClassGuard:
         unforced = run_plan(MockCodec(), MockCodec(), raw, force=False)
         forced = run_plan(MockCodec(), MockCodec(), raw, force=True)
         assert unforced.status == forced.status == MigrationJobStatus.completed
+
+
+class TestScopeAdvisory:
+    """``check_scope_advisory`` — the firewall-target NOTICE (not a gate).
+
+    Deliberately a separate function from ``check_class_compat``: three of
+    that function's arms already return ``severity="warn"`` for "an adapter
+    declared no device_classes", so a caller demuxing on severity alone would
+    render those under this advisory's heading.  See the comment above
+    ``check_class_compat``'s final return.
+    """
+
+    def test_fires_switch_source_into_firewall_target(self):
+        rep = check_scope_advisory(
+            get_codec("cisco_iosxe_cli"), get_codec("fortigate_cli")
+        )
+        assert rep is not None
+        assert rep.compatible is True, "an advisory must never refuse the job"
+        assert rep.severity == "warn"
+        assert len(rep.reasons) == 2
+
+    @pytest.mark.parametrize("target_name", ["fortigate_cli", "opnsense"])
+    def test_every_non_firewall_source_advises_on_both_firewall_targets(
+        self, target_name
+    ):
+        target = get_codec(target_name)
+        fired = [
+            name
+            for name in list_codecs()
+            if check_scope_advisory(get_codec(name), target) is not None
+        ]
+        assert "fortigate_cli" not in fired
+        assert "opnsense" not in fired
+        assert len(fired) == len(list_codecs()) - 2
+
+    @pytest.mark.parametrize("target_name", ["mikrotik_routeros", "vyos", "juniper_junos"])
+    def test_secondary_firewall_targets_do_not_advise(self, target_name):
+        """R1 regression.
+
+        These three declare ``firewall`` but not FIRST, so they are full-scope
+        router/switch platforms.  A membership test (``firewall in tgt``)
+        misfires on every one of them -- that was the plan's original bug.
+        """
+        rep = check_scope_advisory(
+            get_codec("cisco_iosxe_cli"), get_codec(target_name)
+        )
+        assert rep is None
+
+    def test_firewall_to_firewall_does_not_advise(self):
+        """That direction is not silent: the source codec's Tier-3 detector
+        already names the lost policy stanzas in ``dropped_tier3_sections``.
+        """
+        assert check_scope_advisory(get_codec("opnsense"), get_codec("fortigate_cli")) is None
+        assert check_scope_advisory(get_codec("fortigate_cli"), get_codec("opnsense")) is None
+
+    def test_binding_phrase_is_per_target_not_generic(self):
+        """Naming FortiOS syntax on an OPNsense job would be a small,
+        falsifiable error of exactly the kind this wave exists to remove.
+        """
+        fg = check_scope_advisory(get_codec("cisco_iosxe_cli"), get_codec("fortigate_cli"))
+        opn = check_scope_advisory(get_codec("cisco_iosxe_cli"), get_codec("opnsense"))
+        assert "set srcintf" in fg.reasons[1]
+        assert "set srcintf" not in opn.reasons[1]
+        assert "<interface>" in opn.reasons[1]
+
+    def test_advisory_makes_no_security_posture_claim(self):
+        """Binding retraction: both platforms fail CLOSED (FortiOS transit
+        needs an explicit policy; OPNsense pf blocks WAN ingress by default),
+        so any "no security posture" / "traffic is permitted" framing is
+        falsifiable.  The defensible mechanisms are rebinding and silence.
+        """
+        for target in ("fortigate_cli", "opnsense"):
+            text = " ".join(
+                check_scope_advisory(get_codec("cisco_iosxe_cli"), get_codec(target)).reasons
+            ).lower()
+            for banned in ("security posture", "wide open", "permits all", "unprotected"):
+                assert banned not in text, f"{target}: advisory must not claim {banned!r}"
+
+    def test_class_guard_still_blocks_disjoint_pairs(self):
+        """R2 regression.
+
+        The advisory lives OUTSIDE ``check_class_compat`` precisely so it can
+        never shadow the block arm.  A switch-only source against a
+        firewall-only target must still be refused.
+        """
+        src = _StubCodec("switch_only", [DeviceClass.switch])
+        tgt = _StubCodec("firewall_only", [DeviceClass.firewall])
+        assert check_class_compat(src, tgt).severity == "block"
+        assert check_scope_advisory(src, tgt) is not None
+
+
+class TestScopeAdvisoryReachesTheJob:
+    """R3 -- the advisory must be attached to the job, not computed and lost."""
+
+    def test_run_plan_attaches_the_advisory_without_changing_status(self):
+        job = run_plan(
+            get_codec("cisco_iosxe_cli"),
+            get_codec("fortigate_cli"),
+            "hostname edge-01\n!\ninterface GigabitEthernet0/0\n ip address 10.0.0.1 255.255.255.0\n",
+        )
+        assert len(job.scope_advisories) == 2
+        assert job.status is not MigrationJobStatus.failed
+        assert job.rendered is not None, "an advisory must not suppress the render"
+
+    def test_advisory_does_not_leak_into_the_rename_warning_channel(self):
+        """``job.warnings`` is a port-rename side-channel: every UI consumer
+        treats an entry as a renameable port name, and one carrying quotes
+        renders as a phantom interface row.  The advisory must not go there.
+        """
+        job = run_plan(
+            get_codec("cisco_iosxe_cli"),
+            get_codec("fortigate_cli"),
+            "hostname edge-01\n!\ninterface GigabitEthernet0/0\n ip address 10.0.0.1 255.255.255.0\n",
+        )
+        assert job.warnings == []
+
+    def test_switch_to_switch_job_carries_no_advisory(self):
+        job = run_plan(
+            get_codec("cisco_iosxe_cli"),
+            get_codec("juniper_junos"),
+            "hostname access-01\n!\nvlan 10\n name DATA\n",
+        )
+        assert job.scope_advisories == []

--- a/tests/unit/migration/test_scope_boundary.py
+++ b/tests/unit/migration/test_scope_boundary.py
@@ -1,0 +1,157 @@
+"""
+Guards for the product scope line: which platforms Netcanon is *for*.
+
+The scope rule itself lives in ``AGENTS.md`` § Hard Rules ("Never author or
+change a codec's ``device_classes[0]`` without applying the scope test").  This
+module is its teeth.  Background and the measurements behind the rule are in
+``docs/reviews/2026-08-10-firewall-scope-exit/``.
+
+The short version: a codec's FIRST declared device class is its **primary
+device class**, and that single field is the project's authoritative scope
+declaration for the platform.  A ``firewall``-primary codec ships, is
+certified, holds fixtures, is auto-detected and is fully audited — but
+Netcanon translates its L2/L3 layer only, and it does not get to be the face
+of the product.
+
+Covers:
+    * The firewall-primary roster is pinned (changing it is a product call).
+    * Every codec declares at least one device class.
+    * ``vendors/<vendor>.yaml`` and the codec's ``CapabilityMatrix`` agree.
+    * The landing page's capability-matrix evidence is not drawn from a
+      firewall-primary codec.
+    * Firewall-primary demo scenarios do not grow (downward-only ratchet).
+
+See also: ``tests/unit/migration/test_device_class.py`` (the runtime
+compatibility guard), ``tests/unit/migration/test_vendors.py`` (vendor YAML
+schema), ``docs/CAPABILITIES.md`` § Platform fit.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from netcanon.migration.codecs.registry import get_codec, list_codecs
+from netcanon.migration.vendors import load_vendors
+from netcanon.models.migration import DeviceClass
+from netcanon.tools.demo import SCENARIOS
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The scope line.  Membership here is a PRODUCT decision, not a refactor --
+# see the two-clause test in AGENTS.md § Hard Rules before changing it.
+_FIREWALL_PRIMARY = {"fortigate_cli", "opnsense"}
+
+# Firewall-primary scenarios in `netcanon/tools/demo.py`.  The rule's target is
+# AT MOST ONE of the four; HEAD carries two (`fortigate__mikrotik`,
+# `opnsense__junos`).  Closing that gap means re-authoring a demo scenario,
+# which drags the landing-page hero pane + og.png + the paired walkthrough with
+# it (AGENTS.md doc-sync, "a demo-scenario change alters the rendered OUTPUT"),
+# so it is deliberately a separate wave.  This is a RATCHET: it may only ever
+# be lowered.  Raising it re-opens the dilution this rule exists to close.
+_MAX_FIREWALL_PRIMARY_SCENARIOS = 2
+_TARGET_FIREWALL_PRIMARY_SCENARIOS = 1
+
+
+def _primary_class(codec_name: str) -> DeviceClass | None:
+    classes = get_codec(codec_name).capabilities.device_classes
+    return classes[0] if classes else None
+
+
+def _is_firewall_primary(codec_name: str) -> bool:
+    return _primary_class(codec_name) is DeviceClass.firewall
+
+
+class TestScopeLine:
+    """``device_classes[0]`` is the scope declaration."""
+
+    def test_firewall_primary_roster_is_pinned(self):
+        """Changing this set is a product decision, not a refactor.
+
+        If you are here because you added a codec: apply the two-clause scope
+        test in AGENTS.md § Hard Rules and record the reasoning in the PR body.
+        If you are here because you *re-ordered* an existing codec's
+        ``device_classes``, stop -- that silently moves the platform between
+        scope tiers and changes what the landing page promises.
+        """
+        live = {name for name in list_codecs() if _is_firewall_primary(name)}
+        assert live == _FIREWALL_PRIMARY, (
+            f"firewall-primary roster changed: {live} != {_FIREWALL_PRIMARY}. "
+            "device_classes[0] is the project's scope declaration -- see "
+            "AGENTS.md Hard Rules."
+        )
+
+    @pytest.mark.parametrize("codec_name", sorted(list_codecs()))
+    def test_every_codec_declares_a_primary_device_class(self, codec_name):
+        """An empty ``device_classes`` would make the scope test undecidable."""
+        assert _primary_class(codec_name) is not None, (
+            f"{codec_name} declares no device_classes, so it has no primary "
+            "device class and its scope tier cannot be resolved."
+        )
+
+
+class TestVendorYamlAgreement:
+    """The two places device classes are written must not drift apart."""
+
+    def test_vendor_yaml_agrees_with_codec_device_classes(self):
+        """``vendors/<id>.yaml`` and the codec's ``CapabilityMatrix`` must match.
+
+        Order matters as well as membership: the FIRST entry is the scope
+        declaration, so a re-order is a scope change even when the set is
+        identical.
+
+        This guard was written after finding `juniper_junos` drifted -- the
+        YAML named the SRX series and declared `firewall`, the codec did not.
+        The codec was the wrong side (it parses a vSRX fixture), so the codec
+        gained the class rather than the YAML losing it.
+        """
+        vendors = load_vendors()
+        drift = []
+        for name in sorted(list_codecs()):
+            caps = get_codec(name).capabilities
+            vendor = vendors.get(caps.vendor_id)
+            if vendor is None:  # pragma: no cover - schema guard covers this
+                continue
+            codec_classes = list(caps.device_classes or [])
+            yaml_classes = list(vendor.device_classes or [])
+            if codec_classes != yaml_classes:
+                drift.append(
+                    f"{name}: codec={[c.value for c in codec_classes]} "
+                    f"vendors/{caps.vendor_id}.yaml={[c.value for c in yaml_classes]}"
+                )
+        assert not drift, "device_classes drift between codec and vendor YAML:\n  " + "\n  ".join(drift)
+
+
+class TestFirewallPrimaryIsNotTheFaceOfTheProduct:
+    """The operational half of the rule -- what firewall-primary codecs may not be."""
+
+    def test_landing_page_matrix_excerpt_is_not_firewall_primary(self):
+        """site/index.html proves "every field has a declared fate" with one
+        codec panel.  Drawing that proof from a platform we translate only at
+        L2/L3 is the dilution the scope rule exists to prevent.
+        """
+        page = (REPO_ROOT / "site" / "index.html").read_text(encoding="utf-8")
+        section = page.split('id="matrix"', 1)[1].split("</section>", 1)[0]
+        named = re.findall(r"<code>([a-z0-9_]+)</code> panel", section)
+        assert named, "could not find the codec panel named in the #matrix section"
+        offenders = [c for c in named if c in _FIREWALL_PRIMARY]
+        assert not offenders, (
+            f"the landing page's capability-matrix excerpt is drawn from "
+            f"firewall-primary codec(s) {offenders}; use a switch/router codec."
+        )
+
+    def test_firewall_primary_demo_scenarios_do_not_grow(self):
+        """Downward-only ratchet -- see ``_MAX_FIREWALL_PRIMARY_SCENARIOS``."""
+        firewall_scenarios = sorted(
+            key
+            for key, scenario in SCENARIOS.items()
+            if _is_firewall_primary(scenario.source_codec) or _is_firewall_primary(scenario.target_codec)
+        )
+        assert len(firewall_scenarios) <= _MAX_FIREWALL_PRIMARY_SCENARIOS, (
+            f"{len(firewall_scenarios)} of {len(SCENARIOS)} demo scenarios are "
+            f"firewall-primary ({firewall_scenarios}); the ratchet allows at most "
+            f"{_MAX_FIREWALL_PRIMARY_SCENARIOS} and the target is "
+            f"{_TARGET_FIREWALL_PRIMARY_SCENARIOS}.  This ratchet only lowers."
+        )


### PR DESCRIPTION
# Say what Netcanon is for: switches and routers, firewalls at L2/L3

**Branch:** `scope/reweight-wave` → `main` · 5 commits · PR 1 of 3

Answers the complaint that shipping OPNsense and FortiGate felt like *"trying to
half-offer something I don't have"* and diluted how the product reads.

**Nothing is removed. No codec loses capability.** Both firewall platforms remain
first-class parse sources — auto-detected, certified, fixture-backed, fully
audited. What changes is what the product *claims*, and where the claim is
enforced.

## Why re-weight rather than remove

Removal was the starting hypothesis and the measurements killed it. Full workings
in `docs/reviews/2026-08-10-firewall-scope-exit/`:

| | measured |
|---|---|
| FortiGate corpus that is firewall/UTM/VPN stanzas | **66.9%** |
| OPNsense canonical surface unmodelled | **73.6%** |
| Switch/router codecs, same measure | 30–64% |
| Expectation YAMLs that removal would delete | **26 of 56** |
| Coverage ratio after removal | **67% → 60% (worse)** |

The complaint is real — firewall-as-target genuinely under-delivers — but the fix
is to stop over-claiming, not to delete a certified parse path and take the audit
backwards.

## What's in it

**1. Four pre-existing doc-truth defects** (`1335e7d`) — a `CODEC_BUG` triage row
naming a `juniper_junos → fortigate_cli` cell that exists nowhere in the mesh (the
real fifth cell is `juniper_junos → cisco_iosxe_cli`); `ARCHITECTURE.md`
contradicting itself on `unsupported_rename_categories`; and unguarded prose
counts ("the 8 migration vendors" when there are 12, "50+ profiles" when there are
54) deleted per the AGENTS.md rule rather than updated, so they can't rot again.

**2. The landing page and README state a device-class gradient** (`3bc9692`)
instead of a flat vendor list — switches and routers first, firewall platforms
declared L2/L3-layer-only.

**3. The matrix excerpt moved off the FortiGate panel** (`a7c4109`). The landing
page was proving its central capability claim using the one platform it translates
only in part. It now excerpts `cisco_iosxe_cli`, with a guard asserting the rows
are transcribed verbatim from `docs/CAPABILITIES.md` rather than hand-composed.

**4. Scope becomes a declaration, not an argument** (`8bf2710`). A codec's first
`device_classes` entry is its **primary device class** and is the authoritative
scope statement for that platform. Two-clause test in `AGENTS.md` § Hard Rules, a
`Primary class` column in `docs/CAPABILITIES.md`, and
`tests/unit/migration/test_scope_boundary.py` as its teeth — including an
order-sensitive agreement guard between each codec and its `vendors/*.yaml`, since
re-ordering `device_classes` is now a scope change.

This also caught a real disagreement: `juniper_junos` declared `[switch, router]`
while its vendor YAML declared `[switch, router, firewall]` and named the SRX. The
codec was the wrong side — it parses a vSRX fixture to 15 interfaces with 36
`set security *` stanzas surfaced as Tier 3 — so it gained the class and stays
switch-primary. The guard makes the two sides unable to drift again.

**5. Firewall-target jobs now advise instead of completing silently**
(`a01a8b4`). New `check_scope_advisory()` raises a banner on a switch/router →
FortiGate/OPNsense job saying Netcanon emits no policy plane, and that policy
already on the appliance binds to interface names this output may rename or
invent.

Nothing on the page said so before, and the reason is structural: the Tier-3
banner reads the **source** config, so it is silent when the source is a switch;
and while `/filter/rule` and `/nat/rule` are declared `unsupported`, no canonical
field walks to them, so `validate_against` — a loss *detector*, not an absence
detector — cannot fire on them either.

Fires on 22 of 169 ordered codec pairs. Firewall→firewall is excluded because that
direction is already loud. It is notice-only: it never refuses a job or changes
its status.

## Design notes worth flagging

**Why an advisory rather than "build the missing canonical surface."** Considered
and costed. `CanonicalFirewallRule` would flip 24 of 101 fixtures
`completed`→`partial` and *still* not fire, because `validate_against` detects loss
against what was parsed, not absence of what was never modelled. The advisory is
the fix; the deeper property (Tier-3 declarations being structurally unreachable —
55 of them across 24 xpaths on all 12 codecs) is deliberate, guarded and
documented, not a defect to plaster.

**Why `job.scope_advisories` and not `job.warnings`.** `warnings` is populated,
serialized, and then discarded by the UI. The e2e test in this PR is the proof the
new channel is not.

**Known-not-met and deliberately ratcheted:** 2 of 4 demo scenarios are
firewall-primary against a target of 1. `test_scope_boundary.py` ratchets at 2 and
the ratchet only lowers — recorded as a visible debt rather than quietly passing.

## Verification

- Full local suite green; ruff clean on CI's exact scope
- Cross-mesh ratchet unchanged (`CODEC_BUG` = 5, 1224 cells)
- Every guard added here was verified **red** by injecting the defect, then restored
- Banner checked in a real browser, not just asserted — the e2e passed while the
  heading was crushed into a 4-line column (`.mig-banner` is a flex container);
  fixed with a `flex:1` wrapper

## Not in this PR

A7 (the OPNsense static-route severity fix) is PR 2 — a capability-matrix change
fires doc-sync 178 and carries its own regen commit. The expectation-YAML
validator wiring is PR 3.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
