### PR TITLE
docs: cut CHANGELOG for v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ timestamp if your timezone matters for an audit.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-08-24
+
 ### Added
 
 - **A new expectation pair can no longer declare a loss the corpus never


### PR DESCRIPTION
Cuts `[Unreleased]` into a dated `## [0.6.3]` header so the tag has a section
to match. Entries accumulated under `[Unreleased]` as the work landed this
cycle, so this is a **header splice only** — 2 lines inserted, nothing moved,
nothing rewritten. `[Unreleased]` is left empty for the next cycle.

### Why now

`deploy/PINNED_PRODUCT_TAG` on the live demo host still reads `v0.6.1`, so
demo.netcanon.net serves a product image one release behind — verified inside
a running instance, not inferred from the tag: the image label reports `0.6.1`,
`palette-popover.js` (#392) is absent, and `MGMT-PROTECT` (#421) is absent from
`demo.py`. #421 is the pointed one, since it exists specifically to make the
Tier-3 refusal visible in the demo.

Rather than pin the demo to the already-released v0.6.2, this cuts v0.6.3 first
so the demo lands on a product image that includes the firewall-scope re-weight
(#435/#436) — the wave that changed what Netcanon *claims* about firewalls,
which is exactly the claim a visitor evaluates on the demo.

### What's in 0.6.3

Twelve commits since v0.6.2 (2026-08-01):

| Area | PRs |
|---|---|
| Firewall-scope re-weight | #435, #436 |
| Cross-vendor expectation audit (A6) | #437, #444, #445 |
| Release-pipeline hardening | #431, #441, #442 |
| Guards & lint | #439 |
| Doc truth | #440, #443 |
| Dependencies | #438 |

### Verification

- `tests/unit/test_changelog.py` — 5 passed. This is the guard that asserts
  every `vX.Y.Z` tag has a matching `## [X.Y.Z]` header and that released
  headers stay unique and strictly descending.
- Line endings held: CRLF 12045 → 12047 (+2 for the inserted lines), bare LF 0.
  The file is CRLF throughout and a normalising write would have shown up as a
  whole-file diff instead of `1 file changed, 2 insertions(+)`.

### Note

Version is derived from the git tag by `setuptools_scm`, so there is no version
number to bump anywhere — tagging `v0.6.3` after this merges is what publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
