### PR TITLE
OPNsense declared a total loss of your routing table as a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,57 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **OPNsense declared a total loss of your routing table as a warning.**
+  The `config.xml` renderer emits no `<staticroutes>`/`<route>` block, so a
+  static route translated INTO OPNsense vanishes entirely -- destination,
+  next-hop and all.  `/routing/static-route` and its `gateway` / `metric` /
+  `description` leaves were declared `lossy`, which renders as `warn`; they
+  are now `unsupported`, which renders as `block`.  The subtree had been
+  self-contradictory since the f92e97a audit: the total drop reported `warn`
+  while its own child `/routing/static-route/interface` -- the SAME render
+  behaviour, one leaf down -- reported `block`.  Lossy means "survives with
+  caveats", and a record that does not survive has no caveats to report.  An
+  X->OPNsense plan now tells the operator to re-create routing on the target
+  instead of inviting them to skim past it.  Parse is unaffected: OPNsense as
+  a SOURCE still harvests routes from both blocks and translates outward.
+
+  `test_whole_static_route_drop_is_declared` was tightened from "declared
+  lossy or unsupported" to "declared unsupported" and verified to fail
+  against the old declaration.  A sweep of every bidirectional codec found
+  this was the only base-path surface in the registry declared `lossy` at
+  all, so it is the only instance of the defect.  The guard deliberately does
+  NOT generalise to "a parent may never be less severe than its child": a
+  `supported` parent with a `lossy` child is the normal, correct shape -- the
+  record round-trips, one leaf of it does not -- and holds in 63 places
+  across the registry.
+
+  Doc-sync 178 discharged in full: 7 of the 14 OPNsense expectation YAMLs
+  moved (6 `lossy` -> `unsupported`, plus a note correction on the
+  `not_applicable` seventh; the 7 OPNsense-as-source pairs are governed by
+  the other codec's matrix and correctly did not move), 6
+  `docs/vendor-references/` verdicts, `docs/CAPABILITIES.md`,
+  `docs/vendors/opnsense.md`, and a `--write-baseline` regen.  Measured
+  effect on the cross-mesh audit: `EXPECTED_LOSSY` 1226 -> 1196,
+  `EXPECTED_UNSUPPORTED` 738 -> 768, **`CODEC_BUG` unchanged at 5** (proven
+  by regen, not asserted), every other class and the severity roll-up
+  unchanged.  `CROSS_MESH_RESULTS.md` is byte-identical, because the Phase-1
+  comparator resolves "unsupported in target" through
+  `_FIELD_TO_IDENTITY_XPATHS`, which has no `static_routes` entry.
+
+- **Two stale doc-truth claims about our own codecs**, both pre-existing and
+  both found while discharging the doc-sync above: the
+  `juniper_junos -> opnsense` expectation YAML said the OPNsense codec
+  "does not currently parse OR emit either block" (it has parsed both since
+  promotion #15), and
+  `docs/vendor-references/cisco_iosxe_to_opnsense/openconfig_yang_scope.md`
+  described ten paths as declared `supported` "aspirationally ... so
+  cross-codec mesh translations don't classify these paths as `unsupported`"
+  -- all ten now classify `unsupported`, verified against the live matrix.
+  The second is kept as a marked worked example rather than deleted, because
+  declaring a path `supported` to keep mesh arithmetic tidy is a live
+  temptation that `docs/METHODOLOGY.md` treats as a violation equal to
+  under-claiming.
+
 - **`juniper_junos` declared the wrong device classes.**  The codec listed
   `[switch, router]` while `vendors/juniper_junos.yaml` listed
   `[switch, router, firewall]` and named the SRX series.  The codec was the

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -366,7 +366,8 @@ output.
 | `/interfaces/interface/ipv4/address/virtual-gateway-address` | Unsupported | OPNsense uses CARP for HA (distinct semantics); no anycast-gateway grammar. |
 | `/interfaces/interface/ipv6/address/virtual-gateway-address` | Unsupported | Same as IPv4 — no native anycast grammar. |
 | `/anycast-gateway-mac` | Unsupported | No chassis-wide anycast MAC concept. |
-| `/routing/static-route/vrf` | Unsupported | Per-VRF static-route binding parses-and-ignores in v1. |
+| `/routing/static-route` (and `gateway` / `metric` / `description` / `interface`) | Unsupported | The parser harvests routes from `<gateways>` + `<staticroutes>`, so OPNsense-as-**source** translates outward fine — but the `config.xml` renderer emits neither block, so a route translated **into** OPNsense does not survive at all.  A record that vanishes is unsupported, not lossy: validation reports `block`, and an X→OPNsense plan tells the operator to re-create routing on the target rather than warning them past it. |
+| `/routing/static-route/vrf` | Unsupported | Separate rationale from the render gap above: OPNsense's `config.xml` has no VRF model at all, so a per-VRF binding parses-and-ignores and stays unsupported even once `<staticroutes>` rendering lands. |
 | `/interfaces/interface/config/description` | Lossy | OPNsense imposes no length limit on description text; other vendors (Cisco 240 chars, Juniper 900) may truncate on render. |
 | `/filter/rule` | Unsupported | `<filter>` is Tier 3. |
 | `/nat/outbound` | Unsupported | `<nat>` is Tier 3. |

--- a/docs/vendor-references/arista_eos_to_opnsense/static_routes.md
+++ b/docs/vendor-references/arista_eos_to_opnsense/static_routes.md
@@ -76,14 +76,15 @@ CanonicalStaticRoute:
   description: str
 ```
 
-- `static_routes`: **lossy** — Arista's flat `ip route DEST/N GW`
+- `static_routes`: **unsupported** — Arista's flat `ip route DEST/N GW`
   form carries the next-hop IP directly; OPNsense expects a NAMED
   gateway reference plus a separate `<gateway_item>` declaration.
   Cross-pair render would need to synthesise both blocks and pick
-  a gateway name (e.g. `cv_gw_<index>`) — the OPNsense codec
-  capability matrix does not currently advertise
-  `/routing/static-route` on its render side, so this drops
-  pending wire-up.  Arista's `0.0.0.0/0` form would also need
+  a gateway name (e.g. `cv_gw_<index>`).  It synthesises neither, so
+  the route does not survive the trip at all — which is `unsupported`,
+  not `lossy`; the OPNsense codec declares `/routing/static-route`
+  and every leaf beneath it unsupported, and validation blocks rather
+  than warns.  Arista's `0.0.0.0/0` form would also need
   remapping to the OPNsense default-gateway idiom (set via the WAN
   zone interface) rather than emitting an explicit
   `<route><network>0.0.0.0/0</network></route>`.

--- a/docs/vendor-references/aruba_aoss_to_opnsense/static_routes.md
+++ b/docs/vendor-references/aruba_aoss_to_opnsense/static_routes.md
@@ -78,14 +78,16 @@ CanonicalStaticRoute:
 
 Aruba -> OPNsense:
 
-- `static_routes`: **lossy** — Aruba's flat `ip route DEST/N GW` form
-  carries the next-hop IP directly; OPNsense expects a NAMED gateway
-  reference plus a separate `<gateway_item>` declaration.  The
+- `static_routes`: **unsupported** — Aruba's flat `ip route DEST/N GW`
+  form carries the next-hop IP directly; OPNsense expects a NAMED
+  gateway reference plus a separate `<gateway_item>` declaration.  The
   cross-pair render would need to synthesise both blocks and pick a
-  gateway name (e.g. `cv_gw_<index>`) — the OPNsense codec capability
-  matrix does not currently advertise `/routing/static-route` on its
-  render side, so this drops pending wire-up.  Aruba's
-  `ip default-gateway` form is normalised to `0.0.0.0/0` on canonical
-  but the OPNsense idiom is to set the default via the WAN zone's
-  `<gateway>` rather than a `0.0.0.0/0` route.
+  gateway name (e.g. `cv_gw_<index>`).  It synthesises neither, so the
+  route does not survive the trip at all — which is `unsupported`, not
+  `lossy`; the OPNsense codec declares `/routing/static-route` and
+  every leaf beneath it unsupported, and validation blocks rather than
+  warns.  Aruba's `ip default-gateway` form is normalised to
+  `0.0.0.0/0` on canonical but the OPNsense idiom is to set the
+  default via the WAN zone's `<gateway>` rather than a `0.0.0.0/0`
+  route.
 - Per-VRF static routes: **not_applicable** — Aruba has no VRF.

--- a/docs/vendor-references/cisco_iosxe_cli_to_opnsense/static_routes.md
+++ b/docs/vendor-references/cisco_iosxe_cli_to_opnsense/static_routes.md
@@ -103,10 +103,12 @@ but OPNsense has no canonical-portable VRF model and the OPNsense
 codec declares ``/routing/static-route/vrf`` ``unsupported``, so the
 VRF is dropped on render.
 
-Disposition: **lossy** at the field level.  At the WIRE-UP level, the
-OPNsense codec's capability matrix does not currently advertise any
-``/routing/static-route`` path — the canonical static_routes list
-parses but the OPNsense render path does not emit
-``<staticroutes>``.  Cross-pair effectively drops the route list.
-Lands when OPNsense ``<staticroutes>`` + ``<gateways>`` wire-up is
-added.
+Disposition: **unsupported**.  The per-field notes above describe what
+the mapping WOULD lose once OPNsense renders routes at all; today it
+renders none, so the whole record is dropped and the field-level
+nuance never gets a chance to apply.  The OPNsense codec declares
+``/routing/static-route`` and every leaf beneath it ``unsupported``,
+and validation blocks rather than warns — a vanished route is not a
+lossy round-trip.  This row becomes ``lossy`` (per the field notes
+above) when OPNsense ``<staticroutes>`` + ``<gateways>`` render
+wire-up lands.

--- a/docs/vendor-references/cisco_iosxe_to_opnsense/openconfig_yang_scope.md
+++ b/docs/vendor-references/cisco_iosxe_to_opnsense/openconfig_yang_scope.md
@@ -30,25 +30,33 @@ That's the full parse implementation.  `intent.hostname`,
 are NEVER populated by this codec, regardless of what the device's
 NETCONF reply carries.
 
-## What the matrix declares — the aspirational gap
+## What the matrix declares — the aspirational gap, since closed
 
-The codec's `CapabilityMatrix._CAPS` declares these paths as
-`supported`:
+> **Stale-then-corrected (scope re-weight wave, 2026-08).**  When this
+> note was written the codec's `CapabilityMatrix._CAPS` declared
+> `/system/hostname`, `/system/dns-server`, `/system/ntp-server`,
+> `/vlans/vlan/{id,name}`, `/routing/static-route` and
+> `/snmp/{community,location,contact,trap-host}` **`supported`** —
+> aspirationally, so cross-codec mesh translations wouldn't classify
+> them `unsupported` on the target side, even though the parser reads
+> XML for none of them.  **That is no longer true.**  All ten now
+> classify `unsupported` (verified against the live matrix), which is
+> what `docs/CAPABILITIES.md` § `cisco_iosxe` describes: "Every other
+> canonical surface is declared `unsupported` so the cross-mesh audit
+> matrix flags the gap honestly rather than masquerading as drift."
+>
+> The paragraph is kept rather than deleted because the reasoning it
+> records — declaring a path `supported` to keep mesh arithmetic tidy —
+> is a live temptation, and `docs/METHODOLOGY.md` treats it as a
+> violation equal to under-claiming.  This is the worked example of
+> the trap, not a description of current behaviour.
 
-* `/system/hostname`, `/system/dns-server`, `/system/ntp-server`
-* `/vlans/vlan/id`, `/vlans/vlan/name`
-* `/routing/static-route`
-* `/snmp/community`, `/snmp/location`, `/snmp/contact`,
-  `/snmp/trap-host`
-
-These declarations are aspirational: present so cross-codec mesh
-translations don't classify these paths as `unsupported` on the
-target side.  But the parser does not actually read XML for any of
-them.  Operationally, an OPNsense render running on a canonical
-tree produced by `cisco_iosxe` parse will see empty `intent.hostname`,
-empty `intent.snmp`, empty `intent.vlans`, empty `intent.static_routes`
-— so the OPNsense renderer emits nothing for those categories on
-this cross-pair.
+Operationally, an OPNsense render running on a canonical tree produced
+by `cisco_iosxe` parse sees empty `intent.hostname`, empty
+`intent.snmp`, empty `intent.vlans`, empty `intent.static_routes` — so
+the OPNsense renderer emits nothing for those categories on this
+cross-pair, and would emit nothing for `static_routes` regardless,
+since it renders no `<staticroutes>` block for any source.
 
 ## Real Cisco NETCONF replies do carry the data
 

--- a/docs/vendor-references/fortigate_cli_to_opnsense/static_routes.md
+++ b/docs/vendor-references/fortigate_cli_to_opnsense/static_routes.md
@@ -95,7 +95,7 @@ prefix, prefix_length, next_hop, interface, distance, description, vrf
 
 FortiGate -> OPNsense:
 
-- **lossy** — Two-stage divergence:
+- **unsupported** — Two-stage divergence:
   1. FortiGate's flat per-route table flattens into canonical
      `static_routes` cleanly (FortiGate codec parses `dst`/`mask` ->
      prefix/prefix_length; `gateway` -> `next_hop`; `device` ->
@@ -103,9 +103,12 @@ FortiGate -> OPNsense:
   2. OPNsense rendering would have to synthesise a `<gateway_item>`
      per unique next-hop on the canonical list (or reuse an
      existing one if the operator pre-declared it), then emit
-     `<route>` elements.  The OPNsense codec capability matrix
-     does NOT currently advertise `/routing/static-route` as
-     supported — render is unwired pending wire-up.
+     `<route>` elements.  It synthesises neither, so the route does
+     not survive the trip at all — `unsupported`, not `lossy`: the
+     OPNsense codec declares `/routing/static-route` and every leaf
+     beneath it unsupported, and validation blocks rather than warns.
+     The per-field notes below describe what the mapping would lose
+     once OPNsense renders routes at all.
 - The default-route idiom diverges: FortiGate's
   `set dst 0.0.0.0 0.0.0.0 / set gateway X` is a first-class entry
   in `config router static`; the OPNsense equivalent is to set the

--- a/docs/vendor-references/juniper_junos_to_opnsense/_INDEX.md
+++ b/docs/vendor-references/juniper_junos_to_opnsense/_INDEX.md
@@ -18,8 +18,9 @@ roles meet over a small shared canonical surface:
 * VLANs — id good; name/description collapse; port-membership and
   SVI sub-fields unsupported (OPNsense has no VLAN-centric port
   lists, no first-class SVI)
-* Static routes — lossy (OPNsense `<gateways>` + `<staticroutes>`
-  model is two-stage, codec doesn't currently render either)
+* Static routes — unsupported (OPNsense `<gateways>` +
+  `<staticroutes>` model is two-stage and the codec renders neither,
+  so the whole route vanishes rather than degrading)
 * DHCP server scopes — lossy (Junos two-stage `dhcp-local-server`
   versus OPNsense interface-keyed pool, plus codec wire-up gaps)
 * SNMP v1/v2c — good; SNMPv3 USM unsupported (lives in OPNsense

--- a/docs/vendor-references/juniper_junos_to_opnsense/static_routes.md
+++ b/docs/vendor-references/juniper_junos_to_opnsense/static_routes.md
@@ -71,12 +71,14 @@ OPNsense static-route notes:
 
 Junos -> OPNsense:
 
-- `static_routes`: **lossy** — Junos default IPv4 + named-prefix +
-  IPv6 statics in `set routing-options static route X/N next-hop Y`
+- `static_routes`: **unsupported** — Junos default IPv4 + named-prefix
+  + IPv6 statics in `set routing-options static route X/N next-hop Y`
   parse cleanly to canonical entries with `destination` (CIDR), and
-  `gateway`.  The OPNsense codec does not currently render
-  `<gateways>` or `<staticroutes>`; the entire list drops on render
-  pending wire-up.
+  `gateway`.  The OPNsense codec renders neither `<gateways>` nor
+  `<staticroutes>`, so the entire list drops — the record does not
+  survive the trip, which is `unsupported`, not `lossy`; the codec
+  declares `/routing/static-route` and every leaf beneath it
+  unsupported, and validation blocks rather than warns.
 - Per-VRF static routes (Junos `set routing-instances <vrf> routing-
   options static`) are unsupported on the cross-pair: the
   `juniper_junos` source codec now harvests per-VRF statics onto
@@ -89,6 +91,8 @@ Junos -> OPNsense:
 - `metric` / `description` round-trip the canonical scalar through
   to OPNsense's `<descr>` (where wire-up exists).
 
-Disposition: **lossy** dominated by codec wire-up gap on OPNsense
-(structural mapping is straightforward) plus VRF-bound routes
-unsupported.
+Disposition: **unsupported**, dominated by the render gap on OPNsense
+(the structural mapping itself is straightforward, and would be merely
+lossy once `<staticroutes>` rendering lands); VRF-bound routes are
+unsupported for a second, independent reason — OPNsense has no VRF
+model at all.

--- a/docs/vendor-references/mikrotik_routeros_to_opnsense/_INDEX.md
+++ b/docs/vendor-references/mikrotik_routeros_to_opnsense/_INDEX.md
@@ -37,7 +37,7 @@ Asymmetry on this direction concentrates on:
 | `system_services.md` | Hostname (RouterOS bare -> OPNsense `<hostname>`) / DNS (RouterOS comma-list -> OPNsense repeated `<dnsserver>`) / NTP / IANA tz database name (shared shape, OPNsense render wire-up pending) / syslog. |
 | `interfaces.md` | RouterOS `etherN` / `default-name` versus OPNsense zone-tag (`<wan>` / `<lan>` / `<optN>`) plus BSD `<if>`.  IP / MTU / enable round-trip cleanly.  VRF structurally absent. |
 | `vlans.md` | RouterOS two-plane model (Plane 1 `/interface vlan` + Plane 2 bridge VLAN filtering) versus OPNsense's "VLAN as one tagged sub-interface on one parent NIC" model.  No port-membership concept on OPNsense. |
-| `static_routes.md` | RouterOS CIDR `/ip route` versus OPNsense's two-block `<gateways>` + `<staticroutes>` model.  OPNsense codec render wire-up pending. |
+| `static_routes.md` | RouterOS CIDR `/ip route` versus OPNsense's two-block `<gateways>` + `<staticroutes>` model.  OPNsense renders neither block, so this direction is unsupported (the route vanishes), not lossy. |
 | `dhcp.md` | RouterOS three-section DHCP form (`/ip pool` + `/ip dhcp-server` + `/ip dhcp-server network`) versus OPNsense's interface-keyed `<dhcpd>/<lan>` zone form.  Lease-time units shared (seconds). |
 | `snmp.md` | RouterOS overloaded `/snmp community` versus OPNsense `<snmpd>`.  v1/v2c surface round-trips; SNMPv3 USM unsupported on OPNsense (lives in plugin's `snmpd.conf`, not `config.xml`). |
 | `local_users.md` | RouterOS named groups (full/write/read) versus OPNsense binary admin/users.  Hash format gap dominates — RouterOS `/export` carries no password material, OPNsense expects bcrypt. |

--- a/docs/vendor-references/mikrotik_routeros_to_opnsense/static_routes.md
+++ b/docs/vendor-references/mikrotik_routeros_to_opnsense/static_routes.md
@@ -93,10 +93,16 @@ matrix.supported references either path).  RouterOS-source canonical
 
 ### Disposition
 
+The OPNsense renderer emits no `<staticroutes>` block, so the whole
+record vanishes rather than arriving degraded — every leaf below is
+`unsupported`, not `lossy`, and validation blocks rather than warns.
+The parenthesised notes record what each field's disposition WOULD be
+once OPNsense `<staticroutes>` + `<gateways>` render wire-up lands.
+
 | Field | Disposition |
 |---|---|
-| `static_routes[].destination` | lossy (OPNsense render wire-up pending) |
-| `static_routes[].gateway` | lossy (OPNsense render wire-up pending; named-gateway indirection) |
-| `static_routes[].interface` | lossy (OPNsense render wire-up pending) |
-| `static_routes[].metric` | lossy (OPNsense render wire-up pending) |
-| `static_routes[].description` | lossy (OPNsense render wire-up pending; otherwise good) |
+| `static_routes[].destination` | unsupported (no `<staticroutes>` rendered; lossy once wire-up lands) |
+| `static_routes[].gateway` | unsupported (no `<staticroutes>` rendered; then lossy — named-gateway indirection) |
+| `static_routes[].interface` | unsupported (no `<staticroutes>` rendered; then lossy) |
+| `static_routes[].metric` | unsupported (no `<staticroutes>` rendered; then lossy) |
+| `static_routes[].description` | unsupported (no `<staticroutes>` rendered; then good) |

--- a/docs/vendors/opnsense.md
+++ b/docs/vendors/opnsense.md
@@ -138,8 +138,15 @@ XML element mapping:
   `<staticroutes>` + `<gateways>` into `CanonicalStaticRoute` (since
   #350), so OPNsense-*as-source* routes translate outward — but the
   `config.xml` renderer emits **no** `<staticroutes>`/`<route>` block,
-  so an X→OPNsense migration drops every static route on render.  The
-  loss is declared (`opnsense/codec.py` LossyPath), not silent.
+  so an X→OPNsense migration drops every static route on render.
+  Because the record does not survive at all, this is declared
+  **unsupported**, not lossy: `/routing/static-route` and every leaf
+  beneath it (`gateway`, `metric`, `description`, `interface`, `vrf`)
+  are `UnsupportedPath` entries, so validation reports `block` rather
+  than `warn` and the operator is told to re-create routing on the
+  target.  It was declared lossy until the scope re-weight wave —
+  honest about the loss, but understating a total one as a skimmable
+  warning.
 
 ## What we don't do
 

--- a/netcanon/migration/codecs/opnsense/codec.py
+++ b/netcanon/migration/codecs/opnsense/codec.py
@@ -176,16 +176,6 @@ class OPNsenseCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
-                path="/routing/static-route/gateway",
-                reason=(
-                    "Renders no <staticroutes> block (see /routing/static-route), "
-                    "so the next-hop gateway is dropped on render. Declared lossy "
-                    "for parity with the route anchor so validate_against surfaces "
-                    "the loss instead of reporting severity:ok (audit e5b77d7, PR-2c)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
                 path="/interfaces/interface/vrrp-groups/group/mode",
                 reason=(
                     "OPNsense renders only BSD CARP; a non-CARP source mode "
@@ -259,50 +249,6 @@ class OPNsenseCodec(CodecBase):
                 severity="warn",
             ),
             LossyPath(
-                # Base static-route path.  Previously UNDECLARED — so
-                # classify() defaulted it to ``supported`` and a whole
-                # gateway route rendered to nothing while validate_against
-                # reported ``severity: ok`` (audit f92e97a T0-1).  OPNsense's
-                # config.xml renderer emits no <staticroutes>/<route> block at
-                # all (see render.py), so the ENTIRE route — destination +
-                # next-hop — drops on render.  Declared lossy (warn, matching
-                # the cross_vendor_expectations dispositions for this codec)
-                # so the loss surfaces instead of reporting ok; operators
-                # re-add routes on the OPNsense target.  (Interface-only
-                # connected routes are the harder loss and stay unsupported /
-                # block below.)
-                path="/routing/static-route",
-                reason=(
-                    "Parse harvests routes (the <gateways> default route + "
-                    "<staticroutes>/<route> entries, resolving named gateways "
-                    "to their IP; promotion #15), but the config.xml renderer "
-                    "emits no <staticroutes>/<route> block, so the route is "
-                    "dropped on render. Declared lossy so validate_against "
-                    "surfaces the render loss instead of reporting severity:ok "
-                    "(audit f92e97a T0-1)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
-                path="/routing/static-route/metric",
-                reason=(
-                    "Subsumed by the whole-route drop (see "
-                    "/routing/static-route): no <staticroutes> block is "
-                    "rendered, so the administrative distance (metric) is "
-                    "dropped with the route (audit f92e97a T0-1)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
-                path="/routing/static-route/description",
-                reason=(
-                    "Subsumed by the whole-route drop (see "
-                    "/routing/static-route): the route name / description is "
-                    "dropped with the unrendered route (audit f92e97a T0-1)."
-                ),
-                severity="warn",
-            ),
-            LossyPath(
                 path="/interfaces/interface/config/description",
                 reason=(
                     "OPNsense imposes no length limit on description text; "
@@ -360,15 +306,73 @@ class OPNsenseCodec(CodecBase):
                     "instance-type discriminator is dropped (audit e5b77d7, PR-2c)."
                 ),
             ),
+            # ---- static routes: the WHOLE surface, not a partial loss ----
+            #
+            # This codec's config.xml renderer emits no <staticroutes>/<route>
+            # block at all (see render.py), so every static route vanishes on
+            # render — destination, next-hop and all.  A record that does not
+            # survive at all is ``unsupported``; ``lossy`` means "survives with
+            # caveats".  These four leaves were declared lossy from the
+            # f92e97a T0-1 audit (which was fixing a worse bug — the base path
+            # was UNDECLARED, so classify() defaulted it to ``supported`` and
+            # the route vanished under ``severity: ok``).  Lossy was the right
+            # step then and the wrong resting place: it left this subtree
+            # self-contradictory, with the total drop reported ``warn`` while
+            # its own child /routing/static-route/interface — the SAME render
+            # behaviour, one leaf down — reported ``block``.  Now the whole
+            # subtree is unsupported and validate_against blocks uniformly, so
+            # an operator is told to re-create routing on the OPNsense target
+            # rather than to skim a warning.  Guarded by
+            # test_registry_capability_honesty.py::
+            # test_whole_static_route_drop_is_declared, which since this change
+            # requires ``unsupported`` — not merely "declared" — whenever a
+            # plain gateway route round-trips to nothing.
+            UnsupportedPath(
+                path="/routing/static-route",
+                reason=(
+                    "Parse harvests routes (the <gateways> default route + "
+                    "<staticroutes>/<route> entries, resolving named gateways "
+                    "to their IP; promotion #15), but the config.xml renderer "
+                    "emits no <staticroutes>/<route> block, so the ENTIRE "
+                    "route is dropped on render. Declared unsupported (block): "
+                    "the record does not survive, which is not a lossy "
+                    "round-trip (audit f92e97a T0-1; severity corrected in the "
+                    "scope re-weight wave)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/routing/static-route/gateway",
+                reason=(
+                    "Dropped with the whole route (see /routing/static-route): "
+                    "no <staticroutes> block is rendered, so the next-hop "
+                    "gateway has nothing to attach to (audit e5b77d7, PR-2c)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/routing/static-route/metric",
+                reason=(
+                    "Dropped with the whole route (see /routing/static-route): "
+                    "no <staticroutes> block is rendered, so the "
+                    "administrative distance (metric) goes with it "
+                    "(audit f92e97a T0-1)."
+                ),
+            ),
+            UnsupportedPath(
+                path="/routing/static-route/description",
+                reason=(
+                    "Dropped with the whole route (see /routing/static-route): "
+                    "the route name / description goes with the unrendered "
+                    "route (audit f92e97a T0-1)."
+                ),
+            ),
             UnsupportedPath(
                 path="/routing/static-route/interface",
                 reason=(
                     "No <staticroutes> block is rendered (see "
                     "/routing/static-route), so an interface-only (connected) "
                     "static route — which has no gateway to fall back on — is "
-                    "dropped entirely. Declared unsupported (block) to surface "
-                    "the connected-route reachability loss as harder than a "
-                    "gateway route's lossy drop (audit f92e97a T0-1)."
+                    "dropped entirely, a reachability loss (audit f92e97a "
+                    "T0-1)."
                 ),
             ),
             UnsupportedPath(
@@ -553,8 +557,10 @@ class OPNsenseCodec(CodecBase):
                 reason=(
                     "Per-VRF static-route binding parses-and-ignores in "
                     "v1.  Schema exists on CanonicalStaticRoute.vrf; "
-                    "wire-up scheduled for v0.2.0 (closes existing "
-                    "per-VRF static-route lossy declaration)."
+                    "wire-up scheduled for v0.2.0.  Independent of the "
+                    "whole-route render drop above: OPNsense's config.xml "
+                    "has no VRF model at all, so this leaf stays unsupported "
+                    "even once <staticroutes> rendering lands."
                 ),
             ),
         ],

--- a/tests/fixtures/cross_vendor_expectations/arista_eos__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/arista_eos__opnsense.yaml
@@ -465,20 +465,25 @@ per_field_expectation:
     references: [opnsense-vlans, arista-vlan-cg]
 
   static_routes:
-    disposition: lossy
+    disposition: unsupported
     reason: >
       OPNsense splits static-route declaration into two blocks:
       ``<gateways>/<gateway_item>`` (named gateways) and
       ``<staticroutes>/<route>`` (routes referencing named
-      gateways).  The OPNsense codec does not currently render
-      either block on cross-vendor; canonical static_routes from
-      an Arista source therefore drop pending wire-up.  Per-VRF
-      static routes (Arista ``ip route vrf X ...``) carry a
-      populated ``CanonicalStaticRoute.vrf`` but drop on this
-      cross-pair because OPNsense has no VRF model.  Arista's
-      ``0.0.0.0/0`` form would also need
-      remapping to the OPNsense default-gateway idiom (set via
-      the WAN zone interface).
+      gateways).  The OPNsense codec PARSES both (promotion #15)
+      but its ``config.xml`` renderer emits neither, so a route
+      from an Arista source does not survive the trip at all —
+      destination and next-hop alike.  Unsupported, not lossy: the
+      record vanishes rather than arriving with caveats, and the
+      OPNsense capability matrix declares ``/routing/static-route``
+      and every leaf beneath it unsupported so validate_against
+      blocks instead of warning.  Per-VRF static routes (Arista
+      ``ip route vrf X ...``) carry a populated
+      ``CanonicalStaticRoute.vrf`` and would drop on this
+      cross-pair independently, because OPNsense has no VRF model.
+      Arista's ``0.0.0.0/0`` form would also need remapping to the
+      OPNsense default-gateway idiom (set via the WAN zone
+      interface) even once ``<staticroutes>`` rendering lands.
     references: [opnsense-gateways, arista-routing-cg]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/aruba_aoss__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/aruba_aoss__opnsense.yaml
@@ -448,18 +448,23 @@ per_field_expectation:
     references: [opnsense-vlans, aruba-vlans]
 
   static_routes:
-    disposition: lossy
+    disposition: unsupported
     reason: >
       OPNsense splits static-route declaration into two blocks:
       ``<gateways>/<gateway_item>`` (named gateways) and
       ``<staticroutes>/<route>`` (routes referencing named
-      gateways).  The OPNsense codec does not currently render
-      either block on cross-vendor; canonical static_routes from
-      an Aruba source drop pending wire-up.  Aruba's legacy
-      ``ip default-gateway`` form normalises to a ``0.0.0.0/0``
-      canonical record but the OPNsense idiom is to set the
-      default via the WAN zone's ``<gateway>`` rather than a
-      ``0.0.0.0/0`` route.
+      gateways).  The OPNsense codec PARSES both (promotion #15)
+      but its ``config.xml`` renderer emits neither, so a route
+      from an Aruba source does not survive the trip at all.
+      Unsupported, not lossy: the record vanishes rather than
+      arriving with caveats, and the OPNsense capability matrix
+      declares ``/routing/static-route`` and every leaf beneath it
+      unsupported so validate_against blocks instead of warning.
+      Aruba's legacy ``ip default-gateway`` form normalises to a
+      ``0.0.0.0/0`` canonical record, but the OPNsense idiom is to
+      set the default via the WAN zone's ``<gateway>`` rather than
+      a ``0.0.0.0/0`` route — a second, independent mismatch that
+      survives even once ``<staticroutes>`` rendering lands.
     references: [opnsense-gateways, aruba-static-routes]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe__opnsense.yaml
@@ -352,13 +352,17 @@ per_field_expectation:
   static_routes:
     disposition: not_applicable
     note: >
-      cisco_iosxe parser doesn't walk
-      `<network-instances><protocols><protocol identifier=STATIC>`.
-      intent.static_routes is empty after parse.  OPNsense target
-      uses a two-block model (`<gateways>` + `<staticroutes>`)
-      that the OPNsense codec doesn't currently render either —
-      double-gap, with neither end currently producing or
-      consuming canonical static-route records on this pair.
+      Stays `not_applicable` rather than `unsupported` because the
+      gap on this pair is SOURCE-side: the cisco_iosxe parser
+      doesn't walk
+      `<network-instances><protocols><protocol identifier=STATIC>`,
+      so intent.static_routes is empty after parse and there is
+      never a record for the target to lose.  The OPNsense target
+      independently declares `/routing/static-route` unsupported
+      (its config.xml renderer emits neither `<gateways>` nor
+      `<staticroutes>`) — so this is a double-gap, and closing the
+      IOS-XE parse side alone would move this row to
+      `unsupported`, not to `good`.
     references: [oc-network-instance]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe_cli__opnsense.yaml
@@ -408,20 +408,24 @@ per_field_expectation:
     references: [opnsense-vlans]
 
   static_routes:
-    disposition: lossy
+    disposition: unsupported
     reason: >
       OPNsense splits static-route declaration into two blocks:
       ``<gateways>/<gateway_item>`` (named gateways) and
       ``<staticroutes>/<route>`` (routes referencing named
-      gateways).  The OPNsense codec now PARSES both blocks
+      gateways).  The OPNsense codec PARSES both blocks
       (``parse.py`` ``_parse_static_routes`` harvests the
       ``<gateway_item>`` default route + ``<staticroutes>/<route>``
       entries, resolving named gateways to their IP; promotion #15),
-      but the config.xml renderer still emits neither block, so
-      canonical static_routes from a Cisco source drop on render.
+      but the config.xml renderer emits neither, so a route from a
+      Cisco source does not survive the trip at all.  Unsupported,
+      not lossy: the record vanishes rather than arriving with
+      caveats, and the OPNsense capability matrix declares
+      ``/routing/static-route`` and every leaf beneath it
+      unsupported so validate_against blocks instead of warning.
       Per-VRF static routes (Cisco ``ip route vrf X ...``) carry a
-      populated ``CanonicalStaticRoute.vrf`` but drop on this
-      cross-pair because OPNsense has no VRF model.
+      populated ``CanonicalStaticRoute.vrf`` and would drop on this
+      cross-pair independently, because OPNsense has no VRF model.
     references: [opnsense-gateways]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/fortigate_cli__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/fortigate_cli__opnsense.yaml
@@ -482,7 +482,7 @@ per_field_expectation:
     references: [fgt-vlans, opn-vlans]
 
   static_routes:
-    disposition: lossy
+    disposition: unsupported
     reason: >
       FortiGate's flat ``config router static`` per-route table
       flattens cleanly into canonical (FortiGate codec parses
@@ -490,13 +490,17 @@ per_field_expectation:
       device -> interface).  OPNsense rendering would have to
       synthesise a ``<gateway_item>`` per unique next-hop on the
       canonical list (or reuse an existing one if the operator
-      pre-declared it), then emit ``<route>`` elements.  The
-      OPNsense codec capability matrix does NOT currently advertise
-      ``/routing/static-route`` as supported — render is unwired
-      pending wire-up.  Additionally, FortiGate's
+      pre-declared it), then emit ``<route>`` elements.  It emits
+      neither, so a route from a FortiGate source does not survive
+      the trip at all.  Unsupported, not lossy: the record vanishes
+      rather than arriving with caveats, and the OPNsense
+      capability matrix declares ``/routing/static-route`` and
+      every leaf beneath it unsupported so validate_against blocks
+      instead of warning.  Additionally, FortiGate's
       ``set dst 0.0.0.0 0.0.0.0`` (default route) is a first-class
       entry; the OPNsense equivalent is to set the WAN zone's
-      default-gateway flag rather than emit a ``<route>``.
+      default-gateway flag rather than emit a ``<route>`` — an
+      idiom mismatch that outlives the render gap.
     references: [fgt-static-routes, opn-static-routes]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/cross_vendor_expectations/juniper_junos__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/juniper_junos__opnsense.yaml
@@ -528,20 +528,26 @@ per_field_expectation:
   # ── Tier 1 — static routes ──
 
   static_routes:
-    disposition: lossy
+    disposition: unsupported
     reason: >
       Junos's ``set routing-options static route X/N next-hop Y``
       parses cleanly to canonical entries.  OPNsense splits static-
       route declaration into ``<gateways>`` (named gateways) +
       ``<staticroutes>`` (routes referencing named gateways).  The
-      OPNsense codec does not currently parse OR emit either block;
-      canonical static_routes from a Junos source therefore drop on
-      render.  Per-VRF static routes (Junos ``set routing-instances
-      <vrf> routing-options static``) carry a populated
-      ``CanonicalStaticRoute.vrf`` from the Junos source but drop
-      on this cross-pair because OPNsense has no VRF model.
-      Junos's ``qualified-next-hop`` flattens to
-      multiple canonical entries.
+      OPNsense codec PARSES both (promotion #15 — an earlier
+      revision of this file said it parsed neither, which was
+      already stale when written) but its ``config.xml`` renderer
+      emits neither, so a route from a Junos source does not
+      survive the trip at all.  Unsupported, not lossy: the record
+      vanishes rather than arriving with caveats, and the OPNsense
+      capability matrix declares ``/routing/static-route`` and
+      every leaf beneath it unsupported so validate_against blocks
+      instead of warning.  Per-VRF static routes (Junos ``set
+      routing-instances <vrf> routing-options static``) carry a
+      populated ``CanonicalStaticRoute.vrf`` from the Junos source
+      and would drop on this cross-pair independently, because
+      OPNsense has no VRF model.  Junos's ``qualified-next-hop``
+      flattens to multiple canonical entries.
     references: [junos-static-routing, opnsense-gateways]
 
   # ── Tier 2 — DHCP server ──

--- a/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__opnsense.yaml
+++ b/tests/fixtures/cross_vendor_expectations/mikrotik_routeros__opnsense.yaml
@@ -482,19 +482,24 @@ per_field_expectation:
     references: [opnsense-vlans]
 
   static_routes:
-    disposition: lossy
+    disposition: unsupported
     reason: >
       OPNsense splits static-route declaration into two blocks:
       ``<gateways>/<gateway_item>`` (named gateways) and
       ``<staticroutes>/<route>`` (routes referencing named
-      gateways).  The OPNsense codec parses both blocks, but its
-      render path emits neither; canonical static_routes from a
-      RouterOS source therefore drop on render.  Per-VRF routes
-      (RouterOS ``routing-table=TENANT-A``) are unsupported (they
-      have no OPNsense render target and the MikroTik codec does
-      not yet parse VRF context).  Default route (``0.0.0.0/0``)
-      maps to OPNsense's WAN-zone gateway pattern, not a
-      ``<staticroutes>`` entry — operator-curated.
+      gateways).  The OPNsense codec parses both blocks
+      (promotion #15), but its render path emits neither, so a
+      route from a RouterOS source does not survive the trip at
+      all.  Unsupported, not lossy: the record vanishes rather than
+      arriving with caveats, and the OPNsense capability matrix
+      declares ``/routing/static-route`` and every leaf beneath it
+      unsupported so validate_against blocks instead of warning.
+      Per-VRF routes (RouterOS ``routing-table=TENANT-A``) are
+      unsupported independently (they have no OPNsense render
+      target and the MikroTik codec does not yet parse VRF
+      context).  Default route (``0.0.0.0/0``) maps to OPNsense's
+      WAN-zone gateway pattern, not a ``<staticroutes>`` entry —
+      operator-curated, and still true once rendering lands.
     references: [mikrotik_ip_routing, opnsense-gateways]
 
   # ── Tier 2 — auto-translate with review ──

--- a/tests/fixtures/real/PHASE4_RECONCILIATION.md
+++ b/tests/fixtures/real/PHASE4_RECONCILIATION.md
@@ -14,8 +14,8 @@ Intra-vendor self-pairs skipped (no Phase 3 YAML — by design, Phase 3 is cross
 |---|---:|---|
 | ALIGNED | 1690 | ok |
 | CODEC_BUG | 5 | **high** |
-| EXPECTED_LOSSY | 1226 | ok |
-| EXPECTED_UNSUPPORTED | 738 | ok |
+| EXPECTED_LOSSY | 1196 | ok |
+| EXPECTED_UNSUPPORTED | 768 | ok |
 | METHODOLOGY_ISSUE_under | 916 | low/medium |
 | METHODOLOGY_ISSUE_over | 21 | low |
 | STRUCTURAL_ONLY | 1179 | low |

--- a/tests/fixtures/real/_phase4_runs/latest.json
+++ b/tests/fixtures/real/_phase4_runs/latest.json
@@ -1,7 +1,7 @@
 {
-  "started_utc": "2026-07-22T18:10:08+00:00",
-  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260722T180729Z.json",
-  "mesh_run_started_utc": "2026-07-22T18:07:23+00:00",
+  "started_utc": "2026-08-17T16:24:25+00:00",
+  "mesh_json": "tests/fixtures/real/_cross_mesh_runs/20260817T162424Z.json",
+  "mesh_run_started_utc": "2026-08-17T16:24:18+00:00",
   "cells_total": 1224,
   "expectation_yamls_loaded": 56,
   "intra_vendor_cells_skipped": [
@@ -4136,8 +4136,8 @@
   "aggregate": {
     "ALIGNED": 1690,
     "CODEC_BUG": 5,
-    "EXPECTED_LOSSY": 1226,
-    "EXPECTED_UNSUPPORTED": 738,
+    "EXPECTED_LOSSY": 1196,
+    "EXPECTED_UNSUPPORTED": 768,
     "METHODOLOGY_ISSUE_under": 916,
     "METHODOLOGY_ISSUE_over": 21,
     "STRUCTURAL_ONLY": 1179,

--- a/tests/unit/migration/test_registry_capability_honesty.py
+++ b/tests/unit/migration/test_registry_capability_honesty.py
@@ -725,9 +725,14 @@ def test_connected_route_loss_blocks_on_vanishing_codecs(name: str):
 @pytest.mark.parametrize("name", _CODEC_NAMES)
 def test_whole_static_route_drop_is_declared(name: str):
     """A codec that renders a PLAIN gateway static route to nothing — the whole
-    route vanishes — must declare ``/routing/static-route`` lossy/unsupported,
-    else validate_against reports ``severity: ok`` while the route is silently
-    discarded.
+    route vanishes — must declare ``/routing/static-route`` **unsupported**.
+
+    Not "lossy or unsupported": ``lossy`` means the record survives with
+    caveats, and a record that does not survive at all has no caveats to
+    report.  The distinction is operator-visible, not bookkeeping —
+    ``validate_against`` renders lossy as ``warn`` and unsupported as
+    ``block``, so a lossy declaration on a total drop invites an operator to
+    skim past the loss of their entire routing table.
 
     A plain destination+next-hop route (NO VRF, interface-nexthop, metric, or
     description) is unambiguous: every codec with a static-route render path
@@ -735,7 +740,20 @@ def test_whole_static_route_drop_is_declared(name: str):
     — opnsense's ``config.xml`` emits no ``<staticroutes>`` block.  This was
     the f92e97a audit's T0-1: opnsense left the BASE path undeclared, so
     classify() defaulted it to ``supported`` and a whole gateway route vanished
-    silently.
+    silently.  That audit declared it ``lossy``, which stopped the silence but
+    left the subtree self-contradictory — the total drop reported ``warn``
+    while its own child ``/routing/static-route/interface``, the same render
+    behaviour one leaf down, reported ``block``.  The scope re-weight wave
+    corrected it to ``unsupported`` and tightened this guard to the assertion
+    that would have caught it.
+
+    NOTE: this does NOT generalise to "a parent may never be less severe than
+    its child".  A ``supported`` parent with a ``lossy`` child is the normal
+    and correct shape — the record round-trips, one leaf of it does not — and
+    holds in 63 places across the registry (``/routing/static-route`` supported
+    with ``/routing/static-route/description`` lossy on arista_eos, every
+    ``/snmp/v3-user`` subtree, …).  What is forbidden is narrower and
+    behavioural: declaring a drop LOSSY when the record measurably vanishes.
 
     Sub-fields are deliberately omitted so a declared sub-field drop (e.g. the
     VRF binding, which aruba_aoscx drops by dropping the whole VRF-bound route
@@ -743,18 +761,22 @@ def test_whole_static_route_drop_is_declared(name: str):
     path — see the note on ``_NAMING_INDEPENDENT_DROP_FIELDS``."""
     codec = get_codec(name)
     caps = codec.capabilities
-    declared = {u.path for u in caps.unsupported} | {lp.path for lp in caps.lossy}
-    if "/routing/static-route" in declared:
-        return  # honestly declared (lossy or unsupported) — loss surfaces
+    if "/routing/static-route" in {u.path for u in caps.unsupported}:
+        return  # honestly declared a total drop — validate_against blocks
     tree = CanonicalIntent(
         hostname="r1",
         static_routes=[CanonicalStaticRoute(destination="10.9.0.0/24",
                                             gateway="10.0.0.2")],
     )
     rp = codec.parse(codec.render(tree))
+    lossy_paths = {lp.path for lp in caps.lossy}
     assert rp.static_routes, (
-        f"{name}: renders a plain gateway static route to nothing yet declares "
-        f"/routing/static-route neither lossy nor unsupported — "
-        f"validate_against reports 'supported' while the route silently "
-        f"vanishes (audit f92e97a T0-1). Add a LossyPath/UnsupportedPath."
+        f"{name}: renders a plain gateway static route to nothing, so the "
+        f"record does not survive — /routing/static-route must be declared "
+        f"UNSUPPORTED (block), not "
+        f"{'lossy (warn)' if '/routing/static-route' in lossy_paths else 'left undeclared'}. "
+        f"A vanished record is not a lossy round-trip; declaring it lossy "
+        f"under-states a total routing loss as a skimmable warning "
+        f"(audit f92e97a T0-1; severity corrected in the scope re-weight "
+        f"wave). Add an UnsupportedPath."
     )

--- a/tests/unit/migration/test_singleton_subfield_walk_expansion.py
+++ b/tests/unit/migration/test_singleton_subfield_walk_expansion.py
@@ -47,12 +47,14 @@ _SUBPATHS = [_SR + "gateway", _RI + "instance-type", _V6 + "scope"]
 #: anchor at all.
 _EXPECTED: dict[str, dict[str, str]] = {
     # Gateway: every codec renders `ip route <dest> <next-hop>` faithfully
-    # except OPNsense (renders no <staticroutes> -> lossy, parity with the
-    # route anchor) and the NETCONF stub (renders no static routes -> unsupp).
-    _SR + "gateway": {
-        "opnsense": "lossy",
-        "cisco_iosxe": "unsupported",
-    },
+    # except OPNsense and the NETCONF stub, neither of which renders any
+    # <staticroutes> anchor at all -> unsupported for both.  OPNsense was
+    # ``lossy`` here until the scope re-weight wave, in parity with a route
+    # anchor that was itself mis-declared lossy; a next-hop with no route to
+    # hang on has not been downgraded, it is gone.
+    _SR + "gateway": dict.fromkeys(
+        ("opnsense", "cisco_iosxe"), "unsupported",
+    ),
     # instance-type: only Arista (mac-vrf/vrf branch) and Junos (explicit
     # `instance-type`) round-trip the discriminator.  The CLI VRF renderers
     # emit a plain `vrf <name>` (lossy); the codecs with no VRF model at all


### PR DESCRIPTION
# OPNsense declared a total loss of your routing table as a warning

**Branch:** `fix/opnsense-static-route-severity` → `scope/reweight-wave` ·
2 commits · PR 2 of 3

OPNsense's `config.xml` renderer emits no `<staticroutes>`/`<route>` block, so a
static route translated **into** OPNsense vanishes entirely — destination,
next-hop and all. That was declared `lossy`, which `validate_against` renders as
`warn`.

Measured on `cisco_iosxe_cli → opnsense` with a single `ip route` line:

| | severity | compatible |
|---|---|---|
| **before** | `warn` | **`True`** |
| **after** | `block` | `False` |

The plan was actively declaring the migration **compatible** while the entire
routing table would be discarded.

## Why it sat wrong for so long

The subtree has been self-contradictory since the `f92e97a` audit. That audit was
fixing a worse bug — the base path was *undeclared*, so `classify()` defaulted it
to `supported` and the route vanished under `severity: ok` — and `lossy` was the
right step then. It was the wrong resting place: the total drop reported `warn`
while its own child `/routing/static-route/interface`, the **same render
behaviour one leaf down**, reported `block`.

`lossy` means "survives with caveats". A record that does not survive has no
caveats to report.

`/routing/static-route` and its `gateway` / `metric` / `description` leaves are now
`unsupported`. **Parse is untouched** — OPNsense as a *source* still harvests
routes from both blocks (promotion #15) and translates outward.

## The guard, and what it deliberately does not claim

`test_whole_static_route_drop_is_declared` is tightened from *"declared lossy or
unsupported"* to *"declared unsupported"*, and was verified to fail against the old
declaration before the fix landed.

It deliberately does **not** generalise to *"a parent may never be less severe than
its child"*. I probed that first: there are **63** parent-less-severe-than-child
pairs across all 13 registered codecs, and essentially all are the normal, correct
shape — a `supported` record with one `lossy` leaf (`/routing/static-route`
supported with `.../description` lossy on `arista_eos`; every `/snmp/v3-user`
subtree). Shipping that invariant would have been wrong registry-wide.

The rule is narrower and behavioural: **declaring a drop `lossy` when the record
measurably vanishes.** A second probe rendered a minimal record through every
`lossy`-declared base path on every bidirectional codec — this was the **only** such
surface in the registry, so this is the only instance of the defect, not the first
of many.

`test_singleton_subfield_walk_expansion`'s disposition table moves
`/routing/static-route/gateway` for the same reason: a next-hop with no route to
hang on has not been downgraded.

## Doc-sync 178, discharged

Audited **all 14** pairs OPNsense participates in; **7 moved**. The 7
OPNsense-as-source pairs are governed by the *other* codec's render matrix and
correctly did not move — worth stating, since "14 paired YAMLs" reads as 14 edits.

Of the 7 as target: 6 flip `lossy` → `unsupported`. `cisco_iosxe__opnsense` stays
`not_applicable` because its gap is source-side (the IOS-XE NETCONF stub parses no
routes at all), with its note rewritten to say so and to record that closing the
parse side would move it to `unsupported`, not to `good`.

Plus six `docs/vendor-references/` verdicts, `docs/CAPABILITIES.md` (whose OPNsense
panel listed only `.../vrf`, leaving the whole subtree invisible) and
`docs/vendors/opnsense.md`.

**Two stale doc-truth claims fixed in passing**, both pre-existing:

- `juniper_junos__opnsense.yaml` said the OPNsense codec *"does not currently parse
  OR emit either block"*. It has parsed both since promotion #15;
  `cisco_iosxe_cli__opnsense` had it right.
- `cisco_iosxe_to_opnsense/openconfig_yang_scope.md` described ten paths as declared
  `supported` *"aspirationally … so cross-codec mesh translations don't classify
  these paths as unsupported"*. All ten now classify `unsupported`, verified against
  the live matrix. Kept as a **marked** worked example rather than deleted —
  declaring a path supported to keep mesh arithmetic tidy is a live temptation, and
  `docs/METHODOLOGY.md` treats it as a violation equal to under-claiming.

## The regen (second commit)

Split out per doc-sync 178. Effect was **predicted from the `classify_variance`
table before running**, then confirmed by it:

```
EXPECTED_LOSSY        1226 -> 1196   (-30)
EXPECTED_UNSUPPORTED   738 ->  768   (+30)
CODEC_BUG                5 ->    5   (unchanged)
```

**`CODEC_BUG` holding at 5 is proven by the regen, not asserted.** All 30 moved
field-cells were already `drifted`; none were `preserved`, so none crossed into
`METHODOLOGY_ISSUE_under`, whose medium-severity arm is what a
preserved-against-unsupported cell would have hit. Every other class is unchanged
and the severity roll-up is identical — 5 high, 106 medium, 2010 low, 13178 ok —
because both moved classes are `ok`.

`CROSS_MESH_RESULTS.md` is **deliberately absent**: it is byte-identical after the
flip. Phase 1 resolves "unsupported in target" through
`run_full_mesh._FIELD_TO_IDENTITY_XPATHS`, which carries no `static_routes` entry,
so the declaration is invisible to the mechanical layer.

> **Known gap, left alone on purpose.** That means a route dropped by a target
> which *declares* it unsupported still counts as undeclared drift in Phase 1.
> Closing it would move clean% for every codec declaring that path, so it must not
> ride along inside a severity fix. Flagging rather than smuggling.

Regeneration was verified byte-reproducible: the same two commands were run against
the **unmodified** tree first and produced a zero-content diff (provenance
timestamps only), so this diff is wholly attributable to the declaration change.

## Verification

- `6289 passed, 113 skipped` (unit + integration + demo); ruff 0.15.17 clean
- Cross-mesh CI guard green against the new baseline
- Tightened guard proven red against the old declaration

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
