### PR TITLE
fix(site): the landing page named a bundle two versions out of date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ timestamp if your timezone matters for an audit.
   bundle, the same bundle rebuild also re-resolves the Caddy and socket-proxy
   digests, which had drifted two months stale.
 
+### Fixed
+
+- **The landing page claimed a demo bundle two versions older than the one
+  deployed.**  `site/index.html` read `demo-v0.1.3 - deployed 2026-07-28`
+  while the host has run `demo-v0.1.4` since 2026-08-01 and `demo-v0.1.5`
+  since 2026-08-25.  Nothing ties the page's version claim to the deployed
+  bundle, so it went stale silently -- the page's other claims (the printed
+  serve commands, the capability-matrix excerpt) each have a guard in
+  `tests/demo/test_demo_docs_truth.py`, but the version line has none.
+  The date now matches what `make whitepaper` stamps (`date -u`), so
+  `/whitepaper` and the landing page agree.
+
 ## [0.6.3] - 2026-08-24
 
 ### Added

--- a/site/index.html
+++ b/site/index.html
@@ -435,7 +435,7 @@ set servers=192.168.1.10,192.168.1.11</code></pre>
     <a href="https://demo.netcanon.net/whitepaper">demo whitepaper</a> states each claim, and
     <a href="https://github.com/netcanon/netcanon/blob/main/deploy/VERIFY.md">VERIFY</a> gives you
     the commands to check them yourself.</p>
-    <p class="small muted">Demo bundle <code>demo-v0.1.3</code> &middot; deployed 2026-07-28.</p>
+    <p class="small muted">Demo bundle <code>demo-v0.1.5</code> &middot; deployed 2026-08-25.</p>
   </div>
   <p class="small muted" style="margin-top:10px">Your session is a throwaway container. Your config is
   never stored. Sensitive? Don&rsquo;t paste it &mdash; <a href="#install">run it locally instead</a>.</p>


### PR DESCRIPTION
`site/index.html` read `demo-v0.1.3 · deployed 2026-07-28`. The host has run
`demo-v0.1.4` since 2026-08-01 and `demo-v0.1.5` since 2026-08-25 — so the page
understated reality by one bundle for three weeks, and by two as of today.

The date is the **UTC** deploy date, which is what `make whitepaper` stamps
(`date -u`), so `/whitepaper` and the landing page now agree rather than
differing by a day.

### Why it went stale silently

Every other claim on that page is guarded in
`tests/demo/test_demo_docs_truth.py` — the printed `docker run` commands are
executed to prove they start, and the capability-matrix excerpt is transcribed
against `docs/CAPABILITIES.md`. The comment above that second guard reads, in
effect, *a claim on that page must not outlive its truth*.

The version line is the one claim on the page with no guard at all.

### The obvious guard has a wrinkle — your call

The natural fix is "the version in `site/index.html` must equal the newest
`demo-v*` tag", following the `_git_stable_tags()` pattern in
`tests/unit/test_changelog.py` (reads tags via subprocess, skips on a tarball
checkout, hard-fails in CI where tags are guaranteed).

`tests/demo` runs inside `demo-publish.yml`, so such a guard would fire when a
demo tag is cut — a real forcing function, and it would have blocked this
staleness. **But the page claims a deploy *date*, and the deploy happens after
the tag is cut.** So the guard would require writing tomorrow's deploy date
into the page before deploying, which is a claim that isn't true yet at the
moment CI checks it.

Ways out, roughly in order of how much I like them:

1. **Guard the version, not the date** — assert the `demo-vX.Y.Z` in the page
   equals the newest demo tag, and leave the date unchecked. Catches the actual
   rot (wrong bundle) without forcing a false date.
2. **Drop the date from the page** — the bundle version is the verifiable
   claim; the date adds little and is what creates the ordering problem.
3. **Leave it unguarded** and keep fixing it by hand each deploy.

I did not implement any of these — that's a design decision about what the page
promises, and it belongs to you, not to a cleanup PR. Happy to do (1) or (2) in
a follow-up.

### Verification

- `tests/demo/test_demo_docs_truth.py` + `tests/unit/migration/test_scope_boundary.py`
  — **71 passed**.
- `tests/unit/test_changelog.py` — 5 passed.
- The `pages.yml` cleanliness gate checks for inline `<script>`, external
  `src`/`href`, storage APIs, the CSP meta tag and gradient-token usage — a
  version string touches none of them.
- CRLF held at 583, zero bare LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
