### PR TITLE
Close three doc-sync gaps this wave left behind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,30 @@ tests use these exclusively — never CSS classes or element structure.  See
   "the docs lied to me" is what differentiates Netcanon's
   matrix-honesty discipline from the over-claiming alternatives in
   this space.
+- **Never** let a failable step sit between publishing an artifact and
+  signing it.  `Build and push` in `docker-publish.yml` makes every tag
+  live — `:latest` included — the instant it completes, and a failing step
+  aborts the job *with the tag still moved*, so the unsigned window is
+  permanent rather than transient.  Install prerequisite tooling BEFORE the
+  push; put sign / SBOM / attest / verify immediately after it; demote
+  scanning and reporting to the end and mark them `continue-on-error`.
+  Failure mode: three failable steps once sat in that window and a GitHub
+  Code Scanning outage alone was sufficient to ship an unsigned release
+  (#441).  Note `if: always()` does NOT make a step non-fatal — it governs
+  whether the step RUNS after an earlier failure, not whether its own
+  failure propagates.  Guarded by
+  `tests/unit/test_docker_publish_signing_window.py`.
+- **Never** express a CI tool version as a RANGE and call it pinned, and
+  never repeat that version in a second file.  CI installs fresh on every
+  run and pip resolves to the newest match, so a range silently adopts
+  releases: `ruff>=0.15,<0.16` took 0.15.18 through 0.15.22 with no PR and
+  no review (#442).  Pin exactly, in the manifest Dependabot watches
+  (`pyproject.toml` — a pin buried in a workflow `run:` block is invisible
+  to it and freezes the tool instead), and have the workflow DERIVE the
+  value rather than restate it — a duplicated constraint is what makes a
+  dependency-bump PR inert, since the gate and the declared dependency can
+  disagree with nothing noticing.  Guarded by
+  `tests/unit/test_ruff_pin_is_exact.py`.
 - **Never** author or change a codec's `device_classes[0]` without applying
   the scope test.  A codec's **first** entry in `device_classes` — declared in
   `netcanon/migration/vendors/<vendor>.yaml` and mirrored in its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,23 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **Three doc-sync gaps left by this wave's own merges**, found by auditing
+  compliance rather than assuming it.  (1) `SECURITY.md` still described Trivy
+  as running "after `Build and push`" -- literally true but no longer the point,
+  since the unsigned-`:latest` fix deliberately moved scanning to run AFTER
+  signing/attestation; the bullet now states that ordering as the security
+  property it is.  (2) `SECURITY.md` claimed "all three ci.yml jobs are
+  read-only" when there are **six** -- the substantive claim holds (none
+  override the workflow-level `contents: read`), so the count was deleted per
+  the AGENTS.md unguarded-count rule rather than replaced with one that rots
+  again.  This is the same defect class fixed one commit earlier in the same
+  file, missed then because the grep was scoped to the specific claim under
+  review.  (3) Two cross-cutting invariants surfaced by bugs this wave were
+  never written into `AGENTS.md` § Hard Rules, which its own doc-sync table
+  requires: nothing failable may sit between publishing an artifact and signing
+  it, and a version RANGE is not a pin (pin exactly, in the manifest Dependabot
+  watches, and derive it rather than repeating it).
+
 - **The ruff pin did not do what its own comment claimed.**  `pyproject.toml`
   carried `ruff>=0.15,<0.16` under a comment saying the range existed so "a
   ruff release that adds/changes a rule can't silently turn the CI `ruff check`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -551,12 +551,23 @@ hardening.
   `.github/zizmor.yml` implements the hybrid action-pinning policy
   (tag-pin allowed for `actions/*` + `github/*` first-party
   publishers; SHA-pin required for third-party publishers).
-- **Trivy Docker image scanning.**  Runs after `Build and push` in
-  `.github/workflows/docker-publish.yml`; scans the just-built image
-  for OS-package + Python-package CVEs at HIGH+CRITICAL severity
-  (`ignore-unfixed: true` filters noise).  Results upload to Code
-  scanning under the `trivy-image` category.  Fires on every release
-  tag push (`v*.*.*`).
+- **Trivy Docker image scanning.**  Runs at the END of
+  `.github/workflows/docker-publish.yml` — deliberately AFTER the image
+  is signed, SBOM-attested and signature-verified.  It scans the
+  published image by digest for OS-package + Python-package CVEs at
+  HIGH+CRITICAL severity (`ignore-unfixed: true` filters noise).  Results
+  upload to Code scanning under the `trivy-image` category.  Fires on
+  every release tag push (`v*.*.*`).
+
+  The ordering is a security property, not a preference.  `Build and
+  push` makes every tag live — `:latest` included — the instant it
+  completes, and a later step failing aborts the job with the tag still
+  moved.  Scanning used to sit between the push and `cosign sign`, so a
+  GitHub Code Scanning outage could leave GHCR serving a permanently
+  unsigned `:latest`.  Scanning is informational (`exit-code: 0`) and the
+  SARIF upload is `continue-on-error`, so neither can now cost a release
+  its signature.  Enforced by
+  `tests/unit/test_docker_publish_signing_window.py`.
 - **SHA-pinned third-party actions.**  Every third-party action
   reference in the workflow corpus
   (`softprops/action-gh-release`, `docker/setup-buildx-action`,
@@ -570,8 +581,8 @@ hardening.
   the hybrid policy — GitHub controls those repos with force-push
   protection.
 - **Workflow-level `permissions: contents: read` on `ci.yml`.**
-  Default-deny `GITHUB_TOKEN` scope at workflow level; all three
-  ci.yml jobs are read-only.  Other workflow files (`docker-publish`,
+  Default-deny `GITHUB_TOKEN` scope at workflow level; every ci.yml job
+  is read-only (none override it).  Other workflow files (`docker-publish`,
   `pypi-publish`, `desktop-msi-publish`, `zizmor`) declare narrower
   per-job scopes where write access is required (`packages: write` /
   `id-token: write` for publish jobs; `security-events: write` for


### PR DESCRIPTION
## Three doc-sync gaps this wave left behind

Found by auditing my own compliance across the eight merges in this wave rather than assuming it. CHANGELOG coverage was in fact complete — 7/7 where convention requires one, and dependency bumps get none, matching precedent at `5656ab6` and `d1517a6`. These three were not.

### 1. `SECURITY.md` described Trivy as running "after `Build and push`"

Still literally true, but no longer the point. #441 deliberately moved scanning to run **after** signing / SBOM / attestation / verification, because it used to sit between the push and `cosign sign` — where a Code Scanning outage could leave GHCR serving a permanently unsigned `:latest`. The bullet now states that ordering as the security property it is, and names the guard.

This one is self-inflicted staleness: #440 edited this file, #441 changed the behaviour it describes, and nothing re-checked it.

### 2. `SECURITY.md` claimed "all three ci.yml jobs are read-only" — there are six

`lint`, `test`, `e2e`, `desktop`, `build-distribution`, `docker-build-smoke`.

The substantive claim holds: workflow-level `permissions: {contents: read}` with no per-job override. So the **count** was deleted per the AGENTS.md unguarded-count rule, rather than corrected to a number that would rot again.

Same defect class as the "All **11** third-party action references" fixed in #440 — same file, missed then because that grep was scoped to the specific `@release/v1` claim under review. A sweep for sibling numeric claims found no others; the remaining numbers are response SLAs and tier labels backed by an adjacent table.

### 3. Two invariants surfaced by bugs never reached `AGENTS.md` § Hard Rules

Which the doc-sync table explicitly requires for exactly this case:

- **Nothing failable may sit between publishing an artifact and signing it** (#441) — including the note that `if: always()` does *not* make a step non-fatal; it governs whether a step runs after an *earlier* failure, not whether its own failure propagates.
- **A version range is not a pin** (#442) — pin exactly, in the manifest Dependabot watches (a pin in a workflow `run:` block is invisible to it and freezes the tool instead), and *derive* it in the workflow rather than repeating it, since a duplicated constraint is what makes a dependency-bump PR inert.

Both rules point at their guard, per the section's convention.

No behaviour change; docs only. Full unit + integration + demo suites green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
