### PR TITLE
Close the window that could publish an unsigned :latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -210,6 +210,24 @@ jobs:
       # `secrets` context is NOT available in a step-level `if:`, so we map
       # the token to a step env var (allowed) and emit a plain boolean output
       # the downstream `if:` / `with:` can consume via the `steps` context.
+
+      # Trivy scans the published image for CVEs in OS-package layers
+      # (Debian/Alpine under python:3.x-slim), the installed Python
+      # wheel set, and any secrets accidentally baked into image
+      # layers.  CodeQL scans source; this scans the artifact we ship.
+      # Results upload as SARIF to Security → Code scanning under the
+      # `trivy-image` category (distinct from CodeQL findings).
+      #
+      # `exit-code: 0` makes findings informational — they don't fail
+      # the publish.  Triage via the Security tab.  Flip to `1` with
+      # an explicit severity list to gate releases on CRITICAL CVEs.
+      #
+      # `ignore-unfixed: true` filters out CVEs with no upstream patch
+      # available — they'd just be noise we can't act on until the
+      # base image (or upstream maintainer) ships a fix.
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
       - name: Resolve Docker Hub mirror availability
         id: mirror
         env:
@@ -284,6 +302,23 @@ jobs:
             # re-dispatch it moves only when the maintainer sets move_latest=true.
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') && (github.event_name != 'workflow_dispatch' || inputs.move_latest) }}
 
+      # STEP ORDER IS LOAD-BEARING -- do not reorder these two apart.
+      #
+      # `Build and push` publishes every tag, `:latest` included, the moment
+      # it completes.  From that instant until `cosign sign` runs, GHCR is
+      # serving an image nobody has signed.  Anything failable sitting in
+      # that window turns a transient outage into a permanently-published
+      # unsigned `:latest`, because the job aborts and the tag stays moved.
+      #
+      # It used to contain three such steps -- Trivy, the SARIF upload (which
+      # had `if: always()` but no `continue-on-error`, so its own failure
+      # killed the job), and the cosign install itself.  A Code Scanning
+      # outage was therefore sufficient to ship an unsigned release.
+      #
+      # Now: cosign is installed up front, signing/SBOM/attest/verify follow
+      # the push immediately, and scanning is demoted to the end where it is
+      # purely a reporting step.  Guarded by
+      # tests/unit/test_docker_publish_signing_window.py.
       - name: Build and push
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
@@ -314,46 +349,6 @@ jobs:
           provenance: true
           sbom: false   # we generate via syft below for richer SPDX output
 
-      # Trivy scans the published image for CVEs in OS-package layers
-      # (Debian/Alpine under python:3.x-slim), the installed Python
-      # wheel set, and any secrets accidentally baked into image
-      # layers.  CodeQL scans source; this scans the artifact we ship.
-      # Results upload as SARIF to Security → Code scanning under the
-      # `trivy-image` category (distinct from CodeQL findings).
-      #
-      # `exit-code: 0` makes findings informational — they don't fail
-      # the publish.  Triage via the Security tab.  Flip to `1` with
-      # an explicit severity list to gate releases on CRITICAL CVEs.
-      #
-      # `ignore-unfixed: true` filters out CVEs with no upstream patch
-      # available — they'd just be noise we can't act on until the
-      # base image (or upstream maintainer) ships a fix.
-      - name: Scan published image with Trivy
-        # Pinned at v0.36.0 (latest stable, 2026-04-22) — clears
-        # GHSA-?? / CVE-2026-33634 "Trivy ecosystem supply chain was
-        # briefly compromised" advisory.  Vulnerable ranges were
-        # `< 0.35.0` and exact `= 0.69.4`.  Do NOT bump to 0.69.x
-        # without re-confirming v0.69.4 has been remediated.  The
-        # action repo tags use a `v` prefix (`v0.24.0` not `0.24.0`)
-        # — earlier @0.24.0 reference would have failed to resolve.
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
-          format: sarif
-          output: trivy-image.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: '0'
-
-      - name: Upload Trivy SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v4.37.6
-        if: always()      # upload even if Trivy failed, so partial findings still surface
-        with:
-          sarif_file: trivy-image.sarif
-          category: trivy-image
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Sign published image (GHCR only, keyless via Sigstore + GitHub OIDC)
         env:
@@ -423,3 +418,42 @@ jobs:
           cosign verify "${IMAGE_DIGEST}" \
             --certificate-identity "${EXPECTED_IDENTITY}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+      # Trivy scans the published image for CVEs in OS-package layers
+      # (Debian/Alpine under python:3.x-slim), the installed Python
+      # wheel set, and any secrets accidentally baked into image
+      # layers.  CodeQL scans source; this scans the artifact we ship.
+      # Results upload as SARIF to Security → Code scanning under the
+      # `trivy-image` category (distinct from CodeQL findings).
+      #
+      # `exit-code: 0` makes findings informational — they don't fail
+      # the publish.  Triage via the Security tab.  Flip to `1` with
+      # an explicit severity list to gate releases on CRITICAL CVEs.
+      #
+      # `ignore-unfixed: true` filters out CVEs with no upstream patch
+      # available — they'd just be noise we can't act on until the
+      # base image (or upstream maintainer) ships a fix.
+      - name: Scan published image with Trivy
+        # Pinned at v0.36.0 (latest stable, 2026-04-22) — clears
+        # GHSA-?? / CVE-2026-33634 "Trivy ecosystem supply chain was
+        # briefly compromised" advisory.  Vulnerable ranges were
+        # `< 0.35.0` and exact `= 0.69.4`.  Do NOT bump to 0.69.x
+        # without re-confirming v0.69.4 has been remediated.  The
+        # action repo tags use a `v` prefix (`v0.24.0` not `0.24.0`)
+        # — earlier @0.24.0 reference would have failed to resolve.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4.37.6
+        continue-on-error: true   # reporting only; never fail a publish (image is signed + attested by now)
+        if: always()      # upload even if Trivy failed, so partial findings still surface
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,23 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **A Code Scanning outage was enough to publish an unsigned `:latest`.**
+  `docker-publish.yml` pushes every tag the instant `Build and push`
+  completes; until `cosign sign` runs, GHCR serves an image nobody has signed.
+  Three failable steps sat in that window -- the Trivy scan, the SARIF upload,
+  and the cosign install itself -- and because the job aborts on any of them
+  while the tag stays moved, the unsigned `:latest` would have been permanent,
+  not transient.  The SARIF step was the sharpest edge: it carried
+  `if: always()`, which governs whether a step RUNS after an earlier failure
+  and says nothing about its own failure propagating, so a GitHub Code Scanning
+  hiccup alone could ship an unsigned release.  Cosign is now installed up
+  front, sign / SBOM / attest / verify follow the push with **zero** steps in
+  between, scanning is demoted to the end as pure reporting, and the SARIF
+  upload is explicitly `continue-on-error`.  No step was added or removed --
+  18 before, 18 after, one body changed -- and the reordering is guarded by
+  `tests/unit/test_docker_publish_signing_window.py`, whose four assertions
+  were each verified red against the previous ordering.
+
 - **SECURITY.md contradicted itself about how the PyPI publish action is
   pinned.**  One bullet said the workflow uses
   `pypa/gh-action-pypi-publish@release/v1` -- a floating upstream branch --

--- a/tests/unit/test_docker_publish_signing_window.py
+++ b/tests/unit/test_docker_publish_signing_window.py
@@ -1,0 +1,161 @@
+"""Nothing failable may sit between publishing an image and signing it.
+
+``docker-publish.yml`` pushes every tag — ``:latest`` included — in its
+``Build and push`` step.  From that instant until ``cosign sign`` runs, GHCR is
+serving an image nobody has signed.  A step in that window that can fail turns
+a transient outage into a *permanently* published unsigned ``:latest``: the job
+aborts, and the tag stays moved.
+
+The window used to hold three such steps — the Trivy scan, the SARIF upload
+(``if: always()`` but no ``continue-on-error``, so its own failure killed the
+job), and the cosign install itself.  A GitHub Code Scanning outage was
+therefore sufficient to ship an unsigned release.
+
+Why this asserts on YAML shape, when ``tests/demo/test_msi_publish_gate.py``
+argues that asserting "the gate step exists" proves only that the YAML has a
+step and not that it works: that objection is about using structure as a
+*proxy* for behaviour.  Here the structure IS the behaviour under test.  The
+hazard is defined entirely by step ordering and failure propagation, both of
+which are properties of the workflow file — there is no runtime artefact to
+inspect instead, and this workflow only ever runs on a version tag, so nothing
+in PR CI can execute it.  Ordering is therefore checked directly, and checked
+against the parsed document rather than the raw text so that reformatting,
+re-indentation or comment edits cannot make it pass vacuously.
+
+Deliberately in ``tests/unit`` and not ``tests/demo``: CI runs ``tests/unit``,
+``tests/integration``, ``tests/e2e`` and ``tests/desktop``.  ``tests/demo`` runs
+only inside ``demo-publish.yml``, so a guard placed there would not gate a
+single pull request.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _ROOT / ".github" / "workflows" / "docker-publish.yml"
+
+_PUBLISH_JOB = "build-and-publish"
+_PUSH_STEP = "Build and push"
+_SIGN_MARKER = "cosign sign"
+_SCAN_MARKERS = ("trivy", "sarif")
+
+
+def _steps() -> list[dict]:
+    doc = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    return doc["jobs"][_PUBLISH_JOB]["steps"]
+
+
+def _index_of_name(steps: list[dict], name: str) -> int:
+    for i, step in enumerate(steps):
+        if step.get("name") == name:
+            return i
+    raise AssertionError(
+        f"no step named {name!r} in {_PUBLISH_JOB} — if it was renamed, update "
+        f"this guard rather than deleting it"
+    )
+
+
+def _index_of_sign(steps: list[dict]) -> int:
+    for i, step in enumerate(steps):
+        if _SIGN_MARKER in str(step.get("run", "")):
+            return i
+    raise AssertionError(
+        f"no step runs {_SIGN_MARKER!r} — the publish path no longer signs the "
+        f"image it pushes"
+    )
+
+
+def test_signing_immediately_follows_the_push() -> None:
+    """Zero steps between publishing and signing.
+
+    Not "signing happens eventually" — every step in between is one more way
+    to end up with a published, unsigned ``:latest``.
+    """
+    steps = _steps()
+    push = _index_of_name(steps, _PUSH_STEP)
+    sign = _index_of_sign(steps)
+    assert sign > push, (
+        f"{_SIGN_MARKER!r} runs at step {sign} but the push is at step {push} — "
+        f"signing must follow the push, not precede it"
+    )
+    between = [str(s.get("name")) for s in steps[push + 1:sign]]
+    assert not between, (
+        f"{len(between)} step(s) sit between the push and the signature, so a "
+        f"failure in any of them leaves GHCR serving an unsigned :latest with "
+        f"the tag already moved: {between}.  Move them after the signing chain "
+        f"(prerequisite tooling like the cosign install belongs BEFORE the "
+        f"push)."
+    )
+
+
+def test_image_scanning_runs_after_the_image_is_signed() -> None:
+    """Trivy and its SARIF upload are reporting, not gating.
+
+    They scan an image that is already published, so running them before the
+    signature buys nothing and costs the release its signature when Code
+    Scanning has a bad day.
+    """
+    steps = _steps()
+    sign = _index_of_sign(steps)
+    offenders = [
+        (i, str(s.get("name")))
+        for i, s in enumerate(steps[:sign])
+        if any(m in str(s.get("name", "")).lower() for m in _SCAN_MARKERS)
+    ]
+    assert not offenders, (
+        f"image-scanning step(s) run before the signature at step {sign}: "
+        f"{offenders}.  Scanning is informational (the Trivy step sets "
+        f"`exit-code: 0`); it must not be able to abort the job while the "
+        f"pushed tags are unsigned."
+    )
+
+
+def test_sarif_upload_cannot_fail_the_publish() -> None:
+    """The SARIF upload is explicitly non-fatal.
+
+    ``if: always()`` only guarantees the step RUNS after an earlier failure —
+    it does nothing about the step failing on its own, which is exactly what a
+    Code Scanning outage looks like.  ``continue-on-error`` is the property
+    that keeps a reporting hiccup from failing a release.
+    """
+    steps = _steps()
+    for step in steps:
+        if "sarif" in str(step.get("name", "")).lower():
+            assert step.get("continue-on-error") is True, (
+                f"step {step.get('name')!r} uploads scan results but is not "
+                f"`continue-on-error: true` — a Code Scanning outage would "
+                f"fail the publish job.  `if: always()` does NOT cover this; "
+                f"it governs whether the step runs, not whether its own "
+                f"failure propagates."
+            )
+            return
+    raise AssertionError("no SARIF upload step found to check")
+
+
+def test_the_signature_is_verified_before_scanning_reports() -> None:
+    """The post-publish signature smoke test stays inside the trusted chain.
+
+    It is the step that proves the signature is real; ordering it after the
+    scanning steps would let a scan failure skip verification entirely.
+    """
+    steps = _steps()
+    verify = next(
+        (i for i, s in enumerate(steps)
+         if "verify signature" in str(s.get("name", "")).lower()),
+        None,
+    )
+    assert verify is not None, "the post-publish signature smoke test is gone"
+    scans = [
+        i for i, s in enumerate(steps)
+        if any(m in str(s.get("name", "")).lower() for m in _SCAN_MARKERS)
+    ]
+    assert all(verify < i for i in scans), (
+        f"signature verification is at step {verify} but scanning runs at "
+        f"{scans} — verification must not sit behind a step that can abort."
+    )


### PR DESCRIPTION
## A Code Scanning outage was enough to publish an unsigned `:latest`

`Build and push` publishes every tag — `:latest` included — the moment it completes. From that instant until `cosign sign` runs, GHCR serves an image nobody has signed. The job aborts on a failed step **but the tag stays moved**, so anything failable in that window turns a transient outage into a *permanently* published unsigned `:latest`.

Three failable steps were sitting in it:

```
Build and push        ← :latest live from here
Scan ... with Trivy   ← action/registry failure aborts the job
Upload Trivy SARIF    ← see below
Install cosign        ← Sigstore/network outage
Sign published image  ← signature exists only from here
```

The SARIF upload was the sharpest edge. It carried `if: always()`, which is easy to read as "this can't fail the job" — but that governs whether the step **runs** after an *earlier* failure and says nothing about its **own** failure propagating. So a GitHub Code Scanning outage, entirely outside this repo, was sufficient to ship an unsigned release.

### New order — publish, secure, verify, then report

```
Set up Docker Buildx
Install cosign          ← hoisted: prerequisite tooling, no build dependency
... logins / metadata ...
Build and push
Sign published image    ← ZERO steps between push and signature
Generate SBOM (syft)
Attach SBOM attestation
Verify signature
Scan ... with Trivy     ← demoted: pure reporting
Upload Trivy SARIF      ← + continue-on-error: true
```

Scanning loses nothing by moving: it scans an already-published image **by digest**, and the Trivy step already sets `exit-code: 0`, so findings were never gating. What changes is that a scanning failure can no longer cost the release its signature.

### Verified structurally, because CI cannot run this

This workflow only ever fires on a version tag, so no amount of PR CI exercises it. Rather than eyeballing the reorder, I parsed old and new with `yaml.safe_load` and diffed the step lists:

- **18 steps before, 18 after**, same set
- exactly **one** body changed — the SARIF step gaining `continue-on-error`
- other jobs, triggers and `permissions` byte-identical

### Guard

`tests/unit/test_docker_publish_signing_window.py` — four assertions, **each verified red** against the previous ordering. (Checked with `--maxfail=99`; `addopts` carries `-x`, which had initially reported only the first failure and would have overstated how much I'd proven.)

**Placed in `tests/unit` deliberately.** CI runs `tests/unit`, `tests/integration`, `tests/e2e`, `tests/desktop`. `tests/demo` — where the other publish-path guards live — runs only inside `demo-publish.yml`, so a guard placed there would not gate a single pull request. Worth knowing separately: `test_msi_publish_gate.py` is in that category today.

The guard asserts on parsed YAML shape, which `test_msi_publish_gate.py`'s docstring warns against. That warning is about structure standing *in for* behaviour; here the ordering **is** the behaviour under test, there's no runtime artefact to inspect instead, and asserting against the parsed document rather than raw text keeps reformatting from making it pass vacuously.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
