### PR TITLE
Exact-pin the linter, and derive it in one place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,24 @@ jobs:
           cache: "pip"
 
       - name: Install ruff
-        # Keep this constraint in sync with the `ruff` pin in the
-        # pyproject.toml [project.optional-dependencies] dev extra.  A
-        # ruff minor bump can add or change rules, so pinning keeps this
-        # gate deterministic across otherwise-unrelated PRs.
+        # Read the pin out of pyproject.toml rather than repeating it.
+        #
+        # 'Keep this in sync' was the old instruction here, and it did not
+        # hold: nothing checked it, so the gate and the declared dev
+        # dependency could drift apart silently -- which is exactly why a
+        # Dependabot bump to the pyproject constraint would have been
+        # INERT (contributors move, the gate does not).  Deriving it makes
+        # divergence structurally impossible instead of merely forbidden.
+        #
+        # The pin is exact (`ruff==X.Y.Z`) so no ruff release ever reaches
+        # this gate without a reviewed PR; tests/unit/test_ruff_pin_is_exact.py
+        # enforces both that property and the absence of a literal version
+        # here.  A malformed pyproject fails this step loudly.
         run: |
           python -m pip install --upgrade pip
-          pip install "ruff>=0.15,<0.16"
+          RUFF_PIN=$(python -c "import tomllib, pathlib; specs=tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))['project']['optional-dependencies']['dev']; print(next(s for s in specs if s.replace(' ', '').startswith('ruff==')))")
+          echo "Installing pinned linter: ${RUFF_PIN}"
+          pip install "${RUFF_PIN}"
 
       - name: Run ruff
         # Scope: the shipping package, the desktop shell, the dev tools, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,24 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **The ruff pin did not do what its own comment claimed.**  `pyproject.toml`
+  carried `ruff>=0.15,<0.16` under a comment saying the range existed so "a
+  ruff release that adds/changes a rule can't silently turn the CI `ruff check`
+  gate red on an unrelated PR".  A range cannot do that: CI installs fresh
+  every run and pip resolves to the newest match, so the constraint silently
+  adopted 0.15.18 through 0.15.22 as they shipped -- five releases, no PR, no
+  review.  Measured rather than argued: `pip install --dry-run
+  "ruff>=0.15,<0.16"` resolved to `ruff-0.15.22` while the pin was in force.
+  Now `ruff==0.16.3`, so no release reaches the gate without a reviewed,
+  CI-tested PR -- Dependabot watches `pyproject.toml`, which is where its ruff
+  PRs are already raised.  `ci.yml`'s lint job now DERIVES the pin from
+  `pyproject.toml` instead of repeating it: the old "keep this constraint in
+  sync" comment was enforced by nothing, and that divergence is exactly what
+  would have made a Dependabot bump inert (contributors move, the gate does
+  not).  Tree verified clean under 0.16.3 over CI's exact scope.  Guarded by
+  `tests/unit/test_ruff_pin_is_exact.py`, three assertions, each verified red
+  against the previous arrangement.
+
 - **A Code Scanning outage was enough to publish an unsigned `:latest`.**
   `docker-publish.yml` pushes every tag the instant `Build and push`
   completes; until `cosign sign` runs, GHCR serves an image nobody has signed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,24 @@ dev = [
     "pytest-xdist>=3.5.0",
     "coverage>=7.4.0",
     "pytest-cov>=4.1.0",
-    # Linting (v0.2.0 tooling baseline).  Pinned to a minor range so a
-    # ruff release that adds/changes a rule can't silently turn the CI
-    # `ruff check` gate red on an unrelated PR.
-    "ruff>=0.15,<0.16",
+    # Linting (v0.2.0 tooling baseline).  EXACT pin, deliberately.
+    #
+    # A range does not do what the old comment here claimed.  CI installs
+    # fresh on every run and pip resolves to the newest match, so
+    # `ruff>=0.15,<0.16` silently adopted 0.15.18 through 0.15.22 as they
+    # shipped -- five releases, no PR, no review.  Only an exact pin can
+    # keep a new ruff release from reaching the gate on its own.
+    #
+    # This line is the SINGLE source of truth for the linter version:
+    # Dependabot watches pyproject.toml (that is where its ruff PRs are
+    # raised), so each bump now arrives as a reviewable, CI-tested PR
+    # after the 7-day cooldown in .github/dependabot.yml.  ci.yml's lint
+    # job READS this value rather than repeating it -- a duplicated
+    # constraint there is what made the ruff bump PR inert, since the two
+    # could disagree with nothing noticing.
+    #
+    # Guarded by tests/unit/test_ruff_pin_is_exact.py.
+    "ruff==0.16.3",
 ]
 desktop = [
     "PySide6>=6.7.0",

--- a/tests/unit/test_ruff_pin_is_exact.py
+++ b/tests/unit/test_ruff_pin_is_exact.py
@@ -1,0 +1,132 @@
+"""The linter version must never reach CI without a reviewed PR.
+
+``pyproject.toml`` used to carry ``ruff>=0.15,<0.16`` under a comment claiming
+the range existed so "a ruff release that adds/changes a rule can't silently
+turn the CI ``ruff check`` gate red on an unrelated PR".  A range cannot do
+that.  CI installs fresh on every run and pip resolves to the newest match, so
+the constraint silently adopted 0.15.18 through 0.15.22 as they shipped — five
+releases, no PR, no review.  Measured, not assumed: ``pip install --dry-run
+"ruff>=0.15,<0.16"`` resolved to ``ruff-0.15.22`` while the pin was in force.
+
+Two properties make the stated rule true rather than aspirational, and this
+module holds both:
+
+1. **The pin is exact.**  Only ``ruff==X.Y.Z`` prevents a new release from
+   reaching the gate on its own.  Dependabot watches ``pyproject.toml`` — that
+   is where its ruff PRs are raised — so every bump then arrives as a
+   reviewable, CI-tested PR after the cooldown in ``.github/dependabot.yml``.
+
+2. **``ci.yml`` does not repeat the version.**  The lint job derives the pin
+   from ``pyproject.toml``.  The old instruction was a comment saying "keep
+   this constraint in sync", which nothing enforced — so the gate and the
+   declared dev dependency could drift apart silently.  That divergence is
+   precisely why a Dependabot bump to the pyproject constraint would have been
+   *inert*: contributors would move to the new ruff while the gate kept
+   installing the old one.  Deriving makes divergence structurally impossible;
+   this test keeps a literal from creeping back in.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT = _ROOT / "pyproject.toml"
+_CI = _ROOT / ".github" / "workflows" / "ci.yml"
+
+#: ``ruff==1.2.3`` and nothing looser.  Anchored so ``ruff==1.2.3,!=1.2.4`` or a
+#: trailing wildcard (``ruff==1.2.*``) does not slip through as "exact".
+_EXACT_PIN_RE = re.compile(r"^ruff\s*==\s*\d+\.\d+\.\d+$")
+
+#: Any ruff version constraint at all, for the ci.yml literal check.
+_ANY_CONSTRAINT_RE = re.compile(r"ruff\s*(==|>=|<=|~=|!=|<|>)\s*\d")
+
+
+def _dev_extra() -> list[str]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return data["project"]["optional-dependencies"]["dev"]
+
+
+def _ruff_specs() -> list[str]:
+    return [s for s in _dev_extra() if s.replace(" ", "").lower().startswith("ruff")]
+
+
+def test_pyproject_pins_ruff_exactly() -> None:
+    """One ruff spec in the dev extra, and it is an exact ``==`` pin."""
+    specs = _ruff_specs()
+    assert len(specs) == 1, (
+        f"expected exactly one ruff spec in the dev extra, found {specs} — the "
+        f"lint job derives the pin by matching 'ruff==', so more than one is "
+        f"ambiguous"
+    )
+    spec = specs[0].replace(" ", "")
+    assert _EXACT_PIN_RE.match(spec), (
+        f"ruff is pinned as {specs[0]!r}, which is not an exact ==X.Y.Z pin.  A "
+        f"range does not keep new releases out of CI: pip resolves to the "
+        f"newest match on every fresh install, which is how 0.15.18-0.15.22 "
+        f"were adopted without a single PR.  Pin exactly and let Dependabot "
+        f"propose each bump."
+    )
+
+
+def test_ci_derives_the_pin_instead_of_repeating_it() -> None:
+    """The lint job must read the version, not restate it.
+
+    A second copy of the version can disagree with the first, and nothing
+    would notice until someone wondered why a dependency bump changed nothing.
+    """
+    doc = yaml.safe_load(_CI.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["lint"]["steps"]
+    # The INSTALL step specifically — the sibling "Run ruff" step invokes
+    # the linter and rightly mentions neither a version nor pyproject.
+    install = [
+        s for s in steps
+        if "ruff" in str(s.get("name", "")).lower()
+        and "pip install" in str(s.get("run", ""))
+    ]
+    assert install, (
+        "no ruff-install step found in the lint job (a step named for ruff "
+        "whose run: block pip-installs it)"
+    )
+
+    for step in install:
+        run = str(step.get("run", ""))
+        literal = _ANY_CONSTRAINT_RE.search(run)
+        assert literal is None, (
+            f"the lint job hardcodes a ruff version ({literal.group()!r}).  It "
+            f"must derive the pin from pyproject.toml instead — a duplicated "
+            f"constraint is what let the gate and the declared dev dependency "
+            f"drift apart, and it is what made a Dependabot bump to pyproject "
+            f"inert."
+        )
+        assert "pyproject.toml" in run, (
+            "the lint job's ruff install neither hardcodes a version nor reads "
+            "pyproject.toml — it must read the pin from pyproject so the two "
+            "cannot disagree"
+        )
+
+
+def test_the_pinned_ruff_is_the_one_documented_in_ci_scope() -> None:
+    """The derivation the workflow performs is the one this test assumes.
+
+    Runs the same selection logic the lint job runs, so a change to the dev
+    extra's shape (e.g. ruff moving to another extra) fails here rather than
+    at release time in a workflow PR CI does exercise but nobody reads.
+    """
+    specs = _dev_extra()
+    picked = next(
+        (s for s in specs if s.replace(" ", "").startswith("ruff==")), None
+    )
+    assert picked is not None, (
+        "the lint job selects the ruff pin with startswith('ruff==') against "
+        "the dev extra; nothing in that list matches, so the install step "
+        "would fail on the runner"
+    )
+    assert _EXACT_PIN_RE.match(picked.replace(" ", "")), picked


### PR DESCRIPTION
## The ruff pin did not do what its own comment claimed

`pyproject.toml` carried `ruff>=0.15,<0.16` under a comment saying the range existed so *"a ruff release that adds/changes a rule can't silently turn the CI `ruff check` gate red on an unrelated PR"*.

A range cannot do that. CI installs fresh on every run and pip resolves to the newest match, so the pin was never a pin. Measured, with the old constraint still in force:

```
$ pip install --dry-run --no-deps "ruff>=0.15,<0.16"
Would install ruff-0.15.22
```

…while the version in hand was 0.15.17. **0.15.18 through 0.15.22 had been adopted silently as they shipped** — five releases, no PR, no review. The rule was aspirational, and the file asserted a guarantee it did not provide.

## Now `ruff==0.16.3`

An exact pin is the only form where a new release cannot reach the gate on its own — and it keeps Dependabot *in* the loop rather than cutting it out. Dependabot watches `pyproject.toml` (that's where #432 was raised), so each bump now arrives as a reviewable, CI-tested PR after the 7-day cooldown already configured in `.github/dependabot.yml`.

## The second half, and why this isn't a one-line edit

`ci.yml`'s lint job now **derives** the pin from `pyproject.toml` instead of repeating it.

The old comment there said *"keep this constraint in sync"* — enforced by nothing. So the gate and the declared dev dependency could drift apart silently, and that divergence is precisely why merging a Dependabot bump to the pyproject constraint would have been **inert**: contributors move to the new ruff, the gate keeps installing the old one, and nothing reports the disagreement. Deriving makes that structurally impossible rather than merely forbidden.

## Why not #432

#432 widens the range to `>=0.15,<0.17`. Two problems:

- It resolves **identically** to `>=0.16,<0.17` (pip takes the highest), so the floor is decoration.
- It re-enters an **active** series. 0.16 has shipped 4 releases in 21 days, against a ~7-day cadence across each of the last three series — so it raises ongoing exposure rather than settling it, every week, indefinitely.

#432 is superseded and closed with that reasoning recorded on it.

## Verification

Run under the version CI will now actually use (0.16.3, isolated venv) over `ci.yml`'s **exact** scope — `netcanon netcanon_desktop tools tests demo`, broader than the `netcanon tests tools` I'd been checking locally:

```
All checks passed!
```

Guard: `tests/unit/test_ruff_pin_is_exact.py` — the pin is exact, `ci.yml` hardcodes no version, and the derivation the workflow performs is the one the test models. All three **verified red** against the previous arrangement.

One of them caught a bug in itself first: it initially matched both `Install ruff` *and* `Run ruff`, and the latter rightly references neither a version nor pyproject.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
