### PR TITLE
The expectation-YAML validator was wired into nothing, and three files had rotted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,45 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **The expectation-YAML schema validator was wired into nothing, and three
+  files had drifted out of compliance.**
+  `tools/load_cross_vendor_expectations.py` has always checked the 56 pair
+  YAMLs against the schema in their own README, but it was a standalone script
+  no test ran, so it rotted silently.  Three `cisco_iosxe__*` files failed it.
+  Root cause pinned by `git log -S` to `ba86562` ("Wave 7c close-out: flip 3
+  cisco_iosxe-source vendor-wire-correct cells to lossy"), which flipped
+  `interfaces[].name` from `good` to `lossy` in each without renaming the
+  accompanying `note:` to `reason:` -- the requirement is
+  disposition-dependent, so flipping a disposition invalidates the entry.
+  Exactly three cells flipped; exactly three files failed.
+
+  Fixing the key surfaced a second defect the validator's per-file
+  short-circuit had masked: `cisco_iosxe__mikrotik_routeros` cited a reference
+  id `routeros-bridge` that was never declared -- in that file or anywhere in
+  the corpus.  Its claim (RouterOS's VLAN model requires a parent bridge, so
+  the synthesised `bridge1` is vendor-wire-correct rather than a translator
+  phantom) is in fact grounded by the already-declared `vlan-render-gap`, whose
+  note cites MikroTik's "Basic VLAN switching (bridge VLAN filtering)" page and
+  shows the synthetic bridge; the citation now points there rather than at an
+  invented id.  Also removed a dangling `` (commit `1b1b865`) `` from all three
+  files -- that revision exists nowhere in this repo.
+
+  New `tests/unit/migration/test_cross_vendor_expectations.py` (169 cases)
+  calls the tool's own `validate_one` rather than re-implementing the rules, so
+  the schema keeps one definition and a rule added to the tool is enforced
+  automatically.  Two checks the tool does not make, each probed against the
+  corpus before adoption: the filename must equal
+  `<source_vendor>__<target_vendor>` from `meta` (the reconciler indexes by
+  FILENAME, so a disagreement reconciles a cell against the wrong pair's
+  expectations and every resulting variance class is quietly wrong), and every
+  declared `references[].path` must resolve on disk (the tool proves cited ids
+  are declared, never that a declared reference points at a real note).  All
+  three guards were verified red -- the schema one against the actual
+  historical defect.
+
+  No effect on the fidelity baseline: `reason` and `note` are documentation
+  fields the reconciler never reads, and no disposition changed.
+
 - **OPNsense declared a total loss of your routing table as a warning.**
   The `config.xml` renderer emits no `<staticroutes>`/`<route>` block, so a
   static route translated INTO OPNsense vanishes entirely -- destination,

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe__aruba_aoss.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe__aruba_aoss.yaml
@@ -202,7 +202,7 @@ per_field_expectation:
 
   "interfaces[].name":
     disposition: lossy
-    note: >
+    reason: >
       OpenConfig source emits `<name>GigabitEthernet1/0/1</name>`;
       the parser stores verbatim on CanonicalInterface.name.  AOS-S
       target render emits via the port-rename mesh, mapping Cisco
@@ -214,7 +214,7 @@ per_field_expectation:
       `GigabitEthernet0/0/4` carrying nothing other than its name)
       are elided by AOS-S render — there is no AOS-S equivalent
       port-name to emit and no per-port settings to anchor the
-      record.  Wave 7c (commit `1b1b865`) cleared count drift on
+      record.  Wave 7c cleared count drift on
       every other surface; the remaining bare-stub elision is
       vendor-wire-correct and reclassified `good → lossy`.
     references: [oc-interfaces, iosxe-interface-cg, aoss-bog]

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe__juniper_junos.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe__juniper_junos.yaml
@@ -240,7 +240,7 @@ per_field_expectation:
 
   "interfaces[].name":
     disposition: lossy
-    note: >
+    reason: >
       OpenConfig source emits `<name>GigabitEthernet1/0/1</name>`;
       the parser stores verbatim on CanonicalInterface.name.  Junos
       target render emits via the port-rename mesh, mapping Cisco
@@ -253,7 +253,7 @@ per_field_expectation:
       Bare-name stub interfaces with no L3 / VLAN / description /
       LAG-membership content are elided by Junos render — there is
       no Junos equivalent name to emit and no per-port settings to
-      anchor the record.  Wave 7c (commit `1b1b865`) cleared count
+      anchor the record.  Wave 7c cleared count
       drift on every other surface; the remaining bare-stub elision
       is vendor-wire-correct and reclassified `good → lossy`.
     references: [oc-interfaces, iosxe-interface-cg, junos-iface-naming]

--- a/tests/fixtures/cross_vendor_expectations/cisco_iosxe__mikrotik_routeros.yaml
+++ b/tests/fixtures/cross_vendor_expectations/cisco_iosxe__mikrotik_routeros.yaml
@@ -201,7 +201,7 @@ per_field_expectation:
 
   "interfaces[].name":
     disposition: lossy
-    note: >
+    reason: >
       OpenConfig <interface><name> -> RouterOS interface name (after
       the rename mesh translates Cisco's speed-encoded name to
       RouterOS's flat etherN form).  Without the rename mesh, the
@@ -213,10 +213,10 @@ per_field_expectation:
       VLAN model REQUIRES a parent bridge, so this is vendor-wire-
       correct rather than a translator phantom.  The synthesised
       bridge inflates the source-vs-target interface count by 1 on
-      fixtures with VLAN sub-interfaces; Wave 7c (commit `1b1b865`)
+      fixtures with VLAN sub-interfaces; Wave 7c
       cleared other count drift surfaces and reclassified this
       `good → lossy` to reflect the structural delta.
-    references: [oc-interfaces, routeros-iface, routeros-bridge]
+    references: [oc-interfaces, routeros-iface, vlan-render-gap]
 
   "interfaces[].description":
     disposition: good

--- a/tests/unit/migration/test_cross_vendor_expectations.py
+++ b/tests/unit/migration/test_cross_vendor_expectations.py
@@ -1,0 +1,140 @@
+"""
+Schema guard for the Phase 3 cross-vendor expectation YAMLs.
+
+``tools/load_cross_vendor_expectations.py`` has always validated these 56
+files against the schema documented in
+``tests/fixtures/cross_vendor_expectations/README.md`` — but it was a
+standalone script wired into nothing, so nothing ran it.  It rotted: by
+2026-08 three files failed their own documented schema and had done since
+``ba86562`` ("Wave 7c close-out: flip 3 cisco_iosxe-source vendor-wire-correct
+cells to lossy"), which flipped ``interfaces[].name`` from ``good`` to
+``lossy`` in each without renaming the accompanying ``note:`` to ``reason:``.
+The requirement is *disposition-dependent* — ``note`` is the right key for
+``good`` / ``not_applicable`` and ``reason`` is REQUIRED for ``lossy`` /
+``unsupported`` — so flipping a disposition silently invalidates the entry.
+That is precisely the class of drift a human re-reading the diff does not
+catch and a validator does, which is why this module now exists: the tool's
+own docstring named this file as its intended home.
+
+This module deliberately calls the tool's ``validate_one`` rather than
+re-implementing the rules, so the schema has ONE definition.  A rule added to
+the tool is enforced here automatically.
+
+The two checks below it are additions the tool does not make, each verified
+against the current corpus before being adopted:
+
+* the filename must equal ``<source_vendor>__<target_vendor>`` from ``meta``.
+  The reconciler resolves a cell's YAML *by filename*
+  (``run_phase4_reconciliation`` builds its index from the stem), so a file
+  whose meta disagrees with its name would be silently reconciled against the
+  wrong pair's expectations.
+* every ``meta.references[].path`` must resolve on disk.  The tool checks that
+  cited ids are declared, but never that a declared reference points at a real
+  research note — so a moved or deleted note leaves a citation that looks
+  grounded and is not.  (The same wave found ``1b1b865`` cited in three files'
+  prose, a revision that exists nowhere in this repo.)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_FIXTURE_DIR = _REPO_ROOT / "tests" / "fixtures" / "cross_vendor_expectations"
+
+# Load the validator without making ``tools/`` a package — same pattern as
+# ``tests/unit/audit/test_run_phase4_reconciliation.py``.
+_LOADER_PATH = _REPO_ROOT / "tools" / "load_cross_vendor_expectations.py"
+_spec = importlib.util.spec_from_file_location(
+    "load_cross_vendor_expectations", _LOADER_PATH,
+)
+assert _spec is not None and _spec.loader is not None
+loader = importlib.util.module_from_spec(_spec)
+sys.modules["load_cross_vendor_expectations"] = loader
+_spec.loader.exec_module(loader)
+
+validate_one = loader.validate_one
+
+#: Sorted so parametrisation ids are stable across platforms.
+_YAML_PATHS = sorted(_FIXTURE_DIR.glob("*.yaml"))
+_YAML_IDS = [p.stem for p in _YAML_PATHS]
+
+
+def test_the_corpus_is_not_empty() -> None:
+    """A glob that silently matches nothing would make every parametrised
+    test below vacuous — the failure mode where a green suite proves
+    nothing.  Pin a floor rather than an exact count so adding a pair
+    (A6's 16 vyos YAMLs, say) doesn't fail here for the wrong reason."""
+    assert len(_YAML_PATHS) >= 56, (
+        f"expected at least 56 expectation YAMLs under {_FIXTURE_DIR}, "
+        f"found {len(_YAML_PATHS)} — the glob is matching nothing, or pair "
+        f"files were deleted without updating this floor"
+    )
+
+
+@pytest.mark.parametrize("path", _YAML_PATHS, ids=_YAML_IDS)
+def test_yaml_matches_the_documented_schema(path: Path) -> None:
+    """Every pair YAML satisfies the schema in the fixture-dir README.
+
+    Delegates to ``tools/load_cross_vendor_expectations.validate_one`` so
+    there is one definition of the rules.  The most-missed rule is the
+    disposition-dependent one: ``lossy`` and ``unsupported`` REQUIRE
+    ``reason``; ``good`` and ``not_applicable`` take an optional ``note``.
+    Flipping a disposition means re-checking the key.
+    """
+    try:
+        validate_one(path)
+    except (yaml.YAMLError, ValueError) as exc:
+        pytest.fail(
+            f"{path.name} fails the schema documented in "
+            f"{_FIXTURE_DIR.name}/README.md: {exc}"
+        )
+
+
+@pytest.mark.parametrize("path", _YAML_PATHS, ids=_YAML_IDS)
+def test_filename_matches_the_declared_pair(path: Path) -> None:
+    """``<source>__<target>.yaml`` must agree with ``meta``.
+
+    The reconciler keys its expectation index off the FILENAME, so a
+    disagreement here reconciles a cell against another pair's expectations
+    and every resulting variance class is quietly wrong.
+    """
+    meta = yaml.safe_load(path.read_text(encoding="utf-8"))["meta"]
+    expected = f"{meta['source_vendor']}__{meta['target_vendor']}"
+    assert path.stem == expected, (
+        f"{path.name} declares source_vendor={meta['source_vendor']!r} / "
+        f"target_vendor={meta['target_vendor']!r}, so it must be named "
+        f"{expected}.yaml — the Phase 4 reconciler matches cells to YAMLs by "
+        f"filename, not by meta, so this file is being applied to the wrong "
+        f"pair"
+    )
+
+
+@pytest.mark.parametrize("path", _YAML_PATHS, ids=_YAML_IDS)
+def test_every_declared_reference_path_resolves(path: Path) -> None:
+    """A citation is only as good as the note it points at.
+
+    ``validate_one`` proves cited ids are declared; it cannot prove a
+    declared reference's ``path`` still exists.  A research note that is
+    moved or deleted leaves behind a citation that reads as vendor-grounded
+    while grounding nothing.
+    """
+    meta = yaml.safe_load(path.read_text(encoding="utf-8"))["meta"]
+    dangling = [
+        (ref["id"], ref["path"])
+        for ref in meta.get("references", [])
+        if not (_REPO_ROOT / ref["path"]).is_file()
+    ]
+    assert not dangling, (
+        f"{path.name} declares reference(s) whose path does not exist: "
+        f"{dangling}.  Either restore the research note, repoint the "
+        f"reference at the note that actually grounds the claim, or drop "
+        f"the reference — a citation to a missing file is worse than none."
+    )

--- a/tools/load_cross_vendor_expectations.py
+++ b/tools/load_cross_vendor_expectations.py
@@ -10,9 +10,15 @@ repo root::
 Exits non-zero if any file fails validation; prints a summary table
 of (pair, certainty, field-count, disposition-breakdown) on success.
 
-This is a lint-style utility — the test suite wires equivalent checks
-into ``tests/unit/migration/test_cross_vendor_expectations.py`` (when
-that file exists; not required for Phase 3a).
+``tests/unit/migration/test_cross_vendor_expectations.py`` calls
+:func:`validate_one` directly, once per pair file, so the rules below are
+enforced by CI and have exactly one definition — add a rule here and the
+suite picks it up.  Run this script directly when you want the summary
+table; run pytest when you want the gate.
+
+It was NOT always wired: for most of its life this was a standalone
+lint-style utility nothing executed, and three files drifted out of schema
+compliance unnoticed.  Keep the test attached.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
# The expectation-YAML validator was wired into nothing, and three files had rotted

**Branch:** `scope/reweight-track-a` → `fix/opnsense-static-route-severity` ·
1 commit · PR 3 of 3

Found while discharging PR 2's doc-sync. Independent of the scope wave — it only
shares the branch to avoid CHANGELOG conflicts.

`tools/load_cross_vendor_expectations.py` has always validated the 56 pair YAMLs
against the schema documented in their own README. **Nothing ran it.** It was a
standalone script whose docstring named a test file that did not exist — so it
rotted, and three `cisco_iosxe__*` files had been failing their own documented
schema for months.

## Root cause, pinned rather than guessed

`git log -S` puts it at `ba86562` — *"Wave 7c close-out: flip 3
cisco_iosxe-source vendor-wire-correct cells to lossy"*. That commit flipped
`interfaces[].name` from `good` to `lossy` in three files without renaming the
accompanying `note:` to `reason:`.

The schema's key requirement is **disposition-dependent**: `note` is right for
`good` / `not_applicable`, `reason` is REQUIRED for `lossy` / `unsupported`. So
flipping a disposition silently invalidates the entry. Exactly three cells flipped;
exactly three files failed.

This is the class of drift a human re-reading the diff does not catch and a
validator does — which is the whole argument for wiring it in.

## A second defect the first was hiding

Fixing the key surfaced one more: `cisco_iosxe__mikrotik_routeros` cited a reference
id `routeros-bridge` declared **nowhere** — not in that file, not anywhere in the
corpus. The validator short-circuits per file, so the `reason` failure had been
masking it.

The claim it supports (RouterOS's VLAN model *requires* a parent bridge, so the
synthesised `bridge1` is vendor-wire-correct rather than a translator phantom) is
in fact grounded by the already-declared `vlan-render-gap`, whose note cites
MikroTik's "Basic VLAN switching (bridge VLAN filtering)" page and shows
`add name=bridge1 vlan-filtering=yes`. Repointed there — **no new research note
authored, no retrieval date invented.**

Also dropped a dangling ``(commit `1b1b865`)`` from all three files. That revision
exists nowhere in this repo; several Wave 7c commits do and none is confidently the
referent, so the false-precision hash is removed rather than replaced with a guess.

## The guard

New `tests/unit/migration/test_cross_vendor_expectations.py` — the file the tool's
docstring has always pointed at. It calls the tool's own `validate_one` once per
pair rather than re-implementing the rules, so **the schema keeps one definition**
and a rule added to the tool is enforced here automatically.

Two checks the tool does not make, each probed against the whole corpus *before*
adoption (both already clean, so neither is a latent failure being smuggled in):

- **Filename must equal `<source_vendor>__<target_vendor>` from `meta`.**
  `run_phase4_reconciliation` indexes expectations by **filename**, so a file whose
  meta disagrees is reconciled against another pair's expectations and every
  variance class it produces is quietly wrong.
- **Every `meta.references[].path` must resolve on disk.** `validate_one` proves
  cited ids are *declared*; it cannot prove a declared reference points at a real
  note. A moved or deleted note leaves a citation that reads as vendor-grounded and
  grounds nothing — the same failure mode as the dangling `1b1b865`.

Plus a floor assertion on corpus size, so a glob that matches nothing can't make all
168 parametrised cases vacuously green. It's a floor, not an equality, so A6's 16
vyos YAMLs won't trip it for the wrong reason.

**All three guards verified red before being trusted** — the schema one by
re-injecting the actual historical defect (`reason` → `note` on
`cisco_iosxe__aruba_aoss`), the other two by injecting a meta mismatch and a
dangling path.

## No baseline movement

`reason` and `note` are documentation fields the reconciler never reads, and no
disposition changed. `tests/fixtures/real/` is untouched, and the cross-mesh CI
guard — which re-runs the full mesh and reconciliation against the committed
baseline — passes unchanged.

`6196 passed, 80 skipped` (unit + integration; +169 from this file). ruff 0.15.17
clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
