### PR TITLE
The complexity ratchet could not see ruff 0.16's ignore form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,21 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **The complexity ratchet could not see ruff 0.16's second suppression
+  spelling.**  Both guard patterns in `tests/unit/test_complexity_ratchet.py`
+  required the literal `noqa`, but ruff 0.16 stabilised a `ruff:`-prefixed
+  `ignore` directive taking a bracketed code list, which contains no `noqa`
+  token at all.  Measured against both pins rather than inferred: under ruff
+  0.15.17 the form is REJECTED (the C901 violation still reports, plus an
+  invalid-directive error); under 0.16.3 it SILENTLY SUPPRESSES, file-level and
+  inline alike, with a bogus-directive control confirming the probe was valid.
+  Adopting 0.16 without this would have reopened review finding #57 -- the
+  complexity gate dodgeable with a green `ruff check` AND a green ratchet.  Both
+  new patterns were verified red by injecting each form into a real module.  The
+  ratchet is now correct whichever pin is in force, so the ruff-0.16 bump is
+  unblocked (it still needs the `ci.yml` pin moved in the same change to be
+  anything other than inert).
+
 - **The expectation-YAML schema validator was wired into nothing, and three
   files had drifted out of compliance.**
   `tools/load_cross_vendor_expectations.py` has always checked the 56 pair

--- a/tests/unit/test_complexity_ratchet.py
+++ b/tests/unit/test_complexity_ratchet.py
@@ -39,6 +39,19 @@ _TREES = ("netcanon", "netcanon_desktop", "tools")
 #: this guard is neither self-counted nor self-suppressed (review #57 — the old
 #: exact-substring marker matched only the canonical spelling, so every variant
 #: dodged the ratchet).
+#: ``noqa`` is not the only spelling.  ruff 0.16 stabilised a SECOND
+#: suppression form -- a ``ruff:``-prefixed ``ignore`` directive taking a
+#: bracketed code list -- which contains no ``noqa`` token at all, so the
+#: pattern below cannot see it.  Verified empirically against ruff 0.15.17
+#: and 0.16.3: under 0.15 the form is REJECTED (the C901 violation still
+#: reports, plus an invalid-directive error); under 0.16 it SILENTLY
+#: SUPPRESSES, both file-level and inline.  Adopting 0.16 without this
+#: pattern reopens #57 with a green `ruff check` AND a green ratchet.
+#: Matched now so the guard is already correct when the pin moves.
+_C901_IGNORE_RE = re.compile(
+    r"#\s*ruff:\s*ignore\s*\[[^\]]*\bC90\d?\b[^\]]*\]", re.IGNORECASE,
+)
+
 _C901_INLINE_RE = re.compile(r"#\s*noqa:?[^\n]*\bC901\b", re.IGNORECASE)
 
 #: A file-level ruff directive (the ``ruff:``-prefixed noqa form), optionally
@@ -47,6 +60,13 @@ _C901_INLINE_RE = re.compile(r"#\s*noqa:?[^\n]*\bC901\b", re.IGNORECASE)
 #: the inline ratchet inert.  (Kept out of literal form for the reason above.)
 _RUFF_FILE_DIRECTIVE_RE = re.compile(
     r"#\s*ruff:\s*noqa(?::\s*(?P<codes>[^\n]*))?", re.IGNORECASE
+)
+
+#: The ruff-0.16 ``ignore`` form of the same file-level hazard.  A bracketed
+#: code list naming C90/C901 at file scope disables the complexity gate for
+#: the whole module exactly as the ``noqa`` spelling does.
+_RUFF_FILE_IGNORE_RE = re.compile(
+    r"#\s*ruff:\s*ignore\s*\[(?P<codes>[^\]]*)\]", re.IGNORECASE,
 )
 
 #: Pre-existing functions over the max-complexity ceiling, grandfathered with an
@@ -60,7 +80,7 @@ def _c901_suppression_count() -> int:
     for tree in _TREES:
         for path in (_ROOT / tree).rglob("*.py"):
             for line in path.read_text(encoding="utf-8").splitlines():
-                if _C901_INLINE_RE.search(line):
+                if _C901_INLINE_RE.search(line) or _C901_IGNORE_RE.search(line):
                     n += 1
     return n
 
@@ -97,7 +117,8 @@ def test_no_blanket_or_c901_file_directive() -> None:
     for tree in _TREES:
         for path in (_ROOT / tree).rglob("*.py"):
             for line in path.read_text(encoding="utf-8").splitlines():
-                m = _RUFF_FILE_DIRECTIVE_RE.search(line)
+                m = (_RUFF_FILE_DIRECTIVE_RE.search(line)
+                     or _RUFF_FILE_IGNORE_RE.search(line))
                 if m is None:
                     continue
                 codes = (m.group("codes") or "").strip()


### PR DESCRIPTION
## The complexity ratchet could not see ruff 0.16's second suppression spelling

Found while re-verifying the hold on #432 rather than inheriting it.

Both guard patterns in `tests/unit/test_complexity_ratchet.py` required the literal `noqa`. ruff 0.16 stabilised a **second** inline suppression form — a `ruff:`-prefixed `ignore` directive taking a bracketed code list — which contains no `noqa` token at all, so neither pattern could match it.

### Measured, not inferred

Run against both pins in an isolated venv, with a bogus-directive control to prove the probe itself was valid:

| probe | ruff 0.15.17 (current CI pin) | ruff 0.16.3 |
|---|---|---|
| `noqa` form | suppressed | suppressed |
| `ignore` form, file-level | **rejected** | **SUPPRESSED** |
| `ignore` form, inline | **rejected** | **SUPPRESSED** |
| bogus control directive | reported | reported |

"Rejected" = the C901 violation still reports, plus an invalid-directive error. So the form is inert on today's pin and goes live on 0.16.

**Consequence had this shipped unnoticed:** adopting ruff 0.16 in the lint job reopens review finding **#57** — the complexity gate becomes dodgeable with a green `ruff check` *and* a green ratchet test. That pair of green signals is exactly what #57 existed to prevent.

### Both new patterns verified red

Injected each form into a real module (`opnsense/port_names.py`):

- file-level → trips `test_no_blanket_or_c901_file_directive`
- inline → pushes the suppression count 25 → 26 and trips `test_complexity_debt_does_not_grow`

Restored clean afterwards; no `netcanon/` diff.

The guard is correct under **either** pin — the form it matches is absent today and inert under 0.15 — so this is safe to land ahead of any decision about the bump.

### What this does NOT do

It unblocks #432; it does not adopt it. Two things remain deliberately the maintainer's call:

1. **Merging #432 alone is inert.** `.github/workflows/ci.yml:53` pins `ruff>=0.15,<0.16` inline, separately from pyproject's constraint — the gate would keep installing 0.15.x while contributors moved to 0.16.x. Adoption needs both edited together.
2. **`<0.17` widens the window to two minor series.** pyproject's own comment says the narrow pin exists so "a new ruff release that adds/changes a rule can't silently turn the CI `ruff check` gate red on an unrelated PR". `>=0.16,<0.17` would keep that policy. A policy choice, not a mechanical bump.

For the record the tree **is** clean under 0.16.3 over CI's exact scope (`ruff check netcanon tests tools`), so nothing else blocks adoption.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
