### PR TITLE
fix(release): demo-publish had the unsigned window #441 closed in docker-publish

### DIFF
--- a/.github/workflows/demo-publish.yml
+++ b/.github/workflows/demo-publish.yml
@@ -231,6 +231,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Installed BEFORE either push: a failed install after the push would
+      # leave a published image that this run can never sign (AGENTS.md hard
+      # rule; the same window #441 closed in docker-publish.yml).
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
       # No `:latest` on either demo image: the host pins digests, and a mutable
       # tag on a TCB component is exactly what the digest pin exists to avoid.
       #
@@ -260,9 +266,6 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.SHIM_IMAGE_NAME }}:${{ steps.tag.outputs.name }}
           provenance: true
           sbom: false
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Sign both images (keyless via Sigstore + GitHub OIDC)
         env:
@@ -309,23 +312,6 @@ jobs:
           subject-digest: ${{ steps.build_warden.outputs.digest }}
           push-to-registry: true
 
-      - name: Scan warden image with Trivy
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.WARDEN_IMAGE_NAME }}@${{ steps.build_warden.outputs.digest }}
-          format: sarif
-          output: trivy-demo-warden.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: '0'
-
-      - name: Upload Trivy SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v4.37.7
-        if: always()
-        with:
-          sarif_file: trivy-demo-warden.sarif
-          category: trivy-demo-warden
-
       # Post-publish smoke test: the signer identity is fully deterministic for
       # a tag-triggered run of THIS workflow. Pin it EXACTLY, never a
       # tail-unanchored regexp — "…@refs/tags/demo-v" would accept a signature
@@ -341,6 +327,24 @@ jobs:
               --certificate-identity "${EXPECTED_IDENTITY}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
           done
+
+      - name: Scan warden image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.WARDEN_IMAGE_NAME }}@${{ steps.build_warden.outputs.digest }}
+          format: sarif
+          output: trivy-demo-warden.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4.37.7
+        continue-on-error: true   # reporting only; never fail a publish (images are signed + verified by now)
+        if: always()      # upload even if Trivy failed, so partial findings still surface
+        with:
+          sarif_file: trivy-demo-warden.sarif
+          category: trivy-demo-warden
 
   # ── The deploy bundle: rendered demo.env + whitepaper + SHA256SUMS ──
   bundle:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,8 +319,12 @@ tests use these exclusively — never CSS classes or element structure.  See
   Code Scanning outage alone was sufficient to ship an unsigned release
   (#441).  Note `if: always()` does NOT make a step non-fatal — it governs
   whether the step RUNS after an earlier failure, not whether its own
-  failure propagates.  Guarded by
-  `tests/unit/test_docker_publish_signing_window.py`.
+  failure propagates.  This rule is GENERAL, not about one file:
+  `demo-publish.yml` had drifted into all three violations while the
+  guard named only `docker-publish.yml`, so nothing caught it.  Guarded
+  by `tests/unit/test_docker_publish_signing_window.py`, which is
+  parametrised over both workflows — add any new publishing workflow to
+  its `_CASES` table in the same PR that creates it.
 - **Never** express a CI tool version as a RANGE and call it pinned, and
   never repeat that version in a second file.  CI installs fresh on every
   run and pip resolves to the newest match, so a range silently adopts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,31 @@ timestamp if your timezone matters for an audit.
 
 ### Fixed
 
+- **`demo-publish.yml` had the same unsigned-publish window #441 closed in
+  `docker-publish.yml`.**  Its `warden-image` job installed cosign *after*
+  pushing both images, so a failed install left the demo warden and
+  authz-shim public and permanently unsignable by that run.  Two more
+  violations rode along: the Trivy SARIF upload was `if: always()` with no
+  `continue-on-error` (which governs whether a step RUNS, not whether its
+  own failure propagates), and signature *verification* sat behind those
+  scanning steps, so a Code Scanning outage skipped the check that proves
+  the signature is real.
+
+  The AGENTS.md rule was always stated generally -- never let a failable
+  step sit between publishing an artifact and signing it -- but the guard
+  enforcing it named exactly one workflow, so nothing ever looked at the
+  other.  `tests/unit/test_docker_publish_signing_window.py` is now
+  parametrised over both, with a fifth assertion that prerequisite signing
+  tooling is installed BEFORE the first push; all five were verified red
+  against the old ordering.  The job now mirrors `docker-publish`'s shape
+  exactly: prereqs -> push -> sign -> SBOM -> attest -> verify -> scan ->
+  report(`continue-on-error`).
+
+  Found while reviewing a routine Dependabot action-pin bump (#446), which
+  touched two lines in that job.  `demo-publish.yml` signs Trusted Computing
+  Base components, so it was the more sensitive of the two workflows to
+  have left unguarded.
+
 - **The landing page claimed a demo bundle two versions older than the one
   deployed.**  `site/index.html` read `demo-v0.1.3 - deployed 2026-07-28`
   while the host has run `demo-v0.1.4` since 2026-08-01 and `demo-v0.1.5`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -567,7 +567,17 @@ hardening.
   unsigned `:latest`.  Scanning is informational (`exit-code: 0`) and the
   SARIF upload is `continue-on-error`, so neither can now cost a release
   its signature.  Enforced by
-  `tests/unit/test_docker_publish_signing_window.py`.
+  `tests/unit/test_docker_publish_signing_window.py`, which asserts the
+  ordering against the PARSED workflow for **both**
+  `docker-publish.yml` and `demo-publish.yml`.  The second was added
+  after a review found the same three violations there: the cosign
+  install sat after both image pushes, the SARIF upload was
+  `if: always()` with no `continue-on-error`, and signature
+  verification sat behind the scanning steps that could abort the job.
+  The rule had always been stated generally; only the guard was
+  workflow-specific, so nothing looked.  `demo-publish.yml` signs the
+  demo warden and authz-shim, which are Trusted Computing Base
+  components, so it is the more sensitive of the two.
 - **SHA-pinned third-party actions.**  Every third-party action
   reference in the workflow corpus
   (`softprops/action-gh-release`, `docker/setup-buildx-action`,

--- a/tests/unit/test_docker_publish_signing_window.py
+++ b/tests/unit/test_docker_publish_signing_window.py
@@ -1,4 +1,4 @@
-"""Nothing failable may sit between publishing an image and signing it.
+"""Nothing failable may sit between publishing an artifact and signing it.
 
 ``docker-publish.yml`` pushes every tag — ``:latest`` included — in its
 ``Build and push`` step.  From that instant until ``cosign sign`` runs, GHCR is
@@ -11,25 +11,46 @@ The window used to hold three such steps — the Trivy scan, the SARIF upload
 job), and the cosign install itself.  A GitHub Code Scanning outage was
 therefore sufficient to ship an unsigned release.
 
+**This guard covers ``demo-publish.yml`` too, since #446's review found the
+same shape there.**  The rule in AGENTS.md is stated generally, but the guard
+that enforced it named exactly one workflow, so ``demo-publish.yml`` was never
+checked and had drifted into all three violations: the cosign install sat
+*after* both image pushes, the SARIF upload was ``if: always()`` with no
+``continue-on-error``, and signature verification sat *behind* the scanning
+steps that could abort the job.  That workflow signs the demo warden and
+authz-shim — Trusted Computing Base components — so it is the more sensitive
+of the two, not the less.
+
+Known residual, deliberately not asserted away: ``demo-publish``'s
+``warden-image`` job pushes two images before signing either, so a failure of
+the *second* push leaves the *first* published unsigned.  That window contains
+only essential work (the other push), not incidental steps, and unlike
+``:latest`` a demo tag is re-pushable, so the exposure is transient rather than
+permanent.  ``test_signing_immediately_follows_the_push`` therefore measures
+from the LAST push — the invariant is "nothing incidental in the window", not
+"exactly one push per job".
+
 Why this asserts on YAML shape, when ``tests/demo/test_msi_publish_gate.py``
 argues that asserting "the gate step exists" proves only that the YAML has a
 step and not that it works: that objection is about using structure as a
 *proxy* for behaviour.  Here the structure IS the behaviour under test.  The
 hazard is defined entirely by step ordering and failure propagation, both of
 which are properties of the workflow file — there is no runtime artefact to
-inspect instead, and this workflow only ever runs on a version tag, so nothing
-in PR CI can execute it.  Ordering is therefore checked directly, and checked
+inspect instead, and these workflows only ever run on a version tag, so nothing
+in PR CI can execute them.  Ordering is therefore checked directly, and checked
 against the parsed document rather than the raw text so that reformatting,
 re-indentation or comment edits cannot make it pass vacuously.
 
 Deliberately in ``tests/unit`` and not ``tests/demo``: CI runs ``tests/unit``,
 ``tests/integration``, ``tests/e2e`` and ``tests/desktop``.  ``tests/demo`` runs
 only inside ``demo-publish.yml``, so a guard placed there would not gate a
-single pull request.
+single pull request — and would not have caught this drift either, since it
+would only have run at the moment it was already too late.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -38,85 +59,145 @@ import yaml
 pytestmark = pytest.mark.unit
 
 _ROOT = Path(__file__).resolve().parents[2]
-_WORKFLOW = _ROOT / ".github" / "workflows" / "docker-publish.yml"
-
-_PUBLISH_JOB = "build-and-publish"
-_PUSH_STEP = "Build and push"
 _SIGN_MARKER = "cosign sign"
 _SCAN_MARKERS = ("trivy", "sarif")
+_INSTALL_MARKER = "cosign-installer"
 
 
-def _steps() -> list[dict]:
-    doc = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
-    return doc["jobs"][_PUBLISH_JOB]["steps"]
+@dataclass(frozen=True)
+class _Case:
+    workflow: str
+    job: str
+    push_steps: tuple[str, ...]
+    verify_marker: str
 
 
-def _index_of_name(steps: list[dict], name: str) -> int:
+_CASES = {
+    "docker-publish": _Case(
+        workflow="docker-publish.yml",
+        job="build-and-publish",
+        push_steps=("Build and push",),
+        verify_marker="verify signature",
+    ),
+    "demo-publish": _Case(
+        workflow="demo-publish.yml",
+        job="warden-image",
+        push_steps=("Build + push warden", "Build + push authz-shim"),
+        verify_marker="verify both signatures",
+    ),
+}
+
+_IDS = sorted(_CASES)
+
+
+def _steps(case: _Case) -> list[dict]:
+    path = _ROOT / ".github" / "workflows" / case.workflow
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return doc["jobs"][case.job]["steps"]
+
+
+def _index_of_name(steps: list[dict], name: str, case: _Case) -> int:
     for i, step in enumerate(steps):
         if step.get("name") == name:
             return i
     raise AssertionError(
-        f"no step named {name!r} in {_PUBLISH_JOB} — if it was renamed, update "
-        f"this guard rather than deleting it"
+        f"no step named {name!r} in {case.workflow}:{case.job} — if it was "
+        f"renamed, update this guard rather than deleting it"
     )
 
 
-def _index_of_sign(steps: list[dict]) -> int:
+def _index_of_sign(steps: list[dict], case: _Case) -> int:
     for i, step in enumerate(steps):
         if _SIGN_MARKER in str(step.get("run", "")):
             return i
     raise AssertionError(
-        f"no step runs {_SIGN_MARKER!r} — the publish path no longer signs the "
-        f"image it pushes"
+        f"no step in {case.workflow}:{case.job} runs {_SIGN_MARKER!r} — the "
+        f"publish path no longer signs the artifact it pushes"
     )
 
 
-def test_signing_immediately_follows_the_push() -> None:
-    """Zero steps between publishing and signing.
+@pytest.mark.parametrize("case_id", _IDS)
+def test_signing_tooling_is_installed_before_the_push(case_id: str) -> None:
+    """cosign is on the runner BEFORE anything is published.
 
-    Not "signing happens eventually" — every step in between is one more way
-    to end up with a published, unsigned ``:latest``.
+    Installing it afterwards puts a network-dependent download inside the
+    unsigned window: if the install fails, the artifact is already public and
+    can never be signed by that run.  This is the assertion `demo-publish.yml`
+    failed — its cosign install sat after both image pushes.
     """
-    steps = _steps()
-    push = _index_of_name(steps, _PUSH_STEP)
-    sign = _index_of_sign(steps)
-    assert sign > push, (
-        f"{_SIGN_MARKER!r} runs at step {sign} but the push is at step {push} — "
-        f"signing must follow the push, not precede it"
+    case = _CASES[case_id]
+    steps = _steps(case)
+    install = next(
+        (i for i, s in enumerate(steps) if _INSTALL_MARKER in str(s.get("uses", ""))),
+        None,
     )
-    between = [str(s.get("name")) for s in steps[push + 1:sign]]
+    assert install is not None, (
+        f"{case.workflow}:{case.job} never installs cosign, yet signs — the "
+        f"signing step must be relying on a preinstalled binary that is not "
+        f"guaranteed"
+    )
+    first_push = min(_index_of_name(steps, n, case) for n in case.push_steps)
+    assert install < first_push, (
+        f"cosign is installed at step {install} but the first push is at step "
+        f"{first_push} in {case.workflow}:{case.job} — a failed install then "
+        f"leaves a published, permanently unsigned artifact.  Hoist the "
+        f"install above the push."
+    )
+
+
+@pytest.mark.parametrize("case_id", _IDS)
+def test_signing_immediately_follows_the_push(case_id: str) -> None:
+    """Zero incidental steps between publishing and signing.
+
+    Measured from the LAST push, so a job that batches several pushes is
+    allowed — see the module docstring on that residual.  Every other step in
+    between is one more way to end up with a published, unsigned artifact.
+    """
+    case = _CASES[case_id]
+    steps = _steps(case)
+    last_push = max(_index_of_name(steps, n, case) for n in case.push_steps)
+    sign = _index_of_sign(steps, case)
+    assert sign > last_push, (
+        f"{_SIGN_MARKER!r} runs at step {sign} but the last push is at step "
+        f"{last_push} in {case.workflow}:{case.job} — signing must follow the "
+        f"push, not precede it"
+    )
+    between = [str(s.get("name")) for s in steps[last_push + 1:sign]]
     assert not between, (
-        f"{len(between)} step(s) sit between the push and the signature, so a "
-        f"failure in any of them leaves GHCR serving an unsigned :latest with "
-        f"the tag already moved: {between}.  Move them after the signing chain "
-        f"(prerequisite tooling like the cosign install belongs BEFORE the "
-        f"push)."
+        f"{len(between)} step(s) sit between the push and the signature in "
+        f"{case.workflow}:{case.job}, so a failure in any of them leaves the "
+        f"registry serving an unsigned artifact with the tag already moved: "
+        f"{between}.  Move them after the signing chain (prerequisite tooling "
+        f"like the cosign install belongs BEFORE the push)."
     )
 
 
-def test_image_scanning_runs_after_the_image_is_signed() -> None:
+@pytest.mark.parametrize("case_id", _IDS)
+def test_image_scanning_runs_after_the_image_is_signed(case_id: str) -> None:
     """Trivy and its SARIF upload are reporting, not gating.
 
-    They scan an image that is already published, so running them before the
-    signature buys nothing and costs the release its signature when Code
+    They scan an artifact that is already published, so running them before
+    the signature buys nothing and costs the release its signature when Code
     Scanning has a bad day.
     """
-    steps = _steps()
-    sign = _index_of_sign(steps)
+    case = _CASES[case_id]
+    steps = _steps(case)
+    sign = _index_of_sign(steps, case)
     offenders = [
         (i, str(s.get("name")))
         for i, s in enumerate(steps[:sign])
         if any(m in str(s.get("name", "")).lower() for m in _SCAN_MARKERS)
     ]
     assert not offenders, (
-        f"image-scanning step(s) run before the signature at step {sign}: "
-        f"{offenders}.  Scanning is informational (the Trivy step sets "
-        f"`exit-code: 0`); it must not be able to abort the job while the "
-        f"pushed tags are unsigned."
+        f"image-scanning step(s) run before the signature at step {sign} in "
+        f"{case.workflow}:{case.job}: {offenders}.  Scanning is informational "
+        f"(the Trivy step sets `exit-code: 0`); it must not be able to abort "
+        f"the job while the pushed tags are unsigned."
     )
 
 
-def test_sarif_upload_cannot_fail_the_publish() -> None:
+@pytest.mark.parametrize("case_id", _IDS)
+def test_sarif_upload_cannot_fail_the_publish(case_id: str) -> None:
     """The SARIF upload is explicitly non-fatal.
 
     ``if: always()`` only guarantees the step RUNS after an earlier failure —
@@ -124,38 +205,46 @@ def test_sarif_upload_cannot_fail_the_publish() -> None:
     Code Scanning outage looks like.  ``continue-on-error`` is the property
     that keeps a reporting hiccup from failing a release.
     """
-    steps = _steps()
-    for step in steps:
+    case = _CASES[case_id]
+    for step in _steps(case):
         if "sarif" in str(step.get("name", "")).lower():
             assert step.get("continue-on-error") is True, (
-                f"step {step.get('name')!r} uploads scan results but is not "
-                f"`continue-on-error: true` — a Code Scanning outage would "
-                f"fail the publish job.  `if: always()` does NOT cover this; "
-                f"it governs whether the step runs, not whether its own "
-                f"failure propagates."
+                f"step {step.get('name')!r} in {case.workflow}:{case.job} "
+                f"uploads scan results but is not `continue-on-error: true` — "
+                f"a Code Scanning outage would fail the publish job.  "
+                f"`if: always()` does NOT cover this; it governs whether the "
+                f"step runs, not whether its own failure propagates."
             )
             return
-    raise AssertionError("no SARIF upload step found to check")
+    raise AssertionError(
+        f"no SARIF upload step found to check in {case.workflow}:{case.job}"
+    )
 
 
-def test_the_signature_is_verified_before_scanning_reports() -> None:
+@pytest.mark.parametrize("case_id", _IDS)
+def test_the_signature_is_verified_before_scanning_reports(case_id: str) -> None:
     """The post-publish signature smoke test stays inside the trusted chain.
 
     It is the step that proves the signature is real; ordering it after the
     scanning steps would let a scan failure skip verification entirely.
     """
-    steps = _steps()
+    case = _CASES[case_id]
+    steps = _steps(case)
     verify = next(
         (i for i, s in enumerate(steps)
-         if "verify signature" in str(s.get("name", "")).lower()),
+         if case.verify_marker in str(s.get("name", "")).lower()),
         None,
     )
-    assert verify is not None, "the post-publish signature smoke test is gone"
+    assert verify is not None, (
+        f"the post-publish signature smoke test is gone from "
+        f"{case.workflow}:{case.job} (looked for {case.verify_marker!r})"
+    )
     scans = [
         i for i, s in enumerate(steps)
         if any(m in str(s.get("name", "")).lower() for m in _SCAN_MARKERS)
     ]
     assert all(verify < i for i in scans), (
         f"signature verification is at step {verify} but scanning runs at "
-        f"{scans} — verification must not sit behind a step that can abort."
+        f"{scans} in {case.workflow}:{case.job} — verification must not sit "
+        f"behind a step that can abort."
     )


### PR DESCRIPTION
`demo-publish.yml` had the **same unsigned-publish window that #441 closed in
`docker-publish.yml`** — plus two more violations of the same rule.

Found while reviewing Dependabot **#446**, which touched two lines in the
affected job. The bump itself was fine (both `setup-buildx-action` SHAs verified
against their claimed tags; `codeql-action` v4.37.7 is a CodeQL bundle bump) and
is already merged. This is what the review turned up around it.

### The three violations

`warden-image` job, before:

| # | step | problem |
|---|---|---|
| 4–5 | `Build + push warden` / `authz-shim` | images go public here |
| **6** | **`Install cosign`** | **after the push** — a failed install leaves both images published and permanently unsignable by that run |
| 13 | `Upload Trivy SARIF` | `if: always()` with **no** `continue-on-error` — a Code Scanning outage fails the job |
| 14 | `Verify both signatures` | sits **behind** the scanning steps, so that outage skips the check that proves the signature is real |

`if: always()` governs whether a step *runs* after an earlier failure — not
whether its own failure propagates. That distinction is why #441 exists, and
it bit here in exactly the same way.

### Why nothing caught it

The AGENTS.md hard rule is stated **generally**:

> **Never** let a failable step sit between publishing an artifact and signing it.

But the guard enforcing it hardcoded `docker-publish.yml` and
`build-and-publish`. So the rule was general and the enforcement was not, and
`demo-publish.yml` drifted freely — while signing the demo **warden and
authz-shim, which are Trusted Computing Base components**. It was the more
sensitive of the two workflows to have left unguarded.

### The fix

Job now mirrors `docker-publish`'s shape exactly:

```
prereqs (incl. cosign) → push → sign → SBOM → attest → verify → scan → report(continue-on-error)
```

`test_docker_publish_signing_window.py` is parametrised over **both**
workflows and gains a fifth assertion — *prerequisite signing tooling is
installed before the first push* — which is the one that catches this class
directly rather than by side effect.

**Verified red first:** 4 of 5 assertions failed for `demo-publish` while
**every `docker-publish` variant stayed green**, which is what confirms the
generalisation didn't quietly weaken the existing coverage.

### Verified structurally, not by eye

Re-ordering a signing workflow by hand is exactly where a silent mistake would
hurt, so the edit was checked against both parsed documents:

- **15 steps before, 15 after**; jobs, triggers and `permissions` unchanged.
- The **only** step whose parsed body differs is the SARIF upload, which gained
  `continue-on-error`.
- Text surgery rather than a YAML round-trip on purpose — re-emitting would
  discard comments, and this file's comments carry load-bearing rationale (the
  no-cache-poisoning note, the exact-signer-identity note). Both survive.

### The `bundle` job needs no change

I checked it rather than assuming. It installs cosign first, signs
`SHA256SUMS` *before* attaching, and stages everything in a **draft** release
until a final publish step — so nothing is public early. Correct as written.

### Known residual, deliberately not asserted away

`warden-image` pushes two images before signing either, so a failure of the
*second* push leaves the *first* published unsigned. That window contains only
essential work (the other push), and unlike `:latest` a demo tag is
re-pushable, so the exposure is transient rather than permanent. The guard
therefore measures from the **last** push, and the module docstring says so
rather than leaving a future reader to wonder whether it was missed.

### Filename kept

`test_docker_publish_signing_window.py` now covers two workflows, but a
**released** CHANGELOG entry (0.6.3) cites it by name — renaming would orphan
that reference. Generalised in place; AGENTS.md and SECURITY.md updated to say
the guard is parametrised and that new publishing workflows must be added to
its `_CASES` table.

### Verification

- `tests/unit/test_docker_publish_signing_window.py` — 10 passed (5 × 2).
- `tests/unit` — exit 0.
- `tests/demo` — exit 0 (run explicitly: this is the suite `demo-publish.yml`
  itself executes, so a break there would only surface at tag time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYASqzfDEGVes7NfSYtbY
